### PR TITLE
feat(mac): per-model Speed Mode capabilities + delete dead modes

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -164,8 +164,6 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   enum SpeedMode: String, CaseIterable, Identifiable {
     case instant       // Mode A: Raw, no LLM
     case livePolish    // Mode B: Incremental tail rewrite
-    case liveStructured // Mode C: Lightweight formatting
-    case utteranceFinalize // Mode D: Boundary-triggered heavy pass
 
     var id: String { rawValue }
 
@@ -175,10 +173,6 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
         return "Instant"
       case .livePolish:
         return "Auto-Clean"
-      case .liveStructured:
-        return "Auto-Format"
-      case .utteranceFinalize:
-        return "Smart Pause"
       }
     }
 
@@ -188,30 +182,21 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
         return "Raw transcription with no AI cleanup. Fastest output."
       case .livePolish:
         return "AI cleans up spelling and punctuation as you speak."
-      case .liveStructured:
-        return "AI adds formatting and structure in real-time."
-      case .utteranceFinalize:
-        return "AI processes text when you pause speaking."
       }
     }
 
     var usesLivePolish: Bool {
       switch self {
-      case .instant, .utteranceFinalize:
+      case .instant:
         return false
-      case .livePolish, .liveStructured:
+      case .livePolish:
         return true
       }
     }
 
