### PR TITLE
fix(ios): add missing SpeakCore import — unblocks TestFlight releases

### DIFF
--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SpeakCore
 import SpeakiOSLib
 import UIKit
 


### PR DESCRIPTION
## Problem

All iOS TestFlight releases have been failing since March 26 with:

```
SpeakiOSApp.swift:93:46: error: cannot find type 'OpenClawClient' in scope
```

## Root Cause

`SpeakiOSApp.swift` references `OpenClawClient.Conversation` (defined in `SpeakCore`) but only imports `SpeakiOSLib`, which does not re-export `SpeakCore`.

## Fix

Add `import SpeakCore` to `SpeakiOSApp.swift`.

## Impact

Unblocks all iOS releases. One-line fix, zero risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal module integration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->