### PR TITLE
fix(mac): send AssemblyAI keyterms_prompt as JSON array

### DIFF
--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -122,11 +122,15 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
       URLQueryItem(name: "token", value: apiKey)
     ]
 
-    // AssemblyAI streaming v3 only supports keyterms_prompt (not arbitrary prompts).
-    // The preprocessing prompt is applied post-transcription; only keyterms are sent to the WebSocket.
-    let validTerms = keyterms.filter { !$0.isEmpty && $0.count <= 50 }.prefix(100)
-    for term in validTerms {
-      urlComponents.queryItems?.append(URLQueryItem(name: "keyterms_prompt", value: term))
+    // AssemblyAI streaming v3 expects keyterms_prompt as a single JSON-array
+    // query parameter (e.g. ?keyterms_prompt=["foo","bar"]), NOT as repeated
+    // params — sending repeated params triggers close code 3006 with
+    // "Invalid 'keyterms_prompt': Value error, Invalid JSON array".
+    let validTerms = Array(keyterms.filter { !$0.isEmpty && $0.count <= 50 }.prefix(100))
+    if !validTerms.isEmpty,
+       let jsonData = try? JSONSerialization.data(withJSONObject: validTerms),
+       let jsonString = String(data: jsonData, encoding: .utf8) {
+      urlComponents.queryItems?.append(URLQueryItem(name: "keyterms_prompt", value: jsonString))
     }
     if languageDetectionEnabled {
       urlComponents.queryItems?.append(URLQueryItem(name: "language_detection", value: "true"))


### PR DESCRIPTION
## Root cause confirmed

User log capture from mac-v0.29.24 (PR #415 instrumentation):
```
AssemblyAI server Error frame: {"type":"Error","error_code":3006,"error":"User Input Validation Error: Invalid 'keyterms_prompt': Value error, Invalid JSON array; Invalid 'keyterms_prompt': Value error, Invalid JSON array"}
AssemblyAI WS didClose code=3006
```

AssemblyAI streaming v3 expects `keyterms_prompt` as a **single JSON-array** query param (`?keyterms_prompt=["foo","bar"]`), not repeated query params. We were appending one URLQueryItem per term, so the server saw two malformed values and closed with 3006.

This is why the local probe (no keyterms) and Deepgram/ElevenLabs (different keyword wire format) all worked while AAI quietly failed for any user with even one keyterm configured.

## Verification

Local probe `/tmp/aai_probe9.swift` with three keyterms encoded as a JSON array returns `Begin` in <100ms with the same token from the same machine that previously got 3006.

## Ship as

mac-v0.29.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming transcription stability when using multiple keyterms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->