### PR TITLE
fix(agentic-workflows): accept contextual /doit comments

### DIFF
--- a/.github/workflows/issue-planning-architecture.md
+++ b/.github/workflows/issue-planning-architecture.md
@@ -77,7 +77,7 @@ Review the relevant issue planning conversation for `${{ github.repository }}` f
 - Otherwise review the triggering issue #${{ github.event.issue.number }}.
 - Never act on pull requests. If this event is a pull request comment, do nothing.
 - If this run came from `issues` or `issue_comment` and the issue has no `planning:` labels and no prior kickoff comment that starts with `### 🗂️ Planning Kickoff`, do nothing.
-- If this run came from `issue_comment` and the new comment starts with `/doit`, do nothing. The manual planning command workflow owns that path.
+- If this run came from `issue_comment` and the new comment contains an explicit `/doit` command anywhere, do nothing. The manual planning command workflow owns that path, including any surrounding maintainer context.
 - If this run came from `issue_comment`, treat only planning-team comments and maintainer clarifications as new material. Planning-team comments use headings like `### 🗂️ Planning Kickoff`, `### 🧭 Product`, `### 🔐 Security`, `### ⚡ Performance`, `### 🧹 Code Quality`, `### 🏗️ Architecture`, `### ✅ Planning Ready`, `### ♻️ Planning Reopened`. Ignore unrelated automation or chatter.
 
 ## Approval model

--- a/.github/workflows/issue-planning-command.yml
+++ b/.github/workflows/issue-planning-command.yml
@@ -36,11 +36,23 @@ jobs:
           repo = os.environ["REPO"]
           issue_number = os.environ["ISSUE_NUMBER"]
           author = os.environ["COMMENT_AUTHOR"]
-          body = os.environ["COMMENT_BODY"].lstrip()
+          raw_body = os.environ["COMMENT_BODY"]
+          body = raw_body.lstrip()
+          command_pattern = re.compile(r"(?i)(?:^|(?<=\s))/doit(?=$|[\s.!?,:;])")
 
-          if not re.match(r"^/doit(?:\s|$)", body, re.IGNORECASE):
-              print("Comment is not a /doit command; nothing to do.")
+          if not command_pattern.search(body):
+              print("Comment does not contain a /doit command; nothing to do.")
               sys.exit(0)
+
+          context_lines = []
+          for line in raw_body.splitlines():
+              cleaned_line = command_pattern.sub("", line).strip()
+              if cleaned_line:
+                  context_lines.append(cleaned_line)
+
+          command_context = "\n".join(context_lines)
+          if len(command_context) > 600:
+              command_context = command_context[:597].rstrip() + "..."
 
           def gh_json(*args):
               return json.loads(subprocess.check_output(["gh", *args], text=True))
@@ -141,11 +153,18 @@ jobs:
               "--repo",
               repo,
               "--body",
-              (
-                  "### 🗂️ Planning Kickoff\n\n"
-                  f"`/doit` from `@{author}` was accepted, so Product, Security, Performance, Code Quality, and Architecture are now joining this thread. "
-                  "Answer unresolved questions in-thread until the team converges. "
-                  f"When `planning:ready-for-dev` appears, open a pull request that includes `Plan issue: #{issue_number}` in the body."
-              ),
+                  (
+                      "### 🗂️ Planning Kickoff\n\n"
+                      f"`/doit` from `@{author}` was accepted, so Product, Security, Performance, Code Quality, and Architecture are now joining this thread. "
+                      "Answer unresolved questions in-thread until the team converges."
+                      + (
+                          "\n\n**Maintainer context from the `/doit` comment:**\n"
+                          + "\n".join(f"> {line}" for line in command_context.splitlines())
+                          if command_context
+                          else ""
+                      )
+                      + "\n\n"
+                      + f"When `planning:ready-for-dev` appears, open a pull request that includes `Plan issue: #{issue_number}` in the body."
+                  ),
           )
           PY

--- a/.github/workflows/issue-planning-performance.md
+++ b/.github/workflows/issue-planning-performance.md
@@ -77,7 +77,7 @@ Review the relevant issue planning conversation for `${{ github.repository }}` f
 - Otherwise review the triggering issue #${{ github.event.issue.number }}.
 - Never act on pull requests. If this event is a pull request comment, do nothing.
 - If this run came from `issues` or `issue_comment` and the issue has no `planning:` labels and no prior kickoff comment that starts with `### 🗂️ Planning Kickoff`, do nothing.
