### PR TITLE
feat: Add streaming support for post-processing LLM responses

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -118,6 +118,7 @@ final class AppSettings: ObservableObject {
     case ttsSaveToDirectory
     case ttsUseSSML
     case connectionPreWarmingEnabled
+    case postProcessingStreamingEnabled
   }
 
   private static let defaultBatchTranscriptionModel = "google/gemini-2.0-flash-001"
@@ -290,6 +291,10 @@ final class AppSettings: ObservableObject {
     didSet { store(connectionPreWarmingEnabled, key: .connectionPreWarmingEnabled) }
   }
 
+  @Published var postProcessingStreamingEnabled: Bool {
+    didSet { store(postProcessingStreamingEnabled, key: .postProcessingStreamingEnabled) }
+  }
+
   private let defaults: UserDefaults
 
   init(defaults: UserDefaults = .standard) {
@@ -378,6 +383,8 @@ final class AppSettings: ObservableObject {
     ttsUseSSML = defaults.object(forKey: DefaultsKey.ttsUseSSML.rawValue) as? Bool ?? false
     connectionPreWarmingEnabled =
       defaults.object(forKey: DefaultsKey.connectionPreWarmingEnabled.rawValue) as? Bool ?? true
+    postProcessingStreamingEnabled =
+      defaults.object(forKey: DefaultsKey.postProcessingStreamingEnabled.rawValue) as? Bool ?? true
 
     ensureRecordingsDirectoryExists()
   }

--- a/Sources/SpeakApp/HUDManager.swift
+++ b/Sources/SpeakApp/HUDManager.swift
@@ -36,10 +36,11 @@ final class HUDManager: ObservableObject {
     var liveText: String?
     var liveTextIsFinal: Bool
     var liveTextConfidence: Double?
+    var streamingText: String?
 
     static let hidden = Snapshot(
       phase: .hidden, headline: "", subheadline: nil, elapsed: 0,
-      liveText: nil, liveTextIsFinal: true, liveTextConfidence: nil
+      liveText: nil, liveTextIsFinal: true, liveTextConfidence: nil, streamingText: nil
     )
   }
 
@@ -66,6 +67,10 @@ final class HUDManager: ObservableObject {
 
   func beginPostProcessing() {
     transition(.postProcessing, headline: "Post-processing", subheadline: "Cleaning up transcript")
+  }
+
+  func updateStreamingText(_ text: String) {
+    snapshot.streamingText = text
   }
 
   func beginDelivering() {
@@ -103,7 +108,7 @@ final class HUDManager: ObservableObject {
     phaseStartDate = showsTimer ? Date() : nil
     snapshot = Snapshot(
       phase: phase, headline: headline, subheadline: subheadline, elapsed: 0,
-      liveText: nil, liveTextIsFinal: true, liveTextConfidence: nil
+      liveText: nil, liveTextIsFinal: true, liveTextConfidence: nil, streamingText: nil
     )
 
     guard showsTimer else { return }

--- a/Sources/SpeakApp/LLMProtocols.swift
+++ b/Sources/SpeakApp/LLMProtocols.swift
@@ -39,6 +39,15 @@ protocol ChatLLMClient {
     async throws -> ChatResponse
 }
 
+protocol StreamingChatLLMClient: ChatLLMClient {
+  func sendChatStreaming(
+    systemPrompt: String?,
+    messages: [ChatMessage],
+    model: String,
+    temperature: Double
+  ) -> AsyncThrowingStream<String, Error>
+}
+
 struct TranscriptionSegment: Codable, Hashable, Identifiable {
   let id: UUID
   let startTime: TimeInterval


### PR DESCRIPTION
## Summary
This PR adds streaming support for post-processing LLM responses, allowing the HUD to display text incrementally as tokens arrive from the OpenRouter API.

## Changes

### LLMProtocols.swift
- Added `StreamingChatLLMClient` protocol extending `ChatLLMClient` with `sendChatStreaming()` method
- Returns `AsyncThrowingStream<String, Error>` for token chunks

### OpenRouterAPIClient.swift
- Implemented `sendChatStreaming()` using SSE (Server-Sent Events) format
- Added `OpenRouterStreamingChatRequest` and `OpenRouterStreamChunk` types
- Parses SSE `data:` lines and decodes delta content

### PostProcessingManager.swift
- Updated `process()` to accept optional `onStreamingUpdate` callback
- Tries streaming first if enabled and client supports it
- Falls back to non-streaming if streaming fails

### HUDManager.swift
- Added `streamingText` property to `Snapshot` struct
- Added `updateStreamingText()` method for partial text updates

### MainManager.swift
- Wired up streaming callback to update HUD with accumulated text
- Applied to both `endSession()` and `reprocessHistoryItem()`

### AppSettings.swift
- Added `postProcessingStreamingEnabled` setting (default: on)

## Testing
- `swift build` passes ✅
- `swift test` passes (4 tests) ✅

## Success Criteria Met
- ✅ Post-processing text appears incrementally in HUD
- ✅ Full text still captured correctly at end
- ✅ Fallback to non-streaming if streaming fails