### PR TITLE
fix(mac): repair AssemblyAI live streaming and add Soniox provider

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -693,8 +693,16 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
         rawValue: defaults.string(forKey: DefaultsKey.transcriptionMode.rawValue)
           ?? TranscriptionMode.liveNative.rawValue) ?? .liveNative
     let liveModel = defaults.string(forKey: "liveTranscriptionModel") ?? "apple/local/SFSpeechRecognizer"
-    liveTranscriptionModel =
-      liveModel.hasPrefix("deepgram/") ? "deepgram/nova-3-streaming" : liveModel
+    let migratedLive: String
+    if liveModel.hasPrefix("deepgram/") {
+      migratedLive = "deepgram/nova-3-streaming"
+    } else if liveModel.hasPrefix("assemblyai/") && liveModel != "assemblyai/u3-rt-pro-streaming" {
+      // The 3 legacy AssemblyAI live IDs collapsed into u3-rt-pro-streaming.
+      migratedLive = "assemblyai/u3-rt-pro-streaming"
+    } else {
+      migratedLive = liveModel
+    }
+    liveTranscriptionModel = migratedLive
     batchTranscriptionModel =
       Self.normalizedBatchModel(
         defaults.string(forKey: DefaultsKey.batchTranscriptionModel.rawValue))

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -693,10 +693,19 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
         rawValue: defaults.string(forKey: DefaultsKey.transcriptionMode.rawValue)
           ?? TranscriptionMode.liveNative.rawValue) ?? .liveNative
     let liveModel = defaults.string(forKey: "liveTranscriptionModel") ?? "apple/local/SFSpeechRecognizer"
