### PR TITLE
fix(mac): recreate live transcription controllers per session

### DIFF
--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -840,9 +840,16 @@ private extension DeepgramLiveController {
       }
       print("[DeepgramLiveController] API key retrieved (length: \(apiKey.count))")
       return apiKey
+    } catch let error as SecureAppStorageError {
+      if case .valueNotFound = error {
+        print("[DeepgramLiveController] ERROR: Deepgram API key is missing")
+        throw DeepgramError.missingAPIKey
+      }
+      print("[DeepgramLiveController] ERROR: Failed to retrieve API key: \(error.localizedDescription)")
+      throw error
     } catch {
       print("[DeepgramLiveController] ERROR: Failed to retrieve API key: \(error.localizedDescription)")
-      throw DeepgramError.missingAPIKey
+      throw error
     }
   }
 
@@ -1059,13 +1066,7 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
       throw TranscriptionManagerError.permissionsMissing
     }
 
-    let apiKey: String
-    do {
-      apiKey = try await secureStorage.secret(identifier: "assemblyai.apiKey")
-      guard !apiKey.isEmpty else { throw AssemblyAIError.missingAPIKey }
-    } catch {
-      throw AssemblyAIError.missingAPIKey
-    }
+    let apiKey = try await assemblyAIAPIKey()
 
     let sessionContext = await audioDeviceManager.beginUsingPreferredInput()
     activeInputSession = sessionContext
@@ -1467,6 +1468,21 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
     let speech = await permissionsManager.request(.speechRecognition)
     return microphone.isGranted && speech.isGranted
   }
+
+  private func assemblyAIAPIKey() async throws -> String {
+    do {
+      let apiKey = try await secureStorage.secret(identifier: "assemblyai.apiKey")
+      guard !apiKey.isEmpty else { throw AssemblyAIError.missingAPIKey }
+      return apiKey
+    } catch let error as SecureAppStorageError {
+      if case .valueNotFound = error {
+        throw AssemblyAIError.missingAPIKey
+      }
+      throw error
+    } catch {
+      throw error
+    }
+  }
 }
 // swiftlint:enable type_body_length
 
@@ -1533,7 +1549,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   }
 
   private func makeController(for model: String) -> any LiveTranscriptionController {
-    if model.contains("assemblyai") {
+    if model.hasPrefix("assemblyai/") {
       return AssemblyAILiveController(
         appSettings: appSettings,
         permissionsManager: permissionsManager,
@@ -1541,7 +1557,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
         secureStorage: secureStorage
       )
     }
-    if model.contains("deepgram") {
+    if model.hasPrefix("deepgram/") {
       return DeepgramLiveController(
         appSettings: appSettings,
         permissionsManager: permissionsManager,


### PR DESCRIPTION
## Summary
- recreate live transcription controllers per recording session instead of reusing long-lived instances
- clean up partial Deepgram and AssemblyAI startup state when live transcription fails to start
- reduce the chance of stale audio/transcriber state causing the first recording after long idle to crash

## Verification
- make test
- swift build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and recovery during transcription startup, ensuring proper cleanup when initialization fails.
  * Enhanced stability when switching between transcription services and fixed audio session teardown issues.

* **Refactor**
  * Unified transcription startup and controller selection for more consistent behavior and reliable delegate routing.
  * Preserves selected language and model routing across switches to reduce unexpected resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->