### PR TITLE
chore(ios): import SpeakiOSLib for widget control intent

### DIFF
--- a/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtensionControl.swift
+++ b/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtensionControl.swift
@@ -6,9 +6,10 @@
 //
 
 import AppIntents
-import SpeakiOSLib
 import SwiftUI
 import WidgetKit
+
+import SpeakiOSLib
 
 @available(iOS 18.0, *)
 struct JustSpeakToItWidgetExtensionControl: ControlWidget {


### PR DESCRIPTION
## Summary
- import  in 
- fixes widget extension compile resolution for 

## Validation
- swift package plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json
- tuist generate --no-open
- xcodebuild build -workspace 'Just Speak to It.xcworkspace' -scheme SpeakiOS -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->