### PR TITLE
fix: improve accessibility text insertion reliability

### DIFF
--- a/Sources/SpeakApp/LiveTextInserter.swift
+++ b/Sources/SpeakApp/LiveTextInserter.swift
@@ -281,12 +281,10 @@ final class LiveTextInserter: ObservableObject {
   /// Log detailed information about the focused element for debugging
   private func logFocusedElementInfo(_ element: AXUIElement) {
     var role: CFTypeRef?
+    defer { if let role { CFRelease(role) } }
     var roleDesc: CFTypeRef?
-    defer {
-      // Note: Swift bridging to String handles memory, but explicit release is safer
-      if role != nil { role = nil }
-      if roleDesc != nil { roleDesc = nil }
-    }
+    defer { if let roleDesc { CFRelease(roleDesc) } }
+
     AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &role)
     AXUIElementCopyAttributeValue(element, kAXRoleDescriptionAttribute as CFString, &roleDesc)
     let roleStr = (role as? String) ?? "unknown"
@@ -302,7 +300,7 @@ final class LiveTextInserter: ObservableObject {
     Thread.sleep(forTimeInterval: 0.05)
 
     var currentValue: CFTypeRef?
-    defer { if currentValue != nil { currentValue = nil } }
+    defer { if let currentValue { CFRelease(currentValue) } }
     let getStatus = AXUIElementCopyAttributeValue(
       element, kAXValueAttribute as CFString, &currentValue
     )

--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -284,7 +284,7 @@ struct SmartTextOutput: TextOutputting {
     Thread.sleep(forTimeInterval: 0.05)
 
     var currentValue: CFTypeRef?
-    defer { if currentValue != nil { currentValue = nil } }
+    defer { if let currentValue { CFRelease(currentValue) } }
     let getStatus = AXUIElementCopyAttributeValue(
       element, kAXValueAttribute as CFString, &currentValue)
     guard getStatus == .success, let currentString = currentValue as? String else {
@@ -297,11 +297,10 @@ struct SmartTextOutput: TextOutputting {
   /// Log information about the focused element for debugging
   private func logFocusedElementInfo(_ element: AXUIElement) {
     var role: CFTypeRef?
+    defer { if let role { CFRelease(role) } }
     var roleDesc: CFTypeRef?
-    defer {
-      if role != nil { role = nil }
-      if roleDesc != nil { roleDesc = nil }
-    }
+    defer { if let roleDesc { CFRelease(roleDesc) } }
+
     AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &role)
     AXUIElementCopyAttributeValue(element, kAXRoleDescriptionAttribute as CFString, &roleDesc)
     let roleStr = (role as? String) ?? "unknown"


### PR DESCRIPTION
## Summary
Based on expert analysis of accessibility text insertion mechanisms, this PR improves reliability and debugging for text insertion.

## Changes

### SmartTextOutput
- **50ms verification delay** - Adds delay before re-reading value to allow target app to process changes
- **RoleDescription logging** - Logs `kAXRoleDescriptionAttribute` (e.g., 'smart search field', 'text field') for better debugging
- **Element info logging** - Logs focused element details before attempting insertion

### LiveTextInserter
- **Respect settable check** - Falls back to clipboard mode immediately if `kAXValueAttribute` is not settable (previously tried anyway)
- **First insertion verification** - Verifies first insertion worked with 50ms delay; switches to clipboard fallback if verification fails
- **New `usingClipboardFallback` property** - Published property for UI to show fallback status
- **RoleDescription logging** - Same debugging improvements as SmartTextOutput

## Key Findings from Analysis
| Scenario | Behavior |
|----------|----------|
| Native macOS controls | ✅ Works perfectly (NSTextField, NSTextView, NSSearchField, etc.) |
| Safari (including URL bar) | ✅ Works - AXTextField with desc 'smart search field' |
| Calendar | ⚠️ Returns `settable: false`, correctly falls back to Cmd+V |
| Chrome/Electron apps | ⚠️ In blocklist, uses clipboard (correct) |

## Testing
- [x] Build succeeds
- [ ] Manual testing in Safari, Notes, Calendar
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added clipboard fallback mode: text insertion now automatically switches to clipboard when direct accessibility insertion is unavailable.
  * Implemented insertion verification: the app now confirms that text was successfully inserted before proceeding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->