### PR TITLE
chore: [ios] move signing assets to .env

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,8 +28,8 @@ Project-specific patterns and conventions for AI-assisted development.
 - These tags/scopes feed the Sparkle release notes generator so macOS updates only list mac-specific changes.
 
 ## App Store Connect / iOS Signing (sensitive)
-- App Store Connect API Key ID: `S747NJ9DZY`
-- App Store Connect Issuer ID: `69a6de77-8954-47e3-e053-5b8c7c11a4d1`
+- App Store Connect API Key ID: stored in secure notes (do not commit)
+- App Store Connect Issuer ID: stored in secure notes (do not commit)
 - App Store Connect API key: store base64 in `.env` as `APP_STORE_CONNECT_API_KEY` (do not commit)
 - iOS distribution cert: store base64 in `.env` as `IOS_DISTRIBUTION_P12` (password in `.env` as `IOS_DISTRIBUTION_PASSWORD`)
 - GitHub secrets used by CI: `APP_STORE_CONNECT_API_KEY`, `APP_STORE_CONNECT_ISSUER_ID`, `APPLE_TEAM_ID`, `IOS_DISTRIBUTION_P12`, `IOS_DISTRIBUTION_PASSWORD`, `IOS_APPSTORE_PROFILE`, `IOS_WIDGET_APPSTORE_PROFILE`

--- a/Project.swift
+++ b/Project.swift
@@ -18,20 +18,23 @@ var iosAppSettings: [String: SettingValue] = [
     "CURRENT_PROJECT_VERSION": "1",
     "MARKETING_VERSION": "\(version)"
 ]
-if let appProfileName {
-    iosAppSettings["PROVISIONING_PROFILE_SPECIFIER"] = .string(appProfileName)
-    iosAppSettings["CODE_SIGN_STYLE"] = "Manual"
-    iosAppSettings["CODE_SIGN_IDENTITY"] = "Apple Distribution"
-}
-
 var iosWidgetSettings: [String: SettingValue] = [
     "CURRENT_PROJECT_VERSION": "1",
     "MARKETING_VERSION": "\(version)"
 ]
+
+func configureManualSigning(for settings: inout [String: SettingValue], profileName: String) {
+    settings["PROVISIONING_PROFILE_SPECIFIER"] = .string(profileName)
+    settings["CODE_SIGN_STYLE"] = "Manual"
+    settings["CODE_SIGN_IDENTITY"] = "Apple Distribution"
+}
+
+if let appProfileName {
+    configureManualSigning(for: &iosAppSettings, profileName: appProfileName)
+}
+
 if let widgetProfileName {
-    iosWidgetSettings["PROVISIONING_PROFILE_SPECIFIER"] = .string(widgetProfileName)
-    iosWidgetSettings["CODE_SIGN_STYLE"] = "Manual"
-    iosWidgetSettings["CODE_SIGN_IDENTITY"] = "Apple Distribution"
+    configureManualSigning(for: &iosWidgetSettings, profileName: widgetProfileName)
 }
 
 let project = Project(

--- a/Sources/SpeakApp/HUDView.swift
+++ b/Sources/SpeakApp/HUDView.swift
@@ -94,7 +94,7 @@ struct HUDOverlay: View {
     guard #available(macOS 26.0, *) else { return false }
     let version = ProcessInfo.processInfo.operatingSystemVersion
     let isSequoiaDotZero = version.majorVersion == 26 && version.minorVersion == 0 && version.patchVersion == 0
-    return isSequoiaDotZero == false
+    return !isSequoiaDotZero
   }
   #else
   private var shouldUseGlassEffect: Bool { false }


### PR DESCRIPTION
## Description
Move signing asset references to `.env` and set manual iOS code signing when profiles are present.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix/feature works
- [x] Existing tests pass with `make test`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed
- [ ] I have added appropriate comments

## Related Issues
N/A

## Screenshots (if applicable)
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added iOS signing configuration and App Store Connect secrets management guide.

* **Bug Fixes**
  * Fixed visual rendering issue on specific macOS versions affecting the HUD display.

* **Chores**
  * Configured code signing settings for iOS app distribution builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->