### PR TITLE
fix: prevent Sentry test noise, CloudKit crashes, and missing dSYMs

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -339,6 +339,9 @@ jobs:
             sentry-cli releases new "justspeaktoit-mac@${VERSION}+${BUILD_NUMBER}"
             sentry-cli releases set-commits "justspeaktoit-mac@${VERSION}+${BUILD_NUMBER}" --auto
             sentry-cli releases finalize "justspeaktoit-mac@${VERSION}+${BUILD_NUMBER}"
+            # Upload dSYMs for symbolication
+            sentry-cli debug-files upload --include-sources \
+              "$RUNNER_TEMP/$PRODUCT_NAME.xcarchive/dSYMs"
           else
             echo "sentry-cli not found, skipping release creation"
           fi

--- a/Sources/SpeakApp/SentryManager.swift
+++ b/Sources/SpeakApp/SentryManager.swift
@@ -36,12 +36,18 @@ enum SentryManager {
                 options.releaseName = "justspeaktoit-mac@\(version)+\(build)"
                 options.dist = build
             }
+            let isTestRun = NSClassFromString("XCTestCase") != nil
             #if DEBUG
             // Exercises full SDK init so linking/config issues surface in dev.
             options.enabled = false
             options.environment = "debug"
             #else
-            options.environment = "production"
+            if isTestRun {
+                options.enabled = false
+                options.environment = "test"
+            } else {
+                options.environment = "production"
+            }
             #endif
 
             // Enable performance monitoring

--- a/Sources/SpeakSync/SyncConfiguration.swift
+++ b/Sources/SpeakSync/SyncConfiguration.swift
@@ -32,8 +32,10 @@ public enum SyncConfiguration {
     public static let batchSize = 100
 
     /// The CloudKit container.
-    public static var container: CKContainer {
-        CKContainer(identifier: containerIdentifier)
+    /// Returns `nil` when CloudKit entitlements are missing (Developer ID builds).
+    public static var container: CKContainer? {
+        guard hasCloudKitEntitlement else { return nil }
+        return CKContainer(identifier: containerIdentifier)
     }
 
     /// Whether this app build has CloudKit entitlements.
@@ -66,8 +68,9 @@ public enum SyncConfiguration {
     }
 
     /// The private database for user's transcription data.
-    public static var privateDatabase: CKDatabase {
-        container.privateCloudDatabase
+    /// Returns `nil` when CloudKit entitlements are missing.
+    public static var privateDatabase: CKDatabase? {
+        container?.privateCloudDatabase
     }
 
     /// The custom zone for transcription history.


### PR DESCRIPTION
## Problem

Three Sentry issues found in production:

### 1. Test noise polluting production Sentry
Tests run in `-c release` (CI) bypass `#if DEBUG` guard, sending real `capture()` calls to production — ~175 events across 7 issue groups (`Test message`, `test: Code: 42`, `fatal msg`, etc.).

**Fix:** Detect XCTest runtime via `NSClassFromString("XCTestCase")` and disable the SDK during test runs, regardless of build configuration.

### 2. CloudKit EXC_BREAKPOINT crashes (10 events, 2 users)
Developer ID builds lack CloudKit entitlements. While `checkCloudAvailability()` guards `accountStatus()`, the `container` and `privateDatabase` computed properties create `CKContainer`/`CKDatabase` instances without checking entitlements first, which can trigger CloudKit internals that crash.

**Fix:** Make `SyncConfiguration.container` and `.privateDatabase` return `nil` when `hasCloudKitEntitlement` is `false`. Guard all database operations against nil.

### 3. Unsymbolicated crash stacks
All crash/hang stack traces show `??` for in-app frames because dSYMs are never uploaded during releases.

**Fix:** Add `sentry-cli debug-files upload` step after release creation in `release-mac.yml`.

### Sentry cleanup
Ignored 10 test-noise issue groups in Sentry to clean up the dashboard.