### PR TITLE
fix(mac): remove conflicting identity in archive signing

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -131,7 +131,6 @@ jobs:
             -archivePath $RUNNER_TEMP/$PRODUCT_NAME.xcarchive \
             -destination "generic/platform=macOS" \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="Developer ID Application" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
             PRODUCT_BUNDLE_IDENTIFIER=com.justspeaktoit.mac \
             ENABLE_HARDENED_RUNTIME=YES \


### PR DESCRIPTION
## Summary
- remove manual  from archive command
- keep automatic signing + provisioning updates for archive
- keep Developer ID signing for export step

## Why
- mac-v0.19.2 failed in Build Release Archive with conflicting provisioning settings between automatic signing and manual identity override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified macOS release build configuration by adjusting code signing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->