### PR TITLE
fix(mac): use single FN toggle in hotkey selector

### DIFF
--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -492,7 +492,7 @@ struct SettingsView: View {
             }
           }
 
-          HStack(spacing: 0) {
+          HStack(spacing: 12) {
             Button("Preview Start") {
               previewRecordingSound(.start)
             }


### PR DESCRIPTION
## Summary
- removed the redundant standalone Fn selector in Keyboard settings
- kept the existing Shortcut control as the single hotkey selector (its built-in checkbox now governs Fn vs custom)
- when Fn is unchecked, the custom hotkey recorder remains active
- preserved existing hotkey restart behaviour on selection changes

## Verification
- swift package plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Settings hotkey UI: the Fn Key option is now shown as non-interactive, and the separator between Fn Key and custom shortcut is removed for a cleaner layout.
  * Spacing around the custom shortcut control adjusted for visual consistency.
  * Hotkey changes still apply immediately and trigger a restart of the hotkey service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->