-- If this run came from `issue_comment` and the new comment starts with `/doit`, do nothing. The manual planning command workflow owns that path.
+- If this run came from `issue_comment` and the new comment contains an explicit `/doit` command anywhere, do nothing. The manual planning command workflow owns that path, including any surrounding maintainer context.
 - If this run came from `issue_comment`, treat only planning-team comments and maintainer clarifications as new material. Planning-team comments use headings like `### 🗂️ Planning Kickoff`, `### 🧭 Product`, `### 🔐 Security`, `### ⚡ Performance`, `### 🧹 Code Quality`, `### 🏗️ Architecture`, `### ✅ Planning Ready`, `### ♻️ Planning Reopened`. Ignore unrelated automation or chatter.
 
 ## Approval model

--- a/.github/workflows/issue-planning-product.md
+++ b/.github/workflows/issue-planning-product.md
@@ -77,7 +77,7 @@ Review the relevant issue planning conversation for `${{ github.repository }}` f
 - Otherwise review the triggering issue #${{ github.event.issue.number }}.
 - Never act on pull requests. If this event is a pull request comment, do nothing.
 - If this run came from `issues` or `issue_comment` and the issue has no `planning:` labels and no prior kickoff comment that starts with `### 🗂️ Planning Kickoff`, do nothing.
-- If this run came from `issue_comment` and the new comment starts with `/doit`, do nothing. The manual planning command workflow owns that path.
+- If this run came from `issue_comment` and the new comment contains an explicit `/doit` command anywhere, do nothing. The manual planning command workflow owns that path, including any surrounding maintainer context.
 - If this run came from `issue_comment`, treat only planning-team comments and maintainer clarifications as new material. Planning-team comments use headings like `### 🗂️ Planning Kickoff`, `### 🧭 Product`, `### 🔐 Security`, `### ⚡ Performance`, `### 🧹 Code Quality`, `### 🏗️ Architecture`, `### ✅ Planning Ready`, `### ♻️ Planning Reopened`. Ignore unrelated automation or chatter.
 
 ## Approval model

--- a/.github/workflows/issue-planning-quality.md
+++ b/.github/workflows/issue-planning-quality.md
@@ -77,7 +77,7 @@ Review the relevant issue planning conversation for `${{ github.repository }}` f
 - Otherwise review the triggering issue #${{ github.event.issue.number }}.
 - Never act on pull requests. If this event is a pull request comment, do nothing.
 - If this run came from `issues` or `issue_comment` and the issue has no `planning:` labels and no prior kickoff comment that starts with `### 🗂️ Planning Kickoff`, do nothing.
-- If this run came from `issue_comment` and the new comment starts with `/doit`, do nothing. The manual planning command workflow owns that path.
+- If this run came from `issue_comment` and the new comment contains an explicit `/doit` command anywhere, do nothing. The manual planning command workflow owns that path, including any surrounding maintainer context.
 - If this run came from `issue_comment`, treat only planning-team comments and maintainer clarifications as new material. Planning-team comments use headings like `### 🗂️ Planning Kickoff`, `### 🧭 Product`, `### 🔐 Security`, `### ⚡ Performance`, `### 🧹 Code Quality`, `### 🏗️ Architecture`, `### ✅ Planning Ready`, `### ♻️ Planning Reopened`. Ignore unrelated automation or chatter.
 
 ## Approval model

--- a/.github/workflows/issue-planning-security.md
+++ b/.github/workflows/issue-planning-security.md
@@ -77,7 +77,7 @@ Review the relevant issue planning conversation for `${{ github.repository }}` f
 - Otherwise review the triggering issue #${{ github.event.issue.number }}.
 - Never act on pull requests. If this event is a pull request comment, do nothing.
 - If this run came from `issues` or `issue_comment` and the issue has no `planning:` labels and no prior kickoff comment that starts with `### 🗂️ Planning Kickoff`, do nothing.
-- If this run came from `issue_comment` and the new comment starts with `/doit`, do nothing. The manual planning command workflow owns that path.
+- If this run came from `issue_comment` and the new comment contains an explicit `/doit` command anywhere, do nothing. The manual planning command workflow owns that path, including any surrounding maintainer context.
 - If this run came from `issue_comment`, treat only planning-team comments and maintainer clarifications as new material. Planning-team comments use headings like `### 🗂️ Planning Kickoff`, `### 🧭 Product`, `### 🔐 Security`, `### ⚡ Performance`, `### 🧹 Code Quality`, `### 🏗️ Architecture`, `### ✅ Planning Ready`, `### ♻️ Planning Reopened`. Ignore unrelated automation or chatter.
 
 ## Approval model

