### PR TITLE
fix(mac): use ElevenLabs Scribe realtime protocol correctly

### DIFF
--- a/Sources/SpeakApp/ElevenLabsLiveTranscriptionProvider.swift
+++ b/Sources/SpeakApp/ElevenLabsLiveTranscriptionProvider.swift
@@ -53,14 +53,14 @@ private struct ElevenLabsErrorMessage: Decodable {
 
 // MARK: - Live Transcriber (WebSocket client)
 
-/// Streams raw PCM audio to ElevenLabs Scribe Realtime API and delivers partial/final
-/// transcript callbacks.
-///
-/// Protocol reference: https://elevenlabs.io/docs/api-reference/speech-to-text/v-1-speech-to-text-realtime
-/// - URL: `wss://api.elevenlabs.io/v1/speech-to-text/realtime`
-/// - Auth: `xi-api-key` header
-/// - Audio: JSON `input_audio_chunk` messages with base64 PCM (NOT raw binary)
-/// - Commit: `commit_strategy=vad` keeps server-side VAD; manual `commit:true` flushes on stop
+// Streams raw PCM audio to ElevenLabs Scribe Realtime API and delivers partial/final
+// transcript callbacks.
+//
+// Protocol reference: https://elevenlabs.io/docs/api-reference/speech-to-text/v-1-speech-to-text-realtime
+// - URL: `wss://api.elevenlabs.io/v1/speech-to-text/realtime`
+// - Auth: `xi-api-key` header
+// - Audio: JSON `input_audio_chunk` messages with base64 PCM (NOT raw binary)
+// - Commit: `commit_strategy=vad` keeps server-side VAD; manual `commit:true` flushes on stop
 // swiftlint:disable type_body_length
 final class ElevenLabsLiveTranscriber: @unchecked Sendable {
     // Connection URL is constructed in connectWebSocket(); never logged.
@@ -312,8 +312,8 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
                  "insufficient_audio_activity", "commit_throttled", "unaccepted_terms":
                 let err = try? JSONDecoder().decode(ElevenLabsErrorMessage.self, from: data)
                 let detail = err?.error ?? envelope.messageType
-                let mt = envelope.messageType
-                logger.error("ElevenLabs server error (\(mt, privacy: .public)): \(detail, privacy: .public)")
+                let kind = envelope.messageType
+                logger.error("ElevenLabs server error (\(kind, privacy: .public)): \(detail, privacy: .public)")
                 currentOnError()?(NSError(
                     domain: "ElevenLabs", code: -1,
                     userInfo: [NSLocalizedDescriptionKey: "ElevenLabs: \(detail)"]

--- a/Sources/SpeakApp/ElevenLabsLiveTranscriptionProvider.swift
+++ b/Sources/SpeakApp/ElevenLabsLiveTranscriptionProvider.swift
@@ -61,6 +61,7 @@ private struct ElevenLabsErrorMessage: Decodable {
 /// - Auth: `xi-api-key` header
 /// - Audio: JSON `input_audio_chunk` messages with base64 PCM (NOT raw binary)
 /// - Commit: `commit_strategy=vad` keeps server-side VAD; manual `commit:true` flushes on stop
+// swiftlint:disable type_body_length
 final class ElevenLabsLiveTranscriber: @unchecked Sendable {
     // Connection URL is constructed in connectWebSocket(); never logged.
     private static let websocketHost = "api.elevenlabs.io"
@@ -280,6 +281,7 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
         }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     private func parseResponse(_ json: String) {
         guard let data = json.data(using: .utf8) else { return }
         do {
@@ -310,7 +312,8 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
                  "insufficient_audio_activity", "commit_throttled", "unaccepted_terms":
                 let err = try? JSONDecoder().decode(ElevenLabsErrorMessage.self, from: data)
                 let detail = err?.error ?? envelope.messageType
-                logger.error("ElevenLabs server error (\(envelope.messageType, privacy: .public)): \(detail, privacy: .public)")
+                let mt = envelope.messageType
+                logger.error("ElevenLabs server error (\(mt, privacy: .public)): \(detail, privacy: .public)")
                 currentOnError()?(NSError(
                     domain: "ElevenLabs", code: -1,
                     userInfo: [NSLocalizedDescriptionKey: "ElevenLabs: \(detail)"]
@@ -375,3 +378,5 @@ private extension ElevenLabsLiveTranscriber {
         withStateLock { onError }
     }
 }
+
+// swiftlint:enable type_body_length

--- a/Sources/SpeakApp/ElevenLabsLiveTranscriptionProvider.swift
+++ b/Sources/SpeakApp/ElevenLabsLiveTranscriptionProvider.swift
@@ -29,28 +29,38 @@ enum ElevenLabsLiveError: LocalizedError {
 // MARK: - WebSocket response types
 
 private struct ElevenLabsStreamEnvelope: Decodable {
-    let type: String
-}
-
-private struct ElevenLabsTranscriptEvent: Decodable {
-    let text: String
-    let type: String   // "partial" or "final"
+    let messageType: String
+    private enum CodingKeys: String, CodingKey { case messageType = "message_type" }
 }
 
 private struct ElevenLabsTranscriptMessage: Decodable {
-    let type: String
-    let transcriptEvent: ElevenLabsTranscriptEvent?
-
+    let messageType: String
+    let text: String?
     private enum CodingKeys: String, CodingKey {
-        case type
-        case transcriptEvent = "transcript_event"
+        case messageType = "message_type"
+        case text
+    }
+}
+
+private struct ElevenLabsErrorMessage: Decodable {
+    let messageType: String
+    let error: String?
+    private enum CodingKeys: String, CodingKey {
+        case messageType = "message_type"
+        case error
     }
 }
 
 // MARK: - Live Transcriber (WebSocket client)
 
-/// Streams raw PCM audio to ElevenLabs Scribe v2 real-time API and delivers partial/final
-/// transcript callbacks.  Auth uses `xi-api-key` header — no URL-level key exposure.
+/// Streams raw PCM audio to ElevenLabs Scribe Realtime API and delivers partial/final
+/// transcript callbacks.
+///
+/// Protocol reference: https://elevenlabs.io/docs/api-reference/speech-to-text/v-1-speech-to-text-realtime
+/// - URL: `wss://api.elevenlabs.io/v1/speech-to-text/realtime`
+/// - Auth: `xi-api-key` header
+/// - Audio: JSON `input_audio_chunk` messages with base64 PCM (NOT raw binary)
+/// - Commit: `commit_strategy=vad` keeps server-side VAD; manual `commit:true` flushes on stop
 final class ElevenLabsLiveTranscriber: @unchecked Sendable {
     // Connection URL is constructed in connectWebSocket(); never logged.
     private static let websocketHost = "api.elevenlabs.io"
@@ -74,10 +84,13 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
     private var onTranscript: ((String, Bool) -> Void)?
     private var onError: ((Error) -> Void)?
     private var isStopping: Bool = false
+    private var sessionStarted: Bool = false
+    private var preStartAudioBuffer: [Data] = []
+    private static let preStartByteLimit = 16_000 * 2 * 5 // 5s of 16kHz PCM16
 
     init(
         apiKey: String,
-        modelID: String = "scribe_v2",
+        modelID: String = "scribe_v2_realtime",
         sampleRate: Int = 16000,
         session: URLSession = .shared,
         bufferPool: AudioBufferPool = AudioBufferPool(poolSize: 10, bufferSize: 4096)
@@ -95,6 +108,8 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
     ) {
         withStateLock {
             isStopping = false
+            sessionStarted = false
+            preStartAudioBuffer = []
             self.onTranscript = onTranscript
             self.onError = onError
         }
@@ -102,28 +117,68 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
     }
 
     func sendAudio(_ audioData: Data) {
-        guard let task = currentWebSocketTask(), task.state == .running else { return }
+        // Buffer audio until session_started arrives so we don't lose the first words.
+        let snapshot = withStateLock { () -> (URLSessionWebSocketTask?, Bool) in
+            (webSocketTask, sessionStarted)
+        }
+        guard let task = snapshot.0, task.state == .running, snapshot.1 else {
+            withStateLock {
+                preStartAudioBuffer.append(audioData)
+                var totalBytes = preStartAudioBuffer.reduce(0) { $0 + $1.count }
+                while totalBytes > Self.preStartByteLimit, !preStartAudioBuffer.isEmpty {
+                    totalBytes -= preStartAudioBuffer.removeFirst().count
+                }
+            }
+            return
+        }
+        sendAudioFrame(audioData, on: task)
+    }
 
-        var buffer = bufferPool.checkout()
-        buffer.append(audioData)
+    private func sendAudioFrame(_ audioData: Data, on task: URLSessionWebSocketTask) {
+        let payload: [String: Any] = [
+            "message_type": "input_audio_chunk",
+            "audio_base_64": audioData.base64EncodedString(),
+            "sample_rate": sampleRate
+        ]
+        guard
+            let json = try? JSONSerialization.data(withJSONObject: payload, options: []),
+            let text = String(data: json, encoding: .utf8)
+        else { return }
 
-        let dataToSend = buffer
-        let message = URLSessionWebSocketTask.Message.data(dataToSend)
         let sendGroup = pendingSendGroup
         sendGroup.enter()
-
-        task.send(message) { [weak self] error in
+        task.send(.string(text)) { [weak self] error in
             defer { sendGroup.leave() }
             guard let self else { return }
-            var returnBuffer = buffer
-            self.bufferPool.returnBuffer(&returnBuffer)
-
             if let error {
                 if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
-                self.logger.error("Failed to send audio: \(error.localizedDescription)")
+                self.logger.error("Failed to send audio: \(error.localizedDescription, privacy: .public)")
                 self.currentOnError()?(error)
             }
         }
+    }
+
+    /// Flush any audio buffered before `session_started` arrived.
+    private func flushPreStartAudio() {
+        let (task, frames) = withStateLock { () -> (URLSessionWebSocketTask?, [Data]) in
+            let pending = preStartAudioBuffer
+            preStartAudioBuffer = []
+            return (webSocketTask, pending)
+        }
+        guard let task, task.state == .running, !frames.isEmpty else { return }
+        logger.info("Flushing \(frames.count) pre-start audio frames to ElevenLabs")
+        for frame in frames {
+            sendAudioFrame(frame, on: task)
+        }
+    }
+
+    /// Send a manual commit to flush any pending VAD-buffered audio before stop.
+    func sendCommit() {
+        guard let task = currentWebSocketTask(), task.state == .running else { return }
+        let payload = #"{"message_type":"input_audio_chunk","audio_base_64":"","commit":true}"#
+        let sendGroup = pendingSendGroup
+        sendGroup.enter()
+        task.send(.string(payload)) { _ in sendGroup.leave() }
     }
 
     func stop() {
@@ -166,7 +221,8 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
         urlComponents.path = Self.websocketPath
         urlComponents.queryItems = [
             URLQueryItem(name: "model_id", value: modelID),
-            URLQueryItem(name: "inactivity_timeout", value: "10")
+            URLQueryItem(name: "audio_format", value: "pcm_\(sampleRate)"),
+            URLQueryItem(name: "commit_strategy", value: "vad")
         ]
 
         guard let url = urlComponents.url else {
@@ -189,7 +245,7 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
             return
         }
 
-        logger.info("ElevenLabs WebSocket connecting")
+        logger.info("ElevenLabs WebSocket connecting (model: \(self.modelID, privacy: .public))")
         receiveMessages()
     }
 
@@ -205,7 +261,7 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
                 if self.isStoppingState() { return }
                 if self.shouldIgnoreSocketError(error) { return }
                 let mapped = self.mapConnectionError(error)
-                self.logger.error("WebSocket receive error: \(error.localizedDescription)")
+                self.logger.error("WebSocket receive error: \(error.localizedDescription, privacy: .public)")
                 self.currentOnError()?(mapped)
             }
         }
@@ -225,21 +281,46 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
     }
 
     private func parseResponse(_ json: String) {
-        logger.debug("ElevenLabs response (length: \(json.count))")
         guard let data = json.data(using: .utf8) else { return }
-
         do {
             let envelope = try JSONDecoder().decode(ElevenLabsStreamEnvelope.self, from: data)
-            switch envelope.type {
-            case "transcript":
+            switch envelope.messageType {
+            case "session_started":
+                logger.info("ElevenLabs session started")
+                withStateLock { sessionStarted = true }
+                flushPreStartAudio()
+
+            case "partial_transcript":
                 let msg = try JSONDecoder().decode(ElevenLabsTranscriptMessage.self, from: data)
-                guard let event = msg.transcriptEvent, !event.text.isEmpty else { return }
-                let isFinal = event.type == "final"
-                currentOnTranscript()?(event.text, isFinal)
-            case "close_connection":
-                logger.info("ElevenLabs server sent close_connection")
+                guard let text = msg.text, !text.isEmpty else { return }
+                currentOnTranscript()?(text, false)
+
+            case "committed_transcript", "committed_transcript_with_timestamps":
+                let msg = try JSONDecoder().decode(ElevenLabsTranscriptMessage.self, from: data)
+                guard let text = msg.text, !text.isEmpty else { return }
+                currentOnTranscript()?(text, true)
+
+            case "auth_error":
+                logger.error("ElevenLabs auth error: \(json.prefix(200), privacy: .public)")
+                currentOnError()?(ElevenLabsLiveError.invalidAPIKeyOrMissingScribeAccess)
+
+            case "input_error", "transcriber_error", "rate_limited",
+                 "quota_exceeded", "queue_overflow", "resource_exhausted",
+                 "session_time_limit_exceeded", "chunk_size_exceeded",
+                 "insufficient_audio_activity", "commit_throttled", "unaccepted_terms":
+                let err = try? JSONDecoder().decode(ElevenLabsErrorMessage.self, from: data)
+                let detail = err?.error ?? envelope.messageType
+                logger.error("ElevenLabs server error (\(envelope.messageType, privacy: .public)): \(detail, privacy: .public)")
+                currentOnError()?(NSError(
+                    domain: "ElevenLabs", code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "ElevenLabs: \(detail)"]
+                ))
+
+            case "session_closed":
+                logger.info("ElevenLabs server closed session")
+
             default:
-                logger.debug("Unhandled ElevenLabs message type: \(envelope.type)")
+                logger.debug("Unhandled ElevenLabs message type: \(envelope.messageType, privacy: .public)")
             }
         } catch {
             logger.debug("Failed to parse ElevenLabs response: \(error.localizedDescription)")

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -2080,15 +2080,8 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
       }
       targetFormat = outputFormat
 
-      // Convert catalog IDs like "elevenlabs/scribe-v2-streaming" into API model IDs like "scribe_v2".
-      let modelID: String
-      if let model = currentModel, model.hasPrefix("elevenlabs/") {
-        let suffixless = String(model.dropFirst("elevenlabs/".count)).replacingOccurrences(
-          of: "-streaming", with: "")
-        modelID = suffixless.replacingOccurrences(of: "-", with: "_")
-      } else {
-        modelID = "scribe_v2"
-      }
+      // ElevenLabs realtime API requires the `_realtime` suffixed model ID.
+      let modelID = "scribe_v2_realtime"
 
       let newTranscriber = ElevenLabsLiveTranscriber(
         apiKey: apiKey,
@@ -2165,8 +2158,11 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
       audioProcessor.flushPendingAudio(to: transcriber)
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
-      // Brief grace period so the server can deliver any final transcript before the socket closes.
-      try? await Task.sleep(for: .seconds(0.5))
+      // Manual commit flushes any VAD-buffered audio so the server emits
+      // a final committed_transcript for the trailing words. Wait briefly
+      // for that final to arrive before closing the socket.
+      transcriber.sendCommit()
+      try? await Task.sleep(for: .seconds(1.5))
       transcriber.stop()
     } else {
       audioProcessor.setRunning(false)


### PR DESCRIPTION
Our ElevenLabs live transcriber was sending raw binary PCM and parsing
'transcript' / 'transcript_event' fields that the API never emits, so
every frame was rejected with input_error and no transcripts ever surfaced.

Per https://elevenlabs.io/docs/api-reference/speech-to-text/v-1-speech-to-text-realtime
(verified by direct WebSocket probe):

- Audio must be sent as JSON {message_type:'input_audio_chunk',
  audio_base_64:..., sample_rate:16000} - not raw binary frames
- Model id is scribe_v2_realtime (not scribe_v2)
- URL must include audio_format=pcm_16000 and commit_strategy=vad
- Server messages key off message_type and use partial_transcript /
  committed_transcript / session_started / *_error

Changes:
- Rewrote sendAudio to JSON-encode + base64 PCM
- Added pre-session_started audio buffer (5s cap) so the first words are
  not dropped while the WebSocket completes its handshake
- Rewrote parseResponse to handle the real message types incl. all the
  documented error variants (auth_error, quota_exceeded, etc.)
- Added sendCommit() and call it on stop() so VAD-buffered trailing
  audio is finalised before the socket closes (fixes 'cuts off last
  block' for ElevenLabs the same way as Soniox)
- Added URL query params and switched the controller to scribe_v2_realtime


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription accuracy for trailing words by enhancing audio session management.
  * Enhanced error handling and reporting for authentication and connection issues.

* **New Features**
  * Better reliability in capturing complete transcriptions through improved session handshake and audio buffering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->