### PR TITLE
fix(ios): remove iCloud entitlements until profile has correct container

### DIFF
--- a/Sources/SpeakSync/SyncConfiguration.swift
+++ b/Sources/SpeakSync/SyncConfiguration.swift
@@ -38,6 +38,8 @@ public enum SyncConfiguration {
 
     /// Whether this app build has CloudKit entitlements.
     /// Developer ID Sparkle builds may omit CloudKit entitlements.
+    /// iOS builds currently ship without iCloud entitlements until
+    /// the provisioning profile is configured with the correct container.
     static var hasCloudKitEntitlement: Bool {
 #if os(macOS)
         guard let task = SecTaskCreateFromSelf(nil) else {
@@ -59,7 +61,7 @@ public enum SyncConfiguration {
         let hasContainerIdentifier = containers?.contains(containerIdentifier) == true
         return hasCloudKitService && hasContainerIdentifier
 #else
-        return true
+        return false
 #endif
     }
 

--- a/SpeakiOS.entitlements
+++ b/SpeakiOS.entitlements
@@ -14,16 +14,6 @@
         <string>group.com.justspeaktoit.ios</string>
     </array>
 
-    <!-- CloudKit: iCloud container for transcription history sync -->
-    <key>com.apple.developer.icloud-container-identifiers</key>
-    <array>
-        <string>iCloud.com.justspeaktoit.ios</string>
-    </array>
-    <key>com.apple.developer.icloud-services</key>
-    <array>
-        <string>CloudKit</string>
-    </array>
-
     <!-- Push Notifications: Required for CloudKit silent push sync -->
     <key>aps-environment</key>
     <string>development</string>


### PR DESCRIPTION
The provisioning profile 'JustSpeakToIt iOS' doesn't include the iCloud.com.justspeaktoit.ios container, causing the iOS archive to fail.

**Changes:**
- Remove iCloud container identifiers and services from `SpeakiOS.entitlements`
- Set `hasCloudKitEntitlement` to `false` on iOS

CloudKit sync is gracefully disabled via the existing `hasCloudKitEntitlement` guard in `HistorySyncEngine`. Once the provisioning profile is updated with the correct iCloud container, the entitlements can be re-added.

This unblocks the TestFlight build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Feature Updates**
  * Updated cloud synchronization support based on platform requirements.

* **Documentation**
  * Enhanced documentation for platform-specific service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->