### PR TITLE
fix(mac): surface AssemblyAI WS Error frames + trim API key

### DIFF
--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -138,19 +138,28 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
 
     logger.info("AssemblyAI WebSocket connecting via \(host.rawValue)")
     receiveMessages()
-    scheduleBeginTimeout()
+    scheduleBeginTimeout(for: task)
   }
 
   private static let beginTimeoutSeconds: Double = 8
 
-  private func scheduleBeginTimeout() {
-    DispatchQueue.global().asyncAfter(deadline: .now() + Self.beginTimeoutSeconds) { [weak self] in
-      guard let self else { return }
-      let (didBegin, stopping) = self.withStateLock { (self.sessionDidBegin, self.isStopping) }
-      guard !didBegin, !stopping else { return }
+  private func scheduleBeginTimeout(for task: URLSessionWebSocketTask) {
+    DispatchQueue.global().asyncAfter(deadline: .now() + Self.beginTimeoutSeconds) { [weak self, weak task] in
+      guard let self, let task else { return }
+      let shouldFire = self.withStateLock { () -> Bool in
+        // Only act if THIS connection is still the active one and Begin
+        // hasn't arrived. Fallback retries swap webSocketTask, and we don't
+        // want a stale timeout from an aborted attempt to surface an error.
+        guard !self.sessionDidBegin, !self.isStopping else { return false }
+        guard self.webSocketTask === task else { return false }
+        self.isStopping = true
+        return true
+      }
+      guard shouldFire else { return }
       self.logger.error(
         "AssemblyAI WebSocket Begin not received within \(Self.beginTimeoutSeconds, privacy: .public)s; surfacing error"
       )
+      task.cancel(with: .goingAway, reason: nil)
       self.currentOnError()?(AssemblyAIError.streamingFailed("Begin timeout"))
     }
   }

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -138,6 +138,21 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
 
     logger.info("AssemblyAI WebSocket connecting via \(host.rawValue)")
     receiveMessages()
+    scheduleBeginTimeout()
+  }
+
+  private static let beginTimeoutSeconds: Double = 8
+
+  private func scheduleBeginTimeout() {
+    DispatchQueue.global().asyncAfter(deadline: .now() + Self.beginTimeoutSeconds) { [weak self] in
+      guard let self else { return }
+      let (didBegin, stopping) = self.withStateLock { (self.sessionDidBegin, self.isStopping) }
+      guard !didBegin, !stopping else { return }
+      self.logger.error(
+        "AssemblyAI WebSocket Begin not received within \(Self.beginTimeoutSeconds, privacy: .public)s; surfacing error"
+      )
+      self.currentOnError()?(AssemblyAIError.streamingFailed("Begin timeout"))
+    }
   }
 
   private func makeWebSocketURL(for host: EndpointHost) -> URLComponents? {
@@ -296,8 +311,13 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         // arrive on subsequent receive() calls. Re-arm receive() rather than
         // bubbling the error; the isStoppingState() guard above (set on
         // Terminate/Termination) breaks us out when the session actually ends.
+        // We re-arm via asyncAfter (not the completion handler thread) so we
+        // don't starve URLSession's delegate queue and prevent it from
+        // delivering the Begin/Turn frames.
         if self.shouldIgnoreSocketError(error) {
-          self.receiveMessages()
+          DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.01) { [weak self] in
+            self?.receiveMessages()
+          }
           return
         }
         if self.retryWithFallbackEndpointIfNeeded(after: error) { return }
@@ -827,6 +847,7 @@ enum AssemblyAIError: LocalizedError {
   case connectionFailed
   case sendFailed
   case missingAPIKey
+  case streamingFailed(String)
 
   var errorDescription: String? {
     switch self {
@@ -838,6 +859,8 @@ enum AssemblyAIError: LocalizedError {
       return "Failed to send audio data to AssemblyAI"
     case .missingAPIKey:
       return "AssemblyAI API key is missing. Please configure it in Settings."
+    case .streamingFailed(let detail):
+      return "AssemblyAI streaming failed: \(detail)"
     }
   }
 }

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -56,7 +56,7 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
     session: URLSession? = nil,
     bufferPool: AudioBufferPool = AudioBufferPool(poolSize: 10, bufferSize: 4096)
   ) {
-    self.apiKey = apiKey
+    self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
     self.sampleRate = sampleRate
     self.keyterms = keyterms
     self.speechModel = speechModel
@@ -397,7 +397,7 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
   }
 
   private func parseResponse(_ json: String) {
-    logger.debug("Received AssemblyAI response (length: \(json.count))")
+    logger.info("AssemblyAI WS frame received (\(json.count) bytes)")
     guard let data = json.data(using: .utf8) else { return }
 
     do {
@@ -418,10 +418,17 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
       case "Termination":
         logger.info("AssemblyAI session terminated by server")
         withStateLock { isStopping = true }
-      case "SpeechStarted", "":
+      case "SpeechStarted":
         break
+      case "Error":
+        // AssemblyAI sends an Error text frame just before closing with code 3006/4xxx.
+        // Surface it at .info so users can capture it from `log show` filters.
+        logger.error("AssemblyAI server Error frame: \(json.prefix(500), privacy: .public)")
+      case "":
+        // Unknown / typeless. Could be diagnostic text from server.
+        logger.info("AssemblyAI typeless WS message: \(json.prefix(500), privacy: .public)")
       default:
-        logger.debug("Unhandled AssemblyAI message type: \(resolvedType)")
+        logger.info("Unhandled AssemblyAI message type=\(resolvedType, privacy: .public): \(json.prefix(500), privacy: .public)")
       }
     } catch {
       logger.debug("Failed to parse AssemblyAI response: \(error.localizedDescription)")

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -428,7 +428,8 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         // Unknown / typeless. Could be diagnostic text from server.
         logger.info("AssemblyAI typeless WS message: \(json.prefix(500), privacy: .public)")
       default:
-        logger.info("Unhandled AssemblyAI message type=\(resolvedType, privacy: .public): \(json.prefix(500), privacy: .public)")
+        let body = json.prefix(500)
+        logger.info("Unhandled AssemblyAI type=\(resolvedType, privacy: .public): \(body, privacy: .public)")
       }
     } catch {
       logger.debug("Failed to parse AssemblyAI response: \(error.localizedDescription)")

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -73,6 +73,17 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
       self.session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
     }
     delegate.logger = logger
