### PR TITLE
fix(mac): [mac] retry DMG detach during release packaging

### DIFF
--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -103,10 +103,15 @@ hdiutil create -srcfolder "$DMG_TEMP" -volname "$VOLUME_NAME" -fs HFS+ \
 # Mount the DMG
 ATTACH_OUTPUT=$(hdiutil attach -readwrite -noverify "$DMG_TEMP_RW")
 MOUNT_DEVICE=$(printf '%s\n' "$ATTACH_OUTPUT" | awk '/\/Volumes\// {print $1; exit}')
+if [ -z "$MOUNT_DEVICE" ]; then
+    MOUNT_DEVICE=$(printf '%s\n' "$ATTACH_OUTPUT" | awk '$1 ~ /^\/dev\// {print $1; exit}')
+fi
 MOUNT_DIR=$(printf '%s\n' "$ATTACH_OUTPUT" | awk -F '\t' '/\/Volumes\// {print $NF; exit}')
 
 if [ -z "$MOUNT_DEVICE" ] || [ -z "$MOUNT_DIR" ]; then
-    echo "Failed to determine mounted DMG details"
+    echo "Failed to determine mounted DMG details" >&2
+    printf '%s\n' "$ATTACH_OUTPUT" >&2
+    cleanup_mounted_dmg
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- retry DMG detach/eject during packaging when Finder still has the mounted volume busy
- track the mounted device explicitly so release packaging can clean up reliably
- keep the existing DMG layout flow intact while hardening the unmount step

## Validation
- bash -n scripts/create-dmg.sh
- ./scripts/create-dmg.sh /tmp/jsti-dmg-test/JustSpeakToIt.app /tmp/jsti-dmg-test/JustSpeakToIt-test.dmg 0.25.6
- make test

## Release blocker
- fixes mac-v0.25.6 release workflow failure in `Create DMG` with `hdiutil: couldn't eject ... Resource busy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved robustness of the macOS disk image build process: mount detection now fails fast on unexpected output, unmount/eject attempts are retried with backoff, and cleanup runs automatically on early failures. The build flow now ensures resources are released and temporary state is cleared after successful completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->