### PR TITLE
fix(ci): disable shared SwiftPM cache in flaky jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build iOS Library
-        run: swift build --target SpeakiOSLib
+        run: swift build --disable-dependency-cache --target SpeakiOSLib
 
       - name: Test SpeakCore (iOS Simulator)
         run: |
@@ -81,4 +81,4 @@ jobs:
 
       - name: SwiftLint
         run: |
-          swift package plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json
+          swift package --disable-dependency-cache plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json


### PR DESCRIPTION
## Summary
- disable SwiftPM shared dependency cache for the `Build iOS Library` job
- disable SwiftPM shared dependency cache for the `SwiftLint` job
- avoid the GitHub runner artifact collision that was failing on `already exists in file system`

## Validation
- `git diff --check`
- `swift build --disable-dependency-cache --target SpeakiOSLib`
- `swift package --disable-dependency-cache plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json`

## Evidence
Both PR #321 and PR #322 hit the same failure pattern in CI:
- `error: failed downloading ... already exists in file system`
- affected binary artifacts included Sentry, Sparkle, and SwiftLintBinary