### PR TITLE
test(ios): add SpeakiOSLib package coverage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,10 @@ let package = Package(
         .testTarget(
             name: "SpeakAppTests",
             dependencies: ["SpeakApp"]
+        ),
+        .testTarget(
+            name: "SpeakiOSTests",
+            dependencies: ["SpeakiOSLib"]
         )
     ]
 )

--- a/Sources/SpeakiOS/Services/OpenClawConnectionTester.swift
+++ b/Sources/SpeakiOS/Services/OpenClawConnectionTester.swift
@@ -1,4 +1,3 @@
-#if os(iOS)
 import Foundation
 import SpeakCore
 
@@ -16,9 +15,7 @@ enum OpenClawConnectionTester {
     }
 
     static func test(rawURL: String, token: String) async -> Result {
-        let normalisedURL = OpenClawClient.normaliseGatewayURL(rawURL)
-
-        guard let url = URL(string: normalisedURL) else {
+        guard let url = normalisedURL(from: rawURL) else {
             return .failure("Invalid URL")
         }
 
@@ -34,6 +31,11 @@ enum OpenClawConnectionTester {
 
             waitForChallenge(task: task, token: token, start: start, cont: cont)
         }
+    }
+
+    static func normalisedURL(from rawURL: String) -> URL? {
+        let normalisedURL = OpenClawClient.normaliseGatewayURL(rawURL)
+        return URL(string: normalisedURL)
     }
 
     /// Wait for the `connect.challenge` event from the gateway.
@@ -141,7 +143,7 @@ enum OpenClawConnectionTester {
     }
 
     /// Evaluate whether the connect response indicates success.
-    private static func evaluateConnectResponse(_ json: [String: Any], elapsed: Int) -> Result {
+    static func evaluateConnectResponse(_ json: [String: Any], elapsed: Int) -> Result {
         if let err = json["error"] as? [String: Any],
            let msg = err["message"] as? String {
             return .failure(msg)
@@ -175,4 +177,3 @@ enum OpenClawConnectionTester {
         cont.resume(returning: state)
     }
 }
-#endif

--- a/Sources/SpeakiOS/Services/VoiceSummariser.swift
+++ b/Sources/SpeakiOS/Services/VoiceSummariser.swift
@@ -1,4 +1,3 @@
-#if os(iOS)
 import Foundation
 import SpeakCore
 
@@ -7,7 +6,7 @@ import SpeakCore
 /// TTS-optimised system prompt that strips markdown, shortens responses,
 /// and preserves key information.
 @MainActor
-public final class VoiceSummariser: ObservableObject {
+public final class VoiceSummariser {
     private let session: URLSession
 
     public init(session: URLSession = .shared) {
@@ -104,4 +103,3 @@ public enum VoiceSummariserError: LocalizedError {
         }
     }
 }
-#endif

--- a/Tests/SpeakiOSTests/OpenClawConnectionTesterTests.swift
+++ b/Tests/SpeakiOSTests/OpenClawConnectionTesterTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import SpeakiOSLib
+
+final class OpenClawConnectionTesterTests: XCTestCase {
+    func testNormalisedURL_addsWebSocketSchemeForBareHost() {
+        let url = OpenClawConnectionTester.normalisedURL(from: "gateway.example.com:18789")
+
+        XCTAssertEqual(url?.absoluteString, "ws://gateway.example.com:18789")
+    }
+
+    func testNormalisedURL_rewritesHTTPSchemeToSecureWebSocket() {
+        let url = OpenClawConnectionTester.normalisedURL(from: "https://gateway.example.com/socket")
+
+        XCTAssertEqual(url?.absoluteString, "wss://gateway.example.com/socket")
+    }
+
+    func testEvaluateConnectResponse_returnsFailureMessageFromGatewayError() {
+        let result = OpenClawConnectionTester.evaluateConnectResponse(
+            ["error": ["message": "bad token"]],
+            elapsed: 25
+        )
+
+        XCTAssertEqual(result, .failure("bad token"))
+    }
+
+    func testEvaluateConnectResponse_returnsSuccessWithElapsedTime() {
+        let result = OpenClawConnectionTester.evaluateConnectResponse(["ok": true], elapsed: 42)
+
+        XCTAssertEqual(result, .success("Connected (42ms)"))
+    }
+
+    func testEvaluateConnectResponse_returnsUnexpectedResponseWhenGatewayPayloadIsUnknown() {
+        let result = OpenClawConnectionTester.evaluateConnectResponse(["event": "connect.challenge"], elapsed: 12)
+
+        XCTAssertEqual(result, .failure("Unexpected response"))
+    }
+}

--- a/Tests/SpeakiOSTests/VoiceSummariserTests.swift
+++ b/Tests/SpeakiOSTests/VoiceSummariserTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import XCTest
+
+@testable import SpeakiOSLib
+
+private final class VoiceSummariserMockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("VoiceSummariserMockURLProtocol.requestHandler was not set")
+            return
+        }
+
+        Task {
+            do {
+                let (response, data) = try await handler(request)
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func voiceSummariserRequestBody(from request: URLRequest) -> Data? {
+    if let body = request.httpBody {
+        return body
+    }
+
+    guard let stream = request.httpBodyStream else {
+        return nil
+    }
+
+    stream.open()
+    defer { stream.close() }
+
+    var data = Data()
+    let bufferSize = 1024
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+
+    while stream.hasBytesAvailable {
+        let readCount = stream.read(buffer, maxLength: bufferSize)
+        guard readCount > 0 else {
+            break
+        }
+        data.append(buffer, count: readCount)
+    }
+
+    return data.isEmpty ? nil : data
+}
+
+@MainActor
+final class VoiceSummariserTests: XCTestCase {
+    private let markdownInput = """
+    ## Summary
+
+    - First point
+    - Second point
+    """
+
+    override func tearDown() {
+        VoiceSummariserMockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testSummarise_returnsShortPlainTextWithoutCallingAPI() async throws {
+        let summariser = VoiceSummariser(session: makeSession())
+        let result = try await summariser.summarise("Short plain answer.", apiKey: "test-key")
+
+        XCTAssertEqual(result, "Short plain answer.")
+    }
+
+    func testSummarise_sendsExpectedRequestAndTrimsResponse() async throws {
+        VoiceSummariserMockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.absoluteString, "https://openrouter.ai/api/v1/chat/completions")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-key")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Title"), "Just Speak to It iOS")
+
+            let body = try XCTUnwrap(voiceSummariserRequestBody(from: request))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(json["model"] as? String, "openai/gpt-4o-mini")
+            XCTAssertEqual(json["max_tokens"] as? Int, 300)
+
+            let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+            XCTAssertEqual(messages.count, 2)
+            XCTAssertEqual(messages.first?["role"] as? String, "system")
+            XCTAssertEqual(messages.last?["role"] as? String, "user")
+            XCTAssertEqual(messages.last?["content"] as? String, self.markdownInput)
+
+            let data = Data(
+                """
+            {
+              "choices": [
+                {
+                  "message": {
+                    "content": "  Spoken answer with markdown removed.  "
+                  }
+                }
+              ]
+            }
+            """.utf8
+            )
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, data)
+        }
+
+        let summariser = VoiceSummariser(session: makeSession())
+        let result = try await summariser.summarise(markdownInput, apiKey: "test-key")
+
+        XCTAssertEqual(result, "Spoken answer with markdown removed.")
+    }
+
+    func testSummarise_throwsAPIErrorForNonSuccessResponse() async {
+        VoiceSummariserMockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 429,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("rate limited".utf8))
+        }
+
+        let summariser = VoiceSummariser(session: makeSession())
+
+        do {
+            _ = try await summariser.summarise(markdownInput, apiKey: "test-key")
+            XCTFail("Expected apiError")
+        } catch let error as VoiceSummariserError {
+            XCTAssertEqual(error.errorDescription, "Summarisation error (429): rate limited")
+        } catch {
+            XCTFail("Expected VoiceSummariserError, got \(error)")
+        }
+    }
+
+    func testSummarise_throwsInvalidResponseForMalformedPayload() async {
+        VoiceSummariserMockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("{\"choices\":[]}".utf8))
+        }
+
+        let summariser = VoiceSummariser(session: makeSession())
+
+        do {
+            _ = try await summariser.summarise(markdownInput, apiKey: "test-key")
+            XCTFail("Expected invalidResponse")
+        } catch let error as VoiceSummariserError {
+            switch error {
+            case .invalidResponse:
+                break
+            case .apiError:
+                XCTFail("Expected invalidResponse, got apiError")
+            }
+        } catch {
+            XCTFail("Expected VoiceSummariserError, got \(error)")
+        }
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [VoiceSummariserMockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}

