### PR TITLE
feat: Add Pronunciation Dictionary and Lexicon for TTS

### DIFF
--- a/Sources/SpeakApp/Models/PronunciationEntry.swift
+++ b/Sources/SpeakApp/Models/PronunciationEntry.swift
@@ -1,0 +1,258 @@
+import Foundation
+
+/// Represents a custom pronunciation entry for TTS engines.
+struct PronunciationEntry: Codable, Identifiable, Hashable {
+    let id: UUID
+    var word: String           // Original text to match
+    var pronunciation: String  // How to pronounce (IPA or phonetic)
+    var replacement: String?   // Simple text replacement alternative
+    var category: String?      // e.g., "Technical", "Names", "Acronyms"
+    var isRegex: Bool          // Whether word should be treated as a regex pattern
+    var caseSensitive: Bool    // Whether matching should be case-sensitive
+
+    init(
+        id: UUID = UUID(),
+        word: String,
+        pronunciation: String,
+        replacement: String? = nil,
+        category: String? = nil,
+        isRegex: Bool = false,
+        caseSensitive: Bool = false
+    ) {
+        self.id = id
+        self.word = word
+        self.pronunciation = pronunciation
+        self.replacement = replacement
+        self.category = category
+        self.isRegex = isRegex
+        self.caseSensitive = caseSensitive
+    }
+
+    /// Commonly used categories for pronunciation entries.
+    enum Category: String, CaseIterable, Identifiable {
+        case technical = "Technical"
+        case names = "Names"
+        case acronyms = "Acronyms"
+        case symbols = "Symbols"
+        case brands = "Brands"
+        case medical = "Medical"
+        case custom = "Custom"
+
+        var id: String { rawValue }
+
+        var systemImage: String {
+            switch self {
+            case .technical: return "gearshape"
+            case .names: return "person.fill"
+            case .acronyms: return "textformat.abc"
+            case .symbols: return "number"
+            case .brands: return "building.2"
+            case .medical: return "cross.case"
+            case .custom: return "pencil"
+            }
+        }
+    }
+}
+
+// MARK: - Default Entries
+
+extension PronunciationEntry {
+    /// Pre-populated common pronunciation entries.
+    static let defaultEntries: [PronunciationEntry] = [
+        // Technical terms
+        PronunciationEntry(
+            word: "API",
+            pronunciation: "A P I",
+            replacement: "A P I",
+            category: Category.technical.rawValue
+        ),
+        PronunciationEntry(
+            word: "SQL",
+            pronunciation: "sequel",
+            replacement: "sequel",
+            category: Category.technical.rawValue
+        ),
+        PronunciationEntry(
+            word: "iOS",
+            pronunciation: "eye OS",
+            replacement: "eye OS",
+            category: Category.technical.rawValue
+        ),
+        PronunciationEntry(
+            word: "macOS",
+            pronunciation: "mac OS",
+            replacement: "mac OS",
+            category: Category.technical.rawValue
+        ),
+        PronunciationEntry(
+            word: "CLI",
+            pronunciation: "C L I",
+            replacement: "C L I",
+            category: Category.technical.rawValue
+        ),
+        PronunciationEntry(
+            word: "GUI",
+            pronunciation: "gooey",
+            replacement: "gooey",
+            category: Category.technical.rawValue
+        ),
+        PronunciationEntry(
+            word: "JSON",
+            pronunciation: "jay-son",
+            replacement: "jason",
+            category: Category.technical.rawValue
+        ),
+        PronunciationEntry(
+            word: "YAML",
+            pronunciation: "yam-el",
+            replacement: "yamel",
+            category: Category.technical.rawValue
+        ),
+        PronunciationEntry(
+            word: "nginx",
+            pronunciation: "engine-x",
+            replacement: "engine X",
+            category: Category.technical.rawValue
+        ),
+        PronunciationEntry(
+            word: "kubectl",
+            pronunciation: "cube-control",
+            replacement: "cube control",
+            category: Category.technical.rawValue
+        ),
+
+        // Names in tech
+        PronunciationEntry(
+            word: "Kubernetes",
+            pronunciation: "koo-ber-net-ees",
+            replacement: "koo ber nettees",
+            category: Category.names.rawValue
+        ),
+        PronunciationEntry(
+            word: "PostgreSQL",
+            pronunciation: "post-gres-Q-L",
+            replacement: "post gres Q L",
+            category: Category.names.rawValue
+        ),
+        PronunciationEntry(
+            word: "MySQL",
+            pronunciation: "my-S-Q-L",
+            replacement: "my S Q L",
+            category: Category.names.rawValue
+        ),
+        PronunciationEntry(
+            word: "Xcode",
+            pronunciation: "ex-code",
+            replacement: "ex code",
+            category: Category.names.rawValue
+        ),
+
+        // Acronyms
+        PronunciationEntry(
+            word: "URL",
+            pronunciation: "U R L",
+            replacement: "U R L",
+            category: Category.acronyms.rawValue
+        ),
+        PronunciationEntry(
+            word: "HTTP",
+            pronunciation: "H T T P",
+            replacement: "H T T P",
+            category: Category.acronyms.rawValue
+        ),
+        PronunciationEntry(
+            word: "HTTPS",
+            pronunciation: "H T T P S",
+            replacement: "H T T P S",
+            category: Category.acronyms.rawValue
+        ),
+        PronunciationEntry(
+            word: "HTML",
+            pronunciation: "H T M L",
+            replacement: "H T M L",
+            category: Category.acronyms.rawValue
+        ),
+        PronunciationEntry(
+            word: "CSS",
+            pronunciation: "C S S",
+            replacement: "C S S",
+            category: Category.acronyms.rawValue
+        ),
+        PronunciationEntry(
+            word: "AWS",
+            pronunciation: "A W S",
+            replacement: "A W S",
+            category: Category.acronyms.rawValue
+        ),
+        PronunciationEntry(
+            word: "GCP",
+            pronunciation: "G C P",
+            replacement: "G C P",
+            category: Category.acronyms.rawValue
+        ),
+
+        // Symbols
+        PronunciationEntry(
+            word: "@",
+            pronunciation: "at",
+            replacement: " at ",
+            category: Category.symbols.rawValue
+        ),
+        PronunciationEntry(
+            word: "#",
+            pronunciation: "hashtag",
+            replacement: " hashtag ",
+            category: Category.symbols.rawValue
+        ),
+        PronunciationEntry(
+            word: "&",
+            pronunciation: "and",
+            replacement: " and ",
+            category: Category.symbols.rawValue
+        ),
+        PronunciationEntry(
+            word: "->",
+            pronunciation: "arrow",
+            replacement: " arrow ",
+            category: Category.symbols.rawValue
+        ),
+        PronunciationEntry(
+            word: "=>",
+            pronunciation: "arrow",
+            replacement: " arrow ",
+            category: Category.symbols.rawValue
+        ),
+        PronunciationEntry(
+            word: "!=",
+            pronunciation: "not equal",
+            replacement: " not equal ",
+            category: Category.symbols.rawValue
+        ),
+        PronunciationEntry(
+            word: "==",
+            pronunciation: "equals",
+            replacement: " equals ",
+            category: Category.symbols.rawValue
+        ),
+
+        // Brands
+        PronunciationEntry(
+            word: "GitHub",
+            pronunciation: "git-hub",
+            replacement: "git hub",
+            category: Category.brands.rawValue
+        ),
+        PronunciationEntry(
+            word: "GitLab",
+            pronunciation: "git-lab",
+            replacement: "git lab",
+            category: Category.brands.rawValue
+        ),
+        PronunciationEntry(
+            word: "OpenAI",
+            pronunciation: "open A I",
+            replacement: "open A I",
+            category: Category.brands.rawValue
+        ),
+    ]
+}

