### PR TITLE
feat(mac): add utterance boundary detection for pre-emptive live polish

### DIFF
--- a/Sources/SpeakCore/LLMProtocols.swift
+++ b/Sources/SpeakCore/LLMProtocols.swift
@@ -178,6 +178,10 @@ public protocol LiveTranscriptionSessionDelegate: AnyObject {
     func liveTranscriber(
         _ session: any LiveTranscriptionController, didFinishWith result: TranscriptionResult)
     func liveTranscriber(_ session: any LiveTranscriptionController, didFail error: Error)
+    func liveTranscriber(
+        _ session: any LiveTranscriptionController,
+        didDetectUtteranceBoundary utterance: String
+    )
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

Implements Phase 3 from the AssemblyAI Universal Streaming plan — utterance boundary detection for pre-emptive live polish.

### Problem
Live polish currently relies on a debounce timer to trigger polishing. AssemblyAI's Universal Streaming API provides an `utterance` field that signals when a sub-turn speech segment is complete, which arrives faster than the end-of-turn signal.

### Changes
- **SpeakCore/LLMProtocols.swift** — Add `didDetectUtteranceBoundary` to `LiveTranscriptionSessionDelegate` protocol
- **TranscriptionManager.swift** — Expose `utteranceBoundaryText` published property; implement delegate method; call it from `handleTurn` when `turn.utterance` is non-nil
- **MainManager.swift** — Subscribe to `utteranceBoundaryText` and trigger `LivePolishManager.polishNow()` immediately (bypassing debounce) when an utterance boundary is detected

### How it works
1. AssemblyAI sends a Turn message with a populated `utterance` field when a sub-turn speech segment completes
2. `handleTurn` detects this and calls the new delegate method
3. TranscriptionManager publishes the boundary text
4. MainManager observes it and triggers immediate polish (only when live polish speed mode is active)

### Testing
- Build verified ✅
- The utterance boundary is a supplementary signal — if AssemblyAI doesn't send it, the existing debounce-based polish continues to work as before