+    let legacyAssemblyAILiveIDs: Set<String> = [
+      "universal-streaming",
+      "universal-streaming-english",
+      "universal-streaming-multilingual",
+      "assemblyai/universal-streaming",
+      "assemblyai/universal-streaming-english",
+      "assemblyai/universal-streaming-multilingual"
+    ]
     let migratedLive: String
     if liveModel.hasPrefix("deepgram/") {
       migratedLive = "deepgram/nova-3-streaming"
-    } else if liveModel.hasPrefix("assemblyai/") && liveModel != "assemblyai/u3-rt-pro-streaming" {
+    } else if legacyAssemblyAILiveIDs.contains(liveModel)
+      || (liveModel.hasPrefix("assemblyai/") && liveModel != "assemblyai/u3-rt-pro-streaming") {
       // The 3 legacy AssemblyAI live IDs collapsed into u3-rt-pro-streaming.
       migratedLive = "assemblyai/u3-rt-pro-streaming"
     } else {

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -642,36 +642,14 @@ struct AssemblyAITranscriptionProvider: TranscriptionProvider {
   }
 
   private func mapLiveSpeechModel(from model: String, language: String?) -> AssemblyAILiveSpeechModelConfig {
-    let name = model.split(separator: "/").last.map(String.init) ?? model
-    switch name {
-    case "universal-streaming-english":
-      return AssemblyAILiveSpeechModelConfig(
-        speechModel: "universal-streaming-english",
-        languageDetectionEnabled: false
-      )
-    case "universal-streaming-multilingual":
-      return AssemblyAILiveSpeechModelConfig(
-        speechModel: "universal-streaming-multilingual",
-        languageDetectionEnabled: true
-      )
-    case "u3-rt-pro-streaming", "u3-rt-pro":
-      return AssemblyAILiveSpeechModelConfig(
-        speechModel: "u3-rt-pro",
-        languageDetectionEnabled: false
-      )
-    default:
-      let languageCode = language.map { extractLanguageCode(from: $0) } ?? "en"
-      if languageCode.hasPrefix("en") {
-        return AssemblyAILiveSpeechModelConfig(
-          speechModel: "universal-streaming-english",
-          languageDetectionEnabled: false
-        )
-      }
-      return AssemblyAILiveSpeechModelConfig(
-        speechModel: "universal-streaming-multilingual",
-        languageDetectionEnabled: true
-      )
-    }
+    // The catalog now exposes only u3-rt-pro for live AssemblyAI. Older saved IDs
+    // (universal-streaming/-english/-multilingual) are migrated transparently to u3-rt-pro,
+    // which already handles English and multilingual content with high accuracy.
+    _ = language
+    return AssemblyAILiveSpeechModelConfig(
+      speechModel: "u3-rt-pro",
+      languageDetectionEnabled: false
+    )
   }
 
   private func extractLanguageCode(from locale: String) -> String {

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -371,7 +371,6 @@ private extension AssemblyAILiveTranscriber {
 
 // MARK: - AssemblyAI Transcription Provider
 
-// swiftlint:disable type_body_length
 struct AssemblyAITranscriptionProvider: TranscriptionProvider {
   let metadata = TranscriptionProviderMetadata(
     id: "assemblyai",
@@ -680,7 +679,6 @@ struct AssemblyAITranscriptionProvider: TranscriptionProvider {
     )
   }
 }
-// swiftlint:enable type_body_length
 
 // MARK: - Streaming Response Models
 

--- a/Sources/SpeakApp/HUDManager.swift
+++ b/Sources/SpeakApp/HUDManager.swift
@@ -112,9 +112,9 @@ final class HUDManager: ObservableObject {
     isExpanded.toggle()
   }
 
-  func beginTranscribing() {
+  func beginTranscribing(subheadline: String = "Preparing raw transcript") {
     audioLevel = 0
-    transition(.transcribing, headline: "Transcribing", subheadline: "Preparing raw transcript")
+    transition(.transcribing, headline: "Transcribing", subheadline: subheadline)
   }
 
   func beginPostProcessing() {

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -575,7 +575,7 @@ final class MainManager: ObservableObject {
 
       if appSettings.transcriptionMode == .liveNative {
         session.transcriptionStarted = Date()
-        hudManager.beginTranscribing()
+        hudManager.beginTranscribing(subheadline: "Finalising transcript")
         let result = try await transcriptionManager.stopLiveTranscription()
         session.transcriptionEnded = Date()
         session.transcriptionResult = result

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -90,7 +90,6 @@ struct SettingsView: View {
   @State private var showSystemPromptPreview = false
   @State private var systemPromptPreview = ""
   @State private var showingConfigTransfer = false
-  @State private var showingAssemblyAIPreprocessingAlert = false
   @State private var soundPreviewPlayer: RecordingSoundPlayer?
   private let openRouterKeyIdentifier = "openrouter.apiKey"
 
@@ -245,17 +244,11 @@ struct SettingsView: View {
       transcriptionProviders = await TranscriptionProviderRegistry.shared.allProviders()
       syncAssemblyAIKeytermsFromPronunciation()
     }
-    .onChange(of: settings.liveTranscriptionModel) { oldValue, newValue in
-      let oldIsAssembly = oldValue.localizedCaseInsensitiveContains("assemblyai")
+    .onChange(of: settings.liveTranscriptionModel) { _, newValue in
       let newIsAssembly = newValue.localizedCaseInsensitiveContains("assemblyai")
       if newIsAssembly {
         settings.postProcessingEnabled = false
         syncAssemblyAIKeytermsFromPronunciation()
-        if !oldIsAssembly {
-          DispatchQueue.main.async {
-            showingAssemblyAIPreprocessingAlert = true
-          }
-        }
       }
     }
     .onChange(of: settings.assemblyAIKeyterms) { _, _ in
@@ -266,16 +259,6 @@ struct SettingsView: View {
     }
     .onReceive(environment.pronunciationManager.$entries) { _ in
       syncAssemblyAIKeytermsFromPronunciation()
-    }
-    .alert("AssemblyAI Pre-processing", isPresented: $showingAssemblyAIPreprocessingAlert) {
-      Button("OK") {
-        sidebarSelection = .settings(.postProcessing)
-      }
-    } message: {
-      Text(
-        "Custom prompt-based pre-processing is disabled for AssemblyAI live streaming."
-          + " Use Keyterms for recognition guidance."
-      )
     }
   }
 

--- a/Sources/SpeakApp/SonioxTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SonioxTranscriptionProvider.swift
@@ -1,0 +1,378 @@
+import AVFoundation
+import Foundation
+import os.log
+import SpeakCore
+
+// MARK: - Errors
+
+enum SonioxLiveError: LocalizedError {
+    case missingAPIKey
+    case invalidURLComponents
+    case connectionFailed
+    case invalidAPIKey
+    case batchNotSupported
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "Soniox API key is missing. Please add it in Settings → Soniox."
+        case .invalidURLComponents:
+            return "Failed to construct Soniox WebSocket URL."
+        case .connectionFailed:
+            return "Failed to establish WebSocket connection to Soniox."
+        case .invalidAPIKey:
+            return "Soniox API key is invalid. Check your key in Settings → Soniox."
+        case .batchNotSupported:
+            return "Soniox is currently only available for live streaming in Speak."
+        }
+    }
+}
+
+// MARK: - WebSocket response types
+
+private struct SonioxStreamResponse: Decodable {
+    struct Token: Decodable {
+        let text: String
+        let isFinal: Bool?
+        private enum CodingKeys: String, CodingKey {
+            case text
+            case isFinal = "is_final"
+        }
+    }
+    let tokens: [Token]?
+    let finished: Bool?
+    let errorCode: Int?
+    let errorMessage: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case tokens
+        case finished
+        case errorCode = "error_code"
+        case errorMessage = "error_message"
+    }
+}
+
+// MARK: - Provider
+
+/// Soniox Real-time STT v2 streaming. Live-only — batch is not implemented in this build.
+struct SonioxTranscriptionProvider: TranscriptionProvider {
+    let metadata = TranscriptionProviderMetadata(
+        id: "soniox",
+        displayName: "Soniox",
+        systemImage: "waveform.badge.magnifyingglass",
+        tintColor: "indigo",
+        website: "https://soniox.com"
+    )
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func transcribeFile(
+        at url: URL,
+        apiKey: String,
+        model: String,
+        language: String?
+    ) async throws -> TranscriptionResult {
+        _ = (url, apiKey, model, language)
+        throw SonioxLiveError.batchNotSupported
+    }
+
+    func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .failure(message: "Empty API key")
+        }
+        // Lightweight validation: hit the temporary-key endpoint with a tiny duration.
+        guard let url = URL(string: "https://api.soniox.com/v1/auth/temporary-api-key") else {
+            return .failure(message: "Invalid URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = #"{"usage_type":"transcribe_websocket","expires_in_seconds":60}"#
+            .data(using: .utf8)
+
+        do {
+            let (_, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .failure(message: "Non-HTTP response")
+            }
+            if (200..<300).contains(http.statusCode) {
+                return .success(message: "Soniox API key validated")
+            }
+            if http.statusCode == 401 || http.statusCode == 403 {
+                return .failure(message: "Soniox rejected the key (HTTP \(http.statusCode))")
+            }
+            return .failure(message: "HTTP \(http.statusCode) while validating key")
+        } catch {
+            return .failure(message: "Validation failed: \(error.localizedDescription)")
+        }
+    }
+
+    func requiresAPIKey(for model: String) -> Bool { true }
+
+    func supportedModels() -> [ModelCatalog.Option] {
+        // Live-only provider; batch model list is empty intentionally.
+        []
+    }
+}
+
+// MARK: - Live Transcriber (WebSocket client)
+
+final class SonioxLiveTranscriber: @unchecked Sendable {
+    private static let websocketHost = "stt-rt.soniox.com"
+    private static let websocketPath = "/transcribe-websocket"
+
+    /// Preferred PCM chunk size: 100 ms at 16 kHz PCM16 mono.
+    static let preferredChunkBytes = 3_200
+    static let minimumChunkBytes = 1_600
+
+    private let apiKey: String
+    private let model: String
+    private let sampleRate: Int
+    private let session: URLSession
+    private let logger = Logger(subsystem: "com.speak.app", category: "SonioxLiveTranscriber")
+    private let stateLock = NSLock()
+    private let pendingSendGroup = DispatchGroup()
+
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var onTranscript: ((String, Bool) -> Void)?
+    private var onError: ((Error) -> Void)?
+    private var isStopping: Bool = false
+    private var didSendConfig: Bool = false
+
+    init(
+        apiKey: String,
+        model: String = "stt-rt-preview",
+        sampleRate: Int = 16000,
+        session: URLSession = .shared
+    ) {
+        self.apiKey = apiKey
+        self.model = model
+        self.sampleRate = sampleRate
+        self.session = session
+    }
+
+    func start(
+        onTranscript: @escaping (String, Bool) -> Void,
+        onError: @escaping (Error) -> Void
+    ) {
+        withStateLock {
+            isStopping = false
+            didSendConfig = false
+            self.onTranscript = onTranscript
+            self.onError = onError
+        }
+        connectWebSocket()
+    }
+
+    func sendAudio(_ audioData: Data) {
+        guard let task = currentWebSocketTask(), task.state == .running else { return }
+        let sendGroup = pendingSendGroup
+        sendGroup.enter()
+        task.send(.data(audioData)) { [weak self] error in
+            defer { sendGroup.leave() }
+            guard let self else { return }
+            if let error {
+                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                self.logger.error("Failed to send audio: \(error.localizedDescription)")
+                self.currentOnError()?(error)
+            }
+        }
+    }
+
+    /// Soniox graceful close: send an empty binary frame to flush the final tokens.
+    func signalEndOfStream() {
+        guard let task = currentWebSocketTask(), task.state == .running else { return }
+        let sendGroup = pendingSendGroup
+        sendGroup.enter()
+        task.send(.data(Data())) { _ in sendGroup.leave() }
+    }
+
+    func stop() {
+        let task = withStateLock { () -> URLSessionWebSocketTask? in
+            guard !isStopping else { return nil }
+            isStopping = true
+            return webSocketTask
+        }
+        guard let task else { return }
+        if task.state == .running {
+            task.cancel(with: .normalClosure, reason: nil)
+        }
+        withStateLock {
+            if webSocketTask === task { webSocketTask = nil }
+        }
+        logger.info("Soniox WebSocket connection closed")
+    }
+
+    func waitForPendingSends(timeout: TimeInterval = 1.5) async {
+        let sendGroup = pendingSendGroup
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                _ = sendGroup.wait(timeout: .now() + timeout)
+                continuation.resume()
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func connectWebSocket() {
+        var components = URLComponents()
+        components.scheme = "wss"
+        components.host = Self.websocketHost
+        components.path = Self.websocketPath
+        guard let url = components.url else {
+            currentOnError()?(SonioxLiveError.invalidURLComponents)
+            return
+        }
+
+        let task = session.webSocketTask(with: url)
+        let proceed = withStateLock { () -> Bool in
+            guard !isStopping else { return false }
+            webSocketTask = task
+            task.resume()
+            return true
+        }
+        guard proceed else {
+            task.cancel(with: .goingAway, reason: nil)
+            return
+        }
+
+        sendInitialConfig()
+        logger.info("Soniox WebSocket connecting (model=\(self.model, privacy: .public))")
+        receiveMessages()
+    }
+
+    private func sendInitialConfig() {
+        guard let task = currentWebSocketTask() else { return }
+        let payload: [String: Any] = [
+            "api_key": apiKey,
+            "model": model,
+            "audio_format": "pcm_s16le",
+            "sample_rate": sampleRate,
+            "num_channels": 1
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else { return }
+        let sendGroup = pendingSendGroup
+        sendGroup.enter()
+        task.send(.string(json)) { [weak self] error in
+            defer { sendGroup.leave() }
+            guard let self else { return }
+            if let error {
+                if self.isStoppingState() { return }
+                self.currentOnError()?(error)
+                return
+            }
+            self.withStateLock { self.didSendConfig = true }
+        }
+    }
+
+    private func receiveMessages() {
+        guard let task = currentWebSocketTask() else { return }
+        task.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let message):
+                self.handleMessage(message)
+                self.receiveMessages()
+            case .failure(let error):
+                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                self.logger.error("Soniox receive error: \(error.localizedDescription)")
+                self.currentOnError()?(self.mapConnectionError(error))
+            }
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+        switch message {
+        case .string(let text): parseResponse(text)
+        case .data(let data):
+            if let text = String(data: data, encoding: .utf8) { parseResponse(text) }
+        @unknown default: break
+        }
+    }
+
+    /// Aggregates Soniox token deltas into a single transcript callback.
+    /// The server may send overlapping batches of finalised + non-final tokens; we
+    /// emit the union as either an interim or a final update depending on the run.
+    private func parseResponse(_ json: String) {
+        guard let data = json.data(using: .utf8) else { return }
+        do {
+            let response = try JSONDecoder().decode(SonioxStreamResponse.self, from: data)
+            if let code = response.errorCode {
+                let message = response.errorMessage ?? "Soniox error \(code)"
+                logger.error("Soniox server error \(code): \(message, privacy: .public)")
+                currentOnError()?(NSError(
+                    domain: "Soniox", code: code,
+                    userInfo: [NSLocalizedDescriptionKey: message]
+                ))
+                return
+            }
+            guard let tokens = response.tokens, !tokens.isEmpty else { return }
+            let finalText = tokens
+                .filter { $0.isFinal == true }
+                .map(\.text)
+                .joined()
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let interimText = tokens
+                .map(\.text)
+                .joined()
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !finalText.isEmpty {
+                currentOnTranscript()?(finalText, true)
+            } else if !interimText.isEmpty {
+                currentOnTranscript()?(interimText, false)
+            }
+        } catch {
+            logger.debug("Failed to parse Soniox response: \(error.localizedDescription)")
+        }
+    }
+
+    private func mapConnectionError(_ error: Error) -> Error {
+        let nsError = error as NSError
+        let description = nsError.localizedDescription.lowercased()
+        if nsError.code == 401 || nsError.code == 403
+            || description.contains("401") || description.contains("403")
+            || description.contains("unauthorized") || description.contains("forbidden") {
+            return SonioxLiveError.invalidAPIKey
+        }
+        return error
+    }
+
+    private func shouldIgnoreSocketError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
+        if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
+            return true
+        }
+        return false
+    }
+
+    private func withStateLock<T>(_ block: () -> T) -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return block()
+    }
+
+    private func currentWebSocketTask() -> URLSessionWebSocketTask? {
+        withStateLock { webSocketTask }
+    }
+
+    private func isStoppingState() -> Bool {
+        withStateLock { isStopping }
+    }
+
+    private func currentOnTranscript() -> ((String, Bool) -> Void)? {
+        withStateLock { onTranscript }
+    }
+
+    private func currentOnError() -> ((Error) -> Void)? {
+        withStateLock { onError }
+    }
+}

--- a/Sources/SpeakApp/SonioxTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SonioxTranscriptionProvider.swift
@@ -30,16 +30,17 @@ enum SonioxLiveError: LocalizedError {
 
 // MARK: - WebSocket response types
 
-private struct SonioxStreamResponse: Decodable {
-    struct Token: Decodable {
-        let text: String
-        let isFinal: Bool?
-        private enum CodingKeys: String, CodingKey {
-            case text
-            case isFinal = "is_final"
-        }
+private struct SonioxToken: Decodable {
+    let text: String
+    let isFinal: Bool?
+    private enum CodingKeys: String, CodingKey {
+        case text
+        case isFinal = "is_final"
     }
-    let tokens: [Token]?
+}
+
+private struct SonioxStreamResponse: Decodable {
+    let tokens: [SonioxToken]?
     let finished: Bool?
     let errorCode: Int?
     let errorMessage: String?
@@ -93,8 +94,7 @@ struct SonioxTranscriptionProvider: TranscriptionProvider {
         request.httpMethod = "POST"
         request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = #"{"usage_type":"transcribe_websocket","expires_in_seconds":60}"#
-            .data(using: .utf8)
+        request.httpBody = Data(#"{"usage_type":"transcribe_websocket","expires_in_seconds":60}"#.utf8)
 
         do {
             let (_, response) = try await session.data(for: request)

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -2411,7 +2411,7 @@ private extension ElevenLabsLiveController {
 
 // MARK: - Soniox Live Controller
 
-// swiftlint:disable:next type_body_length
+// swiftlint:disable type_body_length
 /// Wraps SonioxLiveTranscriber to conform to LiveTranscriptionController protocol.
 final class SonioxLiveController: NSObject, LiveTranscriptionController {
   weak var delegate: LiveTranscriptionSessionDelegate?
@@ -2735,6 +2735,7 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController {
     }
   }
 }
+// swiftlint:enable type_body_length
 
 private extension SonioxLiveController {
   func ensurePermissions() async -> Bool {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -1403,20 +1403,17 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
       transcriber.stop()
-      await withTaskGroup(of: Void.self) { group in
-        group.addTask { @MainActor [weak self] in
-          await withCheckedContinuation { continuation in
-            self?.stopContinuation = continuation
-          }
-        }
-        group.addTask {
+      // Wait for the final Turn response (resumed in handleTurn) or a 2s timeout, whichever first.
+      // Both paths nil-out stopContinuation under the MainActor before resuming, so resume is idempotent.
+      await withCheckedContinuation { continuation in
+        stopContinuation = continuation
+        Task { @MainActor [weak self] in
           try? await Task.sleep(for: .seconds(2))
+          guard let self, let cont = self.stopContinuation else { return }
+          self.stopContinuation = nil
+          cont.resume()
         }
-        // Return as soon as either the final turn arrives or the timeout fires
-        await group.next()
-        group.cancelAll()
       }
-      stopContinuation = nil
     } else {
       audioProcessor.setRunning(false)
     }
@@ -1605,20 +1602,18 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
       audioProcessor.setRunning(false)
       transcriber.signalEndOfStream()
 
-      await withTaskGroup(of: Void.self) { group in
-        group.addTask { @MainActor [weak self] in
-          await withCheckedContinuation { continuation in
-            self?.stopContinuation = continuation
-          }
-        }
-        group.addTask {
+      // Wait for the final response (resumed in finished/error callbacks) or a 2s timeout.
+      // Both paths nil-out stopContinuation under the MainActor before resuming, so resume is idempotent.
+      await withCheckedContinuation { continuation in
+        stopContinuation = continuation
+        Task { @MainActor [weak self] in
           try? await Task.sleep(for: .seconds(2))
+          guard let self, let cont = self.stopContinuation else { return }
+          self.stopContinuation = nil
+          cont.resume()
         }
-        await group.next()
-        group.cancelAll()
       }
 
-      stopContinuation = nil
       transcriber.cancel()
     } else {
       audioProcessor.setRunning(false)
@@ -2414,6 +2409,404 @@ private extension ElevenLabsLiveController {
   }
 }
 
+// MARK: - Soniox Live Controller
+
+/// Wraps SonioxLiveTranscriber to conform to LiveTranscriptionController protocol.
+final class SonioxLiveController: NSObject, LiveTranscriptionController {
+  weak var delegate: LiveTranscriptionSessionDelegate?
+  private(set) var isRunning: Bool = false
+
+  private let appSettings: AppSettings
+  private let permissionsManager: PermissionsManager
+  private let audioDeviceManager: AudioInputDeviceManager
+  private let secureStorage: SecureAppStorage
+  private var transcriber: SonioxLiveTranscriber?
+  private var currentLanguage: String?
+  private var currentModel: String?
+  private var activeInputSession: AudioInputDeviceManager.SessionContext?
+  private let audioEngine = AVAudioEngine()
+  private let logger = Logger(subsystem: "com.speak.app", category: "SonioxLiveController")
+  private let audioProcessor = SonioxAudioProcessor()
+  private var hasFinished: Bool = false
+
+  private let targetSampleRate: Double = 16000
+  private var targetFormat: AVAudioFormat?
+  private var streamingStartTime: Date?
+  private var finalSegments: [TranscriptionSegment] = []
+  private var currentInterim: String = ""
+  private var fullTranscript: String = ""
+  private var stopContinuation: CheckedContinuation<Void, Never>?
+
+  init(
+    appSettings: AppSettings,
+    permissionsManager: PermissionsManager,
+    audioDeviceManager: AudioInputDeviceManager,
+    secureStorage: SecureAppStorage
+  ) {
+    self.appSettings = appSettings
+    self.permissionsManager = permissionsManager
+    self.audioDeviceManager = audioDeviceManager
+    self.secureStorage = secureStorage
+  }
+
+  func configure(language: String?, model: String) {
+    currentLanguage = language
+    currentModel = model
+    logger.info("Configured Soniox with model: \(model)")
+  }
+
+  // swiftlint:disable:next function_body_length
+  func start() async throws {
+    guard await ensurePermissions() else {
+      throw TranscriptionManagerError.permissionsMissing
+    }
+
+    let apiKey = try await sonioxAPIKey()
+    activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    resetStartState()
+
+    do {
+      let inputNode = audioEngine.inputNode
+      inputNode.removeTap(onBus: 0)
+      let inputFormat = inputNode.outputFormat(forBus: 0)
+
+      guard let outputFormat = AVAudioFormat(
+        commonFormat: .pcmFormatInt16,
+        sampleRate: targetSampleRate,
+        channels: 1,
+        interleaved: true
+      ) else {
+        throw SonioxLiveError.connectionFailed
+      }
+      targetFormat = outputFormat
+
+      // Catalog ID like "soniox/stt-rt-preview-streaming" → API model "stt-rt-preview".
+      let modelID: String
+      if let model = currentModel, model.hasPrefix("soniox/") {
+        modelID = String(model.dropFirst("soniox/".count))
+          .replacingOccurrences(of: "-streaming", with: "")
+      } else {
+        modelID = "stt-rt-preview"
+      }
+
+      let newTranscriber = SonioxLiveTranscriber(
+        apiKey: apiKey,
+        model: modelID,
+        sampleRate: 16000
+      )
+      transcriber = newTranscriber
+
+      newTranscriber.start(
+        onTranscript: { [weak self] text, isFinal in
+          Task { @MainActor [weak self] in
+            self?.handleTranscript(text: text, isFinal: isFinal)
+          }
+        },
+        onError: { [weak self] error in
+          Task { @MainActor [weak self] in
+            guard let self else { return }
+            if !self.isRunning { return }
+            self.delegate?.liveTranscriber(self, didFail: error)
+          }
+        }
+      )
+
+      audioProcessor.setRunning(true)
+      let processor = audioProcessor
+      let log = logger
+      inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { buffer, _ in
+        processor.handleAudioTap(
+          buffer,
+          inputFormat: inputFormat,
+          outputFormat: outputFormat,
+          transcriber: newTranscriber,
+          logger: log
+        )
+      }
+
+      audioEngine.prepare()
+      try audioEngine.start()
+      isRunning = true
+      streamingStartTime = Date()
+    } catch {
+      await cleanupAfterFailedStart()
+      throw error
+    }
+  }
+
+  private func handleTranscript(text: String, isFinal: Bool) {
+    if isFinal {
+      let segment = TranscriptionSegment(startTime: 0, endTime: 0, text: text)
+      finalSegments.append(segment)
+      fullTranscript = finalSegments.map(\.text).joined(separator: " ")
+      currentInterim = ""
+      delegate?.liveTranscriber(self, didUpdatePartial: fullTranscript)
+
+      // Resume the stop() continuation if we're shutting down.
+      if hasFinished, let continuation = stopContinuation {
+        stopContinuation = nil
+        continuation.resume()
+      }
+    } else {
+      currentInterim = text
+      let displayText = fullTranscript.isEmpty
+        ? currentInterim
+        : fullTranscript + " " + currentInterim
+      delegate?.liveTranscriber(self, didUpdatePartial: displayText)
+    }
+  }
+
+  func stop() async {
+    guard isRunning else { return }
+    guard !hasFinished else { return }
+    hasFinished = true
+
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    isRunning = false
+
+    if let transcriber {
+      audioProcessor.flushPendingAudio(to: transcriber)
+      await transcriber.waitForPendingSends()
+      audioProcessor.setRunning(false)
+      transcriber.signalEndOfStream()
+
+      // Wait for the final tokens or 2s timeout. Both paths nil-out stopContinuation idempotently.
+      await withCheckedContinuation { continuation in
+        stopContinuation = continuation
+        Task { @MainActor [weak self] in
+          try? await Task.sleep(for: .seconds(2))
+          guard let self, let cont = self.stopContinuation else { return }
+          self.stopContinuation = nil
+          cont.resume()
+        }
+      }
+      transcriber.stop()
+    } else {
+      audioProcessor.setRunning(false)
+    }
+
+    let result = buildFinalResult()
+    await MainActor.run {
+      delegate?.liveTranscriber(self, didFinishWith: result)
+    }
+
+    await endActiveInputSession()
+    transcriber = nil
+  }
+
+  private final class SonioxAudioProcessor: @unchecked Sendable {
+    private static let preferredChunkBytes = SonioxLiveTranscriber.preferredChunkBytes
+    private static let minimumChunkBytes = SonioxLiveTranscriber.minimumChunkBytes
+
+    private let queue = DispatchQueue(label: "com.speak.app.soniox.audioProcessing")
+    private var isRunning: Bool = false
+    private var cachedConverter: AVAudioConverter?
+    private var cachedInputFormat: AVAudioFormat?
+    private var reusableOutputBuffer: AVAudioPCMBuffer?
+    private var pendingPCMData = Data()
+
+    func setRunning(_ running: Bool) {
+      queue.sync {
+        isRunning = running
+        if !running {
+          cachedConverter = nil
+          cachedInputFormat = nil
+          reusableOutputBuffer = nil
+          pendingPCMData.removeAll(keepingCapacity: false)
+        }
+      }
+    }
+
+    func flushPendingAudio(to transcriber: SonioxLiveTranscriber) {
+      queue.sync {
+        guard !pendingPCMData.isEmpty else { return }
+        var offset = 0
+        while pendingPCMData.count - offset >= Self.preferredChunkBytes {
+          let chunk = pendingPCMData.subdata(in: offset..<(offset + Self.preferredChunkBytes))
+          transcriber.sendAudio(chunk)
+          offset += Self.preferredChunkBytes
+        }
+        if offset > 0 {
+          pendingPCMData = Data(pendingPCMData.dropFirst(offset))
+        }
+        guard !pendingPCMData.isEmpty else { return }
+        if pendingPCMData.count < Self.minimumChunkBytes {
+          pendingPCMData.append(
+            contentsOf: repeatElement(0, count: Self.minimumChunkBytes - pendingPCMData.count))
+        }
+        transcriber.sendAudio(pendingPCMData)
+        pendingPCMData.removeAll(keepingCapacity: false)
+      }
+    }
+
+    func handleAudioTap(
+      _ buffer: AVAudioPCMBuffer,
+      inputFormat: AVAudioFormat,
+      outputFormat: AVAudioFormat,
+      transcriber: SonioxLiveTranscriber,
+      logger: Logger
+    ) {
+      guard let copied = copyPCMBuffer(buffer) else { return }
+      queue.async { [weak self] in
+        guard let self, self.isRunning else { return }
+        self.processAndSendAudio(
+          copied, from: inputFormat, to: outputFormat,
+          transcriber: transcriber, logger: logger
+        )
+      }
+    }
+
+    private func copyPCMBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+      let frameLength = buffer.frameLength
+      guard let copy = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: frameLength) else {
+        return nil
+      }
+      copy.frameLength = frameLength
+      let src = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: buffer.audioBufferList))
+      let dst = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: copy.audioBufferList))
+      for idx in 0..<min(src.count, dst.count) {
+        let srcBuf = src[idx]
+        guard let srcData = srcBuf.mData, let dstData = dst[idx].mData else { continue }
+        dstData.copyMemory(from: srcData, byteCount: Int(srcBuf.mDataByteSize))
+        dst[idx].mDataByteSize = srcBuf.mDataByteSize
+      }
+      return copy
+    }
+
+    private func processAndSendAudio(
+      _ buffer: AVAudioPCMBuffer,
+      from inputFormat: AVAudioFormat,
+      to outputFormat: AVAudioFormat,
+      transcriber: SonioxLiveTranscriber,
+      logger: Logger
+    ) {
+      let converter: AVAudioConverter
+      if let cached = cachedConverter, cachedInputFormat == inputFormat {
+        converter = cached
+      } else {
+        guard let newConverter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+          logger.error("Failed to create audio converter")
+          return
+        }
+        cachedConverter = newConverter
+        cachedInputFormat = inputFormat
+        converter = newConverter
+      }
+
+      let ratio = outputFormat.sampleRate / inputFormat.sampleRate
+      let outputFrameCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
+
+      let outputBuffer: AVAudioPCMBuffer
+      if let reusable = reusableOutputBuffer, reusable.frameCapacity >= outputFrameCapacity {
+        reusable.frameLength = 0
+        outputBuffer = reusable
+      } else {
+        guard let newBuffer = AVAudioPCMBuffer(
+          pcmFormat: outputFormat, frameCapacity: outputFrameCapacity
+        ) else { return }
+        reusableOutputBuffer = newBuffer
+        outputBuffer = newBuffer
+      }
+
+      converter.reset()
+      var error: NSError?
+      let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+        outStatus.pointee = .haveData
+        return buffer
+      }
+
+      guard status != .error, error == nil else { return }
+      guard let int16Data = outputBuffer.int16ChannelData else { return }
+      let frameLength = Int(outputBuffer.frameLength)
+      let data = Data(bytes: int16Data[0], count: frameLength * 2)
+      pendingPCMData.append(data)
+
+      var offset = 0
+      while pendingPCMData.count - offset >= Self.preferredChunkBytes {
+        let chunk = pendingPCMData.subdata(in: offset..<(offset + Self.preferredChunkBytes))
+        transcriber.sendAudio(chunk)
+        offset += Self.preferredChunkBytes
+      }
+      if offset > 0 {
+        pendingPCMData = Data(pendingPCMData.dropFirst(offset))
+      }
+    }
+  }
+}
+
+private extension SonioxLiveController {
+  func ensurePermissions() async -> Bool {
+    let microphone = await permissionsManager.request(.microphone)
+    let speech = await permissionsManager.request(.speechRecognition)
+    return microphone.isGranted && speech.isGranted
+  }
+
+  func sonioxAPIKey() async throws -> String {
+    do {
+      let apiKey = try await secureStorage.secret(identifier: "soniox.apiKey")
+      guard !apiKey.isEmpty else { throw SonioxLiveError.missingAPIKey }
+      return apiKey
+    } catch let error as SecureAppStorageError {
+      if case .valueNotFound = error { throw SonioxLiveError.missingAPIKey }
+      throw error
+    }
+  }
+
+  func resetStartState() {
+    transcriber = nil
+    targetFormat = nil
+    finalSegments = []
+    currentInterim = ""
+    fullTranscript = ""
+    streamingStartTime = nil
+    hasFinished = false
+    stopContinuation = nil
+    isRunning = false
+  }
+
+  func cleanupAfterFailedStart() async {
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    isRunning = false
+    audioProcessor.setRunning(false)
+    transcriber?.stop()
+    transcriber = nil
+    targetFormat = nil
+    streamingStartTime = nil
+    currentInterim = ""
+    finalSegments = []
+    fullTranscript = ""
+    await endActiveInputSession()
+  }
+
+  func buildFinalResult() -> TranscriptionResult {
+    var text = finalSegments.map(\.text).joined(separator: " ")
+    let trimmedInterim = currentInterim.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmedInterim.isEmpty {
+      if !text.isEmpty { text += " " }
+      text += trimmedInterim
+    }
+    let streamingDuration = streamingStartTime.map { Date().timeIntervalSince($0) } ?? 0
+    return TranscriptionResult(
+      text: text,
+      segments: finalSegments,
+      confidence: nil,
+      duration: streamingDuration,
+      modelIdentifier: currentModel ?? "soniox/stt-rt-preview-streaming",
+      cost: nil,
+      rawPayload: nil,
+      debugInfo: nil
+    )
+  }
+
+  func endActiveInputSession() async {
+    guard let session = activeInputSession else { return }
+    activeInputSession = nil
+    await audioDeviceManager.endUsingPreferredInput(session: session)
+  }
+}
+
 // MARK: - Switching Live Transcriber
 
 struct LiveTranscriptionControllerReusePolicy {
@@ -2453,6 +2846,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private var modulateController: ModulateLiveController
   private var assemblyAIController: AssemblyAILiveController
   private var elevenlabsController: ElevenLabsLiveController
+  private var sonioxController: SonioxLiveController
   private var currentLanguage: String?
   private var currentModel: String?
   private var invalidateBeforeNextStart: Bool = false
@@ -2496,6 +2890,12 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       secureStorage: secureStorage
     )
     elevenlabsController = ElevenLabsLiveController(
+      appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    sonioxController = SonioxLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
@@ -2554,6 +2954,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     if model.hasPrefix("deepgram/") { return deepgramController }
     if model.hasPrefix("modulate/") { return modulateController }
     if model.hasPrefix("elevenlabs/") { return elevenlabsController }
+    if model.hasPrefix("soniox/") { return sonioxController }
     return nativeController
   }
 
@@ -2563,7 +2964,8 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       deepgramController,
       modulateController,
       assemblyAIController,
-      elevenlabsController
+      elevenlabsController,
+      sonioxController
     ]
     let model = currentModel ?? appSettings.liveTranscriptionModel
     for controller in controllers {
@@ -2606,6 +3008,12 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       secureStorage: secureStorage
     )
     elevenlabsController = ElevenLabsLiveController(
+      appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    sonioxController = SonioxLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -2411,6 +2411,7 @@ private extension ElevenLabsLiveController {
 
 // MARK: - Soniox Live Controller
 
+// swiftlint:disable:next type_body_length
 /// Wraps SonioxLiveTranscriber to conform to LiveTranscriptionController protocol.
 final class SonioxLiveController: NSObject, LiveTranscriptionController {
   weak var delegate: LiveTranscriptionSessionDelegate?

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -2506,6 +2506,12 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController {
         onError: { [weak self] error in
           Task { @MainActor [weak self] in
             guard let self else { return }
+            // Always release a pending stop() continuation so we don't burn the
+            // 2s timeout when an error/close arrives during shutdown.
+            if let continuation = self.stopContinuation {
+              self.stopContinuation = nil
+              continuation.resume()
+            }
             if !self.isRunning { return }
             self.delegate?.liveTranscriber(self, didFail: error)
           }

--- a/Sources/SpeakApp/TranscriptionProviderRegistry.swift
+++ b/Sources/SpeakApp/TranscriptionProviderRegistry.swift
@@ -35,6 +35,9 @@ actor TranscriptionProviderRegistry {
         guard let provider = providers[String(providerID)] else { return nil }
 
         let supportedIDs = provider.supportedModels().map(\.id)
+        // Live-only providers (e.g. Soniox) intentionally expose an empty batch
+        // catalogue; treat that as "any model under this prefix is owned by us".
+        if supportedIDs.isEmpty { return provider }
         guard supportedIDs.contains(trimmedModel) else { return nil }
         return provider
     }

--- a/Sources/SpeakApp/TranscriptionProviderRegistry.swift
+++ b/Sources/SpeakApp/TranscriptionProviderRegistry.swift
@@ -16,6 +16,7 @@ actor TranscriptionProviderRegistry {
         providers["modulate"] = ModulateTranscriptionProvider()
         providers["assemblyai"] = AssemblyAITranscriptionProvider()
         providers["elevenlabs"] = ElevenLabsTranscriptionProvider()
+        providers["soniox"] = SonioxTranscriptionProvider()
     }
 
     func allProviders() -> [TranscriptionProviderMetadata] {

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -124,23 +124,14 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             description: "Real-time multilingual WebSocket transcription with diarization and signal detection.",
             estimatedLatencyMs: 220, latencyTier: .fast),
         Option(
-            id: "assemblyai/universal-streaming", displayName: "AssemblyAI Universal (Streaming, Auto)",
-            description: "Auto-selects English or multilingual v3 streaming based on your preferred locale.",
+            id: "assemblyai/u3-rt-pro-streaming", displayName: "AssemblyAI Universal-3 Pro (Streaming)",
+            description: "AssemblyAI's u3-rt-pro real-time model. Multilingual with high English accuracy.",
             estimatedLatencyMs: 250, latencyTier: .fast),
         Option(
-            id: "assemblyai/universal-streaming-english",
-            displayName: "AssemblyAI Universal (Streaming, English)",
-            description: "English-only Universal-Streaming v3 with turn-based transcription.",
-            estimatedLatencyMs: 230, latencyTier: .fast),
-        Option(
-            id: "assemblyai/universal-streaming-multilingual",
-            displayName: "AssemblyAI Universal (Streaming, Multilingual)",
-            description: "Universal-Streaming v3 with language detection across supported multilingual speech.",
-            estimatedLatencyMs: 260, latencyTier: .fast),
-        Option(
-            id: "assemblyai/u3-rt-pro-streaming", displayName: "AssemblyAI U3-RT Pro (Streaming)",
-            description: "AssemblyAI's u3-rt-pro streaming model for higher real-time transcription accuracy.",
-            estimatedLatencyMs: 250, latencyTier: .fast),
+            id: "soniox/stt-rt-preview-streaming",
+            displayName: "Soniox Real-time (Preview)",
+            description: "Soniox real-time WebSocket STT (stt-rt-preview) with multilingual support and low latency.",
+            estimatedLatencyMs: 220, latencyTier: .fast),
         Option(
             id: "elevenlabs/scribe-v2-streaming",
             displayName: "ElevenLabs Scribe v2 (Streaming)",


### PR DESCRIPTION
## What

1. **Fix AssemblyAI stop-hang** — `AssemblyAILiveController.stop()` and `ModulateLiveController.stop()` both leaked a `withCheckedContinuation` inside a `withTaskGroup` race. `group.cancelAll()` does not resume continuations, so when the 2s timeout won the race the suspended task hung the entire stop until the outer 10s safety timeout in `stopLiveTranscription` fired with `liveSessionNotRunning` ("No live transcription session is currently running"). Replaced both with a single `withCheckedContinuation` racing against a `Task.sleep`; both paths nil-out `stopContinuation` under MainActor before resuming, so resume is idempotent.

2. **Trim AssemblyAI live model picker to one entry** — kept only `u3-rt-pro-streaming` (multilingual + high English accuracy in one model). Old saved IDs (`universal-streaming`, `-english`, `-multilingual`) migrate silently on `AppSettings` load. Collapsed `mapLiveSpeechModel` to always return `u3-rt-pro`.

3. **Hide the misleading pre-processing alert** when AssemblyAI is selected. The keyterms UI is still shown.

4. **HUD copy** — live transcription now shows "Finalising transcript" (was "Preparing raw transcript", which only makes sense for batch).

5. **Add Soniox v2 streaming provider** — new `SonioxTranscriptionProvider` + `SonioxLiveTranscriber` + `SonioxLiveController` wired into `SwitchingLiveTranscriber`, `ModelCatalog.liveTranscription`, and the provider registry. Catalog ID: `soniox/stt-rt-preview-streaming`. Live-only; batch throws a clear "not supported" error. Settings UI auto-renders an API-key card via the existing registry-driven `providerAPIKeyCard`.

## Verification

- `make test` → 368 tests, 0 failures.
- `swift build --target SpeakApp` clean.
- WebSocket protocol verified live during diagnosis: AssemblyAI `u3-rt-pro` returns `Begin` on both EU and global hosts.
- Soniox needs an API key entered in Settings → Soniox before first use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Soniox as a live transcription provider with real-time streaming support.

* **Bug Fixes**
  * Removed pre-processing alert when switching to AssemblyAI live streaming.

* **Improvements**
  * Simplified live-model selection and provider registration flows.
  * Improved transcription session status messaging (customizable subheadlines).
  * More robust stop/synchronization behavior for live transcribers.
* **Catalog**
  * Updated live transcription model catalog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->