--- a/Sources/SpeakApp/Services/TTS/PronunciationManager.swift
+++ b/Sources/SpeakApp/Services/TTS/PronunciationManager.swift
@@ -1,0 +1,356 @@
+import Foundation
+
+/// Manages the pronunciation dictionary for TTS processing.
+/// Handles loading, saving, applying replacements, and import/export.
+@MainActor
+final class PronunciationManager: ObservableObject {
+    private static let storageKey = "pronunciationDictionary"
+    private static let fileExtension = "json"
+
+    @Published private(set) var entries: [PronunciationEntry] = []
+    @Published private(set) var isLoading = false
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        loadEntries()
+    }
+
+    // MARK: - Entry Management
+
+    func addEntry(_ entry: PronunciationEntry) {
+        // Check for duplicates
+        guard !entries.contains(where: { $0.word.lowercased() == entry.word.lowercased() }) else {
+            return
+        }
+        entries.append(entry)
+        saveEntries()
+    }
+
+    func updateEntry(_ entry: PronunciationEntry) {
+        if let index = entries.firstIndex(where: { $0.id == entry.id }) {
+            entries[index] = entry
+            saveEntries()
+        }
+    }
+
+    func deleteEntry(_ entry: PronunciationEntry) {
+        entries.removeAll { $0.id == entry.id }
+        saveEntries()
+    }
+
+    func deleteEntries(at offsets: IndexSet) {
+        entries.remove(atOffsets: offsets)
+        saveEntries()
+    }
+
+    func moveEntries(from source: IndexSet, to destination: Int) {
+        entries.move(fromOffsets: source, toOffset: destination)
+        saveEntries()
+    }
+
+    // MARK: - Quick Add
+
+    /// Quick-add a word with pronunciation, auto-detecting category.
+    func quickAdd(word: String, pronunciation: String) {
+        let category = detectCategory(for: word)
+        let entry = PronunciationEntry(
+            word: word,
+            pronunciation: pronunciation,
+            replacement: pronunciation,
+            category: category?.rawValue
+        )
+        addEntry(entry)
+    }
+
+    private func detectCategory(for word: String) -> PronunciationEntry.Category? {
+        let upper = word.uppercased()
+        if upper == word && word.count >= 2 && word.count <= 6 {
+            return .acronyms
+        }
+        if word.first?.isSymbol == true || word.first?.isPunctuation == true {
+            return .symbols
+        }
+        if word.first?.isUppercase == true && word.count > 1 {
+            return .names
+        }
+        return .custom
+    }
+
+    // MARK: - Text Processing
+
+    /// Apply pronunciation replacements to text before TTS processing.
+    func applyReplacements(to text: String) -> String {
+        var result = text
+
+        for entry in entries {
+            if let replacement = entry.replacement, !replacement.isEmpty {
+                if entry.isRegex {
+                    result = applyRegexReplacement(
+                        text: result,
+                        pattern: entry.word,
+                        replacement: replacement,
+                        caseSensitive: entry.caseSensitive
+                    )
+                } else {
+                    result = applySimpleReplacement(
+                        text: result,
+                        word: entry.word,
+                        replacement: replacement,
+                        caseSensitive: entry.caseSensitive
+                    )
+                }
+            }
+        }
+
+        return result
+    }
+
+    private func applySimpleReplacement(
+        text: String,
+        word: String,
+        replacement: String,
+        caseSensitive: Bool
+    ) -> String {
+        if caseSensitive {
+            return text.replacingOccurrences(of: word, with: replacement)
+        } else {
+            // Case-insensitive replacement with word boundaries
+            let pattern = "\\b\(NSRegularExpression.escapedPattern(for: word))\\b"
+            guard let regex = try? NSRegularExpression(
+                pattern: pattern,
+                options: .caseInsensitive
+            ) else {
+                return text
+            }
+
+            let range = NSRange(text.startIndex..., in: text)
+            return regex.stringByReplacingMatches(
+                in: text,
+                options: [],
+                range: range,
+                withTemplate: replacement
+            )
+        }
+    }
+
+    private func applyRegexReplacement(
+        text: String,
+        pattern: String,
+        replacement: String,
+        caseSensitive: Bool
+    ) -> String {
+        var options: NSRegularExpression.Options = []
+        if !caseSensitive {
+            options.insert(.caseInsensitive)
+        }
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+            return text
+        }
+
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(
+            in: text,
+            options: [],
+            range: range,
+            withTemplate: replacement
+        )
+    }
+
+    // MARK: - SSML Support
+
+    /// Generate SSML with phoneme tags for providers that support it.
+    /// Uses IPA (International Phonetic Alphabet) when available.
+    func generateSSML(for text: String, provider: TTSProvider) -> String {
+        guard provider.supportsSSMLPhonemes else {
+            // For providers without phoneme support, just use text replacement
+            return applyReplacements(to: text)
+        }
+
+        var result = text
+
+        for entry in entries {
+            let phonemeTag = buildPhonemeTag(
+                word: entry.word,
+                pronunciation: entry.pronunciation,
+                provider: provider
+            )
+
+            if entry.isRegex {
+                // For regex entries, we can't easily apply phoneme tags
+                // Fall back to simple replacement
+                if let replacement = entry.replacement {
+                    result = applyRegexReplacement(
+                        text: result,
+                        pattern: entry.word,
+                        replacement: replacement,
+                        caseSensitive: entry.caseSensitive
+                    )
+                }
+            } else {
+                result = applySimpleReplacement(
+                    text: result,
+                    word: entry.word,
+                    replacement: phonemeTag,
+                    caseSensitive: entry.caseSensitive
+                )
+            }
+        }
+
+        return result
+    }
+
+    private func buildPhonemeTag(word: String, pronunciation: String, provider: TTSProvider) -> String {
+        // Different providers use different phoneme alphabets
+        let alphabet = provider.phonemeAlphabet
+        let escapedPronunciation = pronunciation
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+
+        return "<phoneme alphabet=\"\(alphabet)\" ph=\"\(escapedPronunciation)\">\(word)</phoneme>"
+    }
+
+    // MARK: - Category Filtering
+
+    func entries(for category: PronunciationEntry.Category?) -> [PronunciationEntry] {
+        guard let category = category else {
+            return entries
+        }
+        return entries.filter { $0.category == category.rawValue }
+    }
+
+    var categories: [PronunciationEntry.Category] {
+        let usedCategories = Set(entries.compactMap { $0.category })
+        return PronunciationEntry.Category.allCases.filter { usedCategories.contains($0.rawValue) }
+    }
+
+    // MARK: - Search
+
+    func search(_ query: String) -> [PronunciationEntry] {
+        guard !query.isEmpty else { return entries }
+        let lowercasedQuery = query.lowercased()
+        return entries.filter { entry in
+            entry.word.lowercased().contains(lowercasedQuery) ||
+            entry.pronunciation.lowercased().contains(lowercasedQuery) ||
+            (entry.replacement?.lowercased().contains(lowercasedQuery) ?? false) ||
+            (entry.category?.lowercased().contains(lowercasedQuery) ?? false)
+        }
+    }
+
+    // MARK: - Import/Export
+
+    func exportToJSON() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(entries)
+    }
+
+    func importFromJSON(_ data: Data, merge: Bool = true) throws {
+        let decoder = JSONDecoder()
+        let importedEntries = try decoder.decode([PronunciationEntry].self, from: data)
+
+        if merge {
+            // Merge: add new entries, skip duplicates
+            for entry in importedEntries {
+                if !entries.contains(where: { $0.word.lowercased() == entry.word.lowercased() }) {
+                    entries.append(entry)
+                }
+            }
+        } else {
+            // Replace all entries
+            entries = importedEntries
+        }
+
+        saveEntries()
+    }
+
+    func exportToFile() throws -> URL {
+        let data = try exportToJSON()
+        let tempDir = FileManager.default.temporaryDirectory
+        let filename = "pronunciation_dictionary_\(ISO8601DateFormatter().string(from: Date())).\(Self.fileExtension)"
+        let fileURL = tempDir.appendingPathComponent(filename)
+        try data.write(to: fileURL)
+        return fileURL
+    }
+
+    func importFromFile(_ url: URL, merge: Bool = true) throws {
+        let data = try Data(contentsOf: url)
+        try importFromJSON(data, merge: merge)
+    }
+
+    // MARK: - Reset/Defaults
+
+    func resetToDefaults() {
+        entries = PronunciationEntry.defaultEntries
+        saveEntries()
+    }
+
+    func addDefaultEntries() {
+        for defaultEntry in PronunciationEntry.defaultEntries {
+            if !entries.contains(where: { $0.word.lowercased() == defaultEntry.word.lowercased() }) {
+                entries.append(defaultEntry)
+            }
+        }
+        saveEntries()
+    }
+
+    func clearAll() {
+        entries = []
+        saveEntries()
+    }
+
+    // MARK: - Persistence
+
+    private func loadEntries() {
+        isLoading = true
+        defer { isLoading = false }
+
+        guard let data = defaults.data(forKey: Self.storageKey) else {
+            // First launch: load defaults
+            entries = PronunciationEntry.defaultEntries
+            saveEntries()
+            return
+        }
+
+        do {
+            entries = try JSONDecoder().decode([PronunciationEntry].self, from: data)
+        } catch {
+            // Migration or corruption: reset to defaults
+            entries = PronunciationEntry.defaultEntries
+            saveEntries()
+        }
+    }
+
+    private func saveEntries() {
+        do {
+            let data = try JSONEncoder().encode(entries)
+            defaults.set(data, forKey: Self.storageKey)
+        } catch {
+            // Silent failure - entries will be reloaded on next launch
+        }
+    }
+}
+
+// MARK: - TTSProvider Extensions
+
+extension TTSProvider {
+    /// Whether this provider supports SSML phoneme tags.
+    var supportsSSMLPhonemes: Bool {
+        switch self {
+        case .azure, .system: return true
+        case .elevenlabs, .openai, .deepgram: return false
+        }
+    }
+
+    /// The phoneme alphabet to use for SSML tags.
+    var phonemeAlphabet: String {
+        switch self {
+        case .azure: return "ipa"
+        case .system: return "ipa"
+        default: return "ipa"
+        }
+    }
+}

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -6,6 +6,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
   case transcription
   case postProcessing
   case voiceOutput
