### PR TITLE
fix(mac): instrument AssemblyAI WebSocket handshake

### DIFF
--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -138,19 +138,28 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
 
     logger.info("AssemblyAI WebSocket connecting via \(host.rawValue)")
     receiveMessages()
-    scheduleBeginTimeout()
+    scheduleBeginTimeout(for: task)
   }
 
   private static let beginTimeoutSeconds: Double = 8
 
-  private func scheduleBeginTimeout() {
-    DispatchQueue.global().asyncAfter(deadline: .now() + Self.beginTimeoutSeconds) { [weak self] in
-      guard let self else { return }
-      let (didBegin, stopping) = self.withStateLock { (self.sessionDidBegin, self.isStopping) }
-      guard !didBegin, !stopping else { return }
+  private func scheduleBeginTimeout(for task: URLSessionWebSocketTask) {
+    DispatchQueue.global().asyncAfter(deadline: .now() + Self.beginTimeoutSeconds) { [weak self, weak task] in
+      guard let self, let task else { return }
+      let shouldFire = self.withStateLock { () -> Bool in
+        // Only act if THIS connection is still the active one and Begin
+        // hasn't arrived. Fallback retries swap webSocketTask, and we don't
+        // want a stale timeout from an aborted attempt to surface an error.
+        guard !self.sessionDidBegin, !self.isStopping else { return false }
+        guard self.webSocketTask === task else { return false }
+        self.isStopping = true
+        return true
+      }
+      guard shouldFire else { return }
       self.logger.error(
         "AssemblyAI WebSocket Begin not received within \(Self.beginTimeoutSeconds, privacy: .public)s; surfacing error"
       )
+      task.cancel(with: .goingAway, reason: nil)
       self.currentOnError()?(AssemblyAIError.streamingFailed("Begin timeout"))
     }
   }

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -138,6 +138,21 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
 
     logger.info("AssemblyAI WebSocket connecting via \(host.rawValue)")
     receiveMessages()
+    scheduleBeginTimeout()
+  }
+
+  private static let beginTimeoutSeconds: Double = 8
+
+  private func scheduleBeginTimeout() {
+    DispatchQueue.global().asyncAfter(deadline: .now() + Self.beginTimeoutSeconds) { [weak self] in
+      guard let self else { return }
+      let (didBegin, stopping) = self.withStateLock { (self.sessionDidBegin, self.isStopping) }
+      guard !didBegin, !stopping else { return }
+      self.logger.error(
+        "AssemblyAI WebSocket Begin not received within \(Self.beginTimeoutSeconds, privacy: .public)s; surfacing error"
+      )
+      self.currentOnError()?(AssemblyAIError.streamingFailed("Begin timeout"))
+    }
   }
 
   private func makeWebSocketURL(for host: EndpointHost) -> URLComponents? {
@@ -296,8 +311,13 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         // arrive on subsequent receive() calls. Re-arm receive() rather than
         // bubbling the error; the isStoppingState() guard above (set on
         // Terminate/Termination) breaks us out when the session actually ends.
+        // We re-arm via asyncAfter (not the completion handler thread) so we
+        // don't starve URLSession's delegate queue and prevent it from
+        // delivering the Begin/Turn frames.
         if self.shouldIgnoreSocketError(error) {
-          self.receiveMessages()
+          DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.01) { [weak self] in
+            self?.receiveMessages()
+          }
           return
         }
         if self.retryWithFallbackEndpointIfNeeded(after: error) { return }
@@ -827,6 +847,7 @@ enum AssemblyAIError: LocalizedError {
   case connectionFailed
   case sendFailed
   case missingAPIKey
+  case streamingFailed(String)
 
   var errorDescription: String? {
     switch self {
@@ -838,6 +859,8 @@ enum AssemblyAIError: LocalizedError {
       return "Failed to send audio data to AssemblyAI"
     case .missingAPIKey:
       return "AssemblyAI API key is missing. Please configure it in Settings."
+    case .streamingFailed(let detail):
+      return "AssemblyAI streaming failed: \(detail)"
     }
   }
 }

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -73,6 +73,17 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
       self.session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
     }
     delegate.logger = logger
+    self.ownsSession = (session == nil)
+  }
+
+  private let ownsSession: Bool
+
+  deinit {
+    // Sessions created with a delegate retain that delegate strongly
+    // until invalidated; only invalidate sessions we own (tests inject one).
+    if ownsSession {
+      session.invalidateAndCancel()
+    }
   }
 
   private let delegate: AssemblyAIWebSocketDelegate

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -61,16 +61,21 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
     self.keyterms = keyterms
     self.speechModel = speechModel
     self.languageDetectionEnabled = languageDetectionEnabled
