### PR TITLE
docs(agents): record agentic workflow guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,11 @@ public final class iOSLiveTranscriber: ObservableObject { ... }
 ### PR merge unblock checklist
 - If `gh pr merge` says “required status checks are expected” while checks look green, inspect `mergeStateStatus`; if `BEHIND`, rebase on `origin/main` and force-push with lease.
 - After each push, re-check unresolved review threads (especially CodeRabbit), as new threads can be created on updated diffs and still block merge.
+- If admin merge fails with `All comments must be resolved.`, resolve the remaining review threads before retrying.
+
+### Agentic workflow maintenance
+- When porting agentic workflows from another repository, keep only the generic workflow mechanics; strip source-project names, infra references, docs links, and unrelated workflows.
+- For gh-aw / Copilot workflows, `COPILOT_GITHUB_TOKEN` must be a fine-grained PAT (`github_pat_...`) with `Copilot Requests`. Classic PATs (`ghp_...`) and OAuth tokens (`gho_...`) fail activation.
 
 ## SwiftUI Concurrency Patterns
 


### PR DESCRIPTION
## Summary\n- record the merge-thread unblock note discovered while shipping the agentic workflow PR\n- add repo-specific guardrails for portable agentic workflow ports\n- document the validated fine-grained PAT requirement for gh-aw / Copilot workflows\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated merge process documentation with guidance for handling unresolved review threads in failed admin merges.
* Extended agentic workflow maintenance documentation with rules for porting workflows across repositories.
* Added token compatibility requirements for authenticated workflow automation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->