### PR TITLE
fix: [mac] prevent recursive clipboard expansion DoS

### DIFF
--- a/Sources/SpeakApp/TranscriptionTextProcessor.swift
+++ b/Sources/SpeakApp/TranscriptionTextProcessor.swift
@@ -20,6 +20,11 @@ final class TranscriptionTextProcessor {
         "insert clipboard",
         "insertclipboard"
     ]
+    
+    /// Maximum recursion depth for clipboard expansion to prevent DoS attacks
+    /// when clipboard content contains trigger phrases. Set to 10 to allow
+    /// reasonable legitimate nested triggers while preventing infinite loops.
+    private static let maxClipboardExpansionDepth = 10
 
     init(appSettings: AppSettings) {
         self.appSettings = appSettings
@@ -46,7 +51,7 @@ final class TranscriptionTextProcessor {
 
     /// Expand clipboard insertion triggers with depth limit to prevent infinite recursion
     private func expandClipboardCommands(in text: String, depth: Int) -> String {
-        guard depth < 10 else { return text }
+        guard depth < Self.maxClipboardExpansionDepth else { return text }
 
         let clipboardContent = NSPasteboard.general.string(forType: .string) ?? ""
         guard !clipboardContent.isEmpty else { return text }


### PR DESCRIPTION
Adds recursion depth limit to prevent DoS attack when clipboard content contains trigger phrases that infinitely expand.

## Changes
- Added recursion depth limit (10) to `expandClipboardCommands` function
- Prevents malicious clipboard content from causing infinite recursion
- Refactored to use overloaded function with depth parameter
- Used named constant `maxClipboardExpansionDepth` instead of magic number

## Security Impact
Prevents potential DoS vulnerability where clipboard contains trigger words like "copy pasta" recursively.

## Review Comments Addressed
- ✅ Replaced magic number 10 with named constant `maxClipboardExpansionDepth`
- ✅ Added explanatory comment justifying the depth limit choice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clipboard expansion operations now include a recursion depth limit for enhanced stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->