+  case pronunciation
   case apiKeys
   case hotKeys
   case permissions
@@ -18,6 +19,7 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
     case .transcription: return "Transcription"
     case .postProcessing: return "Post-processing"
     case .voiceOutput: return "Voice Output"
+    case .pronunciation: return "Pronunciation"
     case .apiKeys: return "API Keys"
     case .hotKeys: return "Hotkeys"
     case .permissions: return "Permissions"
@@ -139,6 +141,8 @@ struct SettingsView: View {
       postProcessingSettings
     case .voiceOutput:
       voiceOutputSettings
+    case .pronunciation:
+      pronunciationSettings
     case .apiKeys:
       apiKeySettings
     case .hotKeys:
@@ -978,6 +982,11 @@ struct SettingsView: View {
       }
       .speakTooltip("Add custom pronunciations for words that TTS engines commonly mispronounce.")
     }
+  }
+
+  private var pronunciationSettings: some View {
+    PronunciationDictionaryView()
+      .environmentObject(environment.pronunciationManager)
   }
 
   private var apiKeySettings: some View {

--- a/Sources/SpeakApp/Views/Settings/PronunciationDictionaryView.swift
+++ b/Sources/SpeakApp/Views/Settings/PronunciationDictionaryView.swift
@@ -1,0 +1,623 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// View for managing the pronunciation dictionary.
+struct PronunciationDictionaryView: View {
+    @EnvironmentObject private var pronunciationManager: PronunciationManager
+    @State private var searchText = ""
+    @State private var selectedCategory: PronunciationEntry.Category?
+    @State private var showingAddSheet = false
+    @State private var showingImportSheet = false
+    @State private var showingExportSheet = false
+    @State private var editingEntry: PronunciationEntry?
+    @State private var exportURL: URL?
+    @State private var importMerge = true
+    @State private var alertMessage: String?
+    @State private var showingAlert = false
+
+    private var filteredEntries: [PronunciationEntry] {
+        var result = pronunciationManager.entries
+
+        // Filter by category
+        if let category = selectedCategory {
+            result = result.filter { $0.category == category.rawValue }
+        }
+
+        // Filter by search
+        if !searchText.isEmpty {
+            let lowercasedQuery = searchText.lowercased()
+            result = result.filter { entry in
+                entry.word.lowercased().contains(lowercasedQuery) ||
+                entry.pronunciation.lowercased().contains(lowercasedQuery) ||
+                (entry.replacement?.lowercased().contains(lowercasedQuery) ?? false)
+            }
+        }
+
+        return result
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header with search and actions
+            headerView
+
+            Divider()
+
+            // Category tabs
+            categoryTabsView
+
+            // Entries list
+            if filteredEntries.isEmpty {
+                emptyStateView
+            } else {
+                entriesListView
+            }
+        }
+        .sheet(isPresented: $showingAddSheet) {
+            PronunciationEntryFormView(
+                entry: nil,
+                onSave: { entry in
+                    pronunciationManager.addEntry(entry)
+                }
+            )
+        }
+        .sheet(item: $editingEntry) { entry in
+            PronunciationEntryFormView(
+                entry: entry,
+                onSave: { updatedEntry in
+                    pronunciationManager.updateEntry(updatedEntry)
+                }
+            )
+        }
+        .fileImporter(
+            isPresented: $showingImportSheet,
+            allowedContentTypes: [UTType.json],
+            allowsMultipleSelection: false
+        ) { result in
+            handleImport(result)
+        }
+        .fileExporter(
+            isPresented: $showingExportSheet,
+            document: PronunciationDocument(entries: pronunciationManager.entries),
+            contentType: .json,
+            defaultFilename: "pronunciation_dictionary"
+        ) { result in
+            handleExport(result)
+        }
+        .alert("Pronunciation Dictionary", isPresented: $showingAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(alertMessage ?? "")
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerView: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Text("Pronunciation Dictionary")
+                    .font(.title2.bold())
+                Spacer()
+                HStack(spacing: 8) {
+                    Button {
+                        showingImportSheet = true
+                    } label: {
+                        Label("Import", systemImage: "square.and.arrow.down")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        showingExportSheet = true
+                    } label: {
+                        Label("Export", systemImage: "square.and.arrow.up")
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(pronunciationManager.entries.isEmpty)
+
+                    Button {
+                        showingAddSheet = true
+                    } label: {
+                        Label("Add", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search words or pronunciations...", text: $searchText)
+                    .textFieldStyle(.plain)
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+        }
+        .padding()
+    }
+
+    // MARK: - Category Tabs
+
+    private var categoryTabsView: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                CategoryTab(
+                    title: "All",
+                    count: pronunciationManager.entries.count,
+                    isSelected: selectedCategory == nil
+                ) {
+                    selectedCategory = nil
+                }
+
+                ForEach(PronunciationEntry.Category.allCases) { category in
+                    let count = pronunciationManager.entries.filter { $0.category == category.rawValue }.count
+                    if count > 0 {
+                        CategoryTab(
+                            title: category.rawValue,
+                            count: count,
+                            systemImage: category.systemImage,
+                            isSelected: selectedCategory == category
+                        ) {
+                            selectedCategory = category
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    // MARK: - Entries List
+
+    private var entriesListView: some View {
+        List {
+            ForEach(filteredEntries) { entry in
+                PronunciationEntryRow(entry: entry)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        editingEntry = entry
+                    }
+                    .contextMenu {
+                        Button {
+                            editingEntry = entry
+                        } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+
+                        Button(role: .destructive) {
+                            pronunciationManager.deleteEntry(entry)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            pronunciationManager.deleteEntry(entry)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                    .swipeActions(edge: .leading) {
+                        Button {
+                            editingEntry = entry
+                        } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+                        .tint(.blue)
+                    }
+            }
+        }
+        .listStyle(.inset)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "text.book.closed")
+                .font(.system(size: 48))
+                .foregroundStyle(.tertiary)
+
+            if searchText.isEmpty && selectedCategory == nil {
+                Text("No pronunciation entries")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                Text("Add custom pronunciations for words that TTS engines mispronounce.")
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+
+                HStack(spacing: 12) {
+                    Button("Add Entry") {
+                        showingAddSheet = true
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button("Load Defaults") {
+                        pronunciationManager.resetToDefaults()
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .padding(.top, 8)
+            } else {
+                Text("No matching entries")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                Button("Clear Search") {
+                    searchText = ""
+                    selectedCategory = nil
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    // MARK: - Import/Export
+
+    private func handleImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            do {
+                try pronunciationManager.importFromFile(url, merge: importMerge)
+                alertMessage = "Successfully imported pronunciation entries."
+                showingAlert = true
+            } catch {
+                alertMessage = "Failed to import: \(error.localizedDescription)"
+                showingAlert = true
+            }
+        case .failure(let error):
+            alertMessage = "Import failed: \(error.localizedDescription)"
+            showingAlert = true
+        }
+    }
+
+    private func handleExport(_ result: Result<URL, Error>) {
+        switch result {
+        case .success:
+            alertMessage = "Successfully exported pronunciation dictionary."
+            showingAlert = true
+        case .failure(let error):
+            alertMessage = "Export failed: \(error.localizedDescription)"
+            showingAlert = true
+        }
+    }
+}
+
+// MARK: - Category Tab
+
+private struct CategoryTab: View {
+    let title: String
+    let count: Int
+    var systemImage: String?
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if let systemImage = systemImage {
+                    Image(systemName: systemImage)
+                        .imageScale(.small)
+                }
+                Text(title)
+                    .font(.subheadline.weight(isSelected ? .semibold : .regular))
+                Text("\(count)")
+                    .font(.caption)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(isSelected ? Color.white.opacity(0.2) : Color.secondary.opacity(0.15))
+                    )
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(isSelected ? Color.accentColor : Color.clear)
+            )
+            .foregroundStyle(isSelected ? .white : .primary)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Entry Row
+
+private struct PronunciationEntryRow: View {
+    let entry: PronunciationEntry
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text(entry.word)
+                        .font(.headline)
+
+                    if entry.isRegex {
+                        Text("REGEX")
+                            .font(.caption2.bold())
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule()
+                                    .fill(Color.orange.opacity(0.2))
+                            )
+                            .foregroundStyle(.orange)
+                    }
+
+                    if entry.caseSensitive {
+                        Text("Aa")
+                            .font(.caption2.bold())
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule()
+                                    .fill(Color.blue.opacity(0.2))
+                            )
+                            .foregroundStyle(.blue)
+                    }
+                }
+
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.right")
+                        .imageScale(.small)
+                        .foregroundStyle(.tertiary)
+                    Text(entry.pronunciation)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            if let category = entry.category {
+                Text(category)
+                    .font(.caption)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        Capsule()
+                            .fill(Color.secondary.opacity(0.1))
+                    )
+                    .foregroundStyle(.secondary)
+            }
+
+            Image(systemName: "chevron.right")
+                .imageScale(.small)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Entry Form
+
+struct PronunciationEntryFormView: View {
+    let entry: PronunciationEntry?
+    let onSave: (PronunciationEntry) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var word: String
+    @State private var pronunciation: String
+    @State private var replacement: String
+    @State private var category: PronunciationEntry.Category
+    @State private var isRegex: Bool
+    @State private var caseSensitive: Bool
+
+    init(entry: PronunciationEntry?, onSave: @escaping (PronunciationEntry) -> Void) {
+        self.entry = entry
+        self.onSave = onSave
+
+        _word = State(initialValue: entry?.word ?? "")
+        _pronunciation = State(initialValue: entry?.pronunciation ?? "")
+        _replacement = State(initialValue: entry?.replacement ?? "")
+        _category = State(initialValue: PronunciationEntry.Category(rawValue: entry?.category ?? "") ?? .custom)
+        _isRegex = State(initialValue: entry?.isRegex ?? false)
+        _caseSensitive = State(initialValue: entry?.caseSensitive ?? false)
+    }
+
+    private var isValid: Bool {
+        !word.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !pronunciation.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Text(entry == nil ? "Add Entry" : "Edit Entry")
+                    .font(.headline)
+
+                Spacer()
+
+                Button("Save") {
+                    saveEntry()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!isValid)
+            }
+            .padding()
+
+            Divider()
+
+            // Form
+            Form {
+                Section("Word") {
+                    TextField("Original text", text: $word)
+                        .textFieldStyle(.roundedBorder)
+                    Text("The word or phrase to match in the text.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Pronunciation") {
+                    TextField("How to pronounce", text: $pronunciation)
+                        .textFieldStyle(.roundedBorder)
+                    Text("Enter phonetic spelling or IPA notation.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Replacement (Optional)") {
+                    TextField("Text replacement", text: $replacement)
+                        .textFieldStyle(.roundedBorder)
+                    Text("Simple text replacement for providers without SSML support.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Category") {
+                    Picker("Category", selection: $category) {
+                        ForEach(PronunciationEntry.Category.allCases) { cat in
+                            Label(cat.rawValue, systemImage: cat.systemImage)
+                                .tag(cat)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
+
+                Section("Options") {
+                    Toggle("Use as regex pattern", isOn: $isRegex)
+                    Toggle("Case sensitive", isOn: $caseSensitive)
+                }
+            }
+            .formStyle(.grouped)
+        }
+        .frame(width: 450, height: 500)
+    }
+
+    private func saveEntry() {
+        let trimmedWord = word.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPronunciation = pronunciation.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedReplacement = replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let newEntry = PronunciationEntry(
+            id: entry?.id ?? UUID(),
+            word: trimmedWord,
+            pronunciation: trimmedPronunciation,
+            replacement: trimmedReplacement.isEmpty ? trimmedPronunciation : trimmedReplacement,
+            category: category.rawValue,
+            isRegex: isRegex,
+            caseSensitive: caseSensitive
+        )
+
+        onSave(newEntry)
+        dismiss()
+    }
+}
+
+// MARK: - Quick Add Dialog
+
+/// A compact dialog for quickly adding a pronunciation from context.
+struct QuickAddPronunciationView: View {
+    let word: String
+    let onSave: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var pronunciation: String = ""
+
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Text("Add Pronunciation")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Word:")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(word)
+                    .font(.title3.bold())
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Pronunciation:")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField("How to pronounce", text: $pronunciation)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            HStack {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button("Add") {
+                    onSave(pronunciation)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(pronunciation.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding()
+        .frame(width: 300)
+    }
+}
+
+// MARK: - Document for Export
+
+struct PronunciationDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.json] }
+
+    var entries: [PronunciationEntry]
+
+    init(entries: [PronunciationEntry]) {
+        self.entries = entries
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        entries = try JSONDecoder().decode([PronunciationEntry].self, from: data)
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(entries)
+        return FileWrapper(regularFileWithContents: data)
+    }
+}

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -15,6 +15,7 @@ final class AppEnvironment: ObservableObject {
   let secureStorage: SecureAppStorage
   let openRouter: OpenRouterAPIClient
   let personalLexicon: PersonalLexiconService
+  let pronunciationManager: PronunciationManager
   let main: MainManager
   private let hudPresenter: HUDWindowPresenter
 
@@ -34,6 +35,7 @@ final class AppEnvironment: ObservableObject {
     secureStorage: SecureAppStorage,
     openRouter: OpenRouterAPIClient,
     personalLexicon: PersonalLexiconService,
+    pronunciationManager: PronunciationManager,
     main: MainManager,
     hudPresenter: HUDWindowPresenter
   ) {
@@ -50,6 +52,7 @@ final class AppEnvironment: ObservableObject {
     self.secureStorage = secureStorage
     self.openRouter = openRouter
     self.personalLexicon = personalLexicon
+    self.pronunciationManager = pronunciationManager
     self.main = main
     self.hudPresenter = hudPresenter
   }
@@ -91,6 +94,7 @@ enum WireUp {
     )
     let personalLexiconStore = PersonalLexiconStore()
     let personalLexicon = PersonalLexiconService(store: personalLexiconStore)
+    let pronunciationManager = PronunciationManager()
     let postProcessing = PostProcessingManager(
       client: openRouter,
       settings: settings,
@@ -106,7 +110,8 @@ enum WireUp {
     let tts = TextToSpeechManager(
       appSettings: settings,
       secureStorage: secureStorage,
-      clients: ttsClients
+      clients: ttsClients,
+      pronunciationManager: pronunciationManager
     )
     let main = MainManager(
       appSettings: settings,
@@ -136,6 +141,7 @@ enum WireUp {
       secureStorage: secureStorage,
       openRouter: openRouter,
       personalLexicon: personalLexicon,
+      pronunciationManager: pronunciationManager,
       main: main,
       hudPresenter: hudPresenter
     )


### PR DESCRIPTION
## Summary
This PR adds a user-manageable pronunciation dictionary for custom words, allowing users to correct TTS mispronunciations.

## Changes

### New Files
- **`Sources/SpeakApp/Models/PronunciationEntry.swift`**: Model for pronunciation entries with:
  - Word/pronunciation mapping
  - Optional text replacement
  - Categories (Technical, Names, Acronyms, Symbols, Brands, Medical, Custom)
  - Regex pattern support
  - Case sensitivity option

- **`Sources/SpeakApp/Services/TTS/PronunciationManager.swift`**: Service that:
  - Loads/saves dictionary from UserDefaults
  - Applies text replacements before TTS processing
  - Supports regex patterns for complex matches
  - Generates SSML phoneme tags for providers that support it (Azure, System)
  - Import/export dictionary as JSON
  - Pre-populated with common entries

- **`Sources/SpeakApp/Views/Settings/PronunciationDictionaryView.swift`**: UI for managing entries:
  - List all entries with search/filter
  - Add new entry form
  - Edit existing entries
  - Swipe to delete
  - Category filter tabs
  - Import from file button
  - Export to file button
  - Quick add dialog for context menu actions

### Modified Files
- **`WireUp.swift`**: Integrate PronunciationManager into AppEnvironment
- **`TextToSpeechManager.swift`**: Apply pronunciation processing before TTS synthesis
- **`SettingsView.swift`**: Add Pronunciation tab to settings

## Pre-populated Entries

The dictionary comes pre-loaded with common entries:

| Category | Examples |
|----------|----------|
| Technical | API → "A P I", SQL → "sequel", iOS → "eye OS", JSON → "jay-son" |
| Names | Kubernetes → "koo-ber-net-ees", PostgreSQL → "post-gres-Q-L" |
| Acronyms | URL, HTTP, HTTPS, HTML, CSS, AWS, GCP |
| Symbols | @ → "at", # → "hashtag", & → "and", -> → "arrow" |
| Brands | GitHub, GitLab, OpenAI |

## SSML Phoneme Support

For TTS providers that support SSML (Azure, System), the manager generates proper phoneme tags:
```xml
<phoneme alphabet="ipa" ph="pronunciation">word</phoneme>
```

For providers without SSML support (ElevenLabs, OpenAI, Deepgram), simple text replacement is used.

## Testing
- `make build` - ✅ Passes
- `make test` - ✅ All 4 tests pass