### PR TITLE
fix(agentic-workflows): revisit disproven assumptions

### DIFF
--- a/.github/workflows/issue-planning-architecture.md
+++ b/.github/workflows/issue-planning-architecture.md
@@ -115,7 +115,7 @@ Always read memory first, verify it against the current issue state, then update
 ## Review protocol
 
 1. Read the current issue, labels, and planning comment history in full.
-2. Identify the latest material change: a new blocker, a maintainer clarification, or another role's approval/follow-up.
+2. Identify the latest material change: a new blocker, a maintainer clarification or correction, a disproven assumption, or another role's approval/follow-up.
 3. Ground yourself in your role memory before deciding.
 4. If repo context is missing and the answer is available in code or docs, inspect the repository and record the durable fact in memory.
 5. Evaluate the issue using this role's lens:
@@ -134,6 +134,7 @@ Always read memory first, verify it against the current issue state, then update
 - Behave like one member of a normal product and engineering planning team, not a one-shot gate.
 - Read other reviewers' comments before deciding.
 - If a maintainer explicitly asks your role to respond, or another role directly answers or challenges one of your concerns, leave a visible follow-up comment even if your labels do not change.
+- If a maintainer or verified repo evidence disproves an assumption that you or another role relied on, revisit your stance explicitly. Do not treat approval labels or comments created before that correction as resolving the new concern.
 - When another role raises a concern that changes boundaries or rollout shape, respond directly with the cleanest design or sequencing adjustment that would unblock the plan.
 - When you can answer another role from repo facts or your remit, do so instead of repeating the same blocker.
 - When a concern is resolved, say which comment, fact, or clarification resolved it before you approve.

--- a/.github/workflows/issue-planning-performance.md
+++ b/.github/workflows/issue-planning-performance.md
@@ -115,7 +115,7 @@ Always read memory first, verify it against the current issue state, then update
 ## Review protocol
 
 1. Read the current issue, labels, and planning comment history in full.
-2. Identify the latest material change: a new blocker, a maintainer clarification, or another role's approval/follow-up.
+2. Identify the latest material change: a new blocker, a maintainer clarification or correction, a disproven assumption, or another role's approval/follow-up.
 3. Ground yourself in your role memory before deciding.
 4. If repo context is missing and the answer is available in code or docs, inspect the repository and record the durable fact in memory.
 5. Evaluate the issue using this role's lens:
@@ -134,6 +134,7 @@ Always read memory first, verify it against the current issue state, then update
 - Behave like one member of a normal product and engineering planning team, not a one-shot gate.
 - Read other reviewers' comments before deciding.
 - If a maintainer explicitly asks your role to respond, or another role directly answers or challenges one of your concerns, leave a visible follow-up comment even if your labels do not change.
+- If a maintainer or verified repo evidence disproves an assumption that you or another role relied on, revisit your stance explicitly. Do not treat approval labels or comments created before that correction as resolving the new concern.
 - When another role sets scope or architecture constraints that affect cost or responsiveness, respond directly with the smallest measurement or limit that would make the plan credible.
 - When you can answer another role from repo facts or your remit, do so instead of repeating the same blocker.
 - When a concern is resolved, say which comment, fact, or clarification resolved it before you approve.

--- a/.github/workflows/issue-planning-product.md
+++ b/.github/workflows/issue-planning-product.md
@@ -115,7 +115,7 @@ Always read memory first, verify it against the current issue state, then update
 ## Review protocol
 
 1. Read the current issue, labels, and planning comment history in full.
-2. Identify the latest material change: a new blocker, a maintainer clarification, or another role's approval/follow-up.
+2. Identify the latest material change: a new blocker, a maintainer clarification or correction, a disproven assumption, or another role's approval/follow-up.
 3. Ground yourself in your role memory before deciding.
 4. If repo context is missing and the answer is available in code or docs, inspect the repository and record the durable fact in memory.
 5. Evaluate the issue using this role's lens:
@@ -134,6 +134,7 @@ Always read memory first, verify it against the current issue state, then update
 - Behave like one member of a normal product and engineering planning team, not a one-shot gate.
 - Read other reviewers' comments before deciding.
 - If a maintainer explicitly asks your role to respond, or another role directly answers or challenges one of your concerns, leave a visible follow-up comment even if your labels do not change.
+- If a maintainer or verified repo evidence disproves an assumption that you or another role relied on, revisit your stance explicitly. Do not treat approval labels or comments created before that correction as resolving the new concern.
 - When another role raises a concern that changes scope, user value, or rollout shape, respond directly and say what product trade-off or clarification would unblock the issue.
 - When you can answer another role from repo facts or your remit, do so instead of repeating the same blocker.
 - When a concern is resolved, say which comment, fact, or clarification resolved it before you approve.

--- a/.github/workflows/issue-planning-quality.md
+++ b/.github/workflows/issue-planning-quality.md
@@ -115,7 +115,7 @@ Always read memory first, verify it against the current issue state, then update
 ## Review protocol
 
 1. Read the current issue, labels, and planning comment history in full.
-2. Identify the latest material change: a new blocker, a maintainer clarification, or another role's approval/follow-up.
+2. Identify the latest material change: a new blocker, a maintainer clarification or correction, a disproven assumption, or another role's approval/follow-up.
 3. Ground yourself in your role memory before deciding.
 4. If repo context is missing and the answer is available in code or docs, inspect the repository and record the durable fact in memory.
 5. Evaluate the issue using this role's lens:
@@ -134,6 +134,7 @@ Always read memory first, verify it against the current issue state, then update
 - Behave like one member of a normal product and engineering planning team, not a one-shot gate.
 - Read other reviewers' comments before deciding.
 - If a maintainer explicitly asks your role to respond, or another role directly answers or challenges one of your concerns, leave a visible follow-up comment even if your labels do not change.
