### PR TITLE
fix(agentic-workflows): ignore closed PR comments

### DIFF
--- a/.github/workflows/pr-plan-review-architecture.lock.yml
+++ b/.github/workflows/pr-plan-review-architecture.lock.yml
@@ -22,7 +22,7 @@
 #
 # Architecture reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e73abaaa19428f06d1eadf362d57770e979221542f06a378114aba95ae96344f","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e3e459238afb88e0b05c2f88e6acdc55043f49ce3effadf481e03a7570b9401a","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Architecture"
 "on":
@@ -62,8 +62,8 @@ jobs:
     needs: pre_activation
     if: >
       (needs.pre_activation.outputs.activated == 'true') && ((github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)) &&
-      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
+      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -1060,7 +1060,8 @@ jobs:
   pre_activation:
     if: >
       (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null)) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id))
+      github.event.issue.pull_request != null && github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') ||
+      (github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_skip_bots.outputs.skip_bots_ok == 'true') }}

--- a/.github/workflows/pr-plan-review-architecture.md
+++ b/.github/workflows/pr-plan-review-architecture.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, copilot, dependabot, renovate]
 
-if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) }}
+if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open') }}
 
 permissions:
   contents: read
@@ -77,6 +77,7 @@ Review the relevant pull request plan-review conversation for `${{ github.reposi
 - Otherwise review the triggering pull request #${{ github.event.pull_request.number || github.event.issue.number }}.
 - If the pull request is still a draft, do nothing.
 - If this run came from `issue_comment`, only act when the comment belongs to a pull request.
+- If this run came from `issue_comment` and the pull request is closed or merged, do nothing.
 - If this run came from `issue_comment` and the pull request has no `plan-review:` labels and no prior kickoff comment that starts with `### 🔎 Plan Review Kickoff`, do nothing.
 - If this run came from `issue_comment`, treat only plan-review comments and maintainer clarifications as new material. Plan-review comments use headings like `### 🔎 Plan Review Kickoff`, `### 🧭 Product Review`, `### 🔐 Security Review`, `### ⚡ Performance Review`, `### 🧹 Code Quality Review`, `### 🏗️ Architecture Review`, `### ✅ Plan Review Ready`, `### ♻️ Plan Review Reopened`. Ignore unrelated automation or chatter.
 

--- a/.github/workflows/pr-plan-review-bot-follow-up.yml
+++ b/.github/workflows/pr-plan-review-bot-follow-up.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   dispatch:
-    if: ${{ github.event.issue.pull_request != null }}
+    if: ${{ github.event.issue.pull_request != null && github.event.issue.state == 'open' }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-plan-review-performance.lock.yml
+++ b/.github/workflows/pr-plan-review-performance.lock.yml
@@ -22,7 +22,7 @@
 #
 # Performance reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"925b1cf2ee6250ec703bf1f049193f312651a1890f3ce6e0f30b6ed6945ef47a","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d7dc3ff061fa99727e980c714271a498ac6135715dd610e9f666e2e63030537c","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Performance"
 "on":
@@ -62,8 +62,8 @@ jobs:
     needs: pre_activation
     if: >
       (needs.pre_activation.outputs.activated == 'true') && ((github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)) &&
-      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
+      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -1060,7 +1060,8 @@ jobs:
   pre_activation:
     if: >
       (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null)) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id))
+      github.event.issue.pull_request != null && github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') ||
+      (github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_skip_bots.outputs.skip_bots_ok == 'true') }}

--- a/.github/workflows/pr-plan-review-performance.md
+++ b/.github/workflows/pr-plan-review-performance.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, copilot, dependabot, renovate]
 
-if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) }}
+if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open') }}
 
 permissions:
   contents: read
