### PR TITLE
fix(mac): allow Developer ID export with iCloud entitlements

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -65,8 +65,11 @@ jobs:
         env:
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         run: |
+          KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8
+          umask 077
           mkdir -p ~/.appstoreconnect/private_keys
-          echo "$APP_STORE_CONNECT_API_KEY" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8
+          echo "$APP_STORE_CONNECT_API_KEY" | base64 --decode > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
 
       - name: Generate Xcode Project
         run: |
@@ -377,3 +380,4 @@ jobs:
         if: always()
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
+          rm -f ~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8 || true


### PR DESCRIPTION
## Summary
- add App Store Connect API key setup to macOS release workflow
- enable automatic provisioning updates for archive/export steps
- switch export signingStyle to automatic so Xcode can fetch the iCloud-capable profile

## Why
- Release run 22352837720 failed at Export App with: "requires a provisioning profile with the iCloud feature".

## Validation
- workflow updated to use existing repo secrets: APP_STORE_CONNECT_API_KEY, APP_STORE_CONNECT_ISSUER_ID, APPLE_TEAM_ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS release automation with automatic code signing and improved authentication handling for app deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->