### PR TITLE
chore(ios): fix openclaw coordinator xcode26 compile

### DIFF
--- a/Sources/SpeakiOS/Services/OpenClawChatCoordinator.swift
+++ b/Sources/SpeakiOS/Services/OpenClawChatCoordinator.swift
@@ -113,9 +113,9 @@ public final class OpenClawChatCoordinator: ObservableObject {
     let settings = OpenClawSettings.shared
     let appSettings = AppSettings.shared
 
-    var transcriber: TranscriberCoordinator?
-    var recordingMonitorTask: Task<Void, Never>?
-    var awaitingKeywordAcknowledge = false
+    private var transcriber: TranscriberCoordinator?
+    private var recordingMonitorTask: Task<Void, Never>?
+    private(set) var awaitingKeywordAcknowledge = false
     var currentRunId: String?
     var accumulatedResponse = ""
     var settingsCancellables = Set<AnyCancellable>()


### PR DESCRIPTION
## Summary\n- fix Xcode 26 archive compile failures in OpenClawChatCoordinator\n- remove non-isolated deinit cleanup call and rely on settings-driven command registration lifecycle\n- keep hands-free behaviour unchanged while making split extension compile cleanly\n\n## Verification\n- swift package plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json\n- swift build --target SpeakiOSLib\n- make test