### PR TITLE
fix(mac): make AssemblyAI keyterms-only in live mode

### DIFF
--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -1225,9 +1225,9 @@ final class MainManager: ObservableObject {
       && appSettings.skipPostProcessingWithLivePolish
     guard !shouldSkipForLivePolish else { return false }
 
-    // AssemblyAI streaming supports keyterms prompting only; prompt text runs in Speak clean-up.
-    let hasAssemblyAIPrompt = appSettings.liveTranscriptionModel.contains("assemblyai")
-      && !appSettings.postProcessingSystemPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    let hasAssemblyAIPrompt = false
+      && appSettings.liveTranscriptionModel.contains("assemblyai")
+
     return appSettings.postProcessingEnabled || hasAssemblyAIPrompt
   }
   


### PR DESCRIPTION
## Summary
- disable AssemblyAI prompt-based pre-processing and keep live mode keyterms-only
- update Settings copy/alerts to reflect AssemblyAI streaming constraints from docs
- keep Trigger Key layout inline so the Fn checkbox remains inside the shortcut control row

## Verification
- swift package plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json --target SpeakApp
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed post-processing behavior to properly respect enabled/disabled settings.

* **UI Improvements**
  * Simplified keyboard shortcut configuration interface.
  * Updated AssemblyAI transcription mode indicator label for clarity.

* **Documentation**
  * Added detailed guidance on AssemblyAI pre-processing capabilities and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->