### PR TITLE
feat: Add confidence indicator during live transcription

### DIFF
--- a/Sources/SpeakApp/HUDManager.swift
+++ b/Sources/SpeakApp/HUDManager.swift
@@ -33,8 +33,14 @@ final class HUDManager: ObservableObject {
     var headline: String
     var subheadline: String?
     var elapsed: TimeInterval
+    var liveText: String?
+    var liveTextIsFinal: Bool
+    var liveTextConfidence: Double?
 
-    static let hidden = Snapshot(phase: .hidden, headline: "", subheadline: nil, elapsed: 0)
+    static let hidden = Snapshot(
+      phase: .hidden, headline: "", subheadline: nil, elapsed: 0,
+      liveText: nil, liveTextIsFinal: true, liveTextConfidence: nil
+    )
   }
 
   @Published private(set) var snapshot: Snapshot = .hidden
@@ -45,6 +51,13 @@ final class HUDManager: ObservableObject {
 
   func beginRecording() {
     transition(.recording, headline: "Recording", subheadline: "Capturing audio")
+  }
+
+  func updateLiveTranscription(text: String, isFinal: Bool, confidence: Double?) {
+    guard snapshot.phase == .recording else { return }
+    snapshot.liveText = text.isEmpty ? nil : text
+    snapshot.liveTextIsFinal = isFinal
+    snapshot.liveTextConfidence = confidence
   }
 
   func beginTranscribing() {
@@ -88,7 +101,10 @@ final class HUDManager: ObservableObject {
   ) {
     invalidateTimers()
     phaseStartDate = showsTimer ? Date() : nil
-    snapshot = Snapshot(phase: phase, headline: headline, subheadline: subheadline, elapsed: 0)
+    snapshot = Snapshot(
+      phase: phase, headline: headline, subheadline: subheadline, elapsed: 0,
+      liveText: nil, liveTextIsFinal: true, liveTextConfidence: nil
+    )
 
     guard showsTimer else { return }
 

--- a/Sources/SpeakApp/HUDView.swift
+++ b/Sources/SpeakApp/HUDView.swift
@@ -26,6 +26,9 @@ struct HUDOverlay: View {
             .foregroundStyle(.secondary)
         }
       }
+      if let liveText = manager.snapshot.liveText, !liveText.isEmpty {
+        liveTranscriptionView(text: liveText)
+      }
       if manager.snapshot.phase.isTerminal == false {
         Text(elapsedText)
           .font(.caption.monospacedDigit())
@@ -46,6 +49,34 @@ struct HUDOverlay: View {
     .shadow(color: .black.opacity(0.25), radius: 18, x: 0, y: 12)
     .animation(.spring(response: 0.25, dampingFraction: 0.85), value: manager.snapshot)
     .padding(.horizontal, 60)
+  }
+
+  @ViewBuilder
+  private func liveTranscriptionView(text: String) -> some View {
+    let isFinal = manager.snapshot.liveTextIsFinal
+    let confidence = manager.snapshot.liveTextConfidence
+
+    HStack(spacing: 6) {
+      Text(text)
+        .font(isFinal ? .callout : .callout.italic())
+        .fontWeight(isFinal ? .regular : .light)
+        .foregroundStyle(isFinal ? .primary : .secondary)
+        .lineLimit(2)
+        .animation(.easeInOut(duration: 0.2), value: isFinal)
+
+      if let confidence, confidence > 0 {
+        Text("\(Int(confidence * 100))%")
+          .font(.caption2.monospacedDigit())
+          .foregroundStyle(.tertiary)
+          .padding(.horizontal, 4)
+          .padding(.vertical, 2)
+          .background(
+            Capsule()
+              .fill(.quaternary)
+          )
+      }
+    }
+    .frame(maxWidth: 300)
   }
 
   private var phaseColor: Color {

--- a/Sources/SpeakApp/LLMProtocols.swift
+++ b/Sources/SpeakApp/LLMProtocols.swift
@@ -44,12 +44,23 @@ struct TranscriptionSegment: Codable, Hashable, Identifiable {
   let startTime: TimeInterval
   let endTime: TimeInterval
   let text: String
+  let isFinal: Bool
+  let confidence: Double?
 
-  init(id: UUID = UUID(), startTime: TimeInterval, endTime: TimeInterval, text: String) {
+  init(
+    id: UUID = UUID(),
+    startTime: TimeInterval,
+    endTime: TimeInterval,
+    text: String,
+    isFinal: Bool = true,
+    confidence: Double? = nil
+  ) {
     self.id = id
     self.startTime = startTime
     self.endTime = endTime
     self.text = text
+    self.isFinal = isFinal
+    self.confidence = confidence
   }
 }
 
@@ -78,9 +89,25 @@ protocol BatchTranscriptionClient {
     -> TranscriptionResult
 }
 
+struct LiveTranscriptionUpdate {
+  let text: String
+  let isFinal: Bool
+  let confidence: Double?
+
+  init(text: String, isFinal: Bool = false, confidence: Double? = nil) {
+    self.text = text
+    self.isFinal = isFinal
+    self.confidence = confidence
+  }
+}
+
 @MainActor
 protocol LiveTranscriptionSessionDelegate: AnyObject {
   func liveTranscriber(_ session: any LiveTranscriptionController, didUpdatePartial text: String)
+  func liveTranscriber(
+    _ session: any LiveTranscriptionController,
+    didUpdateWith update: LiveTranscriptionUpdate
+  )
   func liveTranscriber(
     _ session: any LiveTranscriptionController, didFinishWith result: TranscriptionResult)
   func liveTranscriber(_ session: any LiveTranscriptionController, didFail error: Error)

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -61,6 +61,18 @@ final class MainManager: ObservableObject {
       }
       .store(in: &cancellables)
 
+    // Forward live transcription updates to HUD manager
+    Publishers.CombineLatest3(
+      transcriptionManager.$livePartialText,
+      transcriptionManager.$liveTextIsFinal,
+      transcriptionManager.$liveTextConfidence
+    )
+    .receive(on: RunLoop.main)
+    .sink { [weak self] text, isFinal, confidence in
+      self?.hudManager.updateLiveTranscription(text: text, isFinal: isFinal, confidence: confidence)
+    }
+    .store(in: &cancellables)
+
     configureHotKeys()
   }
 


### PR DESCRIPTION
## Summary
Add visual indicators to help users distinguish between interim (may change) and final (stable) transcription text during live transcription.

## Changes
1. **TranscriptionSegment** - Added `isFinal: Bool` and `confidence: Double?` properties
2. **LLMProtocols** - Added `LiveTranscriptionUpdate` struct and extended `LiveTranscriptionSessionDelegate` with `didUpdateWith:` method
3. **NativeOSXLiveTranscriber** - Now passes confidence scores from SFSpeechRecognitionResult segments
4. **HUDManager** - Extended Snapshot with live text state (`liveText`, `liveTextIsFinal`, `liveTextConfidence`) and added `updateLiveTranscription` method
5. **HUDView** - Added visual indicators:
   - Interim text shown in lighter italic style
   - Final text shown in normal weight
   - Optional confidence badge (e.g., "95%")
   - Smooth animation when text transitions from interim to final
6. **MainManager** - Wired up `CombineLatest3` publisher to forward transcription updates to HUD

## Testing
- `swift build` passes ✓
- `swift test` passes ✓

## Screenshots
The HUD now displays live transcription text with:
- Italic, lighter text for interim results
- Normal weight text for final results
- A small confidence percentage badge when available