### PR TITLE
fix(ios): add SpeakCore import to app entrypoint

### DIFF
--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SpeakCore
 import SpeakiOSLib
 import UIKit
 


### PR DESCRIPTION
## Summary
- add the missing `import SpeakCore` to `SpeakiOSApp/SpeakiOSApp.swift`
- make the `OpenClawClient.Conversation` dependency explicit in the app entrypoint
- unblock the iOS release/archive path that failed on `cannot find type 'OpenClawClient' in scope`

## Validation
- `git diff --check`
- `make test`
- `swift build --target SpeakiOSLib`
- local `xcodebuild` validation is blocked by this machine\s Xcode plug-in load failure (`IDESimulatorFoundation` / `xcodebuild -runFirstLaunch`), so CI remains the authoritative iOS build check

Closes #283
Closes #306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minor internal dependency integration to support underlying functionality. This is a low-risk, behind-the-scenes change with no impact on visible behavior, no changes to public interfaces, and no action required from users. Release remains functionally identical for end users; stability and build consistency improvements are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->