### PR TITLE
docs(agentic-workflows): clarify proof pattern

### DIFF
--- a/Docs/agentic-workflows.md
+++ b/Docs/agentic-workflows.md
@@ -247,7 +247,7 @@ For workflows that only exist on a feature branch, `gh workflow run --ref <branc
 
 1. On the feature branch, validate the source changes and generated lock files directly (for example with `gh aw compile`, `git diff`, and any existing CI or push-trigger smoke test).
 2. Open a linked pull request from that branch so the PR review lane can run against the branch workflow definitions before merge.
-3. After merge, open a fresh issue and a small linked pull request on the default branch to prove the paths that depend on default-branch workflow definitions: issue-open Product validation, `/doit` planning kickoff, and any manual `workflow_dispatch` reconcile or ready-check runs.
+3. After merge, open a fresh issue and a small linked pull request (for example, a documentation update) on the default branch to prove the paths that depend on default-branch workflow definitions: issue-open Product validation, `/doit` planning kickoff, and any manual `workflow_dispatch` reconcile or ready-check runs.
 
 This repository used that exact pattern after PR `#175`: the branch proved the workflow sources and PR review lane, while issue `#176` on `main` proved the default-branch intake and reconcile behaviour.
 


### PR DESCRIPTION
## Summary
- document the proof pattern for branch-only workflow changes
- explain that branch validation and linked PR review happen before merge
- explain that default-branch issue-open and manual reconcile proofs should happen on `main` after merge

## Verification
- issue `#176` proved Product validation on open, `/doit` planning kickoff, and `Issue Planning - Reconcile State` on `main`
- this PR is linked back to that approved issue plan

Plan issue: #176
Closes #176


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated agentic workflows guidance with a new three-step validation pattern that validates feature branch sources/lock files, exercises branch-based PR workflows, and verifies default-branch paths through issue and PR creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->