### PR TITLE
fix(mac): decode AssemblyAI u3-rt-pro turns and accumulate Soniox tokens

### DIFF
--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -689,6 +689,7 @@ struct AssemblyAITranscriptionProvider: TranscriptionProvider {
 
 private struct AssemblyAIStreamEnvelope: Decodable {
   let type: String?
+  // swiftlint:disable:next identifier_name
   let turn_order: Int?
 }
 

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -289,7 +289,10 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
 
     do {
       let envelope = try JSONDecoder().decode(AssemblyAIStreamEnvelope.self, from: data)
-      switch envelope.type {
+      // u3-rt-pro (api_version 2025-05-12) omits the "type" field on Turn messages.
+      // Treat any message without a type but with a turn_order as a Turn.
+      let resolvedType = envelope.type ?? (envelope.turn_order != nil ? "Turn" : "")
+      switch resolvedType {
       case "Turn":
         let turn = try JSONDecoder().decode(AssemblyAITurnResponse.self, from: data)
         currentOnTranscript()?(turn)
@@ -300,8 +303,10 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         logger.info("AssemblyAI session started — \(json.prefix(200))")
       case "Termination":
         logger.info("AssemblyAI session terminated by server")
+      case "SpeechStarted", "":
+        break
       default:
-        logger.debug("Unhandled AssemblyAI message type: \(envelope.type)")
+        logger.debug("Unhandled AssemblyAI message type: \(resolvedType)")
       }
     } catch {
       logger.debug("Failed to parse AssemblyAI response: \(error.localizedDescription)")
@@ -683,7 +688,8 @@ struct AssemblyAITranscriptionProvider: TranscriptionProvider {
 // MARK: - Streaming Response Models
 
 private struct AssemblyAIStreamEnvelope: Decodable {
-  let type: String
+  let type: String?
+  let turn_order: Int?
 }
 
 private struct AssemblyAILiveSpeechModelConfig {
@@ -692,7 +698,7 @@ private struct AssemblyAILiveSpeechModelConfig {
 }
 
 struct AssemblyAITurnResponse: Decodable {
-  let type: String
+  let type: String?
   let turn_order: Int
   let turn_is_formatted: Bool
   let end_of_turn: Bool

--- a/Sources/SpeakApp/SonioxTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SonioxTranscriptionProvider.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import AVFoundation
 import Foundation
 import os.log
@@ -412,3 +413,4 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
         withStateLock { onError }
     }
 }
+// swiftlint:enable file_length

--- a/Sources/SpeakApp/SonioxTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SonioxTranscriptionProvider.swift
@@ -53,6 +53,11 @@ private struct SonioxStreamResponse: Decodable {
     }
 }
 
+protocol SonioxFinalizationDelegate: AnyObject {
+    /// Soniox emitted a `finished: true` signal — caller should release any pending stop().
+    func sonioxDidFinishStream()
+}
+
 // MARK: - Provider
 
 /// Soniox Real-time STT v2 streaming. Live-only — batch is not implemented in this build.
@@ -144,6 +149,11 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
     private var onError: ((Error) -> Void)?
     private var isStopping: Bool = false
     private var didSendConfig: Bool = false
+    /// Cumulative final-token text. Soniox sends each final token exactly once;
+    /// we accumulate them so the live transcript grows monotonically instead of
+    /// being clobbered by per-batch emits.
+    private var accumulatedFinalText: String = ""
+    weak var finalizationDelegate: SonioxFinalizationDelegate?
 
     init(
         apiKey: String,
@@ -164,6 +174,7 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
         withStateLock {
             isStopping = false
             didSendConfig = false
+            accumulatedFinalText = ""
             self.onTranscript = onTranscript
             self.onError = onError
         }
@@ -298,9 +309,9 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
         }
     }
 
-    /// Aggregates Soniox token deltas into a single transcript callback.
-    /// The server may send overlapping batches of finalised + non-final tokens; we
-    /// emit the union as either an interim or a final update depending on the run.
+    /// Soniox tokens carry their own whitespace inside `text`; we accumulate
+    /// finals into a running buffer and emit `(accumulated + non_final, false)`
+    /// for every batch. The cumulative final commit is fired by `flushFinal()`.
     private func parseResponse(_ json: String) {
         guard let data = json.data(using: .utf8) else { return }
         do {
@@ -314,23 +325,48 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
                 ))
                 return
             }
-            guard let tokens = response.tokens, !tokens.isEmpty else { return }
-            let finalText = tokens
-                .filter { $0.isFinal == true }
-                .map(\.text)
-                .joined()
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            let interimText = tokens
-                .map(\.text)
-                .joined()
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            if !finalText.isEmpty {
-                currentOnTranscript()?(finalText, true)
-            } else if !interimText.isEmpty {
-                currentOnTranscript()?(interimText, false)
+
+            let tokens = response.tokens ?? []
+            if !tokens.isEmpty {
+                var newFinals = ""
+                var nonFinals = ""
+                for token in tokens {
+                    if token.isFinal == true {
+                        newFinals.append(token.text)
+                    } else {
+                        nonFinals.append(token.text)
+                    }
+                }
+
+                let display: String = withStateLock {
+                    accumulatedFinalText.append(newFinals)
+                    return accumulatedFinalText + nonFinals
+                }
+                let trimmed = display.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    currentOnTranscript()?(trimmed, false)
+                }
+            }
+
+            if response.finished == true {
+                flushFinal()
+                finalizationDelegate?.sonioxDidFinishStream()
             }
         } catch {
             logger.debug("Failed to parse Soniox response: \(error.localizedDescription)")
+        }
+    }
+
+    /// Emit the accumulated final transcript as a single `(text, true)` callback.
+    /// Safe to call multiple times — second call is a no-op.
+    func flushFinal() {
+        let text: String? = withStateLock {
+            let snapshot = accumulatedFinalText.trimmingCharacters(in: .whitespacesAndNewlines)
+            accumulatedFinalText = ""
+            return snapshot.isEmpty ? nil : snapshot
+        }
+        if let text {
+            currentOnTranscript()?(text, true)
         }
     }
 

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -2413,7 +2413,7 @@ private extension ElevenLabsLiveController {
 
 // swiftlint:disable type_body_length
 /// Wraps SonioxLiveTranscriber to conform to LiveTranscriptionController protocol.
-final class SonioxLiveController: NSObject, LiveTranscriptionController {
+final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxFinalizationDelegate {
   weak var delegate: LiveTranscriptionSessionDelegate?
   private(set) var isRunning: Bool = false
 
@@ -2496,6 +2496,7 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController {
         sampleRate: 16000
       )
       transcriber = newTranscriber
+      newTranscriber.finalizationDelegate = self
 
       newTranscriber.start(
         onTranscript: { [weak self] text, isFinal in
@@ -2563,6 +2564,18 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController {
     }
   }
 
+  // MARK: - SonioxFinalizationDelegate
+
+  nonisolated func sonioxDidFinishStream() {
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      if let continuation = self.stopContinuation {
+        self.stopContinuation = nil
+        continuation.resume()
+      }
+    }
+  }
+
   func stop() async {
     guard isRunning else { return }
     guard !hasFinished else { return }
@@ -2576,6 +2589,11 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController {
       audioProcessor.flushPendingAudio(to: transcriber)
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
+      // Flush any accumulated final tokens as our single final commit, then
+      // signal end-of-stream. The wait below releases as soon as the server
+      // returns finished:true (via SonioxFinalizationDelegate) or the WebSocket
+      // closes (via onError), whichever comes first.
+      transcriber.flushFinal()
       transcriber.signalEndOfStream()
 
       // Wait for the final tokens or 2s timeout. Both paths nil-out stopContinuation idempotently.


### PR DESCRIPTION
## Bugs

### 1. AssemblyAI live: empty transcript
Universal-3 Pro (`api_version 2025-05-12`) emits Turn messages **without a `type` field**:
```json
```
Our envelope required `type: String`, so every Turn failed to decode silently. Sessions ended with an empty transcript and no error surfaced.

**Fix:** make `type` optional in the envelope and treat any message with a `turn_order` as a Turn.

Verified by hitting `wss://streaming.eu.assemblyai.com/v3/ws?speech_model=u3-rt-pro&format_turns=true` directly with a generated speech wav — Turn responses are confirmed type-less.

### 2. Soniox: missing spaces between commits, multiple 'Finalising' wait
Soniox sends each final token **exactly once**; tokens carry whitespace inside `text`. The old parser trimmed each batch and emitted N final segments which were re-joined with another space — destroying boundaries and producing "Hello,world" / "how  are  you" artefacts.

**Fix:**
- `SonioxLiveTranscriber` accumulates final-token text into a single running buffer (whitespace preserved) and emits `(accumulated + non_final, false)` per batch
- One final `(accumulated, true)` commit fires when the server returns `finished:true` or when `SonioxLiveController.stop()` calls `flushFinal()`
- New `SonioxFinalizationDelegate` releases the `stop()` continuation the moment `finished:true` arrives, so the 'Finalising transcript' HUD doesn't burn the full 2s timeout in the common case

## Tests
`make test` — 368 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription response handling for turn-based messages from speech providers.
  * Enhanced finalization of transcription streams to ensure all text is properly committed before ending the stream.
  * Refined error logging for unhandled transcription responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->