### PR TITLE
docs: add Sentry monitoring section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,18 +310,20 @@ public final class iOSLiveTranscriber: ObservableObject { ... }
 ### Querying Sentry from CLI
 ```bash
 # Load token from .env
-export SENTRY_AUTH_TOKEN=$(grep SENTRY_AUTH_TOKEN .env | cut -d= -f2)
+export SENTRY_AUTH_TOKEN="$(sed -n 's/^SENTRY_AUTH_TOKEN=//p' .env | tail -n1)"
+export SENTRY_ORG="tally-lz"
+export SENTRY_PROJECT="justspeaktoit"
 
 # List unresolved issues
 curl -s -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://de.sentry.io/api/0/projects/tally-lz/justspeaktoit/issues/?query=is:unresolved&sort=date&limit=25"
+  "https://de.sentry.io/api/0/projects/$SENTRY_ORG/$SENTRY_PROJECT/issues/?query=is:unresolved&sort=date&limit=25"
 
 # Get latest event for an issue
 curl -s -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "https://de.sentry.io/api/0/organizations/tally-lz/issues/{ISSUE_ID}/events/latest/"
+  "https://de.sentry.io/api/0/organizations/$SENTRY_ORG/issues/{ISSUE_ID}/events/latest/"
 
 # Ignore/resolve an issue
 curl -s -X PUT -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" -H "Content-Type: application/json" \
   -d '{"status":"ignored"}' \
-  "https://de.sentry.io/api/0/organizations/tally-lz/issues/{ISSUE_ID}/"
+  "https://de.sentry.io/api/0/organizations/$SENTRY_ORG/issues/{ISSUE_ID}/"
 ```


### PR DESCRIPTION
Adds Sentry error monitoring documentation to AGENTS.md:
- DE region API base URL
- Org/project slugs
- CLI examples for querying issues, getting events, and resolving
- References `SENTRY_AUTH_TOKEN` from `.env` (gitignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an iOS control ergonomics subsection in two places covering Hands-Free Voice Mode and earlier latency guidance. Recommends preferring native iOS controls, maintaining minimum touch target sizes (44 pt for controls, ~50 pt for inputs), and making interaction targets explicit when acknowledgement hints are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->