### PR TITLE
feat: Pre-warm LLM connections to reduce first request latency

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -117,6 +117,7 @@ final class AppSettings: ObservableObject {
     case ttsAutoPlay
     case ttsSaveToDirectory
     case ttsUseSSML
+    case connectionPreWarmingEnabled
   }
 
   private static let defaultBatchTranscriptionModel = "google/gemini-2.0-flash-001"
@@ -285,6 +286,10 @@ final class AppSettings: ObservableObject {
     didSet { store(ttsUseSSML, key: .ttsUseSSML) }
   }
 
+  @Published var connectionPreWarmingEnabled: Bool {
+    didSet { store(connectionPreWarmingEnabled, key: .connectionPreWarmingEnabled) }
+  }
+
   private let defaults: UserDefaults
 
   init(defaults: UserDefaults = .standard) {
@@ -371,6 +376,8 @@ final class AppSettings: ObservableObject {
     ttsSaveToDirectory =
       defaults.object(forKey: DefaultsKey.ttsSaveToDirectory.rawValue) as? Bool ?? false
     ttsUseSSML = defaults.object(forKey: DefaultsKey.ttsUseSSML.rawValue) as? Bool ?? false
+    connectionPreWarmingEnabled =
+      defaults.object(forKey: DefaultsKey.connectionPreWarmingEnabled.rawValue) as? Bool ?? true
 
     ensureRecordingsDirectoryExists()
   }

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -116,7 +116,8 @@ enum WireUp {
       postProcessingManager: postProcessing,
       historyManager: history,
       hudManager: hud,
-      personalLexicon: personalLexicon
+      personalLexicon: personalLexicon,
+      openRouterClient: openRouter
     )
     let hudPresenter = HUDWindowPresenter(manager: hud)
 


### PR DESCRIPTION
## Summary
Pre-warms TCP/TLS connections to OpenRouter API to reduce latency on first LLM requests.

## Changes
- **OpenRouterAPIClient.swift**: Added `warmUp()` method that makes a lightweight HEAD request to establish and cache the connection
- **MainManager.swift**: Calls `warmUp()` at app launch and when recording starts (if post-processing is enabled)
- **AppSettings.swift**: Added `connectionPreWarmingEnabled` setting (default: true) to enable/disable pre-warming
- **WireUp.swift**: Passes `openRouterClient` to MainManager

## How it works
1. On app launch, `configureHotKeys()` triggers a background warm-up
2. When recording starts, if post-processing is enabled, another warm-up is triggered
3. Warm-up uses `Task.detached` to run in background without blocking UI
4. Timing is logged via os.log to measure improvement
5. Failures are logged but don't throw - warming is best-effort

## Testing
- `swift build` - ✅ passes
- `swift test` - ✅ all 4 tests pass