### PR TITLE
ci(mac): [mac] harden auto-release iOS dispatch trigger

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,6 +14,7 @@ jobs:
       !contains(github.event.head_commit.message, 'chore: update appcast')
     permissions:
       contents: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v6
@@ -135,8 +136,12 @@ jobs:
       - name: Trigger iOS TestFlight Release
         if: steps.check.outputs.should_release == 'true'
         env:
-          GH_TOKEN: ${{ secrets.AUTO_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           NEW_VERSION="${{ steps.version.outputs.new_version }}"
           echo "🚀 Triggering iOS TestFlight build for v$NEW_VERSION"
-          gh workflow run "Release iOS (TestFlight)" -f version="$NEW_VERSION"
+          if gh workflow run "Release iOS (TestFlight)" --ref main -f version="$NEW_VERSION"; then
+            echo "✅ Triggered iOS TestFlight release for v$NEW_VERSION"
+          else
+            echo "⚠️ Could not trigger iOS TestFlight release; continuing without failing macOS auto-release"
+          fi


### PR DESCRIPTION
## Summary
- grant `actions: write` permission in auto-release job
- switch iOS dispatch auth to `${{ github.token }}` instead of PAT
- dispatch `Release iOS (TestFlight)` on `main` and handle failure without failing macOS auto-release

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/auto-release.yml")'`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow with improved token handling and error management for automated iOS TestFlight releases, enabling more reliable deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->