### PR TITLE
fix(mac): remove swift-snapshot-testing to fix release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
         run: make build
 
       - name: Test (Debug)
-        run: swift test --enable-code-coverage --skip SpeakAppSnapshotTests
+        run: swift test --enable-code-coverage
 
       - name: Test (Release)
-        run: swift test -c release --skip SpeakAppSnapshotTests
+        run: swift test -c release
 
       - name: Report Coverage
         if: always()

--- a/Package.resolved
+++ b/Package.resolved
@@ -55,24 +55,6 @@
       }
     },
     {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "2a2a938798236b8fa0bc57c453ee9de9f9ec3ab0",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-snapshot-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
-      "state" : {
-        "revision" : "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
-        "version" : "1.18.9"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
@@ -115,15 +97,6 @@
       "state" : {
         "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
         "version" : "7.0.2"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,7 @@ let package = Package(
         .package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.53.6"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
-        .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.3.0"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0")
+        .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.3.0")
     ],
     targets: [
         .target(
@@ -62,13 +61,6 @@ let package = Package(
         .testTarget(
             name: "SpeakAppTests",
             dependencies: ["SpeakApp"]
-        ),
-        .testTarget(
-            name: "SpeakAppSnapshotTests",
-            dependencies: [
-                "SpeakApp",
-                .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
-            ]
         )
     ]
 )


### PR DESCRIPTION
The swift-snapshot-testing dependency causes an SPM InternalError on Xcode 26.3 RC2 during `tuist generate`. Since snapshot tests are local-only (skipped in CI), removing the dependency unblocks releases.

- Remove swift-snapshot-testing from Package.swift dependencies
- Remove SpeakAppSnapshotTests target from Package.swift
- Remove --skip SpeakAppSnapshotTests from CI (target gone)
- Snapshot test files remain for local development use

Fixes release build failure on mac-v0.21.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled code coverage reporting for all test runs in the continuous integration pipeline.
  * Removed snapshot testing infrastructure including the dedicated snapshot test target.

* **Chores**
  * Removed unused Swift package dependencies to streamline the build environment and reduce maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->