--- a/.github/workflows/issue-product-validation.md
+++ b/.github/workflows/issue-product-validation.md
@@ -77,7 +77,7 @@ Review the relevant issue intake conversation for `${{ github.repository }}` fro
 - Otherwise review the triggering issue #${{ github.event.issue.number }}.
 - Never act on pull requests.
 - If the issue already has any `planning:` labels or a prior kickoff comment that starts with `### 🗂️ Planning Kickoff`, do nothing because full planning is already underway.
-- If this run came from `issue_comment` and the new comment starts with `/doit`, do nothing. The manual planning command workflow owns that path.
+- If this run came from `issue_comment` and the new comment contains an explicit `/doit` command anywhere, do nothing. The manual planning command workflow owns that path, including any surrounding maintainer context.
 - If this run came from `issues` and the issue just opened, treat that as the first Product intake pass.
 - If this run came from `issue_comment`, treat maintainer clarifications and direct requests for Product validation as new material. Ignore unrelated automation and your own prior `### 🧭 Product Validation` comments unless a maintainer explicitly asked you to revisit.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ This repository uses an agentic planning flow before implementation starts:
 
 1. New issues go through Product validation on open.
 2. If Product asks for clarification, answer in-thread or edit the issue until it reaches `triage:product-fit`.
-3. Once the issue is Product-fit, someone with repository write access can comment `/doit` to start the five-role planning discussion.
+3. Once the issue is Product-fit, someone with repository write access can comment `/doit` — either on its own or inside a longer maintainer note — to start the five-role planning discussion. Any surrounding text is carried forward as planning context.
 4. When implementation starts, open a PR that includes `Plan issue: #<issue-number>` in the body, along with the validation or testing evidence for the change.
 
 See [`Docs/agentic-workflows.md`](./Docs/agentic-workflows.md) for the full workflow and [`Docs/team-personalities.md`](./Docs/team-personalities.md) for the named role model.

--- a/Docs/agentic-workflows.md
+++ b/Docs/agentic-workflows.md
@@ -79,7 +79,7 @@ On repositories with stricter branch protections, the planning setup is only ope
 Custom planning and plan-review workflows added in this repository:
 
 - `issue-product-validation` — Alex Hale (`Product`) handles the first intake pass and decides whether the issue fits this repository before full planning is allowed to start
-- `issue-planning-command` — accepts an authorised `/doit` comment, seeds planning state, and posts the kickoff comment that starts full planning
+- `issue-planning-command` — accepts an authorised `/doit` command even when it appears inside a longer maintainer comment, seeds planning state, and posts the kickoff comment that starts full planning with any surrounding text carried over as context
 - `issue-planning-kickoff` — seeds the planning labels and explains the issue-planning flow after `/doit`
 - `issue-planning-bot-follow-up` — deterministic dispatcher that re-queues the other reviewers when a bot-authored planning comment lands
 - `issue-planning-product`
@@ -148,7 +148,7 @@ PR implementation review state is tracked with labels:
    - asks for more detail with `triage:needs-clarification`, or
    - marks it `triage:out-of-scope`.
 4. Maintainers can answer Product's questions in-thread or edit the issue until Product validation converges.
-5. Once `triage:product-fit` is present, someone with repository write access comments `/doit` on the issue.
+5. Once `triage:product-fit` is present, someone with repository write access comments `/doit` on the issue. The command can stand alone or appear inside a longer maintainer note; any other text in that comment is carried into planning as context.
 6. `Issue Planning - Command` verifies that the commenter has write access, clears the intake labels, applies the `planning:*` labels, and posts the `### 🗂️ Planning Kickoff` comment.
 7. `Issue Planning - Kickoff` remains available as the manual reset and re-entry path when maintainers want to restart planning explicitly.
 8. The five named teammates now join the thread:
@@ -194,7 +194,9 @@ The rule is simple: names stay stable, judgement improves, and quirks only deepe
 
 Do not use `/doit` while the issue still lacks `triage:product-fit`, or while it is in `triage:needs-clarification` or `triage:out-of-scope`. In those states, continue the Product discussion in-thread or update the issue until Product validation changes.
 
