### PR TITLE
fix(mac): pre-flight live API key alert with deep-link to Settings

### DIFF
--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -26,6 +26,11 @@ final class MainManager: ObservableObject {
   @Published private(set) var lastErrorMessage: String?
   @Published private(set) var canRetryPostProcessing: Bool = false
 
+  /// Set when a live-recording attempt is aborted because the selected
+  /// transcription provider has no API key stored. Observed by `MainView`
+  /// to present an alert with an "Add API Key" deep-link CTA.
+  @Published var missingLiveAPIKeyAlert: MissingLiveAPIKeyAlert?
+
   /// Whether live text insertion is enabled based on current settings
   private var liveInsertionEnabled: Bool {
     appSettings.speedMode.usesLivePolish && appSettings.textOutputMethod != .clipboardOnly
@@ -465,8 +470,26 @@ final class MainManager: ObservableObject {
     }
   }
 
+  /// Returns true (and sets `missingLiveAPIKeyAlert`) when the chosen live
+  /// transcription model needs an API key that has not been stored. Callers
+  /// should abort the session start when this returns true.
+  private func presentMissingLiveAPIKeyAlertIfNeeded() async -> Bool {
+    guard appSettings.transcriptionMode == .liveNative else { return false }
+    guard let missing = await transcriptionManager.missingLiveAPIKeyProvider() else {
+      return false
+    }
+    let modelID = appSettings.liveTranscriptionModel
+    let modelName = ModelCatalog.liveTranscription.first { $0.id == modelID }?.displayName ?? modelID
+    missingLiveAPIKeyAlert = MissingLiveAPIKeyAlert(
+      provider: missing,
+      modelDisplayName: modelName
+    )
+    return true
+  }
+
   private func startSession(trigger: SessionTriggerSource) async {
     guard activeSession == nil else { return }
+    if await presentMissingLiveAPIKeyAlertIfNeeded() { return }
 
     // Failsafe: if live transcription is still running but we have no activeSession,
     // cancel it so the app can always recover without requiring a restart.

--- a/Sources/SpeakApp/MainView.swift
+++ b/Sources/SpeakApp/MainView.swift
@@ -24,6 +24,26 @@ struct MainView: View {
         NSApp.windows.first?.makeKeyAndOrderFront(nil)
       }
     }
+    .alert(
+      environment.main.missingLiveAPIKeyAlert?.title ?? "API key required",
+      isPresented: Binding(
+        get: { environment.main.missingLiveAPIKeyAlert != nil },
+        set: { if !$0 { environment.main.missingLiveAPIKeyAlert = nil } }
+      ),
+      presenting: environment.main.missingLiveAPIKeyAlert
+    ) { alert in
+      Button("Add API Key") {
+        let target = "transcription-\(alert.provider.id)"
+        environment.apiKeysScrollTarget = target
+        selection = .settings(.apiKeys)
+        environment.main.missingLiveAPIKeyAlert = nil
+      }
+      Button("Cancel", role: .cancel) {
+        environment.main.missingLiveAPIKeyAlert = nil
+      }
+    } message: { alert in
+      Text(alert.message)
+    }
   }
 
   @ViewBuilder

