### PR TITLE
[Perf Improver] perf(mac): incrementally append AssemblyAI live turns

### DIFF
--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -1205,7 +1205,11 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
         finalSegments.append(segment)
         finalSegmentIndexByTurnOrder[turn.turn_order] = finalSegments.count - 1
         // Appended a new turn — incremental update
-        fullTranscript = fullTranscript.isEmpty ? turn.transcript : fullTranscript + " " + turn.transcript
+        if fullTranscript.isEmpty {
+          fullTranscript = turn.transcript
+        } else {
+          fullTranscript.append(contentsOf: " \(turn.transcript)")
+        }
       }
       currentInterim = ""
       currentTurnOrder = -1

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -1199,12 +1199,14 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
         finalSegments.indices.contains(existingIndex)
       {
         finalSegments[existingIndex] = segment
+        // Replaced an existing turn — must rebuild from scratch
+        fullTranscript = finalSegments.map(\.text).joined(separator: " ")
       } else {
         finalSegments.append(segment)
         finalSegmentIndexByTurnOrder[turn.turn_order] = finalSegments.count - 1
+        // Appended a new turn — incremental update
+        fullTranscript = fullTranscript.isEmpty ? turn.transcript : fullTranscript + " " + turn.transcript
       }
-
-      fullTranscript = finalSegments.map(\.text).joined(separator: " ")
       currentInterim = ""
       currentTurnOrder = -1
       delegate?.liveTranscriber(self, didUpdatePartial: fullTranscript)


### PR DESCRIPTION
## Summary
- incrementally append new AssemblyAI final turns instead of rebuilding the full transcript on every append
- keep the full rebuild path only when an existing turn is replaced
- finish the remaining half of #311 now that the Deepgram optimisation is already on main

Closes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription accuracy during conversation turn transitions by ensuring transcripts are properly synchronized when final segments are received.
  * Enhanced transcript consistency and optimized update performance during multi-turn conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->