### PR TITLE
fix(mac): buffer AssemblyAI audio until Begin and finalize Soniox on stop

### DIFF
--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -37,6 +37,11 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
   private var currentEndpointHost: EndpointHost = .europe
   private var hasAttemptedGlobalFallback: Bool = false
   private var sessionDidBegin: Bool = false
+  /// Audio frames captured before `Begin` arrives. AssemblyAI's WebSocket
+  /// rejects audio sent before the session is established, and the EU→global
+  /// retry path can otherwise lose the first second or two of speech.
+  private var preBeginAudioBuffer: [Data] = []
+  private static let preBeginAudioByteLimit = 16_000 * 2 * 5 // 5s of 16kHz PCM16
 
   init(
     apiKey: String,
@@ -66,6 +71,7 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
       self.onError = onError
       hasAttemptedGlobalFallback = false
       sessionDidBegin = false
+      preBeginAudioBuffer = []
       currentEndpointHost = preferredEndpointHost
       return currentEndpointHost
     }
@@ -125,8 +131,29 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
   }
 
   func sendAudio(_ audioData: Data) {
-    guard let webSocketTask = currentWebSocketTask(), webSocketTask.state == .running else { return }
+    // If the session hasn't begun yet (or we're between EU and global retry),
+    // buffer the audio so we don't drop the start of an utterance. The buffer
+    // is bounded; oldest frames are discarded if speech outpaces the handshake.
+    let snapshot = withStateLock { () -> (URLSessionWebSocketTask?, Bool) in
+      (webSocketTask, sessionDidBegin)
+    }
+    let task = snapshot.0
+    let didBegin = snapshot.1
+    guard let task, task.state == .running, didBegin else {
+      withStateLock {
+        preBeginAudioBuffer.append(audioData)
+        var totalBytes = preBeginAudioBuffer.reduce(0) { $0 + $1.count }
+        while totalBytes > Self.preBeginAudioByteLimit, !preBeginAudioBuffer.isEmpty {
+          totalBytes -= preBeginAudioBuffer.removeFirst().count
+        }
+      }
+      return
+    }
 
+    sendAudioFrame(audioData, on: task)
+  }
+
+  private func sendAudioFrame(_ audioData: Data, on webSocketTask: URLSessionWebSocketTask) {
     var buffer = bufferPool.checkout()
     buffer.append(audioData)
 
@@ -146,6 +173,20 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         self.logger.error("Failed to send audio: \(error.localizedDescription)")
         self.currentOnError()?(error)
       }
+    }
+  }
+
+  /// Flush any audio that arrived before the WebSocket session began.
+  private func flushPreBeginAudio() {
+    let (task, frames) = withStateLock { () -> (URLSessionWebSocketTask?, [Data]) in
+      let pending = preBeginAudioBuffer
+      preBeginAudioBuffer = []
+      return (webSocketTask, pending)
+    }
+    guard let task, task.state == .running, !frames.isEmpty else { return }
+    logger.info("Flushing \(frames.count) pre-Begin audio frames to AssemblyAI")
+    for frame in frames {
+      sendAudioFrame(frame, on: task)
     }
   }
 
@@ -237,7 +278,7 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         if self.isStoppingState() { return }
         if self.retryWithGlobalEndpointIfNeeded(after: error) { return }
         if self.shouldIgnoreSocketError(error) { return }
-        self.logger.error("WebSocket receive error: \(error.localizedDescription)")
+        self.logger.error("WebSocket receive error: \(error.localizedDescription, privacy: .public)")
         self.currentOnError()?(error)
       }
     }
@@ -263,7 +304,7 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
     guard shouldRetry else { return false }
 
     logger.warning(
-      "AssemblyAI EU endpoint failed before session begin (\(error.localizedDescription)); retrying global endpoint"
+      "AssemblyAI EU endpoint failed before session begin (\(error.localizedDescription, privacy: .public)); retrying global endpoint"
     )
     taskToCancel?.cancel(with: .goingAway, reason: nil)
     connectWebSocket(using: .global)
@@ -300,7 +341,8 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         withStateLock {
           sessionDidBegin = true
         }
-        logger.info("AssemblyAI session started — \(json.prefix(200))")
+        logger.info("AssemblyAI session started — \(json.prefix(200), privacy: .public)")
+        flushPreBeginAudio()
       case "Termination":
         logger.info("AssemblyAI session terminated by server")
       case "SpeechStarted", "":

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -303,8 +303,9 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
     }
     guard shouldRetry else { return false }
 
+    let detail = error.localizedDescription
     logger.warning(
-      "AssemblyAI EU endpoint failed before session begin (\(error.localizedDescription, privacy: .public)); retrying global endpoint"
+      "AssemblyAI EU endpoint failed before session begin (\(detail, privacy: .public)); retrying global"
     )
     taskToCancel?.cancel(with: .goingAway, reason: nil)
     connectWebSocket(using: .global)