--- a/Sources/SpeakApp/MissingLiveAPIKeyAlert.swift
+++ b/Sources/SpeakApp/MissingLiveAPIKeyAlert.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SpeakCore
+
+/// State for the pre-flight "API key required" alert shown when the user
+/// triggers a live recording but the chosen live transcription provider has
+/// no API key stored. The alert exposes an "Add API Key" CTA which navigates
+/// to Settings → API Keys, scrolled to the relevant provider section.
+struct MissingLiveAPIKeyAlert: Identifiable, Equatable {
+  let id = UUID()
+  let provider: TranscriptionProviderMetadata
+  let modelDisplayName: String
+
+  var title: String { "API key required" }
+
+  var message: String {
+    "\(provider.displayName) needs an API key for live transcription "
+      + "with \(modelDisplayName). Add it now and try again."
+  }
+
+  static func == (lhs: MissingLiveAPIKeyAlert, rhs: MissingLiveAPIKeyAlert) -> Bool {
+    lhs.id == rhs.id
+  }
+}

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -1491,9 +1491,10 @@ struct SettingsView: View {
   }
 
   private var apiKeySettings: some View {
-    LazyVStack(spacing: 20) {
-      // OpenRouter (Legacy)
-      apiKeyCard(
+    ScrollViewReader { proxy in
+      LazyVStack(spacing: 20) {
+        // OpenRouter (Legacy)
+        apiKeyCard(
         title: "OpenRouter",
         systemImage: "network",
         tint: .green,
@@ -1532,6 +1533,22 @@ struct SettingsView: View {
       ForEach([TTSProvider.elevenlabs, .openai, .azure, .deepgram]) { provider in
         ttsProviderAPIKeyCard(for: provider)
           .id("tts-\(provider.id)")
+      }
+    }
+    .onAppear {
+        if let target = environment.apiKeysScrollTarget {
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            withAnimation { proxy.scrollTo(target, anchor: .top) }
+            environment.apiKeysScrollTarget = nil
+          }
+        }
+      }
+      .onChange(of: environment.apiKeysScrollTarget) { _, newValue in
+        guard let target = newValue else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+          withAnimation { proxy.scrollTo(target, anchor: .top) }
+          environment.apiKeysScrollTarget = nil
+        }
       }
     }
   }

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -176,6 +176,18 @@ final class TranscriptionManager: ObservableObject {
     return await openRouter.hasStoredAPIKey()
   }
 
+  /// Returns the metadata for the live-transcription provider whose API key is
+  /// missing — `nil` if the current live model needs no key, or its key is set.
+  /// Used for the "API key required" pre-flight alert before a live recording.
+  func missingLiveAPIKeyProvider() async -> TranscriptionProviderMetadata? {
+    let model = appSettings.liveTranscriptionModel
+    let registry = TranscriptionProviderRegistry.shared
+    guard await registry.requiresAPIKey(for: model) else { return nil }
+    guard let provider = await registry.provider(forModel: model) else { return nil }
+    if await hasAPIKey(for: provider.metadata) { return nil }
+    return provider.metadata
+  }
+
   private func getAPIKey(for metadata: TranscriptionProviderMetadata) async throws -> String {
     guard let key = try? await secureStorage.secret(identifier: metadata.apiKeyIdentifier) else {
       throw TranscriptionProviderError.apiKeyMissing

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -28,6 +28,11 @@ final class AppEnvironment: ObservableObject {
   let transportServer: TransportServer
   private let hudPresenter: HUDWindowPresenter
 
+  /// Coordinator state for cross-view navigation. When set, MainView selects
+  /// the API Keys settings tab and the apiKeySettings view scrolls to the
+  /// matching `.id("transcription-<provider.id>")` section.
+  @Published var apiKeysScrollTarget: String?
+
   private(set) var statusBarController: StatusBarController?
   private(set) var menuBarManager: MenuBarManager?
   private(set) var dockMenuManager: DockMenuManager?


### PR DESCRIPTION
Fixes the case the user flagged: selecting a live transcription model that has no API key stored silently failed mid-recording. Now the app pre-flights the check, aborts the session before recording starts, and presents an alert with an 'Add API Key' CTA that navigates to Settings → API Keys and scrolls to the relevant provider section.

## Changes
- `TranscriptionManager.missingLiveAPIKeyProvider()` - returns provider metadata when a key is required but missing
- `MainManager.startSession` - pre-flights via new `presentMissingLiveAPIKeyAlertIfNeeded()`; publishes `missingLiveAPIKeyAlert`
- `MainView` - presents alert, routes 'Add API Key' to `SettingsTab.apiKeys` and sets `environment.apiKeysScrollTarget = transcription-<provider.id>`
- `AppEnvironment.apiKeysScrollTarget` - new coordinator state
- `SettingsView.apiKeySettings` - wrapped in `ScrollViewReader`; scrolls to the published target on appear / change

## Verification
- `swift build --target SpeakApp` ✅
- `swiftlint --strict --baseline` ✅ (0 violations)
- `make test` ✅ (368 tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alert notification when attempting live transcription without a configured API key, with direct navigation to API settings.
  * Settings now automatically scroll to the target API key entry for improved configuration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->