### PR TITLE
feat: show version + commit SHA in iOS settings, auto-bump iOS version

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -131,3 +131,12 @@ jobs:
           git add VERSION
           git commit -m "chore: bump version to $NEW_VERSION"
           git push origin main || echo "⚠️ Could not push VERSION bump (branch protection)"
+
+      - name: Trigger iOS TestFlight Release
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_RELEASE_TOKEN }}
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          echo "🚀 Triggering iOS TestFlight build for v$NEW_VERSION"
+          gh workflow run "Release iOS (TestFlight)" -f version="$NEW_VERSION"

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number (e.g., 0.1.0)'
-        required: true
-        default: '0.1.0'
+        description: 'Version number (leave empty to use VERSION file)'
+        required: false
       build_number:
         description: 'Build number (auto-increments if empty)'
         required: false
@@ -139,6 +138,21 @@ jobs:
           pbx_path.write_text(updated)
           PY
 
+      - name: Determine Version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION=$(cat VERSION)
+          fi
+          COMMIT_SHA="${{ github.sha }}"
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "Building iOS version: $VERSION (commit $SHORT_SHA)"
+
       - name: Determine Build Number
         id: build_number
         env:
@@ -151,9 +165,27 @@ jobs:
             echo "build=$RUN_NUMBER" >> $GITHUB_OUTPUT
           fi
 
+      - name: Stamp Git Commit into Info.plist
+        env:
+          COMMIT_SHA: ${{ steps.version.outputs.commit_sha }}
+        run: |
+          # Tuist generates the Info.plist from the Project.swift extendingDefault.
+          # We inject GitCommitSHA via a build-phase-generated file instead.
+          mkdir -p SpeakiOSApp
+          cat > SpeakiOSApp/BuildInfo.swift << EOF
+          // Auto-generated at build time — do not edit
+          import Foundation
+          public enum BuildInfo {
+              public static let gitCommitSHA = "$COMMIT_SHA"
+              public static let gitCommitShort = "${COMMIT_SHA:0:7}"
+          }
+          EOF
+          echo "Stamped commit: ${COMMIT_SHA:0:7}"
+          cat SpeakiOSApp/BuildInfo.swift
+
       - name: Build and Archive
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
           BUILD_NUMBER: ${{ steps.build_number.outputs.build }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -373,8 +373,16 @@ public struct SettingsView: View {
 
             Section("About") {
                 LabeledContent("Version") {
-                    Text("1.0.0")
+                    let ver = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+                    let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+                    Text("\(ver) (\(build))")
                         .foregroundStyle(.secondary)
+                }
+
+                LabeledContent("Commit") {
+                    Text(BuildInfo.gitCommitShort)
+                        .foregroundStyle(.secondary)
+                        .font(.system(.body, design: .monospaced))
                 }
 
                 LabeledContent("SpeakCore") {

--- a/SpeakiOSApp/BuildInfo.swift
+++ b/SpeakiOSApp/BuildInfo.swift
@@ -1,0 +1,8 @@
+// Auto-generated at CI build time — do not edit manually.
+// Local dev builds use placeholder values below.
+import Foundation
+
+public enum BuildInfo {
+    public static let gitCommitSHA = "dev"
+    public static let gitCommitShort = "dev"
+}


### PR DESCRIPTION
## Changes

### iOS Settings → About section
- **Version** now shows the actual marketing version + build number from the bundle (e.g. `0.17.1 (42)`)
- **Commit** shows the 7-char git SHA so you can confirm exactly which code is running
- **SpeakCore** version unchanged

### iOS Release Workflow
- Version input is now **optional** — defaults to reading the `VERSION` file (same as Mac), so both platforms stay in sync
- `BuildInfo.swift` is generated at CI time with the full commit SHA, overwriting the dev placeholder
- The placeholder file (`SpeakiOSApp/BuildInfo.swift`) ships in the repo so local dev builds still compile

### Auto-Release Workflow
- After tagging `mac-v*` and bumping VERSION, now also triggers `Release iOS (TestFlight)` with the same version
- Both platforms release together from a single version bump