### PR TITLE
fix(mac): send OpenRouter reprocess audio as chat input

### DIFF
--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -643,7 +643,7 @@ final class MainManager: ObservableObject {
         if let payload = result.rawPayload {
           session.networkExchanges.append(
             HistoryNetworkExchange(
-              url: URL(string: "https://openrouter.ai/api/v1/responses")!,
+              url: URL(string: "https://openrouter.ai/api/v1/chat/completions")!,
               method: "POST",
               requestHeaders: [
                 "Model": result.modelIdentifier,
@@ -1043,7 +1043,7 @@ final class MainManager: ObservableObject {
       if let payload = result.rawPayload {
         session.networkExchanges.append(
           HistoryNetworkExchange(
-            url: URL(string: "https://openrouter.ai/api/v1/responses")!,
+            url: URL(string: "https://openrouter.ai/api/v1/chat/completions")!,
             method: "POST",
             requestHeaders: [
               "Model": result.modelIdentifier,

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -1271,6 +1271,8 @@ final class MainManager: ObservableObject {
           return "OpenRouter rejected \(displayName) (status \(code)): \(detail)"
         }
         return "OpenRouter responded with status \(code) while using \(displayName)."
+      case .audioFileTooLarge:
+        return routerError.localizedDescription
       }
     }
 

--- a/Sources/SpeakApp/OpenRouterAPIClient.swift
+++ b/Sources/SpeakApp/OpenRouterAPIClient.swift
@@ -25,8 +25,8 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient { //
   private let session: URLSession
   private let secureStorage: SecureAppStorage
   private let apiKeyOverride: String?
+  private let apiKeyIdentifier: String
   private let logger = Logger(subsystem: "com.github.speakapp", category: "OpenRouter")
-  private let apiKeyIdentifier = "openrouter.apiKey"
   private let titleHeaderValue = "SpeakApp (macOS)"
   private let refererHeaderValue = "https://github.com/speak"
 
@@ -44,18 +44,17 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient { //
   init(
     secureStorage: SecureAppStorage,
     session: URLSession = .shared,
-    apiKeyOverride: String? = nil
+    apiKeyOverride: String? = nil,
+    apiKeyIdentifier: String = "openrouter.apiKey"
   ) {
     self.secureStorage = secureStorage
     self.session = session
     self.apiKeyOverride = apiKeyOverride
+    self.apiKeyIdentifier = apiKeyIdentifier
   }
 
   func hasStoredAPIKey() async -> Bool {
-    if await storedAPIKey() != nil {
-      return true
-    }
-    return await secureStorage.hasSecret(identifier: apiKeyIdentifier)
+    await storedAPIKey() != nil
   }
 
   func requiresRemoteAccess(for model: String) -> Bool {
@@ -171,12 +170,14 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient { //
   private func storedAPIKey() async -> String? {
     if let apiKeyOverride {
       let trimmed = apiKeyOverride.trimmingCharacters(in: .whitespacesAndNewlines)
-      return trimmed.isEmpty ? nil : trimmed
+      if !trimmed.isEmpty {
+        return trimmed
+      }
     }
 
     let rawKey = try? await secureStorage.secret(identifier: apiKeyIdentifier)
     let key = rawKey?.trimmingCharacters(in: .whitespacesAndNewlines)
-    return key?.isEmpty == false ? key : nil
+    return key.flatMap { $0.isEmpty ? nil : $0 }
   }
 
   func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
@@ -662,9 +663,10 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient { //
   }
 
   private func audioInputFormat(for url: URL) -> String {
-    switch url.pathExtension.lowercased() {
+    let ext = url.pathExtension.lowercased()
+    switch ext {
     case "wav", "mp3", "aiff", "aac", "ogg", "flac", "m4a", "pcm16", "pcm24":
-      return url.pathExtension.lowercased()
+      return ext
     case "m4b":
       return "m4a"
     case "wave":

--- a/Sources/SpeakApp/OpenRouterAPIClient.swift
+++ b/Sources/SpeakApp/OpenRouterAPIClient.swift
@@ -20,10 +20,11 @@ enum OpenRouterClientError: LocalizedError {
   }
 }
 
-actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
+actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient { // swiftlint:disable:this type_body_length
   private let baseURL = URL(string: "https://openrouter.ai/api/v1")!
   private let session: URLSession
   private let secureStorage: SecureAppStorage
+  private let apiKeyOverride: String?
   private let logger = Logger(subsystem: "com.github.speakapp", category: "OpenRouter")
   private let apiKeyIdentifier = "openrouter.apiKey"
   private let titleHeaderValue = "SpeakApp (macOS)"
@@ -40,13 +41,21 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
     let message: String
   }
 
-  init(secureStorage: SecureAppStorage, session: URLSession = .shared) {
+  init(
+    secureStorage: SecureAppStorage,
+    session: URLSession = .shared,
+    apiKeyOverride: String? = nil
+  ) {
     self.secureStorage = secureStorage
     self.session = session
+    self.apiKeyOverride = apiKeyOverride
   }
 
   func hasStoredAPIKey() async -> Bool {
-    await secureStorage.hasSecret(identifier: apiKeyIdentifier)
+    if await storedAPIKey() != nil {
+      return true
+    }
+    return await secureStorage.hasSecret(identifier: apiKeyIdentifier)
   }
 
   func requiresRemoteAccess(for model: String) -> Bool {
@@ -59,7 +68,7 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
     model: String,
     temperature: Double
   ) async throws -> ChatResponse {
-    if let key = try? await secureStorage.secret(identifier: apiKeyIdentifier), !key.isEmpty {
+    if let key = await storedAPIKey() {
       return try await performRemoteChat(
         apiKey: key,
         systemPrompt: systemPrompt,
@@ -72,7 +81,7 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
     return performLocalChatFallback(systemPrompt: systemPrompt, messages: messages)
   }
 
-  nonisolated func sendChatStreaming(
+  nonisolated func sendChatStreaming( // swiftlint:disable:this cyclomatic_complexity function_body_length
     systemPrompt: String?,
     messages: [ChatMessage],
     model: String,
@@ -81,13 +90,12 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
     AsyncThrowingStream { continuation in
       Task {
         do {
-          let key = try await self.secureStorage.secret(identifier: self.apiKeyIdentifier)
-          guard !key.isEmpty else {
+          guard let key = await self.storedAPIKey() else {
             continuation.finish(throwing: OpenRouterClientError.apiKeyMissing)
             return
           }
 
-          let url = await self.baseURL.appendingPathComponent("chat/completions")
+          let url = self.baseURL.appendingPathComponent("chat/completions")
           var request = URLRequest(url: url)
           request.httpMethod = "POST"
           request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -147,10 +155,8 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
     -> TranscriptionResult
   {
     let cleanedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
-    let rawKey = try? await secureStorage.secret(identifier: apiKeyIdentifier)
-    let key = rawKey?.trimmingCharacters(in: .whitespacesAndNewlines)
 
-    if let key, !key.isEmpty {
+    if let key = await storedAPIKey() {
       return try await performRemoteTranscription(
         apiKey: key, url: url, model: cleanedModel, language: language)
     }
@@ -160,6 +166,17 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
     }
 
     throw OpenRouterClientError.apiKeyMissing
+  }
+
+  private func storedAPIKey() async -> String? {
+    if let apiKeyOverride {
+      let trimmed = apiKeyOverride.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    }
+
+    let rawKey = try? await secureStorage.secret(identifier: apiKeyIdentifier)
+    let key = rawKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return key?.isEmpty == false ? key : nil
   }
 
   func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
@@ -481,30 +498,33 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
     model: String,
     language: String?
   ) async throws -> TranscriptionResult {
-    let endpoint = baseURL.appendingPathComponent("audio/transcriptions")
+    let endpoint = baseURL.appendingPathComponent("chat/completions")
     var request = URLRequest(url: endpoint)
     request.httpMethod = "POST"
-    let boundary = "Boundary-\(UUID().uuidString)"
-    request.setValue(
-      "multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
     applyBrandHeaders(&request)
 
     let audioData = try Data(contentsOf: url)
-    var body = Data()
-    body.appendFormField(named: "model", value: model, boundary: boundary)
-    if let language {
-      body.appendFormField(named: "language", value: language, boundary: boundary)
-    }
-    body.appendFileField(
-      named: "file",
-      filename: url.lastPathComponent,
-      mimeType: "audio/m4a",
-      fileData: audioData,
-      boundary: boundary
+    let prompt = transcriptionPrompt(language: language)
+    let payload = OpenRouterAudioTranscriptionRequest(
+      model: model,
+      temperature: 0,
+      messages: [
+        OpenRouterAudioTranscriptionRequest.Message(
+          role: "user",
+          content: [
+            .text(prompt),
+            .inputAudio(
+              data: audioData.base64EncodedString(),
+              format: audioInputFormat(for: url)
+            )
+          ]
+        )
+      ],
+      stream: false
     )
-    body.appendString("--\(boundary)--\r\n")
-    request.httpBody = body
+    request.httpBody = try JSONEncoder().encode(payload)
 
     let (data, response) = try await session.data(for: request)
     guard let http = response as? HTTPURLResponse else {
@@ -515,9 +535,17 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
       throw OpenRouterClientError.httpStatus(http.statusCode, body)
     }
 
-    let decoded = try JSONDecoder().decode(OpenRouterTranscriptionResponse.self, from: data)
+    let decoded = try JSONDecoder().decode(OpenRouterChatResponse.self, from: data)
+    guard
+      let text = decoded.choices
+        .compactMap({ $0.message?.content.trimmingCharacters(in: .whitespacesAndNewlines) })
+        .first(where: { !$0.isEmpty })
+    else {
+      throw OpenRouterClientError.invalidResponse
+    }
+
     return try await buildTranscriptionResult(
-      response: decoded,
+      text: text,
       audioURL: url,
       model: model,
       payload: data
@@ -623,8 +651,31 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
     return normalized
   }
 
+  private func transcriptionPrompt(language: String?) -> String {
+    let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    if trimmedLanguage.isEmpty {
+      return "Transcribe this audio file. Return only the transcript text, with no commentary."
+    }
+
+    return "Transcribe this audio file using locale \(trimmedLanguage). "
+      + "Return only the transcript text, with no commentary."
+  }
+
+  private func audioInputFormat(for url: URL) -> String {
+    switch url.pathExtension.lowercased() {
+    case "wav", "mp3", "aiff", "aac", "ogg", "flac", "m4a", "pcm16", "pcm24":
+      return url.pathExtension.lowercased()
+    case "m4b":
+      return "m4a"
+    case "wave":
+      return "wav"
+    default:
+      return "m4a"
+    }
+  }
+
   private func buildTranscriptionResult(
-    response: OpenRouterTranscriptionResponse,
+    text: String,
     audioURL: URL,
     model: String,
     payload: Data
@@ -632,19 +683,12 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient {
     let asset = AVURLAsset(url: audioURL)
     let durationTime = try await asset.load(.duration)
     let duration = durationTime.seconds
-    let segments =
-      response.segments?.map { segment in
-        TranscriptionSegment(
-          startTime: segment.start,
-          endTime: segment.end,
-          text: segment.text
-        )
-      } ?? [TranscriptionSegment(startTime: 0, endTime: duration, text: response.text)]
+    let segments = [TranscriptionSegment(startTime: 0, endTime: duration, text: text)]
 
     return TranscriptionResult(
-      text: response.text,
+      text: text,
       segments: segments,
-      confidence: response.confidence,
+      confidence: nil,
       duration: duration,
       modelIdentifier: model,
       cost: nil,
@@ -723,18 +767,6 @@ private struct OpenRouterChatResponse: Decodable {
   let usage: Usage?
 }
 
-private struct OpenRouterTranscriptionResponse: Decodable {
-  struct Segment: Decodable {
-    let start: TimeInterval
-    let end: TimeInterval
-    let text: String
-  }
-
-  let text: String
-  let segments: [Segment]?
-  let confidence: Double?
-}
-
 private struct OpenRouterValidationResponse: Decodable {
   struct ValidationData: Decodable {
     let valid: Bool?
@@ -756,6 +788,47 @@ private struct OpenRouterStreamingChatRequest: Encodable {
   let stream: Bool
 }
 
+private struct OpenRouterAudioTranscriptionRequest: Encodable {
+  struct Message: Encodable {
+    let role: String
+    let content: [OpenRouterAudioContentPart]
+  }
+
+  let model: String
+  let temperature: Double
+  let messages: [Message]
+  let stream: Bool
+}
+
+private enum OpenRouterAudioContentPart: Encodable {
+  case text(String)
+  case inputAudio(data: String, format: String)
+
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case text
+    case inputAudio = "input_audio"
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case .text(let text):
+      try container.encode("text", forKey: .type)
+      try container.encode(text, forKey: .text)
+    case .inputAudio(let data, let format):
+      try container.encode("input_audio", forKey: .type)
+      let inputAudio = OpenRouterInputAudio(data: data, format: format)
+      try container.encode(inputAudio, forKey: .inputAudio)
+    }
+  }
+}
+
+private struct OpenRouterInputAudio: Encodable {
+  let data: String
+  let format: String
+}
+
 private struct OpenRouterStreamChunk: Decodable {
   struct Choice: Decodable {
     struct Delta: Decodable {
@@ -768,4 +841,4 @@ private struct OpenRouterStreamChunk: Decodable {
   let choices: [Choice]
 }
 
-// @Implement: This class is responsible for interacting with the OpenRouter API and implements the LLMProtocols to do so. It takes the api key from SecureAppStorage
+// swiftlint:disable:this file_length

--- a/Sources/SpeakApp/OpenRouterAPIClient.swift
+++ b/Sources/SpeakApp/OpenRouterAPIClient.swift
@@ -7,6 +7,7 @@ enum OpenRouterClientError: LocalizedError {
   case apiKeyMissing
   case invalidResponse
   case httpStatus(Int, String)
+  case audioFileTooLarge(fileSize: Int64, limit: Int64)
 
   var errorDescription: String? {
     switch self {
@@ -16,6 +17,10 @@ enum OpenRouterClientError: LocalizedError {
       return "The server returned an invalid response."
     case .httpStatus(let code, let body):
       return "OpenRouter responded with status \(code): \(body)"
+    case .audioFileTooLarge(let fileSize, let limit):
+      let fileSizeDescription = ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file)
+      let limitDescription = ByteCountFormatter.string(fromByteCount: limit, countStyle: .file)
+      return "Audio file is too large for OpenRouter reprocessing (\(fileSizeDescription), limit \(limitDescription))."
     }
   }
 }
@@ -26,6 +31,7 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient { //
   private let secureStorage: SecureAppStorage
   private let apiKeyOverride: String?
   private let apiKeyIdentifier: String
+  private let maximumInlineAudioBytes: Int64
   private let logger = Logger(subsystem: "com.github.speakapp", category: "OpenRouter")
   private let titleHeaderValue = "SpeakApp (macOS)"
   private let refererHeaderValue = "https://github.com/speak"
@@ -45,12 +51,14 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient { //
     secureStorage: SecureAppStorage,
     session: URLSession = .shared,
     apiKeyOverride: String? = nil,
-    apiKeyIdentifier: String = "openrouter.apiKey"
+    apiKeyIdentifier: String = "openrouter.apiKey",
+    maximumInlineAudioBytes: Int64 = 50 * 1024 * 1024
   ) {
     self.secureStorage = secureStorage
     self.session = session
     self.apiKeyOverride = apiKeyOverride
     self.apiKeyIdentifier = apiKeyIdentifier
+    self.maximumInlineAudioBytes = maximumInlineAudioBytes
   }
 
   func hasStoredAPIKey() async -> Bool {
@@ -506,6 +514,7 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient { //
     request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
     applyBrandHeaders(&request)
 
+    try enforceInlineAudioSizeLimit(for: url)
     let audioData = try Data(contentsOf: url)
     let prompt = transcriptionPrompt(language: language)
     let payload = OpenRouterAudioTranscriptionRequest(
@@ -674,6 +683,25 @@ actor OpenRouterAPIClient: StreamingChatLLMClient, BatchTranscriptionClient { //
     default:
       return "m4a"
     }
+  }
+
+  private func enforceInlineAudioSizeLimit(for url: URL) throws {
+    let fileSize = try audioFileSize(for: url)
+    guard fileSize <= maximumInlineAudioBytes else {
+      throw OpenRouterClientError.audioFileTooLarge(
+        fileSize: fileSize,
+        limit: maximumInlineAudioBytes
+      )
+    }
+  }
+
+  private func audioFileSize(for url: URL) throws -> Int64 {
+    if let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+      return Int64(fileSize)
+    }
+
+    let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+    return (attributes[.size] as? NSNumber)?.int64Value ?? 0
   }
 
   private func buildTranscriptionResult(

--- a/Sources/SpeakApp/TranscriptionProviderRegistry.swift
+++ b/Sources/SpeakApp/TranscriptionProviderRegistry.swift
@@ -28,9 +28,14 @@ actor TranscriptionProviderRegistry {
 
     func provider(forModel model: String) -> (any TranscriptionProvider)? {
         // Extract provider ID from model string (e.g., "openai/whisper-1" -> "openai")
-        let components = model.split(separator: "/")
+        let trimmedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        let components = trimmedModel.split(separator: "/")
         guard let providerID = components.first else { return nil }
-        return providers[String(providerID)]
+        guard let provider = providers[String(providerID)] else { return nil }
+
+        let supportedIDs = provider.supportedModels().map(\.id)
+        guard supportedIDs.contains(trimmedModel) else { return nil }
+        return provider
     }
 
     func allSupportedModels() -> [ModelCatalog.Option] {

--- a/Tests/SpeakAppTests/OpenRouterAPIClientTests.swift
+++ b/Tests/SpeakAppTests/OpenRouterAPIClientTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+
+@MainActor
+final class OpenRouterAPIClientTests: XCTestCase {
+  func testTranscribeFileUsesChatCompletionsJSONAudioInput() async throws {
+    let requestObserver = OpenRouterRequestObserver()
+    OpenRouterMockURLProtocol.requestHandler = { request in
+      await requestObserver.store(request: request)
+      let response = HTTPURLResponse(
+        url: try XCTUnwrap(request.url),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+      let json = """
+      {
+        "choices": [
+          {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {
+              "role": "assistant",
+              "content": "hello world"
+            }
+          }
+        ]
+      }
+      """
+      return (response, Data(json.utf8))
+    }
+    defer {
+      OpenRouterMockURLProtocol.requestHandler = nil
+    }
+
+    let client = OpenRouterAPIClient(
+      secureStorage: makeSecureStorage(),
+      session: makeMockSession(),
+      apiKeyOverride: "test-openrouter-key"
+    )
+    let audioURL = try makeAudioFile(extension: "m4a", data: Data("fakeaudiodata".utf8))
+    defer {
+      try? FileManager.default.removeItem(at: audioURL)
+    }
+
+    _ = try? await client.transcribeFile(
+      at: audioURL,
+      model: "google/gemini-2.0-flash-001",
+      language: "en_GB"
+    )
+
+    let capturedRequest = await requestObserver.capturedRequest()
+    let capturedBody = await requestObserver.capturedBody()
+    let request = try XCTUnwrap(capturedRequest)
+    let body = try XCTUnwrap(capturedBody)
+
+    try assertRequestMetadata(request, body: body)
+    try assertAudioInputPayload(body)
+  }
+
+  func testProviderRegistryDoesNotClaimOpenRouterOpenAIModel() async {
+    let provider = await TranscriptionProviderRegistry.shared.provider(
+      forModel: "openai/gpt-4o-audio-preview-2024-12-17"
+    )
+
+    XCTAssertNil(provider)
+  }
+
+  func testProviderRegistryStillClaimsDedicatedOpenAIWhisperModel() async {
+    let provider = await TranscriptionProviderRegistry.shared.provider(forModel: "openai/whisper-1")
+
+    XCTAssertEqual(provider?.metadata.id, "openai")
+  }
+
+  private func assertRequestMetadata(_ request: URLRequest, body: Data) throws {
+    let bodyString = String(data: body, encoding: .utf8) ?? ""
+
+    XCTAssertEqual(request.url?.absoluteString, "https://openrouter.ai/api/v1/chat/completions")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-openrouter-key")
+    XCTAssertFalse(bodyString.hasPrefix("--Boundary-"))
+  }
+
+  private func assertAudioInputPayload(_ body: Data) throws {
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    XCTAssertEqual(json["model"] as? String, "google/gemini-2.0-flash-001")
+    XCTAssertEqual(json["stream"] as? Bool, false)
+
+    let messages = try XCTUnwrap(json["messages"] as? [[String: Any]])
+    let firstMessage = try XCTUnwrap(messages.first)
+    XCTAssertEqual(firstMessage["role"] as? String, "user")
+
+    let content = try XCTUnwrap(firstMessage["content"] as? [[String: Any]])
+    XCTAssertEqual(content.count, 2)
+    XCTAssertEqual(content.first?["type"] as? String, "text")
+    XCTAssertTrue((content.first?["text"] as? String)?.contains("en_GB") == true)
+
+    let audioPart = try XCTUnwrap(content.last)
+    XCTAssertEqual(audioPart["type"] as? String, "input_audio")
+    let inputAudio = try XCTUnwrap(audioPart["input_audio"] as? [String: Any])
+    XCTAssertEqual(inputAudio["format"] as? String, "m4a")
+    XCTAssertEqual(inputAudio["data"] as? String, Data("fakeaudiodata".utf8).base64EncodedString())
+  }
+
+  private func makeMockSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [OpenRouterMockURLProtocol.self]
+    return URLSession(configuration: configuration)
+  }
+
+  private func makeSecureStorage() -> SecureAppStorage {
+    let suiteName = "OpenRouterAPIClientTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+    let settings = AppSettings(defaults: defaults)
+    let permissions = PermissionsManager()
+    return SecureAppStorage(permissionsManager: permissions, appSettings: settings)
+  }
+
+  private func makeAudioFile(extension fileExtension: String, data: Data) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("openrouter_audio_\(UUID().uuidString).\(fileExtension)")
+    try data.write(to: url)
+    return url
+  }
+}
+
+private typealias OpenRouterRequestHandler =
+  @Sendable (URLRequest) async throws -> (HTTPURLResponse, Data)
+
+private actor OpenRouterRequestObserver {
+  private var request: URLRequest?
+  private var body: Data?
+
+  func store(request: URLRequest) {
+    self.request = request
+    body = request.httpBody ?? readBody(from: request.httpBodyStream)
+  }
+
+  func capturedRequest() -> URLRequest? {
+    request
+  }
+
+  func capturedBody() -> Data? {
+    body
+  }
+
+  private func readBody(from stream: InputStream?) -> Data? {
+    guard let stream else { return nil }
+    stream.open()
+    defer { stream.close() }
+
+    var data = Data()
+    let bufferSize = 4096
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+
+    while stream.hasBytesAvailable {
+      let readCount = stream.read(buffer, maxLength: bufferSize)
+      if readCount < 0 {
+        return nil
+      }
+      if readCount == 0 {
+        break
+      }
+      data.append(buffer, count: readCount)
+    }
+
+    return data.isEmpty ? nil : data
+  }
+}
+
+private final class OpenRouterMockURLProtocol: URLProtocol {
+  nonisolated(unsafe) static var requestHandler: OpenRouterRequestHandler?
+
+  override static func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    guard let handler = Self.requestHandler else {
+      XCTFail("OpenRouterMockURLProtocol.requestHandler was not set")
+      return
+    }
+
+    Task {
+      do {
+        let (response, data) = try await handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+      } catch {
+        client?.urlProtocol(self, didFailWithError: error)
+      }
+    }
+  }
+
+  override func stopLoading() {}
+}

--- a/Tests/SpeakAppTests/OpenRouterAPIClientTests.swift
+++ b/Tests/SpeakAppTests/OpenRouterAPIClientTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 @MainActor
 final class OpenRouterAPIClientTests: XCTestCase {
-  func testTranscribeFileUsesChatCompletionsJSONAudioInput() async throws {
+  func testTranscribeFileWithAudioInput_UsesChatCompletionsJSONPayload() async throws {
     let requestObserver = OpenRouterRequestObserver()
     OpenRouterMockURLProtocol.requestHandler = { request in
       await requestObserver.store(request: request)
@@ -40,7 +40,7 @@ final class OpenRouterAPIClientTests: XCTestCase {
     try assertAudioInputPayload(body)
   }
 
-  func testBlankAPIKeyOverrideFallsBackToStoredKey() async throws {
+  func testBlankAPIKeyOverride_UsesStoredKey() async throws {
     let secureStorage = makeSecureStorage()
     let apiKeyIdentifier = "openrouter.apiKey.\(UUID().uuidString)"
     try await secureStorage.storeSecret("stored-openrouter-key", identifier: apiKeyIdentifier)
@@ -76,7 +76,7 @@ final class OpenRouterAPIClientTests: XCTestCase {
     try? await secureStorage.removeSecret(identifier: apiKeyIdentifier)
   }
 
-  func testProviderRegistryDoesNotClaimOpenRouterOpenAIModel() async {
+  func testProviderRegistryWithOpenRouterOpenAIModel_DoesNotClaimDedicatedProvider() async {
     let provider = await TranscriptionProviderRegistry.shared.provider(
       forModel: "openai/gpt-4o-audio-preview-2024-12-17"
     )
@@ -84,10 +84,43 @@ final class OpenRouterAPIClientTests: XCTestCase {
     XCTAssertNil(provider)
   }
 
-  func testProviderRegistryStillClaimsDedicatedOpenAIWhisperModel() async {
+  func testProviderRegistryWithDedicatedOpenAIWhisperModel_ReturnsOpenAIProvider() async {
     let provider = await TranscriptionProviderRegistry.shared.provider(forModel: "openai/whisper-1")
 
     XCTAssertEqual(provider?.metadata.id, "openai")
+  }
+
+  func testTranscribeFileWithOversizedAudio_ThrowsBeforeEncodingPayload() async throws {
+    OpenRouterMockURLProtocol.requestHandler = { _ in
+      XCTFail("Oversized audio should be rejected before sending a request")
+      throw OpenRouterClientError.invalidResponse
+    }
+    defer {
+      OpenRouterMockURLProtocol.requestHandler = nil
+    }
+
+    let client = OpenRouterAPIClient(
+      secureStorage: makeSecureStorage(),
+      session: makeMockSession(),
+      apiKeyOverride: "test-openrouter-key",
+      maximumInlineAudioBytes: 4
+    )
+    let audioURL = try makeAudioFile(extension: "m4a", data: Data("fakeaudiodata".utf8))
+    defer {
+      try? FileManager.default.removeItem(at: audioURL)
+    }
+
+    do {
+      _ = try await client.transcribeFile(
+        at: audioURL,
+        model: "google/gemini-2.0-flash-001",
+        language: "en_GB"
+      )
+      XCTFail("Expected oversized audio to be rejected")
+    } catch OpenRouterClientError.audioFileTooLarge(let fileSize, let limit) {
+      XCTAssertEqual(fileSize, 13)
+      XCTAssertEqual(limit, 4)
+    }
   }
 
   private func assertRequestMetadata(_ request: URLRequest, body: Data) throws {

--- a/Tests/SpeakAppTests/OpenRouterAPIClientTests.swift
+++ b/Tests/SpeakAppTests/OpenRouterAPIClientTests.swift
@@ -9,27 +9,7 @@ final class OpenRouterAPIClientTests: XCTestCase {
     let requestObserver = OpenRouterRequestObserver()
     OpenRouterMockURLProtocol.requestHandler = { request in
       await requestObserver.store(request: request)
-      let response = HTTPURLResponse(
-        url: try XCTUnwrap(request.url),
-        statusCode: 200,
-        httpVersion: nil,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      let json = """
-      {
-        "choices": [
-          {
-            "index": 0,
-            "finish_reason": "stop",
-            "message": {
-              "role": "assistant",
-              "content": "hello world"
-            }
-          }
-        ]
-      }
-      """
-      return (response, Data(json.utf8))
+      return try makeOpenRouterResponse(for: request)
     }
     defer {
       OpenRouterMockURLProtocol.requestHandler = nil
@@ -58,6 +38,42 @@ final class OpenRouterAPIClientTests: XCTestCase {
 
     try assertRequestMetadata(request, body: body)
     try assertAudioInputPayload(body)
+  }
+
+  func testBlankAPIKeyOverrideFallsBackToStoredKey() async throws {
+    let secureStorage = makeSecureStorage()
+    let apiKeyIdentifier = "openrouter.apiKey.\(UUID().uuidString)"
+    try await secureStorage.storeSecret("stored-openrouter-key", identifier: apiKeyIdentifier)
+    let requestObserver = OpenRouterRequestObserver()
+    OpenRouterMockURLProtocol.requestHandler = { request in
+      await requestObserver.store(request: request)
+      return try makeOpenRouterResponse(for: request)
+    }
+    defer {
+      OpenRouterMockURLProtocol.requestHandler = nil
+    }
+
+    let client = OpenRouterAPIClient(
+      secureStorage: secureStorage,
+      session: makeMockSession(),
+      apiKeyOverride: "   ",
+      apiKeyIdentifier: apiKeyIdentifier
+    )
+    let audioURL = try makeAudioFile(extension: "m4a", data: Data("fakeaudiodata".utf8))
+    defer {
+      try? FileManager.default.removeItem(at: audioURL)
+    }
+
+    _ = try? await client.transcribeFile(
+      at: audioURL,
+      model: "google/gemini-2.0-flash-001",
+      language: "en_GB"
+    )
+
+    let capturedRequest = await requestObserver.capturedRequest()
+    let request = try XCTUnwrap(capturedRequest)
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer stored-openrouter-key")
+    try? await secureStorage.removeSecret(identifier: apiKeyIdentifier)
   }
 
   func testProviderRegistryDoesNotClaimOpenRouterOpenAIModel() async {
@@ -124,6 +140,30 @@ final class OpenRouterAPIClientTests: XCTestCase {
     try data.write(to: url)
     return url
   }
+}
+
+private func makeOpenRouterResponse(for request: URLRequest) throws -> (HTTPURLResponse, Data) {
+  let response = HTTPURLResponse(
+    url: try XCTUnwrap(request.url),
+    statusCode: 200,
+    httpVersion: nil,
+    headerFields: ["Content-Type": "application/json"]
+  )!
+  let json = """
+  {
+    "choices": [
+      {
+        "index": 0,
+        "finish_reason": "stop",
+        "message": {
+          "role": "assistant",
+          "content": "hello world"
+        }
+      }
+    ]
+  }
+  """
+  return (response, Data(json.utf8))
 }
 
 private typealias OpenRouterRequestHandler =


### PR DESCRIPTION
## Summary\n- Send OpenRouter batch reprocess audio through chat/completions JSON input_audio instead of multipart audio/transcriptions\n- Keep OpenRouter multimodal models from being claimed by dedicated provider prefix routing\n- Add regression coverage for the OpenRouter request shape and model routing\n\n## Verification\n- make test\n- swift package plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key override option for flexible authentication.

* **Improvements**
  * Transcription now sends inline audio and uses a locale-aware prompt for better results.
  * Provider lookup trimmed/validated to avoid routing unsupported models.

* **Bug Fixes**
  * Clearer "audio too large" error surfaced earlier when files exceed the inline limit.
  * Transcriptions consolidated to a single full-duration result for consistency.

* **Tests**
  * Added end-to-end tests covering requests, payloads, model selection, and size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->