### PR TITLE
fix(mac): prevent Data.subdata crash from non-zero startIndex

### DIFF
--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -1260,7 +1260,7 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
           offset += Self.preferredChunkBytes
         }
         if offset > 0 {
-          pendingPCMData.removeFirst(offset)
+          pendingPCMData = Data(pendingPCMData.dropFirst(offset))
         }
 
         guard !pendingPCMData.isEmpty else { return }
@@ -1363,7 +1363,7 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
         offset += Self.preferredChunkBytes
       }
       if offset > 0 {
-        pendingPCMData.removeFirst(offset)
+        pendingPCMData = Data(pendingPCMData.dropFirst(offset))
       }
     }
   }
@@ -1878,7 +1878,7 @@ private extension ModulateLiveController {
           offset += Self.preferredChunkBytes
         }
         if offset > 0 {
-          pendingPCMData.removeFirst(offset)
+          pendingPCMData = Data(pendingPCMData.dropFirst(offset))
         }
 
         guard !pendingPCMData.isEmpty else { return }
@@ -1985,7 +1985,7 @@ private extension ModulateLiveController {
         offset += Self.preferredChunkBytes
       }
       if offset > 0 {
-        pendingPCMData.removeFirst(offset)
+        pendingPCMData = Data(pendingPCMData.dropFirst(offset))
       }
     }
   }


### PR DESCRIPTION
## Problem

`Data.removeFirst(_:)` shifts `startIndex` instead of reindexing to zero. On the next audio tap callback, the chunking loop calls `subdata(in: 0..<3200)` — but `startIndex` is now 3200, so the range is out of bounds → `EXC_BREAKPOINT (SIGTRAP)` in `Data._Representation.subscript.getter`.

Confirmed with a standalone Swift repro:
```swift
var data = Data(repeating: 0xAA, count: 10000)
data.removeFirst(3200)
// startIndex is now 3200, not 0
data.subdata(in: 0..<3200) // 💥 Trace/BPT trap
```

## Fix

Replace all four `pendingPCMData.removeFirst(offset)` calls with `Data(pendingPCMData.dropFirst(offset))`, which always produces a zero-based `Data`.

Affects both Modulate and AssemblyAI live streaming audio processors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live audio buffering and chunk handling in transcription so streamed audio is processed and dispatched more reliably, reducing dropped or corrupted audio and improving transcription stability during live sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->