### PR TITLE
perf(mac): drop 2s tail-wait in AssemblyAI stop()

### DIFF
--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -301,11 +301,28 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
 
     guard let task, task.state == .running else { return }
 
-    // Send ForceEndpoint to flush the current turn before terminating
+    // Send ForceEndpoint to flush the current turn before terminating.
+    //
+    // NOTE: Previously this used a 2.0s sleep before sending Terminate, on the
+    // assumption that we needed to wait for the formatted final Turn response
+    // before tearing down the socket. That wait is already handled higher up
+    // by AssemblyAILiveController.stop() (its `stopContinuation` waits for the
+    // final Turn to be observed in handleTurn, with its own timeout). Holding
+    // the socket open here for an additional 2s just inflates the perceived
+    // "finalising" delay — particularly noticeable on long utterances where
+    // the server-side formatting pass already consumes most of the controller
+    // budget.
+    //
+    // We now send Terminate immediately after ForceEndpoint, with a small
+    // safety delay to give URLSession a moment to flush the ForceEndpoint
+    // frame onto the wire before we send Terminate / cancel the task. If this
+    // ever proves too aggressive (e.g. AssemblyAI starts dropping the
+    // ForceEndpoint when Terminate races it), increase `safetyDelay` or
+    // restore a longer wait.
     let forceMsg = #"{"type":"ForceEndpoint"}"#
+    let safetyDelay: DispatchTimeInterval = .milliseconds(150)
     task.send(.string(forceMsg)) { [weak self] _ in
-      // Wait long enough for the final Turn response to arrive before terminating
-      DispatchQueue.global().asyncAfter(deadline: .now() + 2.0) {
+      DispatchQueue.global().asyncAfter(deadline: .now() + safetyDelay) {
         let terminateMsg = #"{"type":"Terminate"}"#
         task.send(.string(terminateMsg)) { _ in }
         task.cancel(with: .normalClosure, reason: nil)


### PR DESCRIPTION
## Why

AssemblyAI's 'finalising transcript' tail visibly grows with utterance length, while Deepgram's is instant. Two reasons:

1. AssemblyAI Universal Streaming v3 with `format_turns=true` only commits text on **end-of-turn** and runs a server-side formatting pass over the whole turn. Length-dependent — that's just how the API works.
2. **On our side**, `AssemblyAITranscriptionProvider.stop()` had an unconditional **2.0 s `DispatchQueue.asyncAfter`** between `ForceEndpoint` and `Terminate`, sitting on top of the *real* finalisation gate that already lives in `AssemblyAILiveController.stop()` (a 2 s `stopContinuation` that is resumed early in `handleTurn` when the formatted final Turn arrives). So we were paying that 2 s twice in the worst case, and unnecessarily 100% of the time on short utterances.

Deepgram is instant because finals stream during the session — its `stop()` just cancels the socket.

## Change

Replace the 2.0 s sleep with a small **150 ms** safety delay so URLSession can flush the `ForceEndpoint` frame before `Terminate` / cancel.

## Risk

Low, but flagged in a comment in case it ever proves too aggressive (e.g. AssemblyAI drops `ForceEndpoint` when `Terminate` races it). Mitigation is documented inline — bump `safetyDelay` or restore the longer wait.

## Verification

- `swift build --target SpeakApp` — green.
- Manual: short and long AssemblyAI utterances — short tails should now be ~instant; long ones bounded by the controller's 2 s timeout instead of 2 s + 2 s.

Per-model Speed Mode capability work follows in a second PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized transcription shutdown process to reduce finalization latency, enabling faster response times when stopping active transcription sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->