@@ -77,6 +77,7 @@ Review the relevant pull request plan-review conversation for `${{ github.reposi
 - Otherwise review the triggering pull request #${{ github.event.pull_request.number || github.event.issue.number }}.
 - If the pull request is still a draft, do nothing.
 - If this run came from `issue_comment`, only act when the comment belongs to a pull request.
+- If this run came from `issue_comment` and the pull request is closed or merged, do nothing.
 - If this run came from `issue_comment` and the pull request has no `plan-review:` labels and no prior kickoff comment that starts with `### 🔎 Plan Review Kickoff`, do nothing.
 - If this run came from `issue_comment`, treat only plan-review comments and maintainer clarifications as new material. Plan-review comments use headings like `### 🔎 Plan Review Kickoff`, `### 🧭 Product Review`, `### 🔐 Security Review`, `### ⚡ Performance Review`, `### 🧹 Code Quality Review`, `### 🏗️ Architecture Review`, `### ✅ Plan Review Ready`, `### ♻️ Plan Review Reopened`. Ignore unrelated automation or chatter.
 

--- a/.github/workflows/pr-plan-review-product.lock.yml
+++ b/.github/workflows/pr-plan-review-product.lock.yml
@@ -22,7 +22,7 @@
 #
 # Product reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4165aa6e7783e0e77657c0d7c32fbe5bfa125fc39851539e4c47c3c8ed492b6d","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"00fe75e0f546ddb6a77613d70163a96a04b7e34825a9d553192da2005df385f6","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Product"
 "on":
@@ -62,8 +62,8 @@ jobs:
     needs: pre_activation
     if: >
       (needs.pre_activation.outputs.activated == 'true') && ((github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)) &&
-      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
+      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -1060,7 +1060,8 @@ jobs:
   pre_activation:
     if: >
       (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null)) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id))
+      github.event.issue.pull_request != null && github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') ||
+      (github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_skip_bots.outputs.skip_bots_ok == 'true') }}

--- a/.github/workflows/pr-plan-review-product.md
+++ b/.github/workflows/pr-plan-review-product.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, copilot, dependabot, renovate]
 
-if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) }}
+if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open') }}
 
 permissions:
   contents: read
@@ -77,6 +77,7 @@ Review the relevant pull request plan-review conversation for `${{ github.reposi
 - Otherwise review the triggering pull request #${{ github.event.pull_request.number || github.event.issue.number }}.
 - If the pull request is still a draft, do nothing.
 - If this run came from `issue_comment`, only act when the comment belongs to a pull request.
+- If this run came from `issue_comment` and the pull request is closed or merged, do nothing.
 - If this run came from `issue_comment` and the pull request has no `plan-review:` labels and no prior kickoff comment that starts with `### 🔎 Plan Review Kickoff`, do nothing.
 - If this run came from `issue_comment`, treat only plan-review comments and maintainer clarifications as new material. Plan-review comments use headings like `### 🔎 Plan Review Kickoff`, `### 🧭 Product Review`, `### 🔐 Security Review`, `### ⚡ Performance Review`, `### 🧹 Code Quality Review`, `### 🏗️ Architecture Review`, `### ✅ Plan Review Ready`, `### ♻️ Plan Review Reopened`. Ignore unrelated automation or chatter.
 

--- a/.github/workflows/pr-plan-review-quality.lock.yml
+++ b/.github/workflows/pr-plan-review-quality.lock.yml
@@ -22,7 +22,7 @@
 #
 # Code Quality reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3f44697ff12896b6d8bbb0c12867d6184d5cdaca8444642e55dc23e71b66db91","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b69c990a1c766079fbbc335eebb7cc96f7a10c14e7e4169dbd0a219a5694a588","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Code Quality"
 "on":
@@ -62,8 +62,8 @@ jobs:
     needs: pre_activation
     if: >
       (needs.pre_activation.outputs.activated == 'true') && ((github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)) &&
-      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
+      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -1060,7 +1060,8 @@ jobs:
   pre_activation:
     if: >
       (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null)) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id))
+      github.event.issue.pull_request != null && github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') ||
+      (github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_skip_bots.outputs.skip_bots_ok == 'true') }}

--- a/.github/workflows/pr-plan-review-quality.md
+++ b/.github/workflows/pr-plan-review-quality.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, copilot, dependabot, renovate]
 
-if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) }}
+if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open') }}
 
 permissions:
   contents: read