--- a/Tests/SpeakiOSTests/VoiceSummariserTests.swift
+++ b/Tests/SpeakiOSTests/VoiceSummariserTests.swift
@@ -4,7 +4,22 @@ import XCTest
 @testable import SpeakiOSLib
 
 private final class VoiceSummariserMockURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+    private static let handlerQueue = DispatchQueue(label: "VoiceSummariserMockURLProtocol.handler")
+    private static var requestHandler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+
+    static func setRequestHandler(
+        _ handler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+    ) {
+        handlerQueue.sync {
+            requestHandler = handler
+        }
+    }
+
+    static func currentRequestHandler() -> (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))? {
+        handlerQueue.sync {
+            requestHandler
+        }
+    }
 
     override static func canInit(with request: URLRequest) -> Bool {
         true
@@ -15,7 +30,7 @@ private final class VoiceSummariserMockURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        guard let handler = Self.requestHandler else {
+        guard let handler = Self.currentRequestHandler() else {
             XCTFail("VoiceSummariserMockURLProtocol.requestHandler was not set")
             return
         }
@@ -73,7 +88,7 @@ final class VoiceSummariserTests: XCTestCase {
     """
 
     override func tearDown() {
-        VoiceSummariserMockURLProtocol.requestHandler = nil
+        VoiceSummariserMockURLProtocol.setRequestHandler(nil)
         super.tearDown()
     }
 
@@ -85,7 +100,8 @@ final class VoiceSummariserTests: XCTestCase {
     }
 
     func testSummarise_sendsExpectedRequestAndTrimsResponse() async throws {
-        VoiceSummariserMockURLProtocol.requestHandler = { request in
+        let expectedUserContent = markdownInput
+        VoiceSummariserMockURLProtocol.setRequestHandler { request in
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.url?.absoluteString, "https://openrouter.ai/api/v1/chat/completions")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-key")
@@ -101,7 +117,7 @@ final class VoiceSummariserTests: XCTestCase {
             XCTAssertEqual(messages.count, 2)
             XCTAssertEqual(messages.first?["role"] as? String, "system")
             XCTAssertEqual(messages.last?["role"] as? String, "user")
-            XCTAssertEqual(messages.last?["content"] as? String, self.markdownInput)
+            XCTAssertEqual(messages.last?["content"] as? String, expectedUserContent)
 
             let data = Data(
                 """
@@ -132,7 +148,7 @@ final class VoiceSummariserTests: XCTestCase {
     }
 
     func testSummarise_throwsAPIErrorForNonSuccessResponse() async {
-        VoiceSummariserMockURLProtocol.requestHandler = { request in
+        VoiceSummariserMockURLProtocol.setRequestHandler { request in
             let response = HTTPURLResponse(
                 url: try XCTUnwrap(request.url),
                 statusCode: 429,
@@ -155,7 +171,7 @@ final class VoiceSummariserTests: XCTestCase {
     }
 
     func testSummarise_throwsInvalidResponseForMalformedPayload() async {
-        VoiceSummariserMockURLProtocol.requestHandler = { request in
+        VoiceSummariserMockURLProtocol.setRequestHandler { request in
             let response = HTTPURLResponse(
                 url: try XCTUnwrap(request.url),
                 statusCode: 200,


### PR DESCRIPTION
## Summary
- add a SpeakiOSTests package target
- compile VoiceSummariser and OpenClawConnectionTester in the package test runner
- cover the new target with request/response and connection-mapping tests

Closes #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for connection testing and voice summarization functionality, including URL normalization, response evaluation, and API request/response validation.

* **Refactor**
  * Enabled cross-platform support for OpenClawConnectionTester and VoiceSummariser services (previously iOS-only). Simplified VoiceSummariser class structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->