### PR TITLE
fix(mac): throttle AssemblyAI ENOTCONN retries + Begin timeout

### DIFF
--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -138,19 +138,28 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
 
     logger.info("AssemblyAI WebSocket connecting via \(host.rawValue)")
     receiveMessages()
-    scheduleBeginTimeout()
+    scheduleBeginTimeout(for: task)
   }
 
   private static let beginTimeoutSeconds: Double = 8
 
-  private func scheduleBeginTimeout() {
-    DispatchQueue.global().asyncAfter(deadline: .now() + Self.beginTimeoutSeconds) { [weak self] in
-      guard let self else { return }
-      let (didBegin, stopping) = self.withStateLock { (self.sessionDidBegin, self.isStopping) }
-      guard !didBegin, !stopping else { return }
+  private func scheduleBeginTimeout(for task: URLSessionWebSocketTask) {
+    DispatchQueue.global().asyncAfter(deadline: .now() + Self.beginTimeoutSeconds) { [weak self, weak task] in
+      guard let self, let task else { return }
+      let shouldFire = self.withStateLock { () -> Bool in
+        // Only act if THIS connection is still the active one and Begin
+        // hasn't arrived. Fallback retries swap webSocketTask, and we don't
+        // want a stale timeout from an aborted attempt to surface an error.
+        guard !self.sessionDidBegin, !self.isStopping else { return false }
+        guard self.webSocketTask === task else { return false }
+        self.isStopping = true
+        return true
+      }
+      guard shouldFire else { return }
       self.logger.error(
         "AssemblyAI WebSocket Begin not received within \(Self.beginTimeoutSeconds, privacy: .public)s; surfacing error"
       )
+      task.cancel(with: .goingAway, reason: nil)
       self.currentOnError()?(AssemblyAIError.streamingFailed("Begin timeout"))
     }
   }

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -138,6 +138,21 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
 
     logger.info("AssemblyAI WebSocket connecting via \(host.rawValue)")
     receiveMessages()
+    scheduleBeginTimeout()
+  }
+
+  private static let beginTimeoutSeconds: Double = 8
+
+  private func scheduleBeginTimeout() {
+    DispatchQueue.global().asyncAfter(deadline: .now() + Self.beginTimeoutSeconds) { [weak self] in
+      guard let self else { return }
+      let (didBegin, stopping) = self.withStateLock { (self.sessionDidBegin, self.isStopping) }
+      guard !didBegin, !stopping else { return }
+      self.logger.error(
+        "AssemblyAI WebSocket Begin not received within \(Self.beginTimeoutSeconds, privacy: .public)s; surfacing error"
+      )
+      self.currentOnError()?(AssemblyAIError.streamingFailed("Begin timeout"))
+    }
   }
 
   private func makeWebSocketURL(for host: EndpointHost) -> URLComponents? {
@@ -296,8 +311,13 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         // arrive on subsequent receive() calls. Re-arm receive() rather than
         // bubbling the error; the isStoppingState() guard above (set on
         // Terminate/Termination) breaks us out when the session actually ends.
+        // We re-arm via asyncAfter (not the completion handler thread) so we
+        // don't starve URLSession's delegate queue and prevent it from
+        // delivering the Begin/Turn frames.
         if self.shouldIgnoreSocketError(error) {
-          self.receiveMessages()
+          DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.01) { [weak self] in
+            self?.receiveMessages()
+          }
           return
         }
         if self.retryWithFallbackEndpointIfNeeded(after: error) { return }
@@ -827,6 +847,7 @@ enum AssemblyAIError: LocalizedError {
   case connectionFailed
   case sendFailed
   case missingAPIKey
+  case streamingFailed(String)
 
   var errorDescription: String? {
     switch self {
@@ -838,6 +859,8 @@ enum AssemblyAIError: LocalizedError {
       return "Failed to send audio data to AssemblyAI"
     case .missingAPIKey:
       return "AssemblyAI API key is missing. Please configure it in Settings."
+    case .streamingFailed(let detail):
+      return "AssemblyAI streaming failed: \(detail)"
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #412. In mac-v0.29.21 the receive loop re-armed `receive()` synchronously from URLSession's completion thread on every spurious ENOTCONN. In some network environments (reproduced from user logs after 0.29.21 shipped) ENOTCONN fires in a tight loop, **starving URLSession's delegate queue and preventing the Begin/Turn frames from ever being delivered** — recordings appear to capture audio but produce empty transcripts with no error logged.

User log post-0.29.21:
```
22:56:21.311 AssemblyAI WebSocket connecting via streaming.assemblyai.com
22:56:28.463 Building result: segments=0 interim=0 chars
```
No Begin, no Turns, no errors — silent hang.

## Fix

- Re-arm `receive()` via `DispatchQueue.global().asyncAfter(0.01s)` so the delegate queue can interleave message delivery between retries.
- Schedule an 8-second Begin timeout when connecting; if no Begin arrives we surface a `streamingFailed` error instead of hanging silently.

## Verification

- `swift build --target SpeakApp` ✓
- `swiftlint --strict --baseline .swiftlint-baseline.json` ✓
- 368 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming transcription reliability with timeout detection; connections that don't complete handshake within 8 seconds now fail gracefully.
  * Enhanced error recovery for network socket issues with a retry delay strategy to prevent rapid error loops.

* **New Features**
  * Added streaming failure error reporting for improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->