### PR TITLE
ci(workflows): prevent issue comments from triggering PR review

### DIFF
--- a/.github/workflows/pr-plan-review-architecture.lock.yml
+++ b/.github/workflows/pr-plan-review-architecture.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"36a10fc2f211f5cfdc7a1fd3432f8128218d05a12c62d0d881a6e59dada07c55","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"137ce247d5ab7a95db3888def2250a6b9e7bbcb4f7459a4b7b743abf947c67eb","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -88,7 +88,7 @@ jobs:
       needs.pre_activation.outputs.activated == 'true' && ((${{ github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
@@ -205,15 +205,15 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_593bcaef398ce958_EOF'
+          cat << 'GH_AW_PROMPT_a864125fa63cc1d7_EOF'
           <system>
-          GH_AW_PROMPT_593bcaef398ce958_EOF
+          GH_AW_PROMPT_a864125fa63cc1d7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_593bcaef398ce958_EOF'
+          cat << 'GH_AW_PROMPT_a864125fa63cc1d7_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:4), remove_labels(max:4), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -245,15 +245,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_593bcaef398ce958_EOF
+          GH_AW_PROMPT_a864125fa63cc1d7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_593bcaef398ce958_EOF'
+          cat << 'GH_AW_PROMPT_a864125fa63cc1d7_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-plan-review-architecture.md}}
-          GH_AW_PROMPT_593bcaef398ce958_EOF
+          GH_AW_PROMPT_a864125fa63cc1d7_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -450,9 +450,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b3e371007e8cf5be_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2f1a77178599eb46_EOF'
           {"add_comment":{"hide_older_comments":false,"max":1,"target":"*"},"add_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-architecture","plan-review:architecture-approved"],"max":4,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":262144,"max_patch_size":65536}]},"remove_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-architecture","plan-review:architecture-approved"],"max":4,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_b3e371007e8cf5be_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_2f1a77178599eb46_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -672,7 +672,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_ef1928db7d3a3de8_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_0463175c330e1d75_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -713,7 +713,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ef1928db7d3a3de8_EOF
+          GH_AW_MCP_CONFIG_0463175c330e1d75_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1197,7 +1197,7 @@ jobs:
     if: >
       (${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id)
     runs-on: ubuntu-slim

--- a/.github/workflows/pr-plan-review-architecture.md
+++ b/.github/workflows/pr-plan-review-architecture.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, "github-actions[bot]", copilot, dependabot, renovate, "coderabbitai[bot]", "gemini-code-assist[bot]", "augmentcode[bot]", "greptile-apps[bot]"]
 
-if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
+if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
 
 permissions:
   contents: read

--- a/.github/workflows/pr-plan-review-design.lock.yml
+++ b/.github/workflows/pr-plan-review-design.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c639af9f6959dd35110f8cc9ecbc5efcf6a33357a2e15815da4b73a3ae43fa94","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a759ddcb124de2774c6c8e700568155e1e9e062a8b64213d30f2bc235993c8f2","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -88,7 +88,7 @@ jobs:
       needs.pre_activation.outputs.activated == 'true' && ((${{ github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
@@ -205,15 +205,15 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_f9cd6db839787b7c_EOF'
+          cat << 'GH_AW_PROMPT_ca2ff9116eb2db0a_EOF'
           <system>
-          GH_AW_PROMPT_f9cd6db839787b7c_EOF
+          GH_AW_PROMPT_ca2ff9116eb2db0a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f9cd6db839787b7c_EOF'
+          cat << 'GH_AW_PROMPT_ca2ff9116eb2db0a_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:4), remove_labels(max:4), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -245,15 +245,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_f9cd6db839787b7c_EOF
+          GH_AW_PROMPT_ca2ff9116eb2db0a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_f9cd6db839787b7c_EOF'
+          cat << 'GH_AW_PROMPT_ca2ff9116eb2db0a_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-plan-review-design.md}}
-          GH_AW_PROMPT_f9cd6db839787b7c_EOF
+          GH_AW_PROMPT_ca2ff9116eb2db0a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -450,9 +450,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1c0f59a35e3adf9c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_044fc19d6f50094b_EOF'
           {"add_comment":{"hide_older_comments":false,"max":1,"target":"*"},"add_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-design","plan-review:design-approved"],"max":4,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":262144,"max_patch_size":65536}]},"remove_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-design","plan-review:design-approved"],"max":4,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_1c0f59a35e3adf9c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_044fc19d6f50094b_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -672,7 +672,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_f228e51244704d2e_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_b29114cb26398cdc_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -713,7 +713,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f228e51244704d2e_EOF
+          GH_AW_MCP_CONFIG_b29114cb26398cdc_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1197,7 +1197,7 @@ jobs:
     if: >
       (${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id)
     runs-on: ubuntu-slim

--- a/.github/workflows/pr-plan-review-design.md
+++ b/.github/workflows/pr-plan-review-design.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, "github-actions[bot]", copilot, dependabot, renovate, "coderabbitai[bot]", "gemini-code-assist[bot]", "augmentcode[bot]", "greptile-apps[bot]"]
 
-if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
+if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
 
 permissions:
   contents: read

--- a/.github/workflows/pr-plan-review-performance.lock.yml
+++ b/.github/workflows/pr-plan-review-performance.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f490a9f0607bfaa805849cbe0c6bba4083f2efbf5888954c87fccd12d308c084","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c1a885291b4df8f62f5f48784bb99bbf186f8e857cd48bf6f6f1906e4861e5ca","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -88,7 +88,7 @@ jobs:
       needs.pre_activation.outputs.activated == 'true' && ((${{ github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
@@ -205,15 +205,15 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_895ef75e28f396c6_EOF'
+          cat << 'GH_AW_PROMPT_d57348b2797c9a17_EOF'
           <system>
-          GH_AW_PROMPT_895ef75e28f396c6_EOF
+          GH_AW_PROMPT_d57348b2797c9a17_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_895ef75e28f396c6_EOF'
+          cat << 'GH_AW_PROMPT_d57348b2797c9a17_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:4), remove_labels(max:4), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -245,15 +245,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_895ef75e28f396c6_EOF
+          GH_AW_PROMPT_d57348b2797c9a17_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_895ef75e28f396c6_EOF'
+          cat << 'GH_AW_PROMPT_d57348b2797c9a17_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-plan-review-performance.md}}
-          GH_AW_PROMPT_895ef75e28f396c6_EOF
+          GH_AW_PROMPT_d57348b2797c9a17_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -450,9 +450,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_984744fde074672c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8eb76b0421f1bf18_EOF'
           {"add_comment":{"hide_older_comments":false,"max":1,"target":"*"},"add_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-performance","plan-review:performance-approved"],"max":4,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":262144,"max_patch_size":65536}]},"remove_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-performance","plan-review:performance-approved"],"max":4,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_984744fde074672c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8eb76b0421f1bf18_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -672,7 +672,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_0e40433f95a733d2_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_25c7c61f77d294ba_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -713,7 +713,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0e40433f95a733d2_EOF
+          GH_AW_MCP_CONFIG_25c7c61f77d294ba_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1197,7 +1197,7 @@ jobs:
     if: >
       (${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id)
     runs-on: ubuntu-slim

--- a/.github/workflows/pr-plan-review-performance.md
+++ b/.github/workflows/pr-plan-review-performance.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, "github-actions[bot]", copilot, dependabot, renovate, "coderabbitai[bot]", "gemini-code-assist[bot]", "augmentcode[bot]", "greptile-apps[bot]"]
 
-if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
+if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
 
 permissions:
   contents: read

--- a/.github/workflows/pr-plan-review-product.lock.yml
+++ b/.github/workflows/pr-plan-review-product.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4ce4e324e31b5ac33512c621c0d18fadde22341883d44ba2ebc9d1abbe09188b","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"50f0cd55e2d8728a0c7952a2f87e5dde35d6ecd175c04988aaacfaa9c35f4c51","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -88,7 +88,7 @@ jobs:
       needs.pre_activation.outputs.activated == 'true' && ((${{ github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
@@ -205,15 +205,15 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_985e3d4c4323b603_EOF'
+          cat << 'GH_AW_PROMPT_5e7924d0514bea20_EOF'
           <system>
-          GH_AW_PROMPT_985e3d4c4323b603_EOF
+          GH_AW_PROMPT_5e7924d0514bea20_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_985e3d4c4323b603_EOF'
+          cat << 'GH_AW_PROMPT_5e7924d0514bea20_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:4), remove_labels(max:4), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -245,15 +245,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_985e3d4c4323b603_EOF
+          GH_AW_PROMPT_5e7924d0514bea20_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_985e3d4c4323b603_EOF'
+          cat << 'GH_AW_PROMPT_5e7924d0514bea20_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-plan-review-product.md}}
-          GH_AW_PROMPT_985e3d4c4323b603_EOF
+          GH_AW_PROMPT_5e7924d0514bea20_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -450,9 +450,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_db7c0edb539dabb5_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_53b5b50cfa2115ab_EOF'
           {"add_comment":{"hide_older_comments":false,"max":1,"target":"*"},"add_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-product","plan-review:product-approved"],"max":4,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":262144,"max_patch_size":65536}]},"remove_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-product","plan-review:product-approved"],"max":4,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_db7c0edb539dabb5_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_53b5b50cfa2115ab_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -672,7 +672,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_cd7977ce0b90340d_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_45b1682866343f2c_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -713,7 +713,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_cd7977ce0b90340d_EOF
+          GH_AW_MCP_CONFIG_45b1682866343f2c_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1197,7 +1197,7 @@ jobs:
     if: >
       (${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id)
     runs-on: ubuntu-slim

--- a/.github/workflows/pr-plan-review-product.md
+++ b/.github/workflows/pr-plan-review-product.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, "github-actions[bot]", copilot, dependabot, renovate, "coderabbitai[bot]", "gemini-code-assist[bot]", "augmentcode[bot]", "greptile-apps[bot]"]
 
-if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
+if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
 
 permissions:
   contents: read

--- a/.github/workflows/pr-plan-review-quality.lock.yml
+++ b/.github/workflows/pr-plan-review-quality.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"68c9ac76563fde82bf2ac9fe03ef447f193e07fcf15055b4b321e420f99fa5b2","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9847d6abe64db42b5465799ef2ad3efb4560aa80a0f9aaa39ab489315c83783a","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -88,7 +88,7 @@ jobs:
       needs.pre_activation.outputs.activated == 'true' && ((${{ github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
@@ -205,15 +205,15 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_1c1d81021b0aa158_EOF'
+          cat << 'GH_AW_PROMPT_2898c10e7a13f35f_EOF'
           <system>
-          GH_AW_PROMPT_1c1d81021b0aa158_EOF
+          GH_AW_PROMPT_2898c10e7a13f35f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1c1d81021b0aa158_EOF'
+          cat << 'GH_AW_PROMPT_2898c10e7a13f35f_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:4), remove_labels(max:4), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -245,15 +245,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_1c1d81021b0aa158_EOF
+          GH_AW_PROMPT_2898c10e7a13f35f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_1c1d81021b0aa158_EOF'
+          cat << 'GH_AW_PROMPT_2898c10e7a13f35f_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-plan-review-quality.md}}
-          GH_AW_PROMPT_1c1d81021b0aa158_EOF
+          GH_AW_PROMPT_2898c10e7a13f35f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -450,9 +450,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_96fd7f343aab89f0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_15207ecb74e81b4b_EOF'
           {"add_comment":{"hide_older_comments":false,"max":1,"target":"*"},"add_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-quality","plan-review:quality-approved"],"max":4,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":262144,"max_patch_size":65536}]},"remove_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-quality","plan-review:quality-approved"],"max":4,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_96fd7f343aab89f0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_15207ecb74e81b4b_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -672,7 +672,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_3098d4491af2e0e0_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_effeba957f49bf02_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -713,7 +713,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3098d4491af2e0e0_EOF
+          GH_AW_MCP_CONFIG_effeba957f49bf02_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1197,7 +1197,7 @@ jobs:
     if: >
       (${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id)
     runs-on: ubuntu-slim

--- a/.github/workflows/pr-plan-review-quality.md
+++ b/.github/workflows/pr-plan-review-quality.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, "github-actions[bot]", copilot, dependabot, renovate, "coderabbitai[bot]", "gemini-code-assist[bot]", "augmentcode[bot]", "greptile-apps[bot]"]
 
-if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
+if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
 
 permissions:
   contents: read

--- a/.github/workflows/pr-plan-review-security.lock.yml
+++ b/.github/workflows/pr-plan-review-security.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5830d5b44deb019a1ad7a3776eb82bd5d5eb8986d3b5427f775602207e9ef2b5","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ae28413655fd0d34cea730f2160ea2727a71c92db3212617fa06f31465acda9c","compiler_version":"v0.68.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -88,7 +88,7 @@ jobs:
       needs.pre_activation.outputs.activated == 'true' && ((${{ github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
@@ -205,15 +205,15 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_d3a580a6d7f0f29d_EOF'
+          cat << 'GH_AW_PROMPT_a7e70bb1171c902b_EOF'
           <system>
-          GH_AW_PROMPT_d3a580a6d7f0f29d_EOF
+          GH_AW_PROMPT_a7e70bb1171c902b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d3a580a6d7f0f29d_EOF'
+          cat << 'GH_AW_PROMPT_a7e70bb1171c902b_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:4), remove_labels(max:4), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -245,15 +245,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_d3a580a6d7f0f29d_EOF
+          GH_AW_PROMPT_a7e70bb1171c902b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_d3a580a6d7f0f29d_EOF'
+          cat << 'GH_AW_PROMPT_a7e70bb1171c902b_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-plan-review-security.md}}
-          GH_AW_PROMPT_d3a580a6d7f0f29d_EOF
+          GH_AW_PROMPT_a7e70bb1171c902b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -450,9 +450,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_58079b0d0948de7e_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b21689f3beceab7a_EOF'
           {"add_comment":{"hide_older_comments":false,"max":1,"target":"*"},"add_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-security","plan-review:security-approved"],"max":4,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":262144,"max_patch_size":65536}]},"remove_labels":{"allowed":["plan-review:in-discussion","plan-review:ready-to-merge","plan-review:needs-security","plan-review:security-approved"],"max":4,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_58079b0d0948de7e_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_b21689f3beceab7a_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -672,7 +672,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_86e88170cf764ecf_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_2d13c86a6bcda3bc_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -713,7 +713,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_86e88170cf764ecf_EOF
+          GH_AW_MCP_CONFIG_2d13c86a6bcda3bc_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1197,7 +1197,7 @@ jobs:
     if: >
       (${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
+      contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') &&
       contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}) && (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.id == github.repository_id)
     runs-on: ubuntu-slim

--- a/.github/workflows/pr-plan-review-security.md
+++ b/.github/workflows/pr-plan-review-security.md
@@ -14,7 +14,7 @@ on:
         type: string
   skip-bots: [github-actions, "github-actions[bot]", copilot, dependabot, renovate, "coderabbitai[bot]", "gemini-code-assist[bot]", "augmentcode[bot]", "greptile-apps[bot]"]
 
-if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
+if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.pull_request.labels.*.name, ','), 'plan-review:')) || (github.event_name == 'issue_comment' && contains(github.event.issue.html_url, '/pull/') && github.event.issue.state == 'open' && !contains(join(github.event.issue.labels.*.name, ','), 'agentic-workflows') && contains(join(github.event.issue.labels.*.name, ','), 'plan-review:')) }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- stop PR plan-review workflows from treating plain issue comments as PR comments
- use the issue HTML URL shape (`/pull/`) as the PR-only guard instead of the loose `issue.pull_request != null` check
- regenerate the compiled lock workflows so the runtime matches the source definitions

## Why
Plain issue comments on ElevenLabs planning issues were incorrectly triggering PR plan-review workflows and adding stray `plan-review:*` labels/comments to issues.

## Validation
- `gh aw compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pull request detection in issue comment triggers across all PR Plan Review workflows (Architecture, Design, Performance, Product, Quality, and Security) for more reliable workflow activation on comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->