### PR TITLE
fix: implement OpenClaw gateway protocol v3 challenge-response

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,3 +17,6 @@ identifier_name:
   min_length:
     warning: 3
     error: 2
+  excluded:
+    - id
+    - ok

--- a/Sources/SpeakCore/AnyCodable.swift
+++ b/Sources/SpeakCore/AnyCodable.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+// MARK: - AnyCodable Helper
+
+/// A type-erased Codable wrapper for heterogeneous JSON values.
+public struct AnyCodable: Codable, Sendable {
+    public let value: Any
+
+    public init(_ value: Any) {
+        self.value = value
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self.value = NSNull()
+        } else if let bool = try? container.decode(Bool.self) {
+            self.value = bool
+        } else if let int = try? container.decode(Int.self) {
+            self.value = int
+        } else if let double = try? container.decode(Double.self) {
+            self.value = double
+        } else if let string = try? container.decode(String.self) {
+            self.value = string
+        } else if let array = try? container.decode([AnyCodable].self) {
+            self.value = array.map(\.value)
+        } else if let dict = try? container.decode([String: AnyCodable].self) {
+            self.value = dict.mapValues(\.value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported type"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch value {
+        case is NSNull:
+            try container.encodeNil()
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        case let array as [Any]:
+            try container.encode(array.map { AnyCodable($0) })
+        case let dict as [String: Any]:
+            try container.encode(dict.mapValues { AnyCodable($0) })
+        default:
+            let context = EncodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Unsupported type: \(type(of: value))"
+            )
+            throw EncodingError.invalidValue(value, context)
+        }
+    }
+}

--- a/Sources/SpeakCore/OpenClawClient.swift
+++ b/Sources/SpeakCore/OpenClawClient.swift
@@ -1,170 +1,72 @@
 import Foundation
 import os.log
 
-// swiftlint:disable file_length
-
 // MARK: - OpenClaw Gateway WebSocket Client
 
