### PR TITLE
fix(ios): restore TestFlight release build compatibility

### DIFF
--- a/Sources/SpeakiOS/Services/DeepgramTTSClient.swift
+++ b/Sources/SpeakiOS/Services/DeepgramTTSClient.swift
@@ -90,7 +90,7 @@ public final class DeepgramTTSClient: ObservableObject {
         do {
             // Configure audio session for playback
             let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setCategory(.playback, mode: .spokenContent)
+            try audioSession.setCategory(.playback, mode: .spokenAudio)
             try audioSession.setActive(true)
 
             audioPlayer = try AVAudioPlayer(data: data)

--- a/Sources/SpeakiOS/Views/ConversationListView.swift
+++ b/Sources/SpeakiOS/Views/ConversationListView.swift
@@ -94,7 +94,7 @@ public struct ConversationListView: View {
                     OpenClawChatView()
                 } label: {
                     Label("New Conversation", systemImage: "plus.message")
-                        .foregroundStyle(.accentColor)
+                        .foregroundStyle(Color.accentColor)
                 }
             }
 
@@ -254,7 +254,7 @@ struct InfoStepRow: View {
                 .font(.caption.bold())
                 .foregroundStyle(.white)
                 .frame(width: 22, height: 22)
-                .background(.accentColor, in: Circle())
+                .background(Color.accentColor, in: Circle())
 
             Text(text)
                 .font(.caption)

--- a/Sources/SpeakiOS/Views/OpenClawChatView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawChatView.swift
@@ -142,7 +142,7 @@ public struct OpenClawChatView: View {
             } label: {
                 Image(systemName: coordinator.isRecording ? "stop.circle.fill" : "mic.circle.fill")
                     .font(.system(size: 32))
-                    .foregroundStyle(coordinator.isRecording ? .red : .accentColor)
+                    .foregroundStyle(coordinator.isRecording ? .red : Color.accentColor)
             }
             .accessibilityLabel(coordinator.isRecording ? "Stop recording" : "Start voice input")
 
@@ -153,7 +153,7 @@ public struct OpenClawChatView: View {
                 } label: {
                     Image(systemName: "arrow.up.circle.fill")
                         .font(.system(size: 32))
-                        .foregroundStyle(.accentColor)
+                        .foregroundStyle(Color.accentColor)
                 }
                 .transition(.scale.combined(with: .opacity))
                 .accessibilityLabel("Send message")


### PR DESCRIPTION
## Summary\n- replace unsupported iOS audio session mode with `.spokenAudio`\n- use `Color.accentColor` where SwiftUI `ShapeStyle` inference fails in release archive builds\n\n## Verification\n- tuist generate --no-open\n- xcodebuild -workspace "Just Speak to It.xcworkspace" -scheme SpeakiOS -configuration Release -destination 'generic/platform=iOS' build\n- swift package plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced audio playback configuration for improved sound session handling.

* **Style**
  * Updated color specification consistency across UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->