--- a/Sources/SpeakApp/SonioxTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SonioxTranscriptionProvider.swift
@@ -205,6 +205,17 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
         task.send(.data(Data())) { _ in sendGroup.leave() }
     }
 
+    /// Send Soniox `{"type":"finalize"}` to force any in-flight non-final tokens
+    /// to be returned as final tokens. Must be called *before* `signalEndOfStream`
+    /// so the server has a chance to finalize before closing.
+    func sendFinalize() {
+        guard let task = currentWebSocketTask(), task.state == .running else { return }
+        let payload = #"{"type":"finalize"}"#
+        let sendGroup = pendingSendGroup
+        sendGroup.enter()
+        task.send(.string(payload)) { _ in sendGroup.leave() }
+    }
+
     func stop() {
         let task = withStateLock { () -> URLSessionWebSocketTask? in
             guard !isStopping else { return nil }
@@ -331,7 +342,15 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
             if !tokens.isEmpty {
                 var newFinals = ""
                 var nonFinals = ""
+                var sawFinalizationMarker = false
                 for token in tokens {
+                    // Soniox emits `<fin>` to acknowledge a manual `finalize` request
+                    // and `<end>` when the session is fully finished. Don't display
+                    // them; treat both as a signal that buffered finals are committed.
+                    if token.text == "<fin>" || token.text == "<end>" {
+                        sawFinalizationMarker = true
+                        continue
+                    }
                     if token.isFinal == true {
                         newFinals.append(token.text)
                     } else {
@@ -346,6 +365,11 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
                 let trimmed = display.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmed.isEmpty {
                     currentOnTranscript()?(trimmed, false)
+                }
+
+                if sawFinalizationMarker {
+                    flushFinal()
+                    finalizationDelegate?.sonioxDidFinishStream()
                 }
             }
 

--- a/Sources/SpeakApp/SonioxTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SonioxTranscriptionProvider.swift
@@ -129,6 +129,7 @@ struct SonioxTranscriptionProvider: TranscriptionProvider {
 
 // MARK: - Live Transcriber (WebSocket client)
 
+// swiftlint:disable type_body_length
 final class SonioxLiveTranscriber: @unchecked Sendable {
     private static let websocketHost = "stt-rt.soniox.com"
     private static let websocketPath = "/transcribe-websocket"
@@ -437,4 +438,5 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
         withStateLock { onError }
     }
 }
+// swiftlint:enable type_body_length
 // swiftlint:enable file_length

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -2589,14 +2589,14 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
       audioProcessor.flushPendingAudio(to: transcriber)
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
-      // Flush any accumulated final tokens as our single final commit, then
-      // signal end-of-stream. The wait below releases as soon as the server
-      // returns finished:true (via SonioxFinalizationDelegate) or the WebSocket
-      // closes (via onError), whichever comes first.
-      transcriber.flushFinal()
-      transcriber.signalEndOfStream()
+      // Ask Soniox to finalize any in-flight non-final tokens so the trailing
+      // words of the utterance get returned as final tokens. The server replies
+      // with a `<fin>` marker token (handled in parseResponse) which fires the
+      // SonioxFinalizationDelegate and resumes the continuation below.
+      transcriber.sendFinalize()
 
-      // Wait for the final tokens or 2s timeout. Both paths nil-out stopContinuation idempotently.
+      // Wait for `<fin>`/`finished:true` or a 2s timeout. Both paths nil-out
+      // stopContinuation idempotently.
       await withCheckedContinuation { continuation in
         stopContinuation = continuation
         Task { @MainActor [weak self] in
@@ -2606,6 +2606,10 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
           cont.resume()
         }
       }
+
+      // Now flush any accumulated finals (covers the timeout path) and close.
+      transcriber.flushFinal()
+      transcriber.signalEndOfStream()
       transcriber.stop()
     } else {
       audioProcessor.setRunning(false)


### PR DESCRIPTION
- AssemblyAI: queue audio frames before the WebSocket session is established
  (and across the EU→global retry) so the first second of speech is no longer
  dropped; flush queued frames on Begin. Bound queue to 5s.
- AssemblyAI: surface the EU connection error and WebSocket receive errors
  publicly in os_log so we can diagnose endpoint failures instead of seeing
  <private>.
- Soniox: send {"type":"finalize"} on stop to coerce trailing non-final
  tokens into finals. Detect the <fin>/<end> marker tokens and treat them as
  the signal to release the stop continuation, so the trailing block of an
  utterance is captured and the wait closes promptly.

Closes the 'cuts off last block' and 'processing transcript' Soniox issues
and removes a major class of empty-transcript AssemblyAI cases.