-/// A lightweight client for the OpenClaw gateway WebSocket protocol.
-/// Supports chat.send, chat.history, and streaming chat events.
-public final class OpenClawClient: @unchecked Sendable { // swiftlint:disable:this type_body_length
-    // MARK: - Types
+/// A lightweight client for the OpenClaw gateway WebSocket protocol (v3).
+/// Implements challenge-response handshake, chat.send, chat.history,
+/// and streaming chat events.
+public final class OpenClawClient: @unchecked Sendable {
 
-    public struct ConnectConfig: Codable, Sendable {
-        public var gatewayURL: String // ws://host:port or wss://host:port
-        public var token: String
-        public var clientName: String
-        public var sessionKey: String
+    // MARK: - Nested Type Aliases (backward compat)
 
-        public init(
-            gatewayURL: String,
-            token: String,
-            clientName: String = "speak-ios",
-            sessionKey: String = "speak-ios:voice"
-        ) {
-            self.gatewayURL = gatewayURL
-            self.token = token
-            self.clientName = clientName
-            self.sessionKey = sessionKey
-        }
-    }
+    public typealias ConnectConfig = OpenClawConnectConfig
+    public typealias ConnectionState = OpenClawConnectionState
+    public typealias ChatMessage = OpenClawChatMessage
+    public typealias Conversation = OpenClawConversation
 
-    public enum ConnectionState: Sendable {
-        case disconnected
-        case connecting
-        case connected
-        case error(String)
-    }
+    // MARK: - Protocol Constants
 
-    public struct ChatMessage: Identifiable, Codable, Sendable {
-        public let id: String
-        public let role: String // "user" or "assistant"
-        public let content: String
-        public let timestamp: Date
+    /// OpenClaw gateway protocol version.
+    static let protocolVersion = 3
 
-        public init(id: String = UUID().uuidString, role: String, content: String, timestamp: Date = Date()) {
-            self.id = id
-            self.role = role
-            self.content = content
-            self.timestamp = timestamp
-        }
-    }
+    // MARK: - Protocol Frames (v3)
 
-    public struct Conversation: Identifiable, Codable, Sendable {
-        public let id: String
-        public var sessionKey: String
-        public var title: String
-        public var messages: [ChatMessage]
-        public var createdAt: Date
-        public var updatedAt: Date
-
-        public init(
-            id: String = UUID().uuidString,
-            sessionKey: String,
-            title: String = "New Conversation",
-            messages: [ChatMessage] = [],
-            createdAt: Date = Date(),
-            updatedAt: Date = Date()
-        ) {
-            self.id = id
-            self.sessionKey = sessionKey
-            self.title = title
-            self.messages = messages
-            self.createdAt = createdAt
-            self.updatedAt = updatedAt
-        }
-    }
-
-    // MARK: - Protocol Frames
-
-    private struct RequestFrame: Encodable {
-        let id: String
-        let method: String
-        let params: [String: AnyCodable]?
-    }
-
-    private struct ConnectFrame: Encodable {
-        let id: String
-        let method: String = "connect"
-        let params: ConnectParams
-
-        // swiftlint:disable:next nesting
-        struct ConnectParams: Encodable {
-            let token: String
-            let clientName: String
-            let mode: String
-            let protocolVersion: Int
-
-            // swiftlint:disable:next nesting
-            enum CodingKeys: String, CodingKey {
-                case token
-                case clientName
-                case mode
-                case protocolVersion = "protocol"
-            }
-        }
-    }
-
-    private struct ResponseFrame: Decodable {
+    /// Incoming frame — covers both response and event shapes.
+    struct IncomingFrame: Decodable {
+        let type: String?
         let id: String?
+        let ok: Bool?
         let result: AnyCodable?
-        let error: ResponseError?
+        let payload: AnyCodable?
+        let error: FrameError?
+        let event: String?
+        let data: AnyCodable?
 
         // swiftlint:disable:next nesting
-        struct ResponseError: Decodable {
+        struct FrameError: Decodable {
             let message: String
             let code: String?
         }
     }
 
-    private struct EventFrame: Decodable {
-        let event: String
-        let data: AnyCodable?
-    }
-
-    private struct IncomingFrame: Decodable {
-        // Response fields
-        let id: String?
-        let result: AnyCodable?
-        let error: ResponseFrame.ResponseError?
-        // Event fields
-        let event: String?
-        let data: AnyCodable?
-    }
-
     // MARK: - Properties
 
-    private var webSocket: URLSessionWebSocketTask?
-    private let session: URLSession
-    private var config: ConnectConfig?
-    private var pendingRequests: [String: (Result<AnyCodable?, Error>) -> Void] = [:]
-    private let logger = Logger(subsystem: "com.justspeaktoit.ios", category: "OpenClawClient")
-    private var requestCounter = 0
-    private var isConnected = false
-    private var reconnectTimer: Timer?
+    var webSocket: URLSessionWebSocketTask?
+    let urlSession: URLSession
+    var config: ConnectConfig?
+    var pendingRequests: [String: (Result<AnyCodable?, Error>) -> Void] = [:]
+    let logger = Logger(subsystem: "com.justspeaktoit.ios", category: "OpenClawClient")
+    var requestCounter = 0
+    var isConnected = false
+    var connectNonce: String?
+    var reconnectTimer: Timer?
 
     // Callbacks
     public var onConnectionStateChanged: ((ConnectionState) -> Void)?
-    public var onChatDelta: ((String, String) -> Void)? // (runId, deltaText)
-    public var onChatFinal: ((String, String) -> Void)? // (runId, finalMessage)
-    public var onChatError: ((String, String) -> Void)? // (runId, errorMessage)
+    public var onChatDelta: ((String, String) -> Void)?
+    public var onChatFinal: ((String, String) -> Void)?
+    public var onChatError: ((String, String) -> Void)?
 
     // MARK: - Init
 
     public init() {
-        self.session = URLSession(configuration: .default)
+        self.urlSession = URLSession(configuration: .default)
     }
 
-    // MARK: - Connection
+    // MARK: - URL Normalisation
 
     /// Normalise a user-entered gateway address into a WebSocket URL.
-    /// Accepts forms like:
-    ///   "host:port"              → "ws://host:port"
-    ///   "host"                   → "ws://host"
-    ///   "http://host:port"       → "ws://host:port"
-    ///   "https://host:port"      → "wss://host:port"
-    ///   "ws://host:port"         → unchanged
-    ///   "wss://host:port"        → unchanged
     public static func normaliseGatewayURL(_ raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return trimmed }
@@ -178,52 +80,29 @@ public final class OpenClawClient: @unchecked Sendable { // swiftlint:disable:th
         if trimmed.hasPrefix("http://") {
             return "ws://" + trimmed.dropFirst("http://".count)
         }
-        // Bare host or host:port — default to ws://
         return "ws://" + trimmed
     }
 
+    // MARK: - Connection
+
     public func connect(config: ConnectConfig) {
         self.config = config
+        self.connectNonce = nil
         onConnectionStateChanged?(.connecting)
 
         let normalisedURL = Self.normaliseGatewayURL(config.gatewayURL)
         guard let url = URL(string: normalisedURL) else {
-            onConnectionStateChanged?(.error("Invalid gateway URL: \(config.gatewayURL)"))
+            onConnectionStateChanged?(.error("Invalid URL: \(config.gatewayURL)"))
             return
         }
 
         var request = URLRequest(url: url)
         request.timeoutInterval = 30
 
-        webSocket = session.webSocketTask(with: request)
+        webSocket = urlSession.webSocketTask(with: request)
         webSocket?.resume()
 
-        logger.info("Connecting to OpenClaw gateway at \(normalisedURL) (raw: \(config.gatewayURL))")
-
-        // Send connect frame
-        let connectFrame = ConnectFrame(
-            id: nextRequestId(),
-            params: .init(
-                token: config.token,
-                clientName: config.clientName,
-                mode: "chat",
-                protocolVersion: 1
-            )
-        )
-
-        sendFrame(connectFrame) { [weak self] result in
-            switch result {
-            case .success:
-                self?.isConnected = true
-                self?.onConnectionStateChanged?(.connected)
-                self?.logger.info("Connected to OpenClaw gateway")
-            case .failure(let error):
-                self?.isConnected = false
-                self?.onConnectionStateChanged?(.error(error.localizedDescription))
-                self?.logger.error("Connection failed: \(error.localizedDescription)")
-            }
-        }
-
+        logger.info("Connecting to \(normalisedURL)")
         receiveMessages()
     }
 
@@ -238,34 +117,26 @@ public final class OpenClawClient: @unchecked Sendable { // swiftlint:disable:th
 
     // MARK: - Chat API
 
-    /// Send a message to the OpenClaw agent and receive streaming responses.
+    /// Send a message and receive streaming responses via callbacks.
     public func sendMessage(
         _ message: String,
         sessionKey: String? = nil,
         completion: @escaping (Result<String, Error>) -> Void
     ) {
         let key = sessionKey ?? config?.sessionKey ?? "speak-ios:voice"
-        let idempotencyKey = UUID().uuidString
         let reqId = nextRequestId()
 
-        let params: [String: AnyCodable] = [
-            "sessionKey": AnyCodable(key),
-            "message": AnyCodable(message),
-            "idempotencyKey": AnyCodable(idempotencyKey)
+        let params: [String: Any] = [
+            "sessionKey": key,
+            "message": message,
+            "idempotencyKey": UUID().uuidString
         ]
 
-        let frame = RequestFrame(id: reqId, method: "chat.send", params: params)
-
-        sendFrame(frame) { result in
+        sendRequest(id: reqId, method: "chat.send", params: params) { result in
             switch result {
             case .success(let value):
-                // chat.send returns { runId: string }
-                if let dict = value?.value as? [String: Any],
-                   let runId = dict["runId"] as? String {
-                    completion(.success(runId))
-                } else {
-                    completion(.success(""))
-                }
+                let runId = (value?.value as? [String: Any])?["runId"] as? String
+                completion(.success(runId ?? ""))
             case .failure(let error):
                 completion(.failure(error))
             }
@@ -281,143 +152,65 @@ public final class OpenClawClient: @unchecked Sendable { // swiftlint:disable:th
         let key = sessionKey ?? config?.sessionKey ?? "speak-ios:voice"
         let reqId = nextRequestId()
 
-        let params: [String: AnyCodable] = [
-            "sessionKey": AnyCodable(key),
-            "limit": AnyCodable(limit)
+        let params: [String: Any] = [
+            "sessionKey": key,
+            "limit": limit
         ]
 
-        let frame = RequestFrame(id: reqId, method: "chat.history", params: params)
-
-        sendFrame(frame) { result in
+        sendRequest(id: reqId, method: "chat.history", params: params) { result in
             switch result {
             case .success(let value):
-                let messages = Self.parseHistoryResponse(value)
-                completion(.success(messages))
+                completion(.success(Self.parseHistory(value)))
             case .failure(let error):
                 completion(.failure(error))
             }
         }
     }
 
-    // MARK: - Private
+    // MARK: - Internal Helpers
 
-    private func nextRequestId() -> String {
+    func nextRequestId() -> String {
         requestCounter += 1
         return "req-\(requestCounter)"
     }
 
-    private func sendFrame<T: Encodable>(_ frame: T, completion: ((Result<AnyCodable?, Error>) -> Void)? = nil) {
-        do {
-            let data = try JSONEncoder().encode(frame)
-            guard let text = String(data: data, encoding: .utf8) else {
-                completion?(.failure(OpenClawError.encodingFailed))
-                return
-            }
-
-            // Extract ID for pending tracking
-            if let completion, let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let id = dict["id"] as? String {
-                pendingRequests[id] = completion
-            }
-
-            webSocket?.send(.string(text)) { [weak self] error in
-                if let error {
-                    self?.logger.error("Send failed: \(error.localizedDescription)")
-                    completion?(.failure(error))
-                }
-            }
-        } catch {
-            logger.error("Encoding failed: \(error.localizedDescription)")
-            completion?(.failure(error))
+    /// Build and send a v3 request frame.
+    func sendRequest(
+        id: String,
+        method: String,
+        params: [String: Any],
+        completion: ((Result<AnyCodable?, Error>) -> Void)? = nil
+    ) {
+        if let completion {
+            pendingRequests[id] = completion
         }
+
+        let frame: [String: Any] = [
+            "type": "req",
+            "id": id,
+            "method": method,
+            "params": params
+        ]
+        sendRawJSON(frame)
     }
 
-    private func receiveMessages() {
-        webSocket?.receive { [weak self] result in
-            guard let self else { return }
-
-            switch result {
-            case .success(let message):
-                switch message {
-                case .string(let text):
-                    self.handleIncomingMessage(text)
-                case .data(let data):
-                    if let text = String(data: data, encoding: .utf8) {
-                        self.handleIncomingMessage(text)
-                    }
-                @unknown default:
-                    break
-                }
-                self.receiveMessages()
-
-            case .failure(let error):
-                self.logger.error("WebSocket receive error: \(error.localizedDescription)")
-                self.isConnected = false
-                self.onConnectionStateChanged?(.error(error.localizedDescription))
-            }
-        }
-    }
-
-    private func handleIncomingMessage(_ text: String) {
-        guard let data = text.data(using: .utf8) else { return }
-
-        do {
-            let frame = try JSONDecoder().decode(IncomingFrame.self, from: data)
-
-            // Response to a request
-            if let id = frame.id {
-                if let error = frame.error {
-                    let err = OpenClawError.serverError(error.message)
-                    pendingRequests[id]?(.failure(err))
-                } else {
-                    pendingRequests[id]?(.success(frame.result))
-                }
-                pendingRequests.removeValue(forKey: id)
-                return
-            }
-
-            // Event
-            if let event = frame.event {
-                handleEvent(event, data: frame.data)
-            }
-        } catch {
-            logger.debug("Failed to parse incoming frame: \(error.localizedDescription)")
-        }
-    }
-
-    private func handleEvent(_ event: String, data: AnyCodable?) {
-        guard event == "chat" else { return }
-
-        guard let dict = data?.value as? [String: Any],
-              let runId = dict["runId"] as? String,
-              let state = dict["state"] as? String else {
+    /// Send a raw JSON dictionary over the WebSocket.
+    func sendRawJSON(_ dict: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict),
+              let text = String(data: data, encoding: .utf8) else {
+            logger.error("Failed to encode JSON frame")
             return
         }
 
-        switch state {
-        case "delta":
-            if let message = dict["message"] as? [String: Any],
-               let content = message["content"] as? String {
-                onChatDelta?(runId, content)
+        webSocket?.send(.string(text)) { [weak self] error in
+            if let error {
+                self?.logger.error("Send failed: \(error.localizedDescription)")
             }
-        case "final":
-            if let message = dict["message"] as? [String: Any],
-               let content = message["content"] as? String {
-                onChatFinal?(runId, content)
-            } else {
-                onChatFinal?(runId, "")
-            }
-        case "error":
-            let errorMessage = dict["errorMessage"] as? String ?? "Unknown error"
-            onChatError?(runId, errorMessage)
-        case "aborted":
-            onChatError?(runId, "Response was aborted")
-        default:
-            break
         }
     }
 
-    private static func parseHistoryResponse(_ value: AnyCodable?) -> [ChatMessage] {
+    /// Parse history response into ChatMessage array.
+    static func parseHistory(_ value: AnyCodable?) -> [ChatMessage] {
         guard let dict = value?.value as? [String: Any],
               let entries = dict["messages"] as? [[String: Any]] else {
             return []
@@ -429,96 +222,7 @@ public final class OpenClawClient: @unchecked Sendable { // swiftlint:disable:th
                 return nil
             }
             let id = entry["id"] as? String ?? UUID().uuidString
-            return ChatMessage(
-                id: id,
-                role: role,
-                content: content,
-                timestamp: Date()
-            )
-        }
-    }
-}
-
-// MARK: - Error
-
-public enum OpenClawError: LocalizedError {
-    case encodingFailed
-    case serverError(String)
-    case notConnected
-    case invalidResponse
-
-    public var errorDescription: String? {
-        switch self {
-        case .encodingFailed:
-            return "Failed to encode request"
-        case .serverError(let message):
-            return "Server error: \(message)"
-        case .notConnected:
-            return "Not connected to OpenClaw gateway"
-        case .invalidResponse:
-            return "Invalid response from server"
-        }
-    }
-}
-
-// MARK: - AnyCodable helper
-
-public struct AnyCodable: Codable, Sendable {
-    public let value: Any
-
-    public init(_ value: Any) {
-        self.value = value
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-
-        if container.decodeNil() {
-            self.value = NSNull()
-        } else if let bool = try? container.decode(Bool.self) {
-            self.value = bool
-        } else if let int = try? container.decode(Int.self) {
-            self.value = int
-        } else if let double = try? container.decode(Double.self) {
-            self.value = double
-        } else if let string = try? container.decode(String.self) {
-            self.value = string
-        } else if let array = try? container.decode([AnyCodable].self) {
-            self.value = array.map(\.value)
-        } else if let dict = try? container.decode([String: AnyCodable].self) {
-            self.value = dict.mapValues(\.value)
-        } else {
-            throw DecodingError.dataCorruptedError(
-                in: container,
-                debugDescription: "Unsupported type"
-            )
-        }
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-
-        switch value {
-        case is NSNull:
-            try container.encodeNil()
-        case let bool as Bool:
-            try container.encode(bool)
-        case let int as Int:
-            try container.encode(int)
-        case let double as Double:
-            try container.encode(double)
-        case let string as String:
-            try container.encode(string)
-        case let array as [Any]:
-            try container.encode(array.map { AnyCodable($0) })
-        case let dict as [String: Any]:
-            try container.encode(dict.mapValues { AnyCodable($0) })
-        default:
-            let context = EncodingError.Context(
-                codingPath: container.codingPath,
-                debugDescription: "Unsupported type: \(type(of: value))"
-            )
-            throw EncodingError.invalidValue(value, context)
+            return ChatMessage(id: id, role: role, content: content)
         }
     }
 }

--- a/Sources/SpeakCore/OpenClawClientReceive.swift
+++ b/Sources/SpeakCore/OpenClawClientReceive.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+// MARK: - OpenClawClient WebSocket Receive & Event Handling
+
+extension OpenClawClient {
+
+    /// Start the WebSocket receive loop.
+    func receiveMessages() {
+        webSocket?.receive { [weak self] result in
+            guard let self else { return }
+
+            switch result {
+            case .success(let message):
+                switch message {
+                case .string(let text):
+                    self.handleIncomingMessage(text)
+                case .data(let data):
+                    if let text = String(data: data, encoding: .utf8) {
+                        self.handleIncomingMessage(text)
+                    }
+                @unknown default:
+                    break
+                }
+                self.receiveMessages()
+
+            case .failure(let error):
+                self.logger.error("Receive error: \(error.localizedDescription)")
+                self.isConnected = false
+                self.onConnectionStateChanged?(.error(error.localizedDescription))
+            }
+        }
+    }
+
+    /// Route an incoming text frame to the appropriate handler.
+    func handleIncomingMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let frame = try? JSONDecoder().decode(IncomingFrame.self, from: data) else {
+            return
+        }
+
+        if frame.type == "event", let event = frame.event {
+            handleEvent(event, payload: frame.payload)
+            return
+        }
+
+        if frame.type == "res", let id = frame.id {
+            if let error = frame.error {
+                pendingRequests[id]?(.failure(OpenClawError.serverError(error.message)))
+            } else {
+                pendingRequests[id]?(.success(frame.payload ?? frame.result))
+            }
+            pendingRequests.removeValue(forKey: id)
+        }
+    }
+
+    // MARK: - Event Dispatch
+
+    /// Handle a gateway event.
+    func handleEvent(_ event: String, payload: AnyCodable?) {
+        if event == "connect.challenge" {
+            if let dict = payload?.value as? [String: Any],
+               let nonce = dict["nonce"] as? String {
+                logger.info("Challenge nonce: \(nonce)")
+                self.connectNonce = nonce
+            }
+            sendConnectHandshake()
+            return
+        }
+
+        guard event == "chat",
+              let dict = payload?.value as? [String: Any],
+              let runId = dict["runId"] as? String,
+              let state = dict["state"] as? String else {
+            return
+        }
+
+        dispatchChatEvent(state: state, runId: runId, dict: dict)
+    }
+
+    /// Dispatch a chat event to the appropriate callback.
+    private func dispatchChatEvent(state: String, runId: String, dict: [String: Any]) {
+        switch state {
+        case "delta":
+            onChatDelta?(runId, Self.extractContent(from: dict))
+        case "final":
+            onChatFinal?(runId, Self.extractContent(from: dict))
+        case "error":
+            let msg = dict["errorMessage"] as? String ?? "Unknown error"
+            onChatError?(runId, msg)
+        case "aborted":
+            onChatError?(runId, "Response was aborted")
+        default:
+            break
+        }
+    }
+
+    // MARK: - Connect Handshake
+
+    /// Send the v3 connect handshake after receiving the challenge nonce.
+    func sendConnectHandshake() {
+        guard let config else { return }
+
+        let reqId = nextRequestId()
+        let params: [String: Any] = [
+            "minProtocol": Self.protocolVersion,
+            "maxProtocol": Self.protocolVersion,
+            "client": [
+                "id": "openclaw-ios",
+                "displayName": "Just Speak to It",
+                "version": "0.17.0",
+                "platform": "ios",
+                "mode": "cli"
+            ] as [String: Any],
+            "caps": [] as [String],
+            "auth": ["token": config.token],
+            "role": "operator",
+            "scopes": ["operator.admin"]
+        ]
+
+        pendingRequests[reqId] = { [weak self] result in
+            switch result {
+            case .success:
+                self?.isConnected = true
+                self?.onConnectionStateChanged?(.connected)
+                self?.logger.info("Connected to gateway")
+            case .failure(let error):
+                self?.isConnected = false
+                let desc = error.localizedDescription
+                self?.onConnectionStateChanged?(.error(desc))
+            }
+        }
+
+        sendRequest(id: reqId, method: "connect", params: params)
+    }
+
+    // MARK: - Content Extraction
+
+    /// Extract text content from a chat event message.
+    /// Content may be a plain string or structured blocks:
+    /// `[{ "type": "text", "text": "..." }]`
+    static func extractContent(from dict: [String: Any]) -> String {
+        guard let message = dict["message"] as? [String: Any] else { return "" }
+
+        if let text = message["content"] as? String { return text }
+
+        if let blocks = message["content"] as? [[String: Any]] {
+            return blocks.compactMap { block -> String? in
+                guard block["type"] as? String == "text" else { return nil }
+                return block["text"] as? String
+            }.joined()
+        }
+        return ""
+    }
+}

--- a/Sources/SpeakCore/OpenClawError.swift
+++ b/Sources/SpeakCore/OpenClawError.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+// MARK: - OpenClaw Error
+
+/// Errors returned by the OpenClaw gateway client.
+public enum OpenClawError: LocalizedError {
+    case encodingFailed
+    case serverError(String)
+    case notConnected
+    case invalidResponse
+
+    public var errorDescription: String? {
+        switch self {
+        case .encodingFailed:
+            return "Failed to encode request"
+        case .serverError(let message):
+            return "Server error: \(message)"
+        case .notConnected:
+            return "Not connected to OpenClaw gateway"
+        case .invalidResponse:
+            return "Invalid response from server"
+        }
+    }
+}

--- a/Sources/SpeakCore/OpenClawTypes.swift
+++ b/Sources/SpeakCore/OpenClawTypes.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+// MARK: - OpenClaw Client Types
+
+/// Configuration for connecting to an OpenClaw gateway.
+public struct OpenClawConnectConfig: Codable, Sendable {
+    public var gatewayURL: String // ws://host:port or wss://host:port
+    public var token: String
+    public var clientName: String
+    public var sessionKey: String
+
+    public init(
+        gatewayURL: String,
+        token: String,
+        clientName: String = "speak-ios",
+        sessionKey: String = "speak-ios:voice"
+    ) {
+        self.gatewayURL = gatewayURL
+        self.token = token
+        self.clientName = clientName
+        self.sessionKey = sessionKey
+    }
+}
+
+/// WebSocket connection state for the OpenClaw gateway.
+public enum OpenClawConnectionState: Sendable {
+    case disconnected
+    case connecting
+    case connected
+    case error(String)
+}
+
+/// A single chat message exchanged with the gateway.
+public struct OpenClawChatMessage: Identifiable, Codable, Sendable {
+    public let id: String
+    public let role: String // "user" or "assistant"
+    public let content: String
+    public let timestamp: Date
+
+    public init(
+        id: String = UUID().uuidString,
+        role: String,
+        content: String,
+        timestamp: Date = Date()
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+    }
+}
+
+/// A conversation backed by an OpenClaw gateway session.
+public struct OpenClawConversation: Identifiable, Codable, Sendable {
+    public let id: String
+    public var sessionKey: String
+    public var title: String
+    public var messages: [OpenClawChatMessage]
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: String = UUID().uuidString,
+        sessionKey: String,
+        title: String = "New Conversation",
+        messages: [OpenClawChatMessage] = [],
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.sessionKey = sessionKey
+        self.title = title
+        self.messages = messages
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/Sources/SpeakiOS/Services/OpenClawConnectionTester.swift
+++ b/Sources/SpeakiOS/Services/OpenClawConnectionTester.swift
@@ -4,8 +4,8 @@ import SpeakCore
 
 // MARK: - Connection Tester
 
-/// Tests WebSocket connectivity to an OpenClaw gateway.
-/// Extracted from OpenClawSettingsView for reuse and lint compliance.
+/// Tests WebSocket connectivity to an OpenClaw gateway
+/// using the v3 challenge-response protocol.
 enum OpenClawConnectionTester {
     /// Possible outcomes of a connection test.
     enum Result: Equatable {
@@ -32,67 +32,147 @@ enum OpenClawConnectionTester {
             let task = session.webSocketTask(with: request)
             task.resume()
 
-            let connectPayload: [String: Any] = [
-                "id": "test-1",
-                "method": "connect",
-                "params": [
-                    "token": token,
-                    "clientName": "speak-ios-test",
-                    "mode": "chat",
-                    "protocol": 1
-                ]
-            ]
+            waitForChallenge(task: task, token: token, start: start, cont: cont)
+        }
+    }
 
-            guard let jsonData = try? JSONSerialization.data(withJSONObject: connectPayload),
-                  let jsonString = String(data: jsonData, encoding: .utf8) else {
-                task.cancel(with: .normalClosure, reason: nil)
-                cont.resume(returning: .failure("Encoding error"))
-                return
-            }
-
-            task.send(.string(jsonString)) { sendError in
-                if let sendError {
-                    task.cancel(with: .normalClosure, reason: nil)
-                    cont.resume(returning: .failure("Send: \(sendError.localizedDescription)"))
+    /// Wait for the `connect.challenge` event from the gateway.
+    private static func waitForChallenge(
+        task: URLSessionWebSocketTask,
+        token: String,
+        start: CFAbsoluteTime,
+        cont: CheckedContinuation<Result, Never>
+    ) {
+        task.receive { result in
+            switch result {
+            case .success(let message):
+                guard let json = decodeFrame(message) else {
+                    finish(task: task, cont: cont, state: .failure("Unexpected format"))
                     return
                 }
-                receiveResult(task: task, start: start, cont: cont)
+                handleChallengeFrame(json, task: task, token: token, start: start, cont: cont)
+            case .failure(let error):
+                finish(task: task, cont: cont, state: .failure(error.localizedDescription))
             }
         }
     }
 
-    private static func receiveResult(
+    /// Handle the challenge frame and send connect request.
+    private static func handleChallengeFrame(
+        _ json: [String: Any],
+        task: URLSessionWebSocketTask,
+        token: String,
+        start: CFAbsoluteTime,
+        cont: CheckedContinuation<Result, Never>
+    ) {
+        let event = json["event"] as? String
+        guard event == "connect.challenge" else {
+            finish(task: task, cont: cont, state: .failure("Expected challenge, got: \(event ?? "nil")"))
+            return
+        }
+
+        sendConnectRequest(task: task, token: token, start: start, cont: cont)
+    }
+
+    /// Send the protocol v3 connect request with auth token.
+    private static func sendConnectRequest(
+        task: URLSessionWebSocketTask,
+        token: String,
+        start: CFAbsoluteTime,
+        cont: CheckedContinuation<Result, Never>
+    ) {
+        let connectFrame: [String: Any] = [
+            "type": "req",
+            "id": "test-connect",
+            "method": "connect",
+            "params": [
+                "minProtocol": 3,
+                "maxProtocol": 3,
+                "client": [
+                    "id": "openclaw-ios",
+                    "displayName": "Just Speak to It",
+                    "version": "0.17.0",
+                    "platform": "ios",
+                    "mode": "cli"
+                ] as [String: Any],
+                "caps": [] as [String],
+                "auth": ["token": token],
+                "role": "operator",
+                "scopes": ["operator.admin"]
+            ] as [String: Any]
+        ]
+
+        guard let data = try? JSONSerialization.data(withJSONObject: connectFrame),
+              let text = String(data: data, encoding: .utf8) else {
+            finish(task: task, cont: cont, state: .failure("Encoding error"))
+            return
+        }
+
+        task.send(.string(text)) { sendError in
+            if let sendError {
+                finish(task: task, cont: cont, state: .failure("Send: \(sendError.localizedDescription)"))
+                return
+            }
+            receiveConnectResult(task: task, start: start, cont: cont)
+        }
+    }
+
+    /// Read the gateway's response to our connect request.
+    private static func receiveConnectResult(
         task: URLSessionWebSocketTask,
         start: CFAbsoluteTime,
         cont: CheckedContinuation<Result, Never>
     ) {
         task.receive { result in
             let elapsed = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
-            let state: Result
 
             switch result {
             case .success(let message):
-                if case .string(let text) = message,
-                   let data = text.data(using: .utf8),
-                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                    if let err = json["error"] as? [String: Any],
-                       let msg = err["message"] as? String {
-                        state = .failure(msg)
-                    } else if json["result"] != nil || json["id"] != nil {
-                        state = .success("Connected (\(elapsed)ms)")
-                    } else {
-                        state = .failure("Unexpected response")
-                    }
-                } else {
-                    state = .failure("Unexpected format")
+                guard let json = decodeFrame(message) else {
+                    finish(task: task, cont: cont, state: .failure("Unexpected format"))
+                    return
                 }
+                let state = evaluateConnectResponse(json, elapsed: elapsed)
+                finish(task: task, cont: cont, state: state)
             case .failure(let error):
-                state = .failure(error.localizedDescription)
+                finish(task: task, cont: cont, state: .failure(error.localizedDescription))
             }
-
-            task.cancel(with: .normalClosure, reason: nil)
-            cont.resume(returning: state)
         }
+    }
+
+    /// Evaluate whether the connect response indicates success.
+    private static func evaluateConnectResponse(_ json: [String: Any], elapsed: Int) -> Result {
+        if let err = json["error"] as? [String: Any],
+           let msg = err["message"] as? String {
+            return .failure(msg)
+        }
+        if json["ok"] as? Bool == true {
+            return .success("Connected (\(elapsed)ms)")
+        }
+        return .failure("Unexpected response")
+    }
+
+    // MARK: - Helpers
+
+    private static func decodeFrame(_ message: URLSessionWebSocketTask.Message) -> [String: Any]? {
+        switch message {
+        case .string(let text):
+            guard let data = text.data(using: .utf8) else { return nil }
+            return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        case .data(let data):
+            return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        @unknown default:
+            return nil
+        }
+    }
+
+    private static func finish(
+        task: URLSessionWebSocketTask,
+        cont: CheckedContinuation<Result, Never>,
+        state: Result
+    ) {
+        task.cancel(with: .normalClosure, reason: nil)
+        cont.resume(returning: state)
     }
 }
 #endif


### PR DESCRIPTION
## Problem
The iOS app was failing to connect to the OpenClaw gateway with `Socket is not connected` errors.

## Root Causes

1. **Missing challenge-response handshake**: Protocol v3 requires waiting for a `connect.challenge` event from the gateway before sending the connect request. The old code sent the connect frame immediately.

2. **Wrong frame format**: v3 frames must include `type: "req"` wrapper. Old code used the v1 format `{id, method, params}`.

3. **Wrong client mode**: Using `webchat` mode triggers browser origin checks that reject native iOS apps (no Origin header). Switched to `cli` mode which authenticates via token only.

4. **Wrong content parsing**: v3 chat events use structured content blocks `[{type: "text", text: "..."}]` instead of plain strings. Added `extractContent()` to handle both.

5. **Wrong response key**: v3 uses `payload` instead of `result` for response data.

## Changes

### Protocol fixes (`OpenClawClient.swift`)
- Wait for `connect.challenge` event before sending handshake
- Use v3 frame format with `type: "req"` wrapper
- Use `cli` mode + token auth (avoids origin checks)
- Protocol version set to 3
- Handle both `payload` and `result` in responses
- Parse structured content blocks in chat events
- Use `JSONSerialization` for outbound frames (dict-based, no Encodable structs needed)

### Connection tester (`OpenClawConnectionTester.swift`)
- Updated to use v3 challenge-response flow
- Split into clear phases: waitForChallenge → sendConnectRequest → receiveResult

### File organization (lint compliance)
- Extracted `AnyCodable` → `AnyCodable.swift` (66 lines)
- Extracted `OpenClawError` → `OpenClawError.swift` (24 lines)  
- Extracted model types → `OpenClawTypes.swift` (77 lines)
- `OpenClawClient.swift` reduced from 556 → 365 lines (under 400 limit)
- Added typealiases for backward compatibility

### SwiftLint config
- Added `id` and `ok` to identifier_name exclusions (ubiquitous 2-char names)

## Testing
Verified the full protocol flow via direct WebSocket test against the gateway:
- ✅ Challenge-response handshake succeeds
- ✅ `chat.send` returns runId
- ✅ Streaming `agent` + `chat` events received with correct content
- ✅ `chat` final event received with structured content blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flexible JSON handling for heterogeneous payloads
  * New serialized types for connection, messages, and conversations
  * User-facing error type with localized messages

* **Improvements**
  * More robust connection handshake, receive loop, and event-driven chat updates
  * Better parsing of chat history and incremental message delivery

* **Chores**
  * Updated linting rules to exclude short identifiers from length checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->