+    self.bufferPool = bufferPool
+    let delegate = AssemblyAIWebSocketDelegate()
+    self.delegate = delegate
     if let session {
       self.session = session
     } else {
       let config = URLSessionConfiguration.default
       config.waitsForConnectivity = true
       config.timeoutIntervalForRequest = 30
-      self.session = URLSession(configuration: config)
+      self.session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
     }
-    self.bufferPool = bufferPool
+    delegate.logger = logger
   }
+
+  private let delegate: AssemblyAIWebSocketDelegate
 
   func start(
     onTranscript: @escaping (AssemblyAITurnResponse) -> Void,
@@ -847,6 +852,67 @@ private struct AssemblyAIBatchWord: Decodable {
   let start: Int
   let end: Int
   let confidence: Double?
+}
+
+// MARK: - WebSocket Diagnostic Delegate
+
+private final class AssemblyAIWebSocketDelegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate {
+  var logger: Logger?
+
+  func urlSession(
+    _ session: URLSession,
+    webSocketTask: URLSessionWebSocketTask,
+    didOpenWithProtocol protocol: String?
+  ) {
+    logger?.info("AssemblyAI WS didOpen protocol=\(`protocol` ?? "<nil>", privacy: .public)")
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    webSocketTask: URLSessionWebSocketTask,
+    didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+    reason: Data?
+  ) {
+    let reasonStr = reason.flatMap { String(data: $0, encoding: .utf8) } ?? "<nil>"
+    logger?.info(
+      "AssemblyAI WS didClose code=\(closeCode.rawValue, privacy: .public) reason=\(reasonStr, privacy: .public)"
+    )
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didCompleteWithError error: Error?
+  ) {
+    if let error = error as NSError? {
+      let domain = error.domain
+      let code = error.code
+      let desc = error.localizedDescription
+      logger?.error(
+        // swiftlint:disable:next line_length
+        "AssemblyAI WS didComplete error domain=\(domain, privacy: .public) code=\(code, privacy: .public) desc=\(desc, privacy: .public)"
+      )
+    } else {
+      logger?.info("AssemblyAI WS didComplete (no error)")
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    taskIsWaitingForConnectivity task: URLSessionTask
+  ) {
+    logger?.info("AssemblyAI WS waiting for connectivity")
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  ) {
+    logger?.info("AssemblyAI WS auth challenge: \(challenge.protectionSpace.authenticationMethod, privacy: .public)")
+    completionHandler(.performDefaultHandling, nil)
+  }
 }
 
 // MARK: - Error Types


### PR DESCRIPTION
Diagnostic ship — adds URLSessionWebSocketDelegate logging to surface what URLSession is doing during the AssemblyAI wss handshake in notarised builds where Begin never arrives.

In notarised builds the WebSocket silently never emits Begin (no success, no failure callbacks at all on receive()), while the same code in an unsandboxed swift script with the same token + URL connects and streams transcripts in <2s. The delegate hooks (didOpen, didClose, didComplete, waitsForConnectivity, auth challenge) will tell us where URLSession is actually stalling.

Once we have the diagnostic data the real fix can be targeted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeout protection to detect and surface transcription stream initialization failures.

* **Bug Fixes**
  * Enhanced error handling for WebSocket connectivity and authentication challenges.
  * Improved error recovery for WebSocket receive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->