### PR TITLE
fix(ios): make OpenClaw conversation controls match iOS HIG

### DIFF
--- a/Sources/SpeakiOS/Views/OpenClawChatView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawChatView.swift
@@ -159,7 +159,7 @@ public struct OpenClawChatView: View {
             .frame(minHeight: 44)
 
             if settings.conversationModeEnabled {
-                Text("Tap to confirm")
+                Text("Tap the chat area to acknowledge")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
## Summary\n- switch OpenClaw conversation mode control to a native iOS Toggle presentation\n- increase message input control height and spacing for HIG-friendly typing comfort\n\n## Verification\n- swift build --target SpeakiOSLib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned conversation mode control to a vertical, leading-aligned toggle with updated icon/label and accent styling
  * Added a padded, rounded container around the conversation mode area and refined spacing/layout
  * Upgraded the message input to a multi-line-friendly field with improved font, padding, minimum height, rounded background and border
  * Updated confirmation prompt wording to "Tap the chat area to acknowledge"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->