### PR TITLE
fix(mac): tolerate spurious ENOTCONN on AssemblyAI WebSocket

### DIFF
--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -293,24 +293,18 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         // URLSessionWebSocketTask fires spurious ENOTCONN (POSIX 57) callbacks
         // around the wss handshake on macOS — sometimes before Begin, sometimes
         // after — but the underlying connection still works and Turn messages
-        // arrive on subsequent receive() calls. Retry indefinitely; the
-        // isStoppingState() guard above (set on Terminate/Termination) breaks
-        // us out when the session actually ends.
-        if self.isSpuriousENOTCONN(error) {
+        // arrive on subsequent receive() calls. Re-arm receive() rather than
+        // bubbling the error; the isStoppingState() guard above (set on
+        // Terminate/Termination) breaks us out when the session actually ends.
+        if self.shouldIgnoreSocketError(error) {
           self.receiveMessages()
           return
         }
         if self.retryWithFallbackEndpointIfNeeded(after: error) { return }
-        if self.shouldIgnoreSocketError(error) { return }
         self.logger.error("WebSocket receive error: \(error.localizedDescription, privacy: .public)")
         self.currentOnError()?(error)
       }
     }
-  }
-
-  private func isSpuriousENOTCONN(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    return nsError.domain == NSPOSIXErrorDomain && nsError.code == 57
   }
 
   private func retryWithFallbackEndpointIfNeeded(after error: Error) -> Bool {

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -290,12 +290,27 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         self.receiveMessages()
       case .failure(let error):
         if self.isStoppingState() { return }
+        // URLSessionWebSocketTask fires spurious ENOTCONN (POSIX 57) callbacks
+        // around the wss handshake on macOS — sometimes before Begin, sometimes
+        // after — but the underlying connection still works and Turn messages
+        // arrive on subsequent receive() calls. Retry indefinitely; the
+        // isStoppingState() guard above (set on Terminate/Termination) breaks
+        // us out when the session actually ends.
+        if self.isSpuriousENOTCONN(error) {
+          self.receiveMessages()
+          return
+        }
         if self.retryWithFallbackEndpointIfNeeded(after: error) { return }
         if self.shouldIgnoreSocketError(error) { return }
         self.logger.error("WebSocket receive error: \(error.localizedDescription, privacy: .public)")
         self.currentOnError()?(error)
       }
     }
+  }
+
+  private func isSpuriousENOTCONN(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    return nsError.domain == NSPOSIXErrorDomain && nsError.code == 57
   }
 
   private func retryWithFallbackEndpointIfNeeded(after error: Error) -> Bool {
@@ -363,6 +378,7 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         flushPreBeginAudio()
       case "Termination":
         logger.info("AssemblyAI session terminated by server")
+        withStateLock { isStopping = true }
       case "SpeechStarted", "":
         break
       default:


### PR DESCRIPTION
## Summary

URLSessionWebSocketTask fires spurious POSIX ENOTCONN (code 57) callbacks on AssemblyAI's wss endpoint — sometimes before the `Begin` message, sometimes after — but the underlying connection is alive and Turn messages arrive on subsequent `receive()` calls.

## Reproduction

Token-authenticated probe (`/tmp/aai_probe4.swift`) confirms across both global and EU endpoints: every session shows `Begin` arriving normally, then `receive()` fails immediately with ENOTCONN, then more messages (`Termination`, `Turn`) arrive on subsequent receives.

Without retry: the loop exits after the first ENOTCONN → no Turn messages → empty-transcript symptom users reported on mac-v0.29.20.

## Fix

- Detect `NSPOSIXErrorDomain` code 57 in `receiveMessages`'s failure branch and re-arm `receive()` instead of bubbling the error.
- Real failures (other domains/codes) still flow through the existing retry/error path.
- Mark `isStopping=true` on `Termination` message so the retry loop exits cleanly when the server closes the session.

## Why earlier fixes didn't land it

- 0.29.19 (bidirectional fallback) and 0.29.20 (dedicated URLSession + token query auth) treated symptoms (which endpoint fails) rather than the cause (spurious ENOTCONN from URLSession layer regardless of config).

## Verification

- `swift build --target SpeakApp` ✓
- `make test` (368 tests, 0 failures) ✓
- `swiftlint --strict --baseline .swiftlint-baseline.json` ✓
- Local AAI probe with retry: Begin + Termination both delivered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced transcription stream stability with improved error recovery for intermittent connection disruptions
  * Refined handling of server-initiated stream termination to ensure proper cleanup and lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->