-    var usesBoundaryFinalize: Bool {
-      switch self {
-      case .utteranceFinalize:
-        return true
-      case .instant, .livePolish, .liveStructured:
-        return false
-      }
-    }
+    /// Bridge to `SpeakCore.SpeedModeID` — the raw values are kept in sync
+    /// so this is a pure string match.
+    var coreID: SpeedModeID { SpeedModeID(rawValue: rawValue) ?? .instant }
   }
 
   enum DefaultsKey: String {
@@ -584,7 +569,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   // Speed Mode Settings (Live Polish)
   @Published var speedMode: SpeedMode {
     didSet {
-      if speedMode != .instant && !supportsSpeedModeProcessing {
+      if !supports(speedMode: speedMode) {
         speedMode = .instant
         return
       }
@@ -657,8 +642,15 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     didSet { store(Double(recordingSoundVolume), key: .recordingSoundVolume) }
   }
 
-  private var supportsSpeedModeProcessing: Bool {
-    transcriptionMode == .liveNative && liveTranscriptionModel.contains("streaming")
+  /// Per-model capability lookup for the currently selected live model.
+  var liveModelCapabilities: LiveModelCapabilities {
+    guard transcriptionMode == .liveNative else { return .default }
+    return ModelCatalog.liveCapabilities(for: liveTranscriptionModel)
+  }
+
+  /// Whether the currently selected live model supports the given speed mode.
+  func supports(speedMode mode: SpeedMode) -> Bool {
+    liveModelCapabilities.supportedSpeedModes.contains(mode.coreID)
   }
 
   var isAssemblyAIModel: Bool {
@@ -670,7 +662,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   private func enforceSpeedModeConstraints() {
-    if speedMode != .instant && !supportsSpeedModeProcessing {
+    if !supports(speedMode: speedMode) {
       speedMode = .instant
     }
     if speedMode != .instant {

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -194,9 +194,15 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       }
     }
 
-    /// Bridge to `SpeakCore.SpeedModeID` — the raw values are kept in sync
-    /// so this is a pure string match.
-    var coreID: SpeedModeID { SpeedModeID(rawValue: rawValue) ?? .instant }
+    /// Bridge to `SpeakCore.SpeedModeID`. Use a switch so adding a new
+    /// `SpeedMode` is a compile error until a corresponding `SpeedModeID`
+    /// mapping is added (rather than silently falling back to `.instant`).
+    var coreID: SpeedModeID {
+      switch self {
+      case .instant: return .instant
+      case .livePolish: return .livePolish
+      }
+    }
   }
 
   enum DefaultsKey: String {

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -740,8 +740,9 @@ struct SettingsView: View {
               .foregroundStyle(.secondary)
           }
 
-          if settings.isAssemblyAIModel {
-            Text("Note: AssemblyAI may take up to ~2s to finalise after you stop, "
+          if settings.isAssemblyAIModel && capabilities.postStopFinalizeBudget > 0 {
+            let budgetSeconds = String(format: "%.1f", capabilities.postStopFinalizeBudget)
+            Text("Note: AssemblyAI may take up to ~\(budgetSeconds)s to finalise after you stop, "
                  + "because it formats the full turn server-side.")
               .font(.caption)
               .foregroundStyle(.secondary)

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -725,22 +725,31 @@ struct SettingsView: View {
       }
       .speakTooltip("Choose which transcription flow Speak uses and the locale it should prefer.")
       SettingsCard(title: "Processing Speed", systemImage: "gauge.with.dots.needle.67percent", tint: Color.brandLagoon) {
-        let speedModeAvailable = settings.transcriptionMode == .liveNative
-          && settings.liveTranscriptionModel.contains("streaming")
+        let capabilities = settings.liveModelCapabilities
+        let anyEnhancedModeAvailable = AppSettings.SpeedMode.allCases
+          .contains { $0 != .instant && capabilities.supportedSpeedModes.contains($0.coreID) }
 
         VStack(alignment: .leading, spacing: 12) {
-          Text("Auto-clean/format modes require a streaming live transcription model and disable post-processing.")
+          Text("Auto-clean modes require a streaming live transcription model and disable post-processing.")
             .font(.callout)
             .foregroundStyle(.secondary)
 
-          if !speedModeAvailable {
+          if !anyEnhancedModeAvailable {
             Text("To enable these modes, select a streaming Live Model (e.g., Deepgram Nova-3 Streaming).")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+
+          if settings.isAssemblyAIModel {
+            Text("Note: AssemblyAI may take up to ~2s to finalise after you stop, "
+                 + "because it formats the full turn server-side.")
               .font(.caption)
               .foregroundStyle(.secondary)
           }
 
           VStack(spacing: 8) {
             ForEach(AppSettings.SpeedMode.allCases) { mode in
+              let isSupported = settings.supports(speedMode: mode)
               Button {
                 settings.speedMode = mode
               } label: {
@@ -770,8 +779,8 @@ struct SettingsView: View {
                 )
               }
               .buttonStyle(.plain)
-              .disabled(mode != .instant && !speedModeAvailable)
-              .opacity(mode != .instant && !speedModeAvailable ? 0.6 : 1.0)
+              .disabled(!isSupported)
+              .opacity(isSupported ? 1.0 : 0.6)
             }
           }
         }
@@ -2645,10 +2654,6 @@ struct SettingsView: View {
       return "bolt.fill"
     case .livePolish:
       return "sparkles"
-    case .liveStructured:
-      return "list.bullet.rectangle"
-    case .utteranceFinalize:
-      return "pause.circle"
     }
   }
 

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -1408,15 +1408,20 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
       transcriber.stop()
-      // Wait for the final Turn response (resumed in handleTurn) or a 2s timeout, whichever first.
-      // Both paths nil-out stopContinuation under the MainActor before resuming, so resume is idempotent.
-      await withCheckedContinuation { continuation in
-        stopContinuation = continuation
-        Task { @MainActor [weak self] in
-          try? await Task.sleep(for: .seconds(2))
-          guard let self, let cont = self.stopContinuation else { return }
-          self.stopContinuation = nil
-          cont.resume()
+      // Wait for the final Turn response (resumed in handleTurn) or the
+      // model-specific finalize budget, whichever comes first. Both paths
+      // nil-out stopContinuation under the MainActor before resuming, so
+      // resume is idempotent.
+      let budget = appSettings.liveModelCapabilities.postStopFinalizeBudget
+      if budget > 0 {
+        await withCheckedContinuation { continuation in
+          stopContinuation = continuation
+          Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(budget))
+            guard let self, let cont = self.stopContinuation else { return }
+            self.stopContinuation = nil
+            cont.resume()
+          }
         }
       }
     } else {

--- a/Sources/SpeakCore/LiveModelCapabilities.swift
+++ b/Sources/SpeakCore/LiveModelCapabilities.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Identifiers for the user-facing "Processing Speed" modes.
+///
+/// This lives in `SpeakCore` (rather than alongside `AppSettings.SpeedMode`)
+/// so that the model catalogue can declare which modes a model supports
+/// without taking a dependency on the macOS app target.
+///
+/// Raw values intentionally match `AppSettings.SpeedMode.rawValue` so the two
+/// enums can be bridged 1:1 by raw value.
+public enum SpeedModeID: String, Sendable, CaseIterable, Hashable {
+    case instant
+    case livePolish
+}
+
+/// Per-model capabilities that influence the live transcription pipeline.
+public struct LiveModelCapabilities: Sendable, Hashable {
+    /// The set of `SpeedModeID`s this model supports. `instant` is always
+    /// supported — it represents the raw passthrough of the provider's
+    /// transcript with no live LLM rewriting.
+    public let supportedSpeedModes: Set<SpeedModeID>
+
+    /// How long the live controller should wait, after the user stops
+    /// recording, for the provider to deliver its final transcript.
+    ///
+    /// Most streaming providers (Deepgram, Soniox, ElevenLabs) finalise
+    /// during the session, so the budget is 0. AssemblyAI's Universal
+    /// Streaming v3 with `format_turns=true` only commits text on
+    /// end-of-turn and runs a server-side formatting pass over the whole
+    /// turn, so its budget is non-zero.
+    public let postStopFinalizeBudget: TimeInterval
+
+    public init(
+        supportedSpeedModes: Set<SpeedModeID>,
+        postStopFinalizeBudget: TimeInterval = 0
+    ) {
+        self.supportedSpeedModes = supportedSpeedModes
+        self.postStopFinalizeBudget = postStopFinalizeBudget
+    }
+
+    /// The default for any model that doesn't appear in the lookup table:
+    /// instant only, no finalisation wait.
+    public static let `default` = LiveModelCapabilities(
+        supportedSpeedModes: [.instant],
+        postStopFinalizeBudget: 0
+    )
+}
+
+extension ModelCatalog {
+    /// Look up the live transcription capabilities for the given model id.
+    ///
+    /// Unknown ids fall back to `LiveModelCapabilities.default` (instant only).
+    public static func liveCapabilities(for modelID: String) -> LiveModelCapabilities {
+        if let exact = liveCapabilityRegistry[modelID] {
+            return exact
+        }
+        // Conservative fallback: any other model is treated as instant-only.
+        // Add explicit entries above to opt a model into richer modes.
+        return .default
+    }
+
+    /// Explicit per-model capability registry. Keep in sync with
+    /// `ModelCatalog.liveTranscription`.
+    private static let liveCapabilityRegistry: [String: LiveModelCapabilities] = [
+        // Apple on-device — raw passthrough only.
+        "apple/local/SFSpeechRecognizer": .default,
+        "apple/local/Dictation": .default,
+
+        // Streaming providers that emit incremental finals during the session.
+        // Live Polish is supported because MainManager's incremental tail
+        // rewrite pipeline only needs incremental text updates.
+        "deepgram/nova-3-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish]
+        ),
+        "modulate/velma-2-stt-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish]
+        ),
+        "soniox/stt-rt-preview-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish]
+        ),
+        "elevenlabs/scribe-v2-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish]
+        ),
+
+        // AssemblyAI Universal Streaming v3: incremental turns are emitted
+        // during the session, but the *formatted* final turn is produced
+        // server-side after end-of-turn. We therefore need a non-zero
+        // post-stop budget so the controller can wait for that formatted
+        // turn before tearing the socket down.
+        "assemblyai/u3-rt-pro-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish],
+            postStopFinalizeBudget: 2.0
+        )
+    ]
+}


### PR DESCRIPTION
Follow-up to #418.

## Why

Today the Processing Speed card advertises four modes — Instant, Auto-Clean, Auto-Format, Smart Pause — and gates them all on a single global predicate (`liveTranscriptionModel.contains("streaming")`). Audit findings:

| Mode | Implemented? |
|---|---|
| `instant` | ✅ |
| `livePolish` (Auto-Clean) | ✅ — drives `LivePolishManager` via `usesLivePolish` |
| `liveStructured` (Auto-Format) | ⚠️ Falls through to `livePolish` (`usesLivePolish == true`). No distinct behaviour anywhere. |
| `utteranceFinalize` (Smart Pause) | ❌ `usesBoundaryFinalize` is **never read** outside its definition. Pure UI placeholder. |

And the gating treats every streaming model identically, even though e.g. AssemblyAI has a length-dependent server-side formatting tail that Deepgram doesn't.

## What

- **New `Sources/SpeakCore/LiveModelCapabilities.swift`** — `SpeedModeID` + `LiveModelCapabilities` and an explicit per-model registry on `ModelCatalog` (`supportedSpeedModes`, `postStopFinalizeBudget`). AssemblyAI's existing 2 s post-stop formatted-turn budget is now data, not a magic number in the controller.
- **`AppSettings.SpeedMode`** — deleted `.liveStructured` and `.utteranceFinalize`. Old user-default values for those decode to nil and fall back to `.instant` (no migration needed). Added `supports(speedMode:)` and `liveModelCapabilities` driven by the catalogue.
- **`SettingsView` Processing Speed card** — per-row `isSupported` flag, model-aware empty-state copy, and an AssemblyAI-specific footnote explaining the ~2 s tail latency.
- **`AssemblyAILiveController.stop()`** — uses `appSettings.liveModelCapabilities.postStopFinalizeBudget` instead of `seconds(2)`; models with budget 0 skip the wait entirely.

## Capability matrix (initial)

| Model | instant | livePolish | postStopFinalizeBudget |
|---|---|---|---|
| apple/local/SFSpeechRecognizer | ✅ | ❌ | 0 |
| apple/local/Dictation | ✅ | ❌ | 0 |
| deepgram/nova-3-streaming | ✅ | ✅ | 0 |
| modulate/velma-2-stt-streaming | ✅ | ✅ | 0 |
| soniox/stt-rt-preview-streaming | ✅ | ✅ | 0 |
| elevenlabs/scribe-v2-streaming | ✅ | ✅ | 0 |
| assemblyai/u3-rt-pro-streaming | ✅ | ✅ | **2.0** |
| any other / batch | ✅ | ❌ | 0 |

Unknown ids fall through to a conservative default (instant only).

## Verification

- `swift build --target SpeakApp` — green
- `swift test` — **368 passing**, 0 failures, 11 skipped (pre-existing)
- SwiftLint — no new violations in changed regions; pre-existing baseline issues unaffected