### PR TITLE
fix(mac): preserve hardened runtime on export signing

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -162,7 +162,16 @@ jobs:
             -allowProvisioningUpdates \
             -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8 \
             -authenticationKeyID ${{ env.APP_STORE_CONNECT_KEY_ID }} \
-            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
+            ENABLE_HARDENED_RUNTIME=YES \
+            OTHER_CODE_SIGN_FLAGS="--options runtime"
+
+      - name: Verify Hardened Runtime
+        run: |
+          MAIN_BINARY="$RUNNER_TEMP/export/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME"
+          CODESIGN_INFO=$(codesign -dv --verbose=4 "$MAIN_BINARY" 2>&1)
+          echo "$CODESIGN_INFO"
+          echo "$CODESIGN_INFO" | grep -q "runtime"
 
       - name: Notarize App
         env:


### PR DESCRIPTION
## Summary\n- pass hardened-runtime signing flags during \n- add explicit verification step to fail fast if runtime flag is missing before notarization\n\n## Why\n- mac-v0.19.4 reached notarization but failed with "The executable does not have the hardened runtime enabled"\n\n## Validation\n- make test\n- confirmed failure log from run 22355680701