### PR TITLE
fix(mac): disable HUD glass effect on macOS 26

### DIFF
--- a/Sources/SpeakApp/HUDPlatformCompatibility.swift
+++ b/Sources/SpeakApp/HUDPlatformCompatibility.swift
@@ -11,8 +11,7 @@ enum HUDPlatformWorkarounds {
   static func canUseGlassEffect(
     on version: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
   ) -> Bool {
-    guard version.majorVersion >= 26 else { return false }
-    return !shouldUseLegacyRendering(for: version)
+    version.majorVersion >= 27
   }
 
   static var isLegacyRenderingEnabled: Bool {

--- a/Sources/SpeakApp/HUDPlatformCompatibility.swift
+++ b/Sources/SpeakApp/HUDPlatformCompatibility.swift
@@ -18,6 +18,8 @@ enum HUDPlatformWorkarounds {
     shouldUseLegacyRendering()
   }
 
+  static let isGlassEffectEnabled: Bool = canUseGlassEffect()
+
   static var shouldAnimateHUD: Bool {
     !isLegacyRenderingEnabled
   }
@@ -33,6 +35,8 @@ enum HUDPlatformWorkarounds {
   static var isLegacyRenderingEnabled: Bool {
     false
   }
+
+  static let isGlassEffectEnabled: Bool = false
 
   static var shouldAnimateHUD: Bool {
     true

--- a/Sources/SpeakApp/HUDView.swift
+++ b/Sources/SpeakApp/HUDView.swift
@@ -92,7 +92,7 @@ struct HUDOverlay: View {
   private func hudShell<Content: View>(_ view: Content) -> some View {
     let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
     #if compiler(>=6.1) && canImport(SwiftUI, _version: 7.0)
-    if #available(macOS 26.0, *), !shouldUseLegacyRendering {
+    if #available(macOS 26.0, *), HUDPlatformWorkarounds.canUseGlassEffect() {
       view
         .background(phaseTint)
         .glassEffect(.regular.tint(phaseColor.opacity(0.18)).interactive(), in: .rect(cornerRadius: 20))

--- a/Sources/SpeakApp/HUDView.swift
+++ b/Sources/SpeakApp/HUDView.swift
@@ -92,7 +92,7 @@ struct HUDOverlay: View {
   private func hudShell<Content: View>(_ view: Content) -> some View {
     let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
     #if compiler(>=6.1) && canImport(SwiftUI, _version: 7.0)
-    if #available(macOS 26.0, *), HUDPlatformWorkarounds.canUseGlassEffect() {
+    if #available(macOS 26.0, *), HUDPlatformWorkarounds.isGlassEffectEnabled {
       view
         .background(phaseTint)
         .glassEffect(.regular.tint(phaseColor.opacity(0.18)).interactive(), in: .rect(cornerRadius: 20))

--- a/Tests/SpeakAppTests/HUDPlatformWorkaroundsTests.swift
+++ b/Tests/SpeakAppTests/HUDPlatformWorkaroundsTests.swift
@@ -35,7 +35,7 @@ final class HUDPlatformWorkaroundsTests: XCTestCase {
     )
   }
 
-  func testGlassEffectDisabledOnlyForMacOS26Dot0() {
+  func testGlassEffectDisabledForAllMacOS26Builds() {
     XCTAssertFalse(
       HUDPlatformWorkarounds.canUseGlassEffect(
         on: OperatingSystemVersion(majorVersion: 25, minorVersion: 6, patchVersion: 0)
@@ -46,9 +46,19 @@ final class HUDPlatformWorkaroundsTests: XCTestCase {
         on: OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)
       )
     )
-    XCTAssertTrue(
+    XCTAssertFalse(
       HUDPlatformWorkarounds.canUseGlassEffect(
         on: OperatingSystemVersion(majorVersion: 26, minorVersion: 1, patchVersion: 0)
+      )
+    )
+    XCTAssertFalse(
+      HUDPlatformWorkarounds.canUseGlassEffect(
+        on: OperatingSystemVersion(majorVersion: 26, minorVersion: 3, patchVersion: 1)
+      )
+    )
+    XCTAssertTrue(
+      HUDPlatformWorkarounds.canUseGlassEffect(
+        on: OperatingSystemVersion(majorVersion: 27, minorVersion: 0, patchVersion: 0)
       )
     )
   }

--- a/Tests/SpeakAppTests/HUDPlatformWorkaroundsTests.swift
+++ b/Tests/SpeakAppTests/HUDPlatformWorkaroundsTests.swift
@@ -35,7 +35,7 @@ final class HUDPlatformWorkaroundsTests: XCTestCase {
     )
   }
 
-  func testGlassEffectDisabledForAllMacOS26Builds() {
+  func testGlassEffectDisabledForAllMacOS26Builds_OnlyEnablesOnMacOS27OrLater() {
     XCTAssertFalse(
       HUDPlatformWorkarounds.canUseGlassEffect(
         on: OperatingSystemVersion(majorVersion: 25, minorVersion: 6, patchVersion: 0)


### PR DESCRIPTION
## Summary
- disable the HUD glass effect on every macOS 26 build
- keep the heavier legacy HUD fallback scoped to macOS 26.0 only
- update the HUD platform workaround tests to cover the 26.x crash case

## Validation
- make test
- make build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Glass-effect visuals now apply only on macOS 27 and later, improving rendering stability and platform compatibility.
* **New Features**
  * Introduced an explicit runtime flag controlling glass-effect usage to centralize enablement decisions.
* **Tests**
  * Updated unit tests to reflect the new macOS 26/27 glass-effect enablement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->