### PR TITLE
ci(release): preserve notarytool submit output

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -212,14 +212,26 @@ jobs:
           ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/$PRODUCT_NAME.zip"
           
           # Submit for notarization (don't wait, use polling to avoid timeout)
+          set +e
           SUBMIT_OUTPUT=$(xcrun notarytool submit "$RUNNER_TEMP/$PRODUCT_NAME.zip" \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_ID_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" 2>&1)
-          
+          SUBMIT_EXIT_CODE=$?
+          set -e
+
           echo "$SUBMIT_OUTPUT"
-          
+
+          if [ $SUBMIT_EXIT_CODE -ne 0 ]; then
+            echo "Initial notarization submission failed"
+            exit $SUBMIT_EXIT_CODE
+          fi
+
           SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | grep -E "^\s*id:" | head -1 | awk '{print $2}')
+          if [ -z "$SUBMISSION_ID" ]; then
+            echo "Failed to parse notarization submission ID"
+            exit 1
+          fi
           echo "Submission ID: $SUBMISSION_ID"
           
           # Poll for completion with retries


### PR DESCRIPTION
## Summary
- preserve notarytool submit output when notarisation submission fails
- fail explicitly if no submission id is parsed

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-mac.yml")'\n- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the macOS release workflow. The notarization submission process now includes stricter validation and faster failure detection, immediately stopping the workflow with clear error messages if submission fails or critical data parsing is incomplete.

* **Chores**
  * Improved reliability of the release process through tighter control flow in the notarization step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->