@@ -77,6 +77,7 @@ Review the relevant pull request plan-review conversation for `${{ github.reposi
 - Otherwise review the triggering pull request #${{ github.event.pull_request.number || github.event.issue.number }}.
 - If the pull request is still a draft, do nothing.
 - If this run came from `issue_comment`, only act when the comment belongs to a pull request.
+- If this run came from `issue_comment` and the pull request is closed or merged, do nothing.
 - If this run came from `issue_comment` and the pull request has no `plan-review:` labels and no prior kickoff comment that starts with `### 🔎 Plan Review Kickoff`, do nothing.
 - If this run came from `issue_comment`, treat only plan-review comments and maintainer clarifications as new material. Plan-review comments use headings like `### 🔎 Plan Review Kickoff`, `### 🧭 Product Review`, `### 🔐 Security Review`, `### ⚡ Performance Review`, `### 🧹 Code Quality Review`, `### 🏗️ Architecture Review`, `### ✅ Plan Review Ready`, `### ♻️ Plan Review Reopened`. Ignore unrelated automation or chatter.
 

--- a/.github/workflows/pr-plan-review-security.lock.yml
+++ b/.github/workflows/pr-plan-review-security.lock.yml
@@ -22,7 +22,7 @@
 #
 # Security reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bc5bf5a76f84fbf61fc6d0060c4bbfe09be63e74e28e90f703f2963b862c9e8c","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b9f00d724ec46d86b6b621d21b0ba8eb1d5b27a7c7447bfe19e4abb9e4eeb063","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Security"
 "on":
@@ -62,8 +62,8 @@ jobs:
     needs: pre_activation
     if: >
       (needs.pre_activation.outputs.activated == 'true') && ((github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)) &&
-      ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
+      github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -1060,7 +1060,8 @@ jobs:
   pre_activation:
     if: >
       (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null)) && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id))
+      github.event.issue.pull_request != null && github.event.issue.state == 'open')) && ((github.event_name != 'pull_request') ||
+      (github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_skip_bots.outputs.skip_bots_ok == 'true') }}

--- a/.github/workflows/pr-plan-review-security.md
+++ b/.github/workflows/pr-plan-review-security.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, copilot, dependabot, renovate]
 
-if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) }}
+if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open') }}
 
 permissions:
   contents: read
@@ -77,6 +77,7 @@ Review the relevant pull request plan-review conversation for `${{ github.reposi
 - Otherwise review the triggering pull request #${{ github.event.pull_request.number || github.event.issue.number }}.
 - If the pull request is still a draft, do nothing.
 - If this run came from `issue_comment`, only act when the comment belongs to a pull request.
+- If this run came from `issue_comment` and the pull request is closed or merged, do nothing.
 - If this run came from `issue_comment` and the pull request has no `plan-review:` labels and no prior kickoff comment that starts with `### 🔎 Plan Review Kickoff`, do nothing.
 - If this run came from `issue_comment`, treat only plan-review comments and maintainer clarifications as new material. Plan-review comments use headings like `### 🔎 Plan Review Kickoff`, `### 🧭 Product Review`, `### 🔐 Security Review`, `### ⚡ Performance Review`, `### 🧹 Code Quality Review`, `### 🏗️ Architecture Review`, `### ✅ Plan Review Ready`, `### ♻️ Plan Review Reopened`. Ignore unrelated automation or chatter.
 


### PR DESCRIPTION
## Summary
- stop PR role review workflows from reacting to `issue_comment` events on closed or merged PRs
- mirror the same open-PR guard in the PR bot follow-up dispatcher
- keep `pull_request` and `workflow_dispatch` behaviour unchanged

## Verification
- `gh aw compile`
- verified the generated lock files keep the new `github.event.issue.state == 'open'` guard
- traced the failing `main` runs back to closed PR `#161`, confirming the guard matches the real failure mode

Plan issue: #180
Closes #180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated automated review workflow trigger conditions across architecture, performance, product, quality, and security review categories. Workflows now only execute when pull requests are open, preventing unnecessary processing on closed or merged pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->