### PR TITLE
fix: add -allowProvisioningUpdates for CI signing

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -61,6 +61,7 @@ jobs:
             -scheme SpeakiOS \
             -destination 'generic/platform=iOS' \
             -archivePath build/SpeakiOS.xcarchive \
+            -allowProvisioningUpdates \
             MARKETING_VERSION="$VERSION" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             CODE_SIGN_STYLE=Automatic \
@@ -90,7 +91,8 @@ jobs:
           xcodebuild -exportArchive \
             -archivePath build/SpeakiOS.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
-            -exportPath build/export
+            -exportPath build/export \
+            -allowProvisioningUpdates
 
       - name: Upload to TestFlight
         env:


### PR DESCRIPTION
## Problem
The TestFlight build failed because automatic signing couldn't generate provisioning profiles:

```
error: No profiles for 'com.justspeaktoit.ios' were found: Xcode couldn't find any iOS App Development provisioning profiles matching 'com.justspeaktoit.ios'. Automatic signing is disabled and unable to generate a profile. To enable automatic signing, pass -allowProvisioningUpdates to xcodebuild.
```

## Solution
Add `-allowProvisioningUpdates` flag to both xcodebuild commands:
- Archive step
- Export step

This allows xcodebuild to automatically create/update provisioning profiles on CI runners when using `CODE_SIGN_STYLE=Automatic`.

## Testing
- This should fix run [#21542064463](https://github.com/crmitchelmore/justspeaktoit/actions/runs/21542064463) which failed at 09:03 UTC

🍺 Trust the awesomeness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS release workflow configuration to enable provisioning updates during the build and export process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->