### PR TITLE
docs(mac): [mac] add Homebrew tap to landing page install command

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -941,7 +941,7 @@
 
     <button class="brew-install" title="Click to copy" type="button">
       <span class="brew-install__prompt">$</span>
-      <code>brew install --cask justspeaktoit</code>
+      <code>brew tap crmitchelmore/justspeaktoit && brew install --cask justspeaktoit</code>
       <span class="brew-install__copy">Click to copy</span>
     </button>
     
@@ -1368,7 +1368,7 @@
     if (brewInstallBlock) {
       brewInstallBlock.addEventListener('click', () => {
         const copyText = brewInstallBlock.querySelector('.brew-install__copy');
-        navigator.clipboard.writeText('brew install --cask justspeaktoit').then(() => {
+        navigator.clipboard.writeText('brew tap crmitchelmore/justspeaktoit && brew install --cask justspeaktoit').then(() => {
           if (copyText) {
             copyText.textContent = 'Copied!';
             setTimeout(() => { copyText.textContent = 'Click to copy'; }, 1500);


### PR DESCRIPTION
## Summary
- add brew tap command to landing page install snippet
- update copy-to-clipboard command to include tap

## Verification
- manual diff review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Homebrew installation instructions to include the required tap step. The updated command is now displayed in the installation interface and available for copy-to-clipboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->