### PR TITLE
fix(mac): remove duplicate hardened runtime check

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -168,13 +168,6 @@ jobs:
 
       - name: Verify Hardened Runtime
         run: |
-          MAIN_BINARY="$RUNNER_TEMP/export/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME"
-          CODESIGN_INFO=$(codesign -dv --verbose=4 "$MAIN_BINARY" 2>&1)
-          echo "$CODESIGN_INFO"
-          echo "$CODESIGN_INFO" | grep -q "runtime"
-
-      - name: Verify Hardened Runtime
-        run: |
           APP_PATH="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
           MAIN_BINARY="$APP_PATH/Contents/MacOS/$PRODUCT_NAME"
 


### PR DESCRIPTION
## Summary\n- remove the earlier duplicate Verify Hardened Runtime step that only checked and failed early\n- keep the re-sign + verify step that enforces runtime options before notarization\n\n## Why\n- mac-v0.19.6 failed in the first duplicate verify step before the re-sign logic could run\n\n## Validation\n- make test\n- inspected release run 22358045582 logs