### PR TITLE
fix(mac): keep audio input active during live stop

### DIFF
--- a/Sources/SpeakApp/AudioInputDeviceManager.swift
+++ b/Sources/SpeakApp/AudioInputDeviceManager.swift
@@ -129,41 +129,41 @@ final class AudioInputDeviceManager: ObservableObject {
   }
 
   func beginUsingPreferredInput() async -> SessionContext {
-    if self.sessionTracker.hasActiveSession {
-      self.logger.debug("Joining active preferred input device session")
-      return self.sessionTracker.beginSession(previousDeviceID: nil, didChangeDevice: false)
+    if sessionTracker.hasActiveSession {
+      logger.debug("Joining active preferred input device session")
+      return sessionTracker.beginSession(previousDeviceID: nil, didChangeDevice: false)
     }
 
-    let preferredUID = self.selectedDeviceUID ?? self.appSettings.preferredAudioInputUID
+    let preferredUID = selectedDeviceUID ?? appSettings.preferredAudioInputUID
     guard
       let uid = preferredUID,
-      let targetDeviceID = self.deviceID(forUID: uid),
-      let currentDefaultID = self.currentDefaultInputDeviceID(),
+      let targetDeviceID = deviceID(forUID: uid),
+      let currentDefaultID = currentDefaultInputDeviceID(),
       targetDeviceID != currentDefaultID
     else {
-      return self.sessionTracker.beginSession(previousDeviceID: nil, didChangeDevice: false)
+      return sessionTracker.beginSession(previousDeviceID: nil, didChangeDevice: false)
     }
 
-    if self.setDefaultInputDevice(to: targetDeviceID) {
-      self.refreshDevices()
-      self.logger.debug("Activated preferred input device with UID \(uid, privacy: .public)")
-      return self.sessionTracker.beginSession(previousDeviceID: currentDefaultID, didChangeDevice: true)
+    if setDefaultInputDevice(to: targetDeviceID) {
+      refreshDevices()
+      logger.debug("Activated preferred input device with UID \(uid, privacy: .public)")
+      return sessionTracker.beginSession(previousDeviceID: currentDefaultID, didChangeDevice: true)
     }
 
-    self.logger.error("Failed to activate preferred input \(uid, privacy: .public); continuing with system default")
-    return self.sessionTracker.beginSession(previousDeviceID: nil, didChangeDevice: false)
+    logger.error("Failed to activate preferred input \(uid, privacy: .public); continuing with system default")
+    return sessionTracker.beginSession(previousDeviceID: nil, didChangeDevice: false)
   }
 
   func endUsingPreferredInput(session: SessionContext) async {
-    guard let previous = self.sessionTracker.endSession(session) else {
+    guard let previous = sessionTracker.endSession(session) else {
       return
     }
 
-    if self.setDefaultInputDevice(to: previous) {
-      self.refreshDevices()
-      self.logger.debug("Restored previous input device after session")
+    if setDefaultInputDevice(to: previous) {
+      refreshDevices()
+      logger.debug("Restored previous input device after session")
     } else {
-      self.logger.error("Failed to restore previous input device after session")
+      logger.error("Failed to restore previous input device after session")
     }
   }
 

--- a/Sources/SpeakApp/AudioInputDeviceManager.swift
+++ b/Sources/SpeakApp/AudioInputDeviceManager.swift
@@ -2,8 +2,6 @@ import AVFoundation
 import CoreAudio
 import os.log
 
-// swiftlint:disable file_length
-
 @MainActor
 // swiftlint:disable:next type_body_length
 final class AudioInputDeviceManager: ObservableObject {
@@ -445,4 +443,4 @@ final class AudioInputDeviceManager: ObservableObject {
     let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &value)
     return status == noErr ? value : nil
   }
-}
+} // swiftlint:disable:this file_length

--- a/Sources/SpeakApp/AudioInputDeviceManager.swift
+++ b/Sources/SpeakApp/AudioInputDeviceManager.swift
@@ -2,7 +2,10 @@ import AVFoundation
 import CoreAudio
 import os.log
 
+// swiftlint:disable file_length
+
 @MainActor
+// swiftlint:disable:next type_body_length
 final class AudioInputDeviceManager: ObservableObject {
   struct Device: Identifiable, Equatable {
     let id: String
@@ -28,10 +31,7 @@ final class AudioInputDeviceManager: ObservableObject {
     }
   }
 
-  struct SessionContext {
-    fileprivate let previousDeviceID: AudioDeviceID?
-    fileprivate let didChangeDevice: Bool
-  }
+  typealias SessionContext = AudioInputDeviceSessionTracker.Context
 
   static let systemDefaultToken = "__system_default_input__"
 
@@ -43,6 +43,7 @@ final class AudioInputDeviceManager: ObservableObject {
   private let logger = Logger(subsystem: "com.github.speakapp", category: "AudioInput")
   private var devicesListener: AudioObjectPropertyListenerBlock?
   private var defaultDeviceListener: AudioObjectPropertyListenerBlock?
+  private var sessionTracker = AudioInputDeviceSessionTracker()
 
   init(appSettings: AppSettings) {
     self.appSettings = appSettings
@@ -128,36 +129,41 @@ final class AudioInputDeviceManager: ObservableObject {
   }
 
   func beginUsingPreferredInput() async -> SessionContext {
-    let preferredUID = selectedDeviceUID ?? appSettings.preferredAudioInputUID
+    if self.sessionTracker.hasActiveSession {
+      self.logger.debug("Joining active preferred input device session")
+      return self.sessionTracker.beginSession(previousDeviceID: nil, didChangeDevice: false)
+    }
+
+    let preferredUID = self.selectedDeviceUID ?? self.appSettings.preferredAudioInputUID
     guard
       let uid = preferredUID,
-      let targetDeviceID = deviceID(forUID: uid),
-      let currentDefaultID = currentDefaultInputDeviceID(),
+      let targetDeviceID = self.deviceID(forUID: uid),
+      let currentDefaultID = self.currentDefaultInputDeviceID(),
       targetDeviceID != currentDefaultID
     else {
-      return SessionContext(previousDeviceID: nil, didChangeDevice: false)
+      return self.sessionTracker.beginSession(previousDeviceID: nil, didChangeDevice: false)
     }
 
-    if setDefaultInputDevice(to: targetDeviceID) {
-      refreshDevices()
-      logger.debug("Activated preferred input device with UID \(uid, privacy: .public)")
-      return SessionContext(previousDeviceID: currentDefaultID, didChangeDevice: true)
+    if self.setDefaultInputDevice(to: targetDeviceID) {
+      self.refreshDevices()
+      self.logger.debug("Activated preferred input device with UID \(uid, privacy: .public)")
+      return self.sessionTracker.beginSession(previousDeviceID: currentDefaultID, didChangeDevice: true)
     }
 
-    logger.error("Failed to activate preferred input \(uid, privacy: .public); continuing with system default")
-    return SessionContext(previousDeviceID: nil, didChangeDevice: false)
+    self.logger.error("Failed to activate preferred input \(uid, privacy: .public); continuing with system default")
+    return self.sessionTracker.beginSession(previousDeviceID: nil, didChangeDevice: false)
   }
 
   func endUsingPreferredInput(session: SessionContext) async {
-    guard session.didChangeDevice, let previous = session.previousDeviceID else {
+    guard let previous = self.sessionTracker.endSession(session) else {
       return
     }
 
-    if setDefaultInputDevice(to: previous) {
-      refreshDevices()
-      logger.debug("Restored previous input device after session")
+    if self.setDefaultInputDevice(to: previous) {
+      self.refreshDevices()
+      self.logger.debug("Restored previous input device after session")
     } else {
-      logger.error("Failed to restore previous input device after session")
+      self.logger.error("Failed to restore previous input device after session")
     }
   }
 

--- a/Sources/SpeakApp/AudioInputDeviceSessionTracker.swift
+++ b/Sources/SpeakApp/AudioInputDeviceSessionTracker.swift
@@ -1,0 +1,49 @@
+import CoreAudio
+import Foundation
+
+struct AudioInputDeviceSessionTracker {
+  struct Context: Equatable {
+    let id: UUID
+    let participatesInSharedSession: Bool
+  }
+
+  private var activeSessionIDs: Set<UUID> = []
+  private var previousDeviceID: AudioDeviceID?
+  private var didChangeDevice = false
+
+  var hasActiveSession: Bool {
+    !self.activeSessionIDs.isEmpty
+  }
+
+  mutating func beginSession(
+    previousDeviceID: AudioDeviceID?,
+    didChangeDevice: Bool,
+    id: UUID = UUID()
+  ) -> Context {
+    let participatesInSharedSession = didChangeDevice || self.hasActiveSession
+
+    if participatesInSharedSession {
+      if self.activeSessionIDs.isEmpty {
+        self.previousDeviceID = previousDeviceID
+        self.didChangeDevice = didChangeDevice
+      }
+      self.activeSessionIDs.insert(id)
+    }
+
+    return Context(
+      id: id,
+      participatesInSharedSession: participatesInSharedSession
+    )
+  }
+
+  mutating func endSession(_ context: Context) -> AudioDeviceID? {
+    guard context.participatesInSharedSession else { return nil }
+    self.activeSessionIDs.remove(context.id)
+    guard self.activeSessionIDs.isEmpty else { return nil }
+
+    let deviceToRestore = self.didChangeDevice ? self.previousDeviceID : nil
+    self.previousDeviceID = nil
+    self.didChangeDevice = false
+    return deviceToRestore
+  }
+}

--- a/Sources/SpeakApp/AudioInputDeviceSessionTracker.swift
+++ b/Sources/SpeakApp/AudioInputDeviceSessionTracker.swift
@@ -12,7 +12,7 @@ struct AudioInputDeviceSessionTracker {
   private var didChangeDevice = false
 
   var hasActiveSession: Bool {
-    !self.activeSessionIDs.isEmpty
+    !activeSessionIDs.isEmpty
   }
 
   mutating func beginSession(
@@ -20,14 +20,14 @@ struct AudioInputDeviceSessionTracker {
     didChangeDevice: Bool,
     id: UUID = UUID()
   ) -> Context {
-    let participatesInSharedSession = didChangeDevice || self.hasActiveSession
+    let participatesInSharedSession = didChangeDevice || hasActiveSession
 
     if participatesInSharedSession {
-      if self.activeSessionIDs.isEmpty {
+      if activeSessionIDs.isEmpty {
         self.previousDeviceID = previousDeviceID
         self.didChangeDevice = didChangeDevice
       }
-      self.activeSessionIDs.insert(id)
+      activeSessionIDs.insert(id)
     }
 
     return Context(
@@ -38,12 +38,12 @@ struct AudioInputDeviceSessionTracker {
 
   mutating func endSession(_ context: Context) -> AudioDeviceID? {
     guard context.participatesInSharedSession else { return nil }
-    self.activeSessionIDs.remove(context.id)
-    guard self.activeSessionIDs.isEmpty else { return nil }
+    activeSessionIDs.remove(context.id)
+    guard activeSessionIDs.isEmpty else { return nil }
 
-    let deviceToRestore = self.didChangeDevice ? self.previousDeviceID : nil
-    self.previousDeviceID = nil
-    self.didChangeDevice = false
+    let deviceToRestore = didChangeDevice ? previousDeviceID : nil
+    previousDeviceID = nil
+    didChangeDevice = false
     return deviceToRestore
   }
 }

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -80,9 +80,11 @@ final class TranscriptionManager: ObservableObject {
   }
 
   func stopLiveTranscription() async throws -> TranscriptionResult {
-    // If there was a mid-session error, throw it now
+    // If there was a mid-session error, still stop the controller so audio resources
+    // and preferred input-device sessions are released before surfacing the failure.
     if let error = pendingError {
       pendingError = nil
+      await liveController.stop()
       isLiveTranscribing = false
       throw error
     }

--- a/Tests/SpeakAppTests/AudioInputDeviceSessionTrackerTests.swift
+++ b/Tests/SpeakAppTests/AudioInputDeviceSessionTrackerTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+@testable import SpeakApp
+
+final class AudioInputDeviceSessionTrackerTests: XCTestCase {
+  func testEndSession_DelaysRestoreUntilAllSharedUsersEnd() {
+    var tracker = AudioInputDeviceSessionTracker()
+    let firstID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    let secondID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+
+    let first = tracker.beginSession(previousDeviceID: 10, didChangeDevice: true, id: firstID)
+    let second = tracker.beginSession(previousDeviceID: nil, didChangeDevice: false, id: secondID)
+
+    XCTAssertTrue(first.participatesInSharedSession)
+    XCTAssertTrue(second.participatesInSharedSession)
+    XCTAssertNil(tracker.endSession(first))
+    XCTAssertEqual(tracker.endSession(second), 10)
+  }
+
+  func testEndSession_DoesNotRestoreWhenNoDeviceChangeWasActivated() {
+    var tracker = AudioInputDeviceSessionTracker()
+    let context = tracker.beginSession(
+      previousDeviceID: nil,
+      didChangeDevice: false,
+      id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+    )
+
+    XCTAssertFalse(context.participatesInSharedSession)
+    XCTAssertNil(tracker.endSession(context))
+  }
+}


### PR DESCRIPTION
## Summary
- keep preferred audio input sessions shared across the recorder and live transcription engine
- delay restoring the previous input device until every borrower has released the session
- stop live controllers before throwing a stored mid-session live transcription error so audio resources are cleaned up

## Verification
- swift package plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio resource cleanup when stopping live transcription with pending errors, ensuring device/session state is properly released.

* **Improvements**
  * More reliable handling of shared audio input sessions to prevent unintended device switches and restore behavior.

* **Tests**
  * Added tests validating shared-session behavior and restoration logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->