### PR TITLE
fix(mac): disable restricted entitlements in Sparkle builds

### DIFF
--- a/Config/SpeakMacOS.entitlements
+++ b/Config/SpeakMacOS.entitlements
@@ -76,7 +76,8 @@
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
 
-	<!-- Restricted for Developer ID: requires embedded provisioning profile
+	<!-- Restricted for Developer ID (iCloud/APNs): requires embedded provisioning profile.
+	     For App Store builds, uncomment and set aps-environment to production.
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.justspeaktoit</string>


### PR DESCRIPTION
## Summary\n- disable restricted iCloud/APNs entitlements in Developer ID entitlements file used by Sparkle release builds\n- keep a commented block so App Store profile-based builds can re-enable them later\n\n## Why\n- released app could not launch with \n- system logs showed AMFI rejection:  due restricted entitlements without an embedded provisioning profile\n\n## Validation\n- make test\n- reproduced launch failure and confirmed AMFI/provisioning-profile root cause in macOS logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled iCloud/CloudKit identifiers in the macOS app entitlements by commenting them out.
  * Disabled Push Notifications (aps-environment) in the macOS app entitlements by consolidating those entries into the commented block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->