-Once `/doit` is accepted, the issue moves into `planning:*` labels, the kickoff comment starts the five-role discussion, and maintainers should answer open questions in-thread until `planning:ready-for-dev` appears. The resulting pull request should then include `Plan issue: #<issue-number>` in the body so the PR review lane can compare the implementation against the approved plan.
+`/doit` does not need to be the whole comment. A maintainer can write a short note such as scope guidance, a preferred option, or an answer to an open question in the same comment. The workflow will treat `/doit` as the command and carry the surrounding text into the kickoff comment as planning context.
+
+Once `/doit` is accepted, the issue moves into `planning:*` labels, the kickoff comment starts the five-role discussion, and maintainers should answer open questions in-thread until `planning:ready-for-dev` appears. If the `/doit` comment included extra text, that text is quoted into the kickoff comment as maintainer planning context. The resulting pull request should then include `Plan issue: #<issue-number>` in the body so the PR review lane can compare the implementation against the approved plan.
 
 ### Portable rollout pattern for other repositories
 
@@ -214,7 +216,7 @@ Use this rollout order when you add the planning team elsewhere:
 
 ### Resetting or retesting planning and plan review
 
-On the default branch, new issues enter `Issue Product Validation` automatically, `/doit` from an authorised repository writer starts the planning lane, `Issue Planning - Reconcile State` keeps the planning labels aligned after each role workflow completes, and `PR Plan Review - Reconcile State` does the same for pull requests.
+On the default branch, new issues enter `Issue Product Validation` automatically, `/doit` from an authorised repository writer starts the planning lane, and any extra text in that comment is carried into the kickoff note as planning context. `Issue Planning - Reconcile State` keeps the planning labels aligned after each role workflow completes, and `PR Plan Review - Reconcile State` does the same for pull requests.
 
 Before merge, or when manually re-running either stage, use `workflow_dispatch` with an issue number or pull request number. For example:
 
@@ -251,7 +253,7 @@ For workflows that only exist on a feature branch, `gh workflow run --ref <branc
 
 This repository used that exact pattern after PR `#175`: the branch proved the workflow sources and PR review lane, while issue `#176` on `main` proved the default-branch intake and reconcile behaviour.
 
-To restart intake for an existing issue, re-run `Issue Product Validation`. To restart full planning for an intake-approved issue, use `/doit` again or manually dispatch `Issue Planning - Kickoff`. To restart PR plan review for an existing pull request, re-run `PR Plan Review - Kickoff` or push a new commit after clarifying the linked plan.
+To restart intake for an existing issue, re-run `Issue Product Validation`. To restart full planning for an intake-approved issue, use `/doit` again (optionally with a short maintainer note that will be carried into kickoff) or manually dispatch `Issue Planning - Kickoff`. To restart PR plan review for an existing pull request, re-run `PR Plan Review - Kickoff` or push a new commit after clarifying the linked plan.
 
 #### Recovering from stale PR plan-review comments
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository uses a named five-role planning and implementation review team:
 - **Casey Doyle** (`Code Quality`) protects maintainability, testability, and operational clarity
 - **Morgan Reed** (`Architecture`) guards system boundaries, sequencing, and coupling
 
-Every new issue goes straight to Product validation. Once Product marks an issue `triage:product-fit`, someone with repository write access can comment `/doit` to start the five-role planning discussion. Pull requests that include `Plan issue: #<number>` in the body are then reviewed by the same team against the approved plan.
+Every new issue goes straight to Product validation. Once Product marks an issue `triage:product-fit`, someone with repository write access can comment `/doit` — either on its own or inside a longer maintainer note — to start the five-role planning discussion. Any surrounding text is carried into the kickoff comment as planning context. Pull requests that include `Plan issue: #<number>` in the body are then reviewed by the same team against the approved plan.
 
 See [`Docs/agentic-workflows.md`](Docs/agentic-workflows.md) for the workflow setup and [`Docs/team-personalities.md`](Docs/team-personalities.md) for the persona map, memory model, and interaction diagrams.
 


### PR DESCRIPTION
## Summary
- accept `/doit` when it appears anywhere in an authorised maintainer comment instead of only at the start
- carry any surrounding maintainer text into the planning kickoff comment as explicit planning context
- update the planning/product-validation prompts and maintainer docs to describe the new behaviour

## Why
The same parser hardening applied in `career-framework` should stay in parity here so maintainers can add scope guidance in the same comment that starts planning.

## Validation
- updated the command parser in `.github/workflows/issue-planning-command.yml`
- ran `gh aw compile`
- restored the known `issue-product-validation.lock.yml` activation fix after compile
- normalised the known PR plan-review lock boolean guards after compile
- ran parser sanity checks for bare `/doit`, prefixed comments, and inline comments
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `/doit` planning command now works when embedded within longer maintainer comments; surrounding text is automatically captured as planning context for the workflow.

* **Documentation**
  * Updated guides to reflect that `/doit` can be issued standalone or as part of a larger maintainer note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->