### PR TITLE
fix: duplicate messages + TTS voice/model/speed settings

### DIFF
--- a/Sources/SpeakiOS/Services/DeepgramTTSClient.swift
+++ b/Sources/SpeakiOS/Services/DeepgramTTSClient.swift
@@ -20,8 +20,9 @@ public final class DeepgramTTSClient: ObservableObject {
 
     // MARK: - Configuration
 
-    public var model: String = "aura-2-en"
+    public var model: String = "aura-2"
     public var voice: String = "asteria"
+    public var speed: Double = 1.0
 
     // MARK: - Init
 
@@ -50,7 +51,9 @@ public final class DeepgramTTSClient: ObservableObject {
             throw DeepgramTTSError.missingAPIKey
         }
 
-        let url = URL(string: "https://api.deepgram.com/v1/speak?model=\(model)-\(voice)")!
+        // Deepgram model format: aura-2-{voice}-en or aura-{voice}-en
+        let modelParam = "\(model)-\(voice)-en"
+        let url = URL(string: "https://api.deepgram.com/v1/speak?model=\(modelParam)")!
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -94,6 +97,8 @@ public final class DeepgramTTSClient: ObservableObject {
             try audioSession.setActive(true)
 
             audioPlayer = try AVAudioPlayer(data: data)
+            audioPlayer?.enableRate = true
+            audioPlayer?.rate = Float(speed)
             audioPlayer?.prepareToPlay()
 
             isSpeaking = true

--- a/Sources/SpeakiOS/Services/OpenClawSettings.swift
+++ b/Sources/SpeakiOS/Services/OpenClawSettings.swift
@@ -31,6 +31,42 @@ public final class OpenClawSettings: ObservableObject {
         didSet { UserDefaults.standard.set(summariseResponses, forKey: "openclaw.summarise") }
     }
 
+    @Published public var ttsVoice: String {
+        didSet { UserDefaults.standard.set(ttsVoice, forKey: "openclaw.ttsVoice") }
+    }
+
+    @Published public var ttsModel: String {
+        didSet { UserDefaults.standard.set(ttsModel, forKey: "openclaw.ttsModel") }
+    }
+
+    @Published public var ttsSpeed: Double {
+        didSet { UserDefaults.standard.set(ttsSpeed, forKey: "openclaw.ttsSpeed") }
+    }
+
+    // MARK: - Available Voices & Models
+
+    /// Deepgram Aura-2 voices.
+    public static let availableVoices: [(id: String, label: String)] = [
+        ("asteria", "Asteria (American, Female)"),
+        ("luna", "Luna (American, Female)"),
+        ("stella", "Stella (American, Female)"),
+        ("athena", "Athena (British, Female)"),
+        ("hera", "Hera (American, Female)"),
+        ("orion", "Orion (American, Male)"),
+        ("arcas", "Arcas (American, Male)"),
+        ("perseus", "Perseus (American, Male)"),
+        ("angus", "Angus (Irish, Male)"),
+        ("orpheus", "Orpheus (American, Male)"),
+        ("helios", "Helios (British, Male)"),
+        ("zeus", "Zeus (American, Male)")
+    ]
+
+    /// Deepgram TTS models — the id is used as a prefix before the voice name.
+    public static let availableModels: [(id: String, label: String)] = [
+        ("aura-2", "Aura 2 (English)"),
+        ("aura", "Aura 1 (English)")
+    ]
+
     public var isConfigured: Bool {
         !gatewayURL.isEmpty && !token.isEmpty && enabled
     }
@@ -41,6 +77,9 @@ public final class OpenClawSettings: ObservableObject {
         self.enabled = UserDefaults.standard.bool(forKey: "openclaw.enabled")
         self.ttsEnabled = UserDefaults.standard.object(forKey: "openclaw.ttsEnabled") as? Bool ?? true
         self.summariseResponses = UserDefaults.standard.object(forKey: "openclaw.summarise") as? Bool ?? true
+        self.ttsVoice = UserDefaults.standard.string(forKey: "openclaw.ttsVoice") ?? "asteria"
+        self.ttsModel = UserDefaults.standard.string(forKey: "openclaw.ttsModel") ?? "aura-2"
+        self.ttsSpeed = UserDefaults.standard.object(forKey: "openclaw.ttsSpeed") as? Double ?? 1.0
     }
 
     // MARK: - Keychain

--- a/Sources/SpeakiOS/Views/ConversationListView.swift
+++ b/Sources/SpeakiOS/Views/ConversationListView.swift
@@ -241,7 +241,31 @@ public struct OpenClawSettingsView: View {
                 }
 
                 if settings.ttsEnabled {
-                    Text("Responses will be spoken using Deepgram Aura TTS (requires Deepgram API key).")
+                    Picker("Voice", selection: $settings.ttsVoice) {
+                        ForEach(OpenClawSettings.availableVoices, id: \.id) { voice in
+                            Text(voice.label).tag(voice.id)
+                        }
+                    }
+
+                    Picker("Model", selection: $settings.ttsModel) {
+                        ForEach(OpenClawSettings.availableModels, id: \.id) { mdl in
+                            Text(mdl.label).tag(mdl.id)
+                        }
+                    }
+
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("Speed")
+                            Spacer()
+                            Text(String(format: "%.1f×", settings.ttsSpeed))
+                                .foregroundStyle(.secondary)
+                        }
+                        Slider(value: $settings.ttsSpeed, in: 0.5...2.0, step: 0.1)
+                    }
+
+                    Text(
+                        "Requires a Deepgram API key in the main app settings."
+                    )
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/SpeakiOS/Views/OpenClawChatView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawChatView.swift
@@ -102,10 +102,12 @@ public struct OpenClawChatView: View {
                     coordinator.selectConversation(conv)
                 } else {
                     coordinator.startNewConversation()
+                    // Only connect here if startNewConversation didn't
+                    // already trigger a reconnect.
+                    if settings.isConfigured {
+                        coordinator.connect()
+                    }
                 }
-            }
-            if settings.isConfigured {
-                coordinator.connect()
             }
         }
         .onDisappear {


### PR DESCRIPTION
## What this fixes

### 1. Duplicate/garbled assistant messages
The gateway's `chat` delta events carry **cumulative text** (full content so far), not incremental fragments. The code was appending (`+=`) each delta to `accumulatedResponse`, resulting in doubled text like `"HelloHello! Yes, it's working..."`.

**Fix:** Replace (`=`) instead of append (`+=`) on delta events.

### 2. Double WebSocket connections on navigation
When opening a conversation from the list, `onAppear` called both `selectConversation()` (which calls `connect()` internally) and then `connect()` again unconditionally — opening two simultaneous WebSocket connections.

**Fix:** Only call `connect()` in the new-conversation code path, since `selectConversation()` already handles its own connection.

### 3. TTS not speaking / wrong API URL
The Deepgram API URL was malformed: `model=aura-2-en-asteria` instead of the correct `model=aura-2-asteria-en`. This caused silent 4xx failures.

**Fix:** Corrected the URL construction to `{model}-{voice}-en` format (e.g. `aura-2-asteria-en`).

### 4. No TTS voice configuration
Previously there was just a toggle for TTS on/off. Now there are full settings:
- **Voice picker** — all Aura-2 voices (Asteria, Luna, Orion, Arcas, etc.)
- **Model picker** — Aura 2 (default) or Aura 1
- **Speed slider** — 0.5×–2.0× playback speed
- Settings persist across launches and are applied before each TTS call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable text-to-speech settings with voice selection, model choice, and playback speed adjustment
  * TTS configuration options now persist across sessions

* **Bug Fixes**
  * Improved connection handling to ensure proper configuration before establishing connections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->