+    self.ownsSession = (session == nil)
+  }
+
+  private let ownsSession: Bool
+
+  deinit {
+    // Sessions created with a delegate retain that delegate strongly
+    // until invalidated; only invalidate sessions we own (tests inject one).
+    if ownsSession {
+      session.invalidateAndCancel()
+    }
   }
 
   private let delegate: AssemblyAIWebSocketDelegate

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -61,16 +61,21 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
     self.keyterms = keyterms
     self.speechModel = speechModel
     self.languageDetectionEnabled = languageDetectionEnabled
+    self.bufferPool = bufferPool
+    let delegate = AssemblyAIWebSocketDelegate()
+    self.delegate = delegate
     if let session {
       self.session = session
     } else {
       let config = URLSessionConfiguration.default
       config.waitsForConnectivity = true
       config.timeoutIntervalForRequest = 30
-      self.session = URLSession(configuration: config)
+      self.session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
     }
-    self.bufferPool = bufferPool
+    delegate.logger = logger
   }
+
+  private let delegate: AssemblyAIWebSocketDelegate
 
   func start(
     onTranscript: @escaping (AssemblyAITurnResponse) -> Void,
@@ -847,6 +852,67 @@ private struct AssemblyAIBatchWord: Decodable {
   let start: Int
   let end: Int
   let confidence: Double?
+}
+
+// MARK: - WebSocket Diagnostic Delegate
+
+private final class AssemblyAIWebSocketDelegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate {
+  var logger: Logger?
+
+  func urlSession(
+    _ session: URLSession,
+    webSocketTask: URLSessionWebSocketTask,
+    didOpenWithProtocol protocol: String?
+  ) {
+    logger?.info("AssemblyAI WS didOpen protocol=\(`protocol` ?? "<nil>", privacy: .public)")
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    webSocketTask: URLSessionWebSocketTask,
+    didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+    reason: Data?
+  ) {
+    let reasonStr = reason.flatMap { String(data: $0, encoding: .utf8) } ?? "<nil>"
+    logger?.info(
+      "AssemblyAI WS didClose code=\(closeCode.rawValue, privacy: .public) reason=\(reasonStr, privacy: .public)"
+    )
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didCompleteWithError error: Error?
+  ) {
+    if let error = error as NSError? {
+      let domain = error.domain
+      let code = error.code
+      let desc = error.localizedDescription
+      logger?.error(
+        // swiftlint:disable:next line_length
+        "AssemblyAI WS didComplete error domain=\(domain, privacy: .public) code=\(code, privacy: .public) desc=\(desc, privacy: .public)"
+      )
+    } else {
+      logger?.info("AssemblyAI WS didComplete (no error)")
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    taskIsWaitingForConnectivity task: URLSessionTask
+  ) {
+    logger?.info("AssemblyAI WS waiting for connectivity")
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  ) {
+    logger?.info("AssemblyAI WS auth challenge: \(challenge.protectionSpace.authenticationMethod, privacy: .public)")
+    completionHandler(.performDefaultHandling, nil)
+  }
 }
 
 // MARK: - Error Types


### PR DESCRIPTION
## Why

Latest 0.29.23 diagnostic logs revealed that the AssemblyAI WebSocket is closing with code **3006** ("See Error message for details") **318 ms after the handshake completes** — and we've been silently swallowing the AAI Error text frame the server sends right before that close.

A direct WS probe (`/tmp/aai_probe8.swift`) using the **exact same** URLSession config, headers, query params and token from the same machine receives `Begin` in <100 ms. So the difference is something AAI is seeing about the request inside the notarised app.

## What this changes

1. `parseResponse` now logs every WS frame at `.info` (was `.debug`) and explicitly logs `Error` / typeless / unknown-type messages with their raw body so they appear under `log show --info`.
2. Trim whitespace/newlines from the API key on init — defensive against keychain values that may have been pasted with a trailing newline.

## Verification next step

Ship as 0.29.24, ask user to retest, and capture:
```
log show --last 2m --predicate 'subsystem == "com.speak.app"' --info | grep -i assembly
```
The new "AssemblyAI server Error frame:" or "typeless WS message:" line will reveal the actual rejection reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeout mechanism for streaming transcription startup to detect and report connection failures more reliably.
  * Introduced dedicated error messaging for streaming connection issues.

* **Bug Fixes**
  * Improved WebSocket connection stability by adjusting error recovery behavior.
  * Enhanced handling of transient connection errors during handshake.
  * Fixed WebSocket session lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->