+- If a maintainer or verified repo evidence disproves an assumption that you or another role relied on, revisit your stance explicitly. Do not treat approval labels or comments created before that correction as resolving the new concern.
 - When another role identifies a constraint that changes testing, ownership, or implementation shape, respond directly with the cleanest way to encode that requirement.
 - When you can answer another role from repo facts or your remit, do so instead of repeating the same blocker.
 - When a concern is resolved, say which comment, fact, or clarification resolved it before you approve.

--- a/.github/workflows/issue-planning-security.md
+++ b/.github/workflows/issue-planning-security.md
@@ -115,7 +115,7 @@ Always read memory first, verify it against the current issue state, then update
 ## Review protocol
 
 1. Read the current issue, labels, and planning comment history in full.
-2. Identify the latest material change: a new blocker, a maintainer clarification, or another role's approval/follow-up.
+2. Identify the latest material change: a new blocker, a maintainer clarification or correction, a disproven assumption, or another role's approval/follow-up.
 3. Ground yourself in your role memory before deciding.
 4. If repo context is missing and the answer is available in code or docs, inspect the repository and record the durable fact in memory.
 5. Evaluate the issue using this role's lens:
@@ -134,6 +134,7 @@ Always read memory first, verify it against the current issue state, then update
 - Behave like one member of a normal product and engineering planning team, not a one-shot gate.
 - Read other reviewers' comments before deciding.
 - If a maintainer explicitly asks your role to respond, or another role directly answers or challenges one of your concerns, leave a visible follow-up comment even if your labels do not change.
+- If a maintainer or verified repo evidence disproves an assumption that you or another role relied on, revisit your stance explicitly. Do not treat approval labels or comments created before that correction as resolving the new concern.
 - When another role proposes a shortcut that changes trust boundaries, auth, or data handling, respond directly and explain the minimum safe shape that would unblock the plan.
 - When you can answer another role from repo facts or your remit, do so instead of repeating the same blocker.
 - When a concern is resolved, say which comment, fact, or clarification resolved it before you approve.

--- a/Docs/agentic-workflows.md
+++ b/Docs/agentic-workflows.md
@@ -56,6 +56,8 @@ Each role memory should keep four compact files on its `planning/<role>` branch:
 - `issues/<issue-number>.md` — the live stance and resolved blockers for a specific issue
 - `history/recent-decisions.md` — durable decisions and learnings
 
+On repositories with stricter branch protections, the planning setup is only operationally complete once workflow-driven memory updates can still land on `planning/<role>`. If the repository requires signed commits on all branches, either exempt `planning/*` or configure workflow commit signing up front.
+
 ### Workflows
 
 Custom planning workflows added in this repository:
@@ -95,6 +97,7 @@ Planning state is tracked with labels:
 4. Each role reviewer comments in thread, asks focused follow-up questions, and bot-authored reviewer comments re-dispatch the other reviewers without letting a workflow react to its own comment directly.
 5. Maintainers answer unresolved questions in-thread, and those direct maintainer comments trigger the role reviewers as well.
 6. If a maintainer explicitly asks a named role to respond, that role should leave a visible follow-up comment even if its approval label stays unchanged.
+If a maintainer correction or verified repo fact disproves an earlier assumption, reviewers should revisit any approval that depended on it rather than leaning on older labels or comments as if the corrected concern were already resolved.
 7. Role approval labels accumulate as concerns are resolved.
 8. `Issue Planning - Reconcile State` normalises the pending labels and applies `planning:ready-for-dev` once all five approvals are present.
 
@@ -109,8 +112,9 @@ Use this rollout order when you add the planning team elsewhere:
 2. Install the kickoff workflow, the deterministic bot-follow-up dispatcher, the five role workflows, the manual ready-check, and the deterministic reconcile workflow.
 3. Create the planning labels before live testing so approvals have a stable target.
 4. Seed all five `planning/<role>` memory branches up front by creating the files `principles.md`, `repository-context.md`, and `history/recent-decisions.md`, plus the `issues/` directory, rather than waiting for first use.
-5. Retest on at least one realistic issue and one workflow-health issue, and confirm that reviewers reference each other's comments, visibly answer direct maintainer asks, and do more than leave one-shot approvals.
-6. Keep `Issue Planning - Ready Check` as a manual audit path and let `Issue Planning - Reconcile State` own the live label normalisation.
+5. Before expecting repo-memory writes to work, verify that `planning/*` can accept workflow-created commits. On repositories with required signed commits, either provide an approved `planning/*` exemption or configure workflow commit signing before live rollout.
+6. Retest on at least one realistic issue and one workflow-health issue. Use the realistic issue as the main proof. For workflow-health issues, ask a concrete portability or design question; otherwise reviewers may collapse into one-shot approvals instead of a real discussion.
+7. Keep `Issue Planning - Ready Check` as a manual audit path and let `Issue Planning - Reconcile State` own the live label normalisation.
 
 ### Resetting or retesting planning
 


### PR DESCRIPTION
## Summary
- require planning reviewers to revisit approvals when a maintainer correction disproves an earlier assumption
- document that stale approval labels/comments do not resolve the corrected concern
- keep the rollout guidance aligned with the live issue behaviour we observed

## Testing
- gh aw compile --validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review workflow protocols to recognize maintainer corrections and disproven assumptions as material changes requiring explicit re-evaluation.
  * Enhanced operational setup documentation with branch-protection prerequisites and improved assumption-handling guidance.
  * Refined rollout retest procedures to include workflow commit verification and health-assessment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->