### PR TITLE
fix(mac): enforce hardened runtime before notarization

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -187,6 +187,8 @@ jobs:
 
           codesign --force --timestamp \
             --sign "Developer ID Application" \
+            --options runtime \
+            --entitlements Config/SpeakMacOS.entitlements \
             "$APP_PATH"
 
           CODESIGN_INFO=$(codesign -dv --verbose=4 "$MAIN_BINARY" 2>&1)


### PR DESCRIPTION
## Summary\n- re-sign exported app main binary with  before notarization\n- refresh app bundle signature after runtime re-sign\n- keep explicit runtime verification so CI fails before notarization if runtime is missing\n\n## Why\n- mac-v0.19.5 failed notary checks because exported binary had  (no hardened runtime)\n\n## Validation\n- make test\n- inspected failed run logs for 22356866176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the macOS release process with additional verification and security checks to ensure proper hardened runtime configuration on the main binary and app bundle.
  * Improved the notarization workflow with credential management enhancements for streamlined submission and status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->