### PR TITLE
fix(agentic-workflows): disable failure issue creation on all workflows

### DIFF
--- a/.github/workflows/ci-doctor.lock.yml
+++ b/.github/workflows/ci-doctor.lock.yml
@@ -27,7 +27,7 @@
 #
 # Source: githubnext/agentics/workflows/ci-doctor.md@4957663821dbb3260348084fa2f1659701950fef
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f48dcdb82fdd650a728cb069003b219e72c4772233fd0a202eb4a0c609bee9af","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6c1c392a3d05cbd8d687b613170088ad4b5a6fa4a6cf41983c77f2ab31f297ad","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "CI Failure Doctor"
 "on":
@@ -1014,7 +1014,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "10"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-doctor.md
+++ b/.github/workflows/ci-doctor.md
@@ -21,6 +21,7 @@ permissions: read-all
 network: defaults
 
 safe-outputs:
+  report-failure-as-issue: false
   create-issue:
     title-prefix: "${{ github.workflow }}"
     labels: [automation, ci]

--- a/.github/workflows/daily-doc-updater.lock.yml
+++ b/.github/workflows/daily-doc-updater.lock.yml
@@ -24,7 +24,7 @@
 #
 # Source: githubnext/agentics/workflows/daily-doc-updater.md@4957663821dbb3260348084fa2f1659701950fef
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"15713f53b491ed6d5a08f26afaecec00d97644ee07096f4b00cdc02fdfa5c6ae","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"505306b18d6c45632a76b32d9066ecf581ce340cd13c336a1fbaebbf15ba7fef","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Daily Documentation Updater"
 "on":
@@ -933,7 +933,7 @@ jobs:
           GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "30"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily-doc-updater.md
+++ b/.github/workflows/daily-doc-updater.md
@@ -28,6 +28,7 @@ tools:
 timeout-minutes: 30
 
 safe-outputs:
+  report-failure-as-issue: false
   create-pull-request:
     expires: 2d
     title-prefix: "[docs] "

--- a/.github/workflows/daily-perf-improver.lock.yml
+++ b/.github/workflows/daily-perf-improver.lock.yml
@@ -32,7 +32,7 @@
 #
 # Source: githubnext/agentics/workflows/daily-perf-improver.md@4957663821dbb3260348084fa2f1659701950fef
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0c6d3679d1187e27b4706cb76e3effa9463d70e0c94a7c22cdae28499954d86b","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"379afa9edbca3249c5005c7330b56f5ff5ef49b0b24df50a63108d3163943d74","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Daily Perf Improver"
 "on":
@@ -1208,7 +1208,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "60"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily-perf-improver.md
+++ b/.github/workflows/daily-perf-improver.md
@@ -31,6 +31,7 @@ network:
   - java
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 10
     target: "*"

--- a/.github/workflows/daily-repo-status.lock.yml
+++ b/.github/workflows/daily-repo-status.lock.yml
@@ -27,7 +27,7 @@
 #
 # Source: githubnext/agentics/workflows/daily-repo-status.md@4957663821dbb3260348084fa2f1659701950fef
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9d2e952c804d757c5086b6bc77d9ac4acf0a3fa91cdd29de9ade498e861143f7","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fec0e69da093f57668a2ac3db557bcd3c825b98bce81349b4a143afdb52dba53","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Daily Repo Status"
 "on":
@@ -914,7 +914,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "20"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily-repo-status.md
+++ b/.github/workflows/daily-repo-status.md
@@ -26,6 +26,7 @@ tools:
     repos: all
 
 safe-outputs:
+  report-failure-as-issue: false
   mentions: false
   allowed-github-references: []
   create-issue:

--- a/.github/workflows/daily-test-improver.lock.yml
+++ b/.github/workflows/daily-test-improver.lock.yml
@@ -32,7 +32,7 @@
 #
 # Source: githubnext/agentics/workflows/daily-test-improver.md@4957663821dbb3260348084fa2f1659701950fef
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"932b3332147520439f0de3e1921ceae6a962898cc7ed0c3472bd4cd8488ff1e5","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e149fbb94df861a21ed05f18aa7dbf15ba95b9f5fc7e3f617b87922a73a2f4a6","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Daily Test Improver"
 "on":
@@ -1208,7 +1208,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "30"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily-test-improver.md
+++ b/.github/workflows/daily-test-improver.md
@@ -31,6 +31,7 @@ network:
   - java
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 10
     target: "*"

--- a/.github/workflows/improvement-coordinator.lock.yml
+++ b/.github/workflows/improvement-coordinator.lock.yml
@@ -22,7 +22,7 @@
 #
 # Check for open improvement PRs before daily agents run to prevent duplicates
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"54c45e1f13ddd864657ecf08604e043b0743e1ca1e6f3bf81e5ee99894f4fee2","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0d3fc717ad6b455d7fc1096f0e1477cdd524c38358f7a87b3c730fb67aeec3c5","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Improvement Coordinator"
 "on":
@@ -940,7 +940,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "10"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/improvement-coordinator.md
+++ b/.github/workflows/improvement-coordinator.md
@@ -20,6 +20,7 @@ tools:
       key: improvement-coordinator-${{ github.workflow }}
 
 safe-outputs:
+  report-failure-as-issue: false
   create-issue:
     max: 1
     labels: [automation, coordination]

--- a/.github/workflows/issue-planning-architecture.lock.yml
+++ b/.github/workflows/issue-planning-architecture.lock.yml
@@ -22,7 +22,7 @@
 #
 # Architecture reviewer for issue planning discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d2eb38c9d68840ca66c24c97ded1aee2d6ee49448ce8d97bde46edf078b7bb45","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c064628707167684eb20b0a8092279f99c786204ffdca0ce73094141dacb43a5","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Architecture"
 "on":
@@ -1021,7 +1021,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-architecture.md
+++ b/.github/workflows/issue-planning-architecture.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-design.lock.yml
+++ b/.github/workflows/issue-planning-design.lock.yml
@@ -22,7 +22,7 @@
 #
 # Design reviewer for issue planning discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2dcf6f65b65c3dc685fca413c43da1d19e37f28e9269cd55f60e2b4550cd4759","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"386870dd15a6546176e56edc4d5b35f703400d91bdefc7803ed71e864a369b07","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Design"
 "on":
@@ -1021,7 +1021,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-design.md
+++ b/.github/workflows/issue-planning-design.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-em.lock.yml
+++ b/.github/workflows/issue-planning-em.lock.yml
@@ -22,7 +22,7 @@
 #
 # Engineering Manager facilitator for issue planning discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"82b6f4d286b212f0c646d670bd5ed7a0f48bba2d7d2c5f1bf70bd2eac9f4e53a","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c7cdf8dcbce993371c8541bfb8b95a4df7a7b4274d6edbe25bb90b9e575aebcf","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Engineering Manager"
 "on":
@@ -977,7 +977,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-em.md
+++ b/.github/workflows/issue-planning-em.md
@@ -38,6 +38,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-kickoff.lock.yml
+++ b/.github/workflows/issue-planning-kickoff.lock.yml
@@ -22,7 +22,7 @@
 #
 # Seed the planning labels and explain the issue-planning flow after an explicit /doit request
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"11b9c563fe9336325a1422a9859957d472926cf8629b5ed89892ebafa74ea47a","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1940f74647706504129fda1c59d1c09d20fba15fb767bb52756478dedf8de44d","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Kickoff"
 "on":
@@ -953,7 +953,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "10"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-kickoff.md
+++ b/.github/workflows/issue-planning-kickoff.md
@@ -21,6 +21,7 @@ tools:
     toolsets: [issues, labels]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-performance.lock.yml
+++ b/.github/workflows/issue-planning-performance.lock.yml
@@ -22,7 +22,7 @@
 #
 # Performance reviewer for issue planning discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a49d3ea9ba79a4f124120f063dead887040c13cb2fd67dfbf1f3b8f7673ed263","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"87014752e69c1d516b327dc08b9819b2a1c40046f72e9fb3b6e48490cad4ce17","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Performance"
 "on":
@@ -1021,7 +1021,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-performance.md
+++ b/.github/workflows/issue-planning-performance.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-product.lock.yml
+++ b/.github/workflows/issue-planning-product.lock.yml
@@ -22,7 +22,7 @@
 #
 # Product reviewer for issue planning discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8f660ba9f2198b2b3321a16d28f19ff851a7a6db0dacd791865dec4bf9e9fc36","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b32b0e9e46f3062e298889ace290e083bcff9abe267f0ad278854579d19a8230","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Product"
 "on":
@@ -1021,7 +1021,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-product.md
+++ b/.github/workflows/issue-planning-product.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-quality.lock.yml
+++ b/.github/workflows/issue-planning-quality.lock.yml
@@ -22,7 +22,7 @@
 #
 # Code Quality reviewer for issue planning discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9185d455b21454033848decafcabcd12ad413c5dafb84cd0515ae5ae54c85c57","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"78625d10bd2946bde8568d48734c5f923f87609a66ef5adf75bc5677afa937bf","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Code Quality"
 "on":
@@ -1021,7 +1021,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-quality.md
+++ b/.github/workflows/issue-planning-quality.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-ready-check.lock.yml
+++ b/.github/workflows/issue-planning-ready-check.lock.yml
@@ -22,7 +22,7 @@
 #
 # Manually audit ready-for-development state for a specific issue
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"27bccdd943308b949c7d8b1da3dcb1a9f703c4479b56793d0f5b481e4307fd69","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3e03a9a9ecad3e2495687b7363f6d06155db50792a17e6974fd6b2f832571dc0","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Ready Check"
 "on":
@@ -944,7 +944,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "10"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-ready-check.md
+++ b/.github/workflows/issue-planning-ready-check.md
@@ -20,6 +20,7 @@ tools:
     toolsets: [issues, labels]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-reliability.lock.yml
+++ b/.github/workflows/issue-planning-reliability.lock.yml
@@ -22,7 +22,7 @@
 #
 # Reliability reviewer for issue planning discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f09527f2d0b187362f03f903a346e5dc9e7eee1d2d684febff0f1a7e19939892","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9352807e75fd20fe2bd7306e17befff053fd0908dea7df0ae1fddcec260ecb3c","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Reliability"
 "on":
@@ -1021,7 +1021,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-reliability.md
+++ b/.github/workflows/issue-planning-reliability.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-security.lock.yml
+++ b/.github/workflows/issue-planning-security.lock.yml
@@ -22,7 +22,7 @@
 #
 # Security reviewer for issue planning discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c1972c06d02e8f59888a9935e680ec3d1b707f412993f6bd810156298f386fbe","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2f1e0d8a28bab453eb162e3e5ba1021a0b43fea8be8dffe95952ff0ebd2eaaec","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Security"
 "on":
@@ -1021,7 +1021,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-security.md
+++ b/.github/workflows/issue-planning-security.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-planning-synthesis.lock.yml
+++ b/.github/workflows/issue-planning-synthesis.lock.yml
@@ -22,7 +22,7 @@
 #
 # Summarise multi-role planning discussion and post a unified team view
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7726071d927de2280d60e48ed8b77949f43b73f782a47ab96d492d014cc17f2d","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ef332f41c17c60203844258552830115a68ac6cbb6e1d931eec4150bdb753bfc","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Planning - Synthesis"
 "on":
@@ -944,7 +944,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "10"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-planning-synthesis.md
+++ b/.github/workflows/issue-planning-synthesis.md
@@ -33,6 +33,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/issue-product-validation.lock.yml
+++ b/.github/workflows/issue-product-validation.lock.yml
@@ -22,7 +22,7 @@
 #
 # Assess whether an issue fits this repository before the full planning team starts
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4a6eea0a7f116eabf80009a52e990e8c3b73a408874d686ef1c9e64459c59d7a","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4e2886d9b263c0213b8c0fdd4448f6fbe238ca67ca244a32b5952b0f99bdf90b","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Issue Product Validation"
 "on":
@@ -1021,7 +1021,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-product-validation.md
+++ b/.github/workflows/issue-product-validation.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/memory-curator.lock.yml
+++ b/.github/workflows/memory-curator.lock.yml
@@ -22,7 +22,7 @@
 #
 # Curate and evolve planning role memories by graduating patterns and pruning stale entries
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0281b4c8c5618db37db031cc85886ff1f3e923fcd0ccfbc0bc15620d04149b6e","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7369f16a5563d9ddb9c89ecdfcb11cff241bf612831c6c78077cb645ce3add80","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Memory Curator"
 "on":
@@ -940,7 +940,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "20"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/memory-curator.md
+++ b/.github/workflows/memory-curator.md
@@ -26,6 +26,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment: {}
 
 timeout-minutes: 20

--- a/.github/workflows/pr-plan-review-architecture.lock.yml
+++ b/.github/workflows/pr-plan-review-architecture.lock.yml
@@ -22,7 +22,7 @@
 #
 # Architecture reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e3e459238afb88e0b05c2f88e6acdc55043f49ce3effadf481e03a7570b9401a","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f1e877b6ac19ab8d8b07e64639763f62d754bc7cd96170cf1f8348b5ccc78e4b","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Architecture"
 "on":
@@ -1030,7 +1030,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-plan-review-architecture.md
+++ b/.github/workflows/pr-plan-review-architecture.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/pr-plan-review-design.lock.yml
+++ b/.github/workflows/pr-plan-review-design.lock.yml
@@ -22,7 +22,7 @@
 #
 # Design reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"319794a89884348adf99c9aaa3af1f1e84671dd2d3351a742beaba9e47281276","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cc174c34bc45f56055f2680ff832a248796fff59278581a6296c933f0072c66d","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Design"
 "on":
@@ -1030,7 +1030,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-plan-review-design.md
+++ b/.github/workflows/pr-plan-review-design.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/pr-plan-review-kickoff.lock.yml
+++ b/.github/workflows/pr-plan-review-kickoff.lock.yml
@@ -22,7 +22,7 @@
 #
 # Seed PR plan-review labels and explain the implementation review flow
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d074d4465b71485ad451ca14fd7d76551fcb2fe9644c398abe0fe8ca0a98fb22","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d3e31be53c484e511f026547043a74b2c1d25d2c6fef060ab158f887e4b9c3af","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Kickoff"
 "on":
@@ -969,7 +969,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "10"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-plan-review-kickoff.md
+++ b/.github/workflows/pr-plan-review-kickoff.md
@@ -24,6 +24,7 @@ tools:
     toolsets: [default, labels]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/pr-plan-review-performance.lock.yml
+++ b/.github/workflows/pr-plan-review-performance.lock.yml
@@ -22,7 +22,7 @@
 #
 # Performance reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d7dc3ff061fa99727e980c714271a498ac6135715dd610e9f666e2e63030537c","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5bc3a726db3c10e6ddd51b38d3f094164ed2bbd7be99542c02dbc037133db6a4","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Performance"
 "on":
@@ -1030,7 +1030,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-plan-review-performance.md
+++ b/.github/workflows/pr-plan-review-performance.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/pr-plan-review-product.lock.yml
+++ b/.github/workflows/pr-plan-review-product.lock.yml
@@ -22,7 +22,7 @@
 #
 # Product reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"00fe75e0f546ddb6a77613d70163a96a04b7e34825a9d553192da2005df385f6","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2efc8fc3ac26317a36f6a079b8c45641792dc503e7dde80cd9f8be95240bb13f","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Product"
 "on":
@@ -1030,7 +1030,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-plan-review-product.md
+++ b/.github/workflows/pr-plan-review-product.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/pr-plan-review-quality.lock.yml
+++ b/.github/workflows/pr-plan-review-quality.lock.yml
@@ -22,7 +22,7 @@
 #
 # Code Quality reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b69c990a1c766079fbbc335eebb7cc96f7a10c14e7e4169dbd0a219a5694a588","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"06c6fef620365834fb0797f7663b8a55800e4bacd33d1446987a32b201926c59","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Code Quality"
 "on":
@@ -1030,7 +1030,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-plan-review-quality.md
+++ b/.github/workflows/pr-plan-review-quality.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/pr-plan-review-ready-check.lock.yml
+++ b/.github/workflows/pr-plan-review-ready-check.lock.yml
@@ -22,7 +22,7 @@
 #
 # Manually audit ready-to-merge state for a specific pull request
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f51cf9d31a3da9179814f43be3f9547786cea2da1c885c2234c756a5d6e403a6","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"42a7258c2edf21994b227c52196e2366f4fcc931ac1bf1f69fa13e434c3dbc97","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Ready Check"
 "on":
@@ -945,7 +945,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "10"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-plan-review-ready-check.md
+++ b/.github/workflows/pr-plan-review-ready-check.md
@@ -21,6 +21,7 @@ tools:
     toolsets: [default, labels]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/pr-plan-review-security.lock.yml
+++ b/.github/workflows/pr-plan-review-security.lock.yml
@@ -22,7 +22,7 @@
 #
 # Security reviewer for PR plan-review discussions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b9f00d724ec46d86b6b621d21b0ba8eb1d5b27a7c7447bfe19e4abb9e4eeb063","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9a2229cef1a1ec93e890a7f3393b0d356cf2c987939a7b4ec95e789dff8ab11a","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "PR Plan Review - Security"
 "on":
@@ -1030,7 +1030,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-plan-review-security.md
+++ b/.github/workflows/pr-plan-review-security.md
@@ -40,6 +40,7 @@ tools:
     allowed-extensions: [".md", ".json"]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 1
     target: "*"

--- a/.github/workflows/repository-context-refresh.lock.yml
+++ b/.github/workflows/repository-context-refresh.lock.yml
@@ -22,7 +22,7 @@
 #
 # Update each planning role's repository-context.md with current codebase facts
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3d811b99faad5a2122a8901293c76bd12e0b2da729d34c1513c9be1ee429bb25","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4a54b10c79fe3753be10845269285360bc4b802a6154511959537250e0fcec1b","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Repository Context Refresh"
 "on":
@@ -956,7 +956,7 @@ jobs:
           GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
           GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "15"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repository-context-refresh.md
+++ b/.github/workflows/repository-context-refresh.md
@@ -25,7 +25,8 @@ tools:
     max-patch-size: 65536
     allowed-extensions: [".md", ".json"]
 
-safe-outputs: {}
+safe-outputs:
+  report-failure-as-issue: false
 
 timeout-minutes: 15
 engine: copilot

--- a/.github/workflows/repository-quality-improver.lock.yml
+++ b/.github/workflows/repository-quality-improver.lock.yml
@@ -24,7 +24,7 @@
 #
 # Source: githubnext/agentics/workflows/repository-quality-improver.md@4957663821dbb3260348084fa2f1659701950fef
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"83dc9495566842663ece232650bd36d6e684bb3b517a197566d5aff3f2f0595b","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0be5c1eebb85b82d478c07a29b9fe150afaf2f9d900cf56c04dc477aea4fb090","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Repository Quality Improver"
 "on":
@@ -949,7 +949,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "20"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repository-quality-improver.md
+++ b/.github/workflows/repository-quality-improver.md
@@ -20,6 +20,7 @@ tools:
       - default
 
 safe-outputs:
+  report-failure-as-issue: false
   create-issue:
     expires: 2d
     labels: [quality, automated-analysis]

--- a/.github/workflows/stale-issue-cleanup.lock.yml
+++ b/.github/workflows/stale-issue-cleanup.lock.yml
@@ -22,7 +22,7 @@
 #
 # Close stale automation failure issues that are no longer actionable
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a308e74749391ce39f85875de3025ce31c09a8ec31dd4a191b5a544bd527c83e","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f360e9ddb31d78dd2b212ac4e76fe41f6961829e7f607f0567e5265fc9511d46","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Stale Issue Cleanup"
 "on":
@@ -921,7 +921,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "10"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-issue-cleanup.md
+++ b/.github/workflows/stale-issue-cleanup.md
@@ -17,6 +17,7 @@ tools:
     toolsets: [default, issues]
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
     max: 20
     target: "*"

--- a/.github/workflows/verify-basics.lock.yml
+++ b/.github/workflows/verify-basics.lock.yml
@@ -21,7 +21,7 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5070594a0cf7702557b3ce9d76bdbb2b18d06393ede41d3962f7688e8a1e3419","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b66d8420548286bc9aae00f6b02a37ce487e93ceda935eb077a8e6ba4cafe0d1","compiler_version":"v0.62.3","strict":true,"agent_id":"copilot"}
 
 name: "Verify basics"
 "on":
@@ -906,7 +906,7 @@ jobs:
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_TIMEOUT_MINUTES: "20"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-basics.md
+++ b/.github/workflows/verify-basics.md
@@ -23,6 +23,7 @@ tools:
 network: defaults
 
 safe-outputs:
+  report-failure-as-issue: false
   add-comment:
 
 ---


### PR DESCRIPTION
Adds `report-failure-as-issue: false` to all 31 workflow safe-outputs blocks. Stops the flood of `[aw] ... failed` issues. Failures remain visible in Actions tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation workflows to disable automatic issue creation when workflow failures occur. Failures will no longer be automatically reported as GitHub issues across multiple CI/automation workflows in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->