### PR TITLE
fix(ios): separate voice lists for Aura-1 and Aura-2 TTS models

### DIFF
--- a/Sources/SpeakiOS/Services/OpenClawSettings.swift
+++ b/Sources/SpeakiOS/Services/OpenClawSettings.swift
@@ -74,8 +74,31 @@ public final class OpenClawSettings: ObservableObject {
 
     // MARK: - Available Voices & Models
 
-    /// Deepgram Aura-2 voices.
-    public static let availableVoices: [(id: String, label: String)] = [
+    /// Deepgram Aura-2 voices (from official docs).
+    public static let aura2Voices: [(id: String, label: String)] = [
+        ("andromeda", "Andromeda (American, Female)"),
+        ("apollo", "Apollo (American, Male)"),
+        ("arcas", "Arcas (American, Male)"),
+        ("aries", "Aries (American, Male)"),
+        ("asteria", "Asteria (American, Female)"),
+        ("athena", "Athena (American, Female)"),
+        ("aurora", "Aurora (American, Female)"),
+        ("callista", "Callista (American, Female)"),
+        ("cora", "Cora (American, Female)"),
+        ("draco", "Draco (British, Male)"),
+        ("electra", "Electra (American, Female)"),
+        ("helena", "Helena (American, Female)"),
+        ("hera", "Hera (American, Female)"),
+        ("hermes", "Hermes (American, Male)"),
+        ("luna", "Luna (American, Female)"),
+        ("orion", "Orion (American, Male)"),
+        ("orpheus", "Orpheus (American, Male)"),
+        ("pandora", "Pandora (British, Female)"),
+        ("thalia", "Thalia (American, Female)")
+    ]
+
+    /// Deepgram Aura-1 voices.
+    public static let aura1Voices: [(id: String, label: String)] = [
         ("asteria", "Asteria (American, Female)"),
         ("luna", "Luna (American, Female)"),
         ("stella", "Stella (American, Female)"),
@@ -90,11 +113,25 @@ public final class OpenClawSettings: ObservableObject {
         ("zeus", "Zeus (American, Male)")
     ]
 
+    /// Returns voices available for the given model.
+    public static func voices(for model: String) -> [(id: String, label: String)] {
+        model.hasPrefix("aura-2") ? aura2Voices : aura1Voices
+    }
+
     /// Deepgram TTS models — the id is used as a prefix before the voice name.
     public static let availableModels: [(id: String, label: String)] = [
         ("aura-2", "Aura 2 (English)"),
         ("aura", "Aura 1 (English)")
     ]
+
+    /// Validate that the current voice is compatible with the current model,
+    /// falling back to the first available voice if not.
+    public func validateVoiceModelCombination() {
+        let validVoices = Self.voices(for: ttsModel)
+        if !validVoices.contains(where: { $0.id == ttsVoice }) {
+            ttsVoice = validVoices.first?.id ?? "asteria"
+        }
+    }
 
     public var isConfigured: Bool {
         !gatewayURL.isEmpty && !token.isEmpty && enabled
@@ -119,6 +156,9 @@ public final class OpenClawSettings: ObservableObject {
         self.keywordAcknowledgePhrase =
             UserDefaults.standard.string(forKey: "openclaw.keywordAcknowledgePhrase") ?? "over"
         self.lowLatencySpeech = UserDefaults.standard.object(forKey: "openclaw.lowLatencySpeech") as? Bool ?? false
+
+        // Validate saved voice is compatible with saved model
+        validateVoiceModelCombination()
     }
 
     // MARK: - Keychain

--- a/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
@@ -98,7 +98,10 @@ public struct OpenClawSettingsView: View {
 
                 if settings.ttsEnabled {
                     Picker("Voice", selection: $settings.ttsVoice) {
-                        ForEach(OpenClawSettings.availableVoices, id: \.id) { voice in
+                        ForEach(
+                            OpenClawSettings.voices(for: settings.ttsModel),
+                            id: \.id
+                        ) { voice in
                             Text(voice.label).tag(voice.id)
                         }
                     }
@@ -107,6 +110,9 @@ public struct OpenClawSettingsView: View {
                         ForEach(OpenClawSettings.availableModels, id: \.id) { mdl in
                             Text(mdl.label).tag(mdl.id)
                         }
+                    }
+                    .onChange(of: settings.ttsModel) { _ in
+                        settings.validateVoiceModelCombination()
                     }
 
                     VStack(alignment: .leading) {


### PR DESCRIPTION
## Problem

Selecting Helios (British, Male) voice with Aura 2 model causes a 400 error from Deepgram:

```
No such model/version combination found
```

This is because `helios` is an Aura-1 only voice — it doesn't exist in the Aura-2 lineup. The app was using a single voice list for both models.

## Fix

- Split into separate `aura2Voices` and `aura1Voices` lists sourced from Deepgram's official docs
- Voice picker dynamically shows only compatible voices for the selected model
- Auto-validates on model change and on init (fixes existing broken saved combos)
- Adds `validateVoiceModelCombination()` method

## Testing

Select Aura 2 → voice list should show only Aura-2 voices (no helios/zeus/stella/perseus/angus). Switch to Aura 1 → original voices appear. Test Voice button should work without errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced separate voice collections for Aura-2 and Aura-1 audio models, with voice selections tailored to each model's capabilities.

* **Improvements**
  * Added automatic voice-model compatibility validation ensuring selected voices work correctly with your chosen model, with automatic adjustments when switching between models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->