### PR TITLE
feat(mac): OpenAI gpt-realtime-whisper streaming live provider

### DIFF
--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -109,7 +109,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
       transcriber = provider.createLiveTranscriber(
         apiKey: apiKey,
         model: realtimeName,
-        language: currentLanguage,
+        language: currentLanguage.map(Self.extractLanguageCode(from:)),
         // OpenAI Realtime's transcription `prompt` is a glossary-style
         // bias — use the AssemblyAI keyterms list as a comma-joined hint.
         // We deliberately do *not* forward the post-processing system prompt
@@ -127,7 +127,11 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
         onError: { [weak self] error in
           Task { @MainActor [weak self] in
             guard let self else { return }
-            if !self.isRunning { return }
+            // NOTE: we no longer drop errors that arrive before isRunning
+            // flips true. WebSocket failures during the connecting window
+            // (invalid API key, 401, DNS, etc.) used to be swallowed,
+            // leaving the user with a session that ran locally but never
+            // produced text. Surface them via the delegate.
             self.delegate?.liveTranscriber(self, didFail: error)
           }
         }
@@ -228,7 +232,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
       logger.info("OpenAI Realtime session ready (config applied)")
     case .delta(let text, let itemId):
       let key = itemId.isEmpty ? "_pending" : itemId
-      if !itemOrder.contains(key), finalsByItem[key] == nil {
+      if currentDeltasByItem[key] == nil, finalsByItem[key] == nil {
         itemOrder.append(key)
       }
       currentDeltasByItem[key, default: ""].append(text)
@@ -236,7 +240,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
     case .completed(let transcript, let itemId):
       let key = itemId.isEmpty ? "_pending" : itemId
       let isNewItem = !preStopCompletedItemIDs.contains(key)
-      if !itemOrder.contains(key) {
+      if currentDeltasByItem[key] == nil, finalsByItem[key] == nil {
         itemOrder.append(key)
       }
       finalsByItem[key] = transcript
@@ -327,6 +331,14 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
   private func trimmedKeytermsPrompt() -> String? {
     let raw = appSettings.assemblyAIKeyterms.trimmingCharacters(in: .whitespacesAndNewlines)
     return raw.isEmpty ? nil : raw
+  }
+
+  /// Normalises a BCP-47 locale identifier (e.g. "en-GB", "en_US") to the
+  /// ISO-639-1 two-letter code OpenAI Realtime expects (e.g. "en"). Mirrors
+  /// the helper used by every other transcription provider.
+  static func extractLanguageCode(from locale: String) -> String {
+    let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
+    return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
   }
 
   private func openAIAPIKey() async throws -> String {
@@ -473,7 +485,11 @@ private final class OpenAIRealtimeAudioProcessor: @unchecked Sendable {
       outputBuffer = newBuffer
     }
 
-    converter.reset()
+    // NOTE: We deliberately do NOT call converter.reset() between chunks —
+    // doing so wipes the resampler's filter history and priming/trailing
+    // frames, which audibly clicks at chunk boundaries (~50 Hz). The
+    // converter is only created once per inputFormat (cachedConverter), so
+    // its state is the *correct* thing to preserve across taps.
     var error: NSError?
     let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
       outStatus.pointee = .haveData

--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -1,0 +1,500 @@
+import AVFoundation
+import Foundation
+import SpeakCore
+import os.log
+
+// swiftlint:disable file_length
+
+// MARK: - OpenAI Realtime Live Controller
+
+/// Wraps `OpenAIRealtimeLiveTranscriber` to conform to
+/// `LiveTranscriptionController`. Mirrors `AssemblyAILiveController`:
+/// captures audio, resamples to PCM16 / 24 kHz, forwards to the WebSocket,
+/// and on stop sends `input_audio_buffer.commit` and waits up to the
+/// per-model `postStopFinalizeBudget` for the final completed event.
+@MainActor
+// swiftlint:disable:next type_body_length
+final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController {
+  weak var delegate: LiveTranscriptionSessionDelegate?
+  private(set) var isRunning: Bool = false
+
+  private let appSettings: AppSettings
+  private let permissionsManager: PermissionsManager
+  private let audioDeviceManager: AudioInputDeviceManager
+  private let secureStorage: SecureAppStorage
+  private var transcriber: OpenAIRealtimeLiveTranscriber?
+  private var currentModel: String?
+  private var currentLanguage: String?
+  private var activeInputSession: AudioInputDeviceManager.SessionContext?
+  private let audioEngine = AVAudioEngine()
+  private let logger = Logger(subsystem: "com.speak.app", category: "OpenAIRealtimeLiveController")
+  private let audioProcessor = OpenAIRealtimeAudioProcessor(targetSampleRate: 24_000)
+  private var hasFinished: Bool = false
+
+  private let targetSampleRate: Double = 24_000
+  private var targetFormat: AVAudioFormat?
+  private var streamingStartTime: Date?
+  /// Map item_id → committed final transcript. OpenAI Realtime emits one
+  /// `…completed` event per conversation item; deltas accumulate into
+  /// `currentDeltasByItem` until we see `.completed`.
+  private var finalsByItem: [String: String] = [:]
+  private var itemOrder: [String] = []
+  private var currentDeltasByItem: [String: String] = [:]
+  /// Item IDs that were completed *before* the user pressed stop. Used to
+  /// guard the stop continuation: we only resume on a *new* completion
+  /// (i.e. one not in this set) so a stale `.completed` for an earlier
+  /// segment doesn't cause us to close the socket before the final
+  /// commit-triggered completion arrives.
+  private var preStopCompletedItemIDs: Set<String> = []
+  private var stopContinuation: CheckedContinuation<Void, Never>?
+
+  init(
+    appSettings: AppSettings,
+    permissionsManager: PermissionsManager,
+    audioDeviceManager: AudioInputDeviceManager,
+    secureStorage: SecureAppStorage
+  ) {
+    self.appSettings = appSettings
+    self.permissionsManager = permissionsManager
+    self.audioDeviceManager = audioDeviceManager
+    self.secureStorage = secureStorage
+  }
+
+  func configure(language: String?, model: String) {
+    currentModel = model
+    currentLanguage = language
+    logger.info("Configured OpenAI Realtime with model: \(model)")
+  }
+
+  // swiftlint:disable:next function_body_length
+  func start() async throws {
+    guard await ensurePermissions() else {
+      throw TranscriptionManagerError.permissionsMissing
+    }
+
+    let apiKey = try await openAIAPIKey()
+
+    let sessionContext = await audioDeviceManager.beginUsingPreferredInput()
+    activeInputSession = sessionContext
+
+    transcriber = nil
+    targetFormat = nil
+    finalsByItem = [:]
+    itemOrder = []
+    currentDeltasByItem = [:]
+    preStopCompletedItemIDs = []
+    streamingStartTime = nil
+    hasFinished = false
+    stopContinuation = nil
+    isRunning = false
+
+    do {
+      let inputNode = audioEngine.inputNode
+      inputNode.removeTap(onBus: 0)
+      let inputFormat = inputNode.outputFormat(forBus: 0)
+
+      guard let outputFormat = AVAudioFormat(
+        commonFormat: .pcmFormatInt16,
+        sampleRate: targetSampleRate,
+        channels: 1,
+        interleaved: true
+      ) else {
+        throw OpenAIRealtimeError.encodingFailed
+      }
+      targetFormat = outputFormat
+
+      let provider = OpenAIRealtimeTranscriptionProvider()
+      let modelID = currentModel ?? appSettings.liveTranscriptionModel
+      let realtimeName = OpenAIRealtimeTranscriptionProvider.realtimeModelName(from: modelID)
+      transcriber = provider.createLiveTranscriber(
+        apiKey: apiKey,
+        model: realtimeName,
+        language: currentLanguage,
+        // OpenAI Realtime's transcription `prompt` is a glossary-style
+        // bias — use the AssemblyAI keyterms list as a comma-joined hint.
+        // We deliberately do *not* forward the post-processing system prompt
+        // here; that's still applied later by PostProcessingManager.
+        prompt: trimmedKeytermsPrompt(),
+        sampleRate: 24_000
+      )
+
+      transcriber?.start(
+        onEvent: { [weak self] event in
+          Task { @MainActor [weak self] in
+            self?.handleEvent(event)
+          }
+        },
+        onError: { [weak self] error in
+          Task { @MainActor [weak self] in
+            guard let self else { return }
+            if !self.isRunning { return }
+            self.delegate?.liveTranscriber(self, didFail: error)
+          }
+        }
+      )
+
+      guard let transcriber else { throw OpenAIRealtimeError.encodingFailed }
+
+      audioProcessor.setRunning(true)
+      let processor = audioProcessor
+      let log = logger
+      inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { buffer, _ in
+        processor.handleAudioTap(
+          buffer,
+          inputFormat: inputFormat,
+          outputFormat: outputFormat,
+          transcriber: transcriber,
+          logger: log
+        )
+      }
+
+      audioEngine.prepare()
+      try audioEngine.start()
+      isRunning = true
+      streamingStartTime = Date()
+    } catch {
+      await cleanupAfterFailedStart()
+      throw error
+    }
+  }
+
+  func stop() async {
+    guard isRunning else { return }
+    guard !hasFinished else { return }
+    hasFinished = true
+
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    isRunning = false
+
+    // Snapshot which item ids have already finalised before stop. Any
+    // .completed that arrives during the stop wait must be for a *new* item
+    // id (the one created by our explicit commit) before we treat it as
+    // the trigger to resume early.
+    preStopCompletedItemIDs = Set(finalsByItem.keys)
+
+    if let transcriber {
+      // 1. Make sure the OpenAI session has acknowledged our config so any
+      //    pre-ready buffered audio has somewhere correct to land.
+      _ = await transcriber.awaitSessionReady(timeout: 1.0)
+      // 2. Flush local resampler tail into the transcriber (which will send
+      //    immediately now that the session is ready, or buffer briefly if
+      //    the readiness timeout lapsed).
+      audioProcessor.flushPendingAudio(to: transcriber)
+      // 3. Await all pending audio appends so the server has the full tail.
+      await transcriber.waitForPendingSends()
+      audioProcessor.setRunning(false)
+      // 4. Commit; the commit send is also tracked by pendingSendGroup.
+      transcriber.commitInputBuffer()
+      // 5. Await the commit send completion before starting the finalize
+      //    budget — otherwise the budget can elapse before the server has
+      //    even seen our commit.
+      await transcriber.waitForPendingSends()
+
+      // 6. Wait for a *new* `.completed` event triggered by our commit, or
+      //    the model-specific finalize budget, whichever comes first.
+      let budget = appSettings.liveModelCapabilities.postStopFinalizeBudget
+      if budget > 0 {
+        await withCheckedContinuation { continuation in
+          stopContinuation = continuation
+          Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(budget))
+            guard let self, let cont = self.stopContinuation else { return }
+            self.stopContinuation = nil
+            cont.resume()
+          }
+        }
+      }
+
+      transcriber.stop()
+    } else {
+      audioProcessor.setRunning(false)
+    }
+
+    let result = buildFinalResult()
+    delegate?.liveTranscriber(self, didFinishWith: result)
+
+    await endActiveInputSession()
+    transcriber = nil
+  }
+
+  // MARK: - Event handling
+
+  private func handleEvent(_ event: OpenAIRealtimeLiveTranscriber.Event) {
+    switch event {
+    case .sessionCreated:
+      logger.info("OpenAI Realtime session created (awaiting config ack)")
+    case .sessionReady:
+      logger.info("OpenAI Realtime session ready (config applied)")
+    case .delta(let text, let itemId):
+      let key = itemId.isEmpty ? "_pending" : itemId
+      if !itemOrder.contains(key), finalsByItem[key] == nil {
+        itemOrder.append(key)
+      }
+      currentDeltasByItem[key, default: ""].append(text)
+      delegate?.liveTranscriber(self, didUpdatePartial: composedTranscript())
+    case .completed(let transcript, let itemId):
+      let key = itemId.isEmpty ? "_pending" : itemId
+      let isNewItem = !preStopCompletedItemIDs.contains(key)
+      if !itemOrder.contains(key) {
+        itemOrder.append(key)
+      }
+      finalsByItem[key] = transcript
+      currentDeltasByItem.removeValue(forKey: key)
+      delegate?.liveTranscriber(self, didUpdatePartial: composedTranscript())
+
+      // Resume the stop continuation only on a NEW completion — one that
+      // wasn't already final before stop fired. Stale completions for
+      // earlier items must not race the final commit.
+      if hasFinished, isNewItem, let continuation = stopContinuation {
+        stopContinuation = nil
+        continuation.resume()
+      }
+    }
+  }
+
+  private func composedTranscript() -> String {
+    var pieces: [String] = []
+    for key in itemOrder {
+      if let final = finalsByItem[key], !final.isEmpty {
+        pieces.append(final)
+      } else if let delta = currentDeltasByItem[key], !delta.isEmpty {
+        pieces.append(delta)
+      }
+    }
+    return pieces.joined(separator: " ")
+  }
+
+  // MARK: - Result building
+
+  private func buildFinalResult() -> TranscriptionResult {
+    let text = composedTranscript()
+    let segments: [TranscriptionSegment] = itemOrder.compactMap { key in
+      guard let final = finalsByItem[key], !final.isEmpty else { return nil }
+      return TranscriptionSegment(startTime: 0, endTime: 0, text: final)
+    }
+
+    let streamingDuration: TimeInterval
+    if let startTime = streamingStartTime {
+      streamingDuration = Date().timeIntervalSince(startTime)
+    } else {
+      streamingDuration = 0
+    }
+
+    return TranscriptionResult(
+      text: text,
+      segments: segments,
+      confidence: nil,
+      duration: streamingDuration,
+      modelIdentifier: currentModel ?? "openai/gpt-realtime-whisper-streaming",
+      cost: nil,
+      rawPayload: nil,
+      debugInfo: nil
+    )
+  }
+
+  // MARK: - Cleanup
+
+  private func cleanupAfterFailedStart() async {
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    isRunning = false
+    audioProcessor.setRunning(false)
+    transcriber?.stop()
+    transcriber = nil
+    targetFormat = nil
+    streamingStartTime = nil
+    finalsByItem = [:]
+    itemOrder = []
+    currentDeltasByItem = [:]
+    preStopCompletedItemIDs = []
+    stopContinuation = nil
+    await endActiveInputSession()
+  }
+
+  private func endActiveInputSession() async {
+    guard let session = activeInputSession else { return }
+    activeInputSession = nil
+    await audioDeviceManager.endUsingPreferredInput(session: session)
+  }
+
+  private func ensurePermissions() async -> Bool {
+    let microphone = await permissionsManager.request(.microphone)
+    let speech = await permissionsManager.request(.speechRecognition)
+    return microphone.isGranted && speech.isGranted
+  }
+
+  private func trimmedKeytermsPrompt() -> String? {
+    let raw = appSettings.assemblyAIKeyterms.trimmingCharacters(in: .whitespacesAndNewlines)
+    return raw.isEmpty ? nil : raw
+  }
+
+  private func openAIAPIKey() async throws -> String {
+    do {
+      let apiKey = try await secureStorage.secret(identifier: "openai.apiKey")
+      guard !apiKey.isEmpty else { throw OpenAIRealtimeError.missingAPIKey }
+      return apiKey
+    } catch let error as SecureAppStorageError {
+      if case .valueNotFound = error {
+        throw OpenAIRealtimeError.missingAPIKey
+      }
+      throw error
+    } catch {
+      throw error
+    }
+  }
+}
+
+// MARK: - Audio Processor
+
+/// PCM16 audio resampler that batches frames into ≥50 ms chunks and forwards
+/// them to the OpenAI Realtime WebSocket. Logically identical to
+/// `AssemblyAILiveController.AssemblyAIAudioProcessor` except for the target
+/// sample rate (24 kHz here, 16 kHz there) and the destination type.
+private final class OpenAIRealtimeAudioProcessor: @unchecked Sendable {
+  private let queue = DispatchQueue(label: "com.speak.app.openairealtime.audioProcessing")
+  private let minimumChunkBytes: Int
+  private let preferredChunkBytes: Int
+
+  private var isRunning: Bool = false
+  private var cachedConverter: AVAudioConverter?
+  private var cachedInputFormat: AVAudioFormat?
+  private var reusableOutputBuffer: AVAudioPCMBuffer?
+  private var pendingPCMData = Data()
+
+  init(targetSampleRate: Int) {
+    // 50 ms safety lower bound, 100 ms preferred upload chunk size.
+    self.minimumChunkBytes = (targetSampleRate / 1000) * 50 * 2
+    self.preferredChunkBytes = (targetSampleRate / 1000) * 100 * 2
+  }
+
+  func setRunning(_ running: Bool) {
+    queue.sync {
+      isRunning = running
+      if !running {
+        cachedConverter = nil
+        cachedInputFormat = nil
+        reusableOutputBuffer = nil
+        pendingPCMData.removeAll(keepingCapacity: false)
+      }
+    }
+  }
+
+  func flushPendingAudio(to transcriber: OpenAIRealtimeLiveTranscriber) {
+    queue.sync {
+      guard !pendingPCMData.isEmpty else { return }
+
+      var offset = 0
+      while pendingPCMData.count - offset >= preferredChunkBytes {
+        let chunk = pendingPCMData.subdata(in: offset..<(offset + preferredChunkBytes))
+        transcriber.sendAudio(chunk)
+        offset += preferredChunkBytes
+      }
+      if offset > 0 {
+        pendingPCMData = Data(pendingPCMData.dropFirst(offset))
+      }
+
+      guard !pendingPCMData.isEmpty else { return }
+      if pendingPCMData.count < minimumChunkBytes {
+        pendingPCMData.append(
+          contentsOf: repeatElement(0, count: minimumChunkBytes - pendingPCMData.count))
+      }
+      transcriber.sendAudio(pendingPCMData)
+      pendingPCMData.removeAll(keepingCapacity: false)
+    }
+  }
+
+  func handleAudioTap(
+    _ buffer: AVAudioPCMBuffer,
+    inputFormat: AVAudioFormat,
+    outputFormat: AVAudioFormat,
+    transcriber: OpenAIRealtimeLiveTranscriber,
+    logger: Logger
+  ) {
+    guard let copied = copyPCMBuffer(buffer) else { return }
+    queue.async { [weak self] in
+      guard let self, self.isRunning else { return }
+      self.processAndSendAudio(
+        copied, from: inputFormat, to: outputFormat,
+        transcriber: transcriber, logger: logger
+      )
+    }
+  }
+
+  private func copyPCMBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+    let frameLength = buffer.frameLength
+    guard let copy = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: frameLength) else {
+      return nil
+    }
+    copy.frameLength = frameLength
+    let src = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: buffer.audioBufferList))
+    let dst = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: copy.audioBufferList))
+    for idx in 0..<min(src.count, dst.count) {
+      let srcBuf = src[idx]
+      guard let srcData = srcBuf.mData, let dstData = dst[idx].mData else { continue }
+      dstData.copyMemory(from: srcData, byteCount: Int(srcBuf.mDataByteSize))
+      dst[idx].mDataByteSize = srcBuf.mDataByteSize
+    }
+    return copy
+  }
+
+  private func processAndSendAudio(
+    _ buffer: AVAudioPCMBuffer,
+    from inputFormat: AVAudioFormat,
+    to outputFormat: AVAudioFormat,
+    transcriber: OpenAIRealtimeLiveTranscriber,
+    logger: Logger
+  ) {
+    let converter: AVAudioConverter
+    if let cached = cachedConverter, cachedInputFormat == inputFormat {
+      converter = cached
+    } else {
+      guard let newConverter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+        logger.error("Failed to create audio converter")
+        return
+      }
+      cachedConverter = newConverter
+      cachedInputFormat = inputFormat
+      converter = newConverter
+    }
+
+    let ratio = outputFormat.sampleRate / inputFormat.sampleRate
+    let outputFrameCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
+
+    let outputBuffer: AVAudioPCMBuffer
+    if let reusable = reusableOutputBuffer, reusable.frameCapacity >= outputFrameCapacity {
+      reusable.frameLength = 0
+      outputBuffer = reusable
+    } else {
+      guard let newBuffer = AVAudioPCMBuffer(
+        pcmFormat: outputFormat, frameCapacity: outputFrameCapacity
+      ) else { return }
+      reusableOutputBuffer = newBuffer
+      outputBuffer = newBuffer
+    }
+
+    converter.reset()
+    var error: NSError?
+    let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+      outStatus.pointee = .haveData
+      return buffer
+    }
+
+    guard status != .error, error == nil else { return }
+
+    guard let int16Data = outputBuffer.int16ChannelData else { return }
+    let frameLength = Int(outputBuffer.frameLength)
+    let data = Data(bytes: int16Data[0], count: frameLength * 2)
+    pendingPCMData.append(data)
+
+    var offset = 0
+    while pendingPCMData.count - offset >= preferredChunkBytes {
+      let chunk = pendingPCMData.subdata(in: offset..<(offset + preferredChunkBytes))
+      transcriber.sendAudio(chunk)
+      offset += preferredChunkBytes
+    }
+    if offset > 0 {
+      pendingPCMData = Data(pendingPCMData.dropFirst(offset))
+    }
+  }
+}

--- a/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
@@ -1,0 +1,542 @@
+import AVFoundation
+import Foundation
+import SpeakCore
+import os.log
+
+// MARK: - OpenAI Realtime Live Transcriber
+
+// swiftlint:disable file_length type_body_length
+
+/// Streams microphone audio to OpenAI's Realtime API in transcription mode and
+/// emits incremental + final transcripts.
+///
+/// Endpoint: `wss://api.openai.com/v1/realtime?intent=transcription`.
+/// Audio is sent as JSON text frames containing base64 PCM16 (mono, 24 kHz by
+/// default). On stop we send `input_audio_buffer.commit` to force the server
+/// to finalise the in-flight buffer, then close the socket once the
+/// `…transcription.completed` event arrives (or the controller's
+/// `postStopFinalizeBudget` elapses).
+final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
+  enum Event {
+    case sessionCreated
+    case sessionReady
+    case delta(String, itemId: String)
+    case completed(String, itemId: String)
+  }
+
+  private let apiKey: String
+  private let model: String
+  private let language: String?
+  private let prompt: String?
+  private let sampleRate: Int
+  private let session: URLSession
+  private let logger = Logger(subsystem: "com.speak.app", category: "OpenAIRealtimeLiveTranscriber")
+  private let stateLock = NSLock()
+  private let pendingSendGroup = DispatchGroup()
+
+  private var webSocketTask: URLSessionWebSocketTask?
+  private var onEvent: ((Event) -> Void)?
+  private var onError: ((Error) -> Void)?
+  private var isStopping: Bool = false
+  /// The OpenAI Realtime session is "ready" only after we receive
+  /// `transcription_session.updated` — that's the acknowledgement of *our*
+  /// `transcription_session.update` config, so we know `turn_detection`,
+  /// language, prompt etc are applied. `transcription_session.created` can
+  /// arrive before our update is acknowledged and the server still has its
+  /// default config, which is why we deliberately do not mark ready on
+  /// `.created`.
+  private var sessionReady: Bool = false
+  private var readyWaitTokens: [WaitToken] = []
+  private var preReadyAudioBuffer: [Data] = []
+  private static let preReadyAudioByteLimit = 24_000 * 2 * 5 // 5s of 24 kHz PCM16
+
+  private let ownsSession: Bool
+
+  init(
+    apiKey: String,
+    model: String,
+    language: String?,
+    prompt: String?,
+    sampleRate: Int = 24_000,
+    session: URLSession? = nil
+  ) {
+    self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    self.model = model
+    self.language = language
+    self.prompt = prompt
+    self.sampleRate = sampleRate
+    if let session {
+      self.session = session
+      self.ownsSession = false
+    } else {
+      let config = URLSessionConfiguration.default
+      config.waitsForConnectivity = true
+      config.timeoutIntervalForRequest = 30
+      self.session = URLSession(configuration: config)
+      self.ownsSession = true
+    }
+  }
+
+  deinit {
+    if ownsSession {
+      session.invalidateAndCancel()
+    }
+  }
+
+  // MARK: - Lifecycle
+
+  func start(
+    onEvent: @escaping (Event) -> Void,
+    onError: @escaping (Error) -> Void
+  ) {
+    withStateLock {
+      isStopping = false
+      sessionReady = false
+      preReadyAudioBuffer = []
+      self.onEvent = onEvent
+      self.onError = onError
+    }
+
+    guard var components = URLComponents(string: "wss://api.openai.com/v1/realtime") else {
+      currentOnError()?(OpenAIRealtimeError.invalidURL)
+      return
+    }
+    components.queryItems = [URLQueryItem(name: "intent", value: "transcription")]
+    guard let url = components.url else {
+      currentOnError()?(OpenAIRealtimeError.invalidURL)
+      return
+    }
+
+    var request = URLRequest(url: url)
+    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+    // Required by the Realtime API while it's in beta.
+    request.setValue("realtime=v1", forHTTPHeaderField: "OpenAI-Beta")
+
+    let task = session.webSocketTask(with: request)
+    let shouldReceive = withStateLock { () -> Bool in
+      guard !isStopping else { return false }
+      webSocketTask = task
+      task.resume()
+      return true
+    }
+    guard shouldReceive else {
+      task.cancel(with: .goingAway, reason: nil)
+      return
+    }
+
+    logger.info("OpenAI Realtime WebSocket connecting (model=\(self.model, privacy: .public))")
+    receiveMessages()
+    sendSessionUpdate()
+  }
+
+  func sendAudio(_ pcm16Data: Data) {
+    // Decide "send now" vs "buffer until ready" inside a single critical
+    // section to avoid a race where a flush triggered by .sessionReady can
+    // run between an outer readiness check and an append, stranding the
+    // newly-appended frame in preReadyAudioBuffer.
+    let taskToSend: URLSessionWebSocketTask? = withStateLock {
+      guard let task = webSocketTask, task.state == .running else { return nil }
+      if sessionReady {
+        return task
+      }
+      preReadyAudioBuffer.append(pcm16Data)
+      var totalBytes = preReadyAudioBuffer.reduce(0) { $0 + $1.count }
+      while totalBytes > Self.preReadyAudioByteLimit, !preReadyAudioBuffer.isEmpty {
+        totalBytes -= preReadyAudioBuffer.removeFirst().count
+      }
+      return nil
+    }
+    if let taskToSend {
+      sendAudioFrame(pcm16Data, on: taskToSend)
+    }
+  }
+
+  /// Sends `input_audio_buffer.commit` which forces the server to finalise
+  /// the buffered audio as a single conversation item — the equivalent of
+  /// AssemblyAI's `ForceEndpoint`.
+  ///
+  /// The send completion is tracked via `pendingSendGroup` so callers can
+  /// await it through `waitForPendingSends()` before starting any
+  /// "wait for the final transcript" budget.
+  func commitInputBuffer() {
+    let task = withStateLock { webSocketTask }
+    guard let task, task.state == .running else { return }
+    let json = #"{"type":"input_audio_buffer.commit"}"#
+    let sendGroup = pendingSendGroup
+    sendGroup.enter()
+    task.send(.string(json)) { [weak self] error in
+      defer { sendGroup.leave() }
+      if let error, let self, !self.isStoppingState() {
+        self.logger.error("Failed to commit input buffer: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// Awaits `transcription_session.updated`, the acknowledgement of our
+  /// session config. Returns `true` if ready within the timeout, `false`
+  /// otherwise. Used by the controller's stop path so a quick
+  /// stop-after-start doesn't commit an empty server-side buffer.
+  func awaitSessionReady(timeout: TimeInterval) async -> Bool {
+    if withStateLock({ sessionReady }) { return true }
+
+    let token = WaitToken()
+    let alreadyReady: Bool = withStateLock {
+      if sessionReady { return true }
+      readyWaitTokens.append(token)
+      return false
+    }
+    if alreadyReady { return true }
+
+    DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+      token.signal(false)
+    }
+    return await token.wait()
+  }
+
+  func stop() {
+    let task = withStateLock { () -> URLSessionWebSocketTask? in
+      guard !isStopping else { return nil }
+      isStopping = true
+      return webSocketTask
+    }
+
+    guard let task, task.state == .running else { return }
+
+    // The actual "wait for the final completed event" gate is enforced by the
+    // controller's `postStopFinalizeBudget`, mirroring the AssemblyAI pattern.
+    // Here we just close the socket; any in-flight `.completed` events will
+    // race against the cancellation, and the controller will resume early
+    // when `.completed` arrives.
+    task.cancel(with: .normalClosure, reason: nil)
+    withStateLock {
+      if webSocketTask === task {
+        webSocketTask = nil
+      }
+    }
+    logger.info("OpenAI Realtime WebSocket connection closed")
+  }
+
+  func waitForPendingSends(timeout: TimeInterval = 1.5) async {
+    let sendGroup = pendingSendGroup
+    await withCheckedContinuation { continuation in
+      DispatchQueue.global().async {
+        _ = sendGroup.wait(timeout: .now() + timeout)
+        continuation.resume()
+      }
+    }
+  }
+
+  // MARK: - Outbound
+
+  private func sendSessionUpdate() {
+    let task = withStateLock { webSocketTask }
+    guard let task else { return }
+
+    var transcription: [String: Any] = ["model": model]
+    if let language, !language.isEmpty {
+      transcription["language"] = language
+    }
+    if let prompt, !prompt.isEmpty {
+      transcription["prompt"] = prompt
+    }
+
+    // `turn_detection: null` keeps the session push-to-talk: the server won't
+    // auto-finalise on silence; we explicitly commit on stop. This mirrors
+    // the AssemblyAI / Deepgram UX where the user controls the boundaries.
+    let payload: [String: Any] = [
+      "type": "transcription_session.update",
+      "session": [
+        "input_audio_format": "pcm16",
+        "input_audio_transcription": transcription,
+        "input_audio_noise_reduction": ["type": "near_field"],
+        "turn_detection": NSNull()
+      ]
+    ]
+
+    guard let data = try? JSONSerialization.data(withJSONObject: payload),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      currentOnError()?(OpenAIRealtimeError.encodingFailed)
+      return
+    }
+
+    task.send(.string(json)) { [weak self] error in
+      if let error, let self, !self.isStoppingState() {
+        self.logger.error("Failed to send session.update: \(error.localizedDescription)")
+        self.currentOnError()?(error)
+      }
+    }
+  }
+
+  private func sendAudioFrame(_ pcm16Data: Data, on task: URLSessionWebSocketTask) {
+    let base64 = pcm16Data.base64EncodedString()
+    let payload: [String: Any] = [
+      "type": "input_audio_buffer.append",
+      "audio": base64
+    ]
+    guard let data = try? JSONSerialization.data(withJSONObject: payload),
+      let json = String(data: data, encoding: .utf8)
+    else { return }
+
+    let sendGroup = pendingSendGroup
+    sendGroup.enter()
+    task.send(.string(json)) { [weak self] error in
+      defer { sendGroup.leave() }
+      guard let self else { return }
+      if let error, !self.isStoppingState(), !self.shouldIgnoreSocketError(error) {
+        self.logger.error("Failed to send audio: \(error.localizedDescription)")
+        self.currentOnError()?(error)
+      }
+    }
+  }
+
+  private func flushPreReadyAudio() {
+    let (task, frames) = withStateLock { () -> (URLSessionWebSocketTask?, [Data]) in
+      let pending = preReadyAudioBuffer
+      preReadyAudioBuffer = []
+      return (webSocketTask, pending)
+    }
+    guard let task, task.state == .running, !frames.isEmpty else { return }
+    logger.info("Flushing \(frames.count) pre-ready OpenAI Realtime audio frames")
+    for frame in frames {
+      sendAudioFrame(frame, on: task)
+    }
+  }
+
+  // MARK: - Inbound
+
+  private func receiveMessages() {
+    guard let task = withStateLock({ webSocketTask }) else { return }
+    task.receive { [weak self] result in
+      guard let self else { return }
+      switch result {
+      case .success(let message):
+        self.handleMessage(message)
+        self.receiveMessages()
+      case .failure(let error):
+        if self.isStoppingState() { return }
+        if self.shouldIgnoreSocketError(error) {
+          DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.01) { [weak self] in
+            self?.receiveMessages()
+          }
+          return
+        }
+        self.logger.error("WebSocket receive error: \(error.localizedDescription, privacy: .public)")
+        self.currentOnError()?(error)
+      }
+    }
+  }
+
+  private func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+    switch message {
+    case .string(let text):
+      OpenAIRealtimeEventParser.parse(text, logger: logger).forEach(dispatch)
+    case .data(let data):
+      if let text = String(data: data, encoding: .utf8) {
+        OpenAIRealtimeEventParser.parse(text, logger: logger).forEach(dispatch)
+      }
+    @unknown default:
+      break
+    }
+  }
+
+  private func dispatch(_ outcome: OpenAIRealtimeEventParser.ParsedOutcome) {
+    switch outcome {
+    case .event(let event):
+      if case .sessionReady = event {
+        let tokensToFire: [WaitToken] = withStateLock {
+          sessionReady = true
+          let tokens = readyWaitTokens
+          readyWaitTokens.removeAll()
+          return tokens
+        }
+        for token in tokensToFire {
+          token.signal(true)
+        }
+        flushPreReadyAudio()
+      }
+      currentOnEvent()?(event)
+    case .error(let error):
+      currentOnError()?(error)
+    case .ignored:
+      break
+    }
+  }
+}
+// swiftlint:enable type_body_length
+
+/// Lightweight one-shot async latch. The first `signal(_:)` resolves any
+/// pending `wait()` and is idempotent thereafter.
+private final class WaitToken: @unchecked Sendable {
+  private let lock = NSLock()
+  private var resolved: Bool = false
+  private var value: Bool = false
+  private var continuation: CheckedContinuation<Bool, Never>?
+
+  func signal(_ value: Bool) {
+    let cont: CheckedContinuation<Bool, Never>?
+    let resolvedValue: Bool
+    lock.lock()
+    if resolved {
+      lock.unlock()
+      return
+    }
+    resolved = true
+    self.value = value
+    cont = continuation
+    continuation = nil
+    resolvedValue = value
+    lock.unlock()
+    cont?.resume(returning: resolvedValue)
+  }
+
+  func wait() async -> Bool {
+    await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+      lock.lock()
+      if resolved {
+        let resolvedValue = value
+        lock.unlock()
+        cont.resume(returning: resolvedValue)
+        return
+      }
+      continuation = cont
+      lock.unlock()
+    }
+  }
+}
+
+// MARK: - Locking helpers
+
+private extension OpenAIRealtimeLiveTranscriber {
+  func withStateLock<T>(_ block: () -> T) -> T {
+    stateLock.lock()
+    defer { stateLock.unlock() }
+    return block()
+  }
+
+  func currentOnEvent() -> ((Event) -> Void)? {
+    withStateLock { onEvent }
+  }
+
+  func currentOnError() -> ((Error) -> Void)? {
+    withStateLock { onError }
+  }
+
+  func isStoppingState() -> Bool {
+    withStateLock { isStopping }
+  }
+
+  func shouldIgnoreSocketError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
+    if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
+      return true
+    }
+    return false
+  }
+}
+
+// MARK: - Event Parser (testable)
+
+/// Pure-function parser for OpenAI Realtime JSON events. Extracted so it can
+/// be exercised directly in unit tests without spinning up a WebSocket.
+enum OpenAIRealtimeEventParser {
+  enum ParsedOutcome {
+    case event(OpenAIRealtimeLiveTranscriber.Event)
+    case error(Error)
+    case ignored
+  }
+
+  static func parse(_ json: String, logger: Logger? = nil) -> [ParsedOutcome] {
+    guard let data = json.data(using: .utf8) else { return [] }
+    guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      return []
+    }
+    guard let type = object["type"] as? String else { return [] }
+
+    switch type {
+    case "transcription_session.created":
+      // `created` confirms the socket is open with default config; we still
+      // need to wait for `updated` (the ack of *our* session.update) before
+      // sending audio.
+      return [.event(.sessionCreated)]
+    case "transcription_session.updated":
+      return [.event(.sessionReady)]
+    case "conversation.item.input_audio_transcription.delta":
+      let delta = (object["delta"] as? String) ?? ""
+      let itemId = (object["item_id"] as? String) ?? ""
+      guard !delta.isEmpty else { return [.ignored] }
+      return [.event(.delta(delta, itemId: itemId))]
+    case "conversation.item.input_audio_transcription.completed":
+      let transcript = (object["transcript"] as? String) ?? ""
+      let itemId = (object["item_id"] as? String) ?? ""
+      return [.event(.completed(transcript, itemId: itemId))]
+    case "error":
+      let payload = object["error"] as? [String: Any]
+      let message = (payload?["message"] as? String) ?? "Unknown error"
+      let code = (payload?["code"] as? String) ?? "unknown"
+      logger?.error("OpenAI Realtime error: code=\(code, privacy: .public) msg=\(message, privacy: .public)")
+      return [.error(OpenAIRealtimeError.serverError(code: code, message: message))]
+    default:
+      logger?.debug("OpenAI Realtime ignored event type=\(type, privacy: .public)")
+      return [.ignored]
+    }
+  }
+}
+
+// MARK: - Errors
+
+enum OpenAIRealtimeError: LocalizedError {
+  case invalidURL
+  case missingAPIKey
+  case encodingFailed
+  case serverError(code: String, message: String)
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidURL:
+      return "Failed to construct OpenAI Realtime WebSocket URL"
+    case .missingAPIKey:
+      return "OpenAI API key is missing. Add it in Settings → Models / Keys."
+    case .encodingFailed:
+      return "Failed to encode OpenAI Realtime payload"
+    case .serverError(let code, let message):
+      return "OpenAI Realtime error (\(code)): \(message)"
+    }
+  }
+}
+
+// MARK: - Provider (factory)
+
+/// Lightweight factory for `OpenAIRealtimeLiveTranscriber`. Unlike the
+/// AssemblyAI / ElevenLabs / OpenAI batch providers, this isn't a
+/// `TranscriptionProvider` because it doesn't expose a batch transcription
+/// path — `OpenAITranscriptionProvider` already covers Whisper batch.
+struct OpenAIRealtimeTranscriptionProvider {
+  func createLiveTranscriber(
+    apiKey: String,
+    model: String,
+    language: String?,
+    prompt: String?,
+    sampleRate: Int = 24_000,
+    session: URLSession? = nil
+  ) -> OpenAIRealtimeLiveTranscriber {
+    OpenAIRealtimeLiveTranscriber(
+      apiKey: apiKey,
+      model: model,
+      language: language,
+      prompt: prompt,
+      sampleRate: sampleRate,
+      session: session
+    )
+  }
+
+  /// Translates an `openai/...-streaming` model id into the bare model name
+  /// expected by the Realtime API.
+  static func realtimeModelName(from catalogID: String) -> String {
+    let suffix = catalogID.split(separator: "/").last.map(String.init) ?? catalogID
+    return suffix.replacingOccurrences(of: "-streaming", with: "")
+  }
+}
+
+// swiftlint:enable file_length

--- a/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
@@ -168,6 +168,9 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
       defer { sendGroup.leave() }
       if let error, let self, !self.isStoppingState() {
         self.logger.error("Failed to commit input buffer: \(error.localizedDescription)")
+        // Surface this — without it, a failed commit can leave callers
+        // waiting indefinitely for a final transcript that will never come.
+        self.currentOnError()?(error)
       }
     }
   }
@@ -316,9 +319,12 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
       case .failure(let error):
         if self.isStoppingState() { return }
         if self.shouldIgnoreSocketError(error) {
-          DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.01) { [weak self] in
-            self?.receiveMessages()
-          }
+          // ENOTCONN / "Socket is not connected" is terminal — a
+          // URLSessionWebSocketTask cannot be reused for receiving once
+          // disconnected. Stop the receive loop instead of spinning every
+          // 10 ms; higher-level reconnect logic (or stop()) is responsible
+          // for replacing the task.
+          self.logger.info("WebSocket receive loop ending (socket disconnected)")
           return
         }
         self.logger.error("WebSocket receive error: \(error.localizedDescription, privacy: .public)")

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -2884,6 +2884,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private var assemblyAIController: AssemblyAILiveController
   private var elevenlabsController: ElevenLabsLiveController
   private var sonioxController: SonioxLiveController
+  private var openAIRealtimeController: OpenAIRealtimeLiveController
   private var currentLanguage: String?
   private var currentModel: String?
   private var invalidateBeforeNextStart: Bool = false
@@ -2933,6 +2934,12 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       secureStorage: secureStorage
     )
     sonioxController = SonioxLiveController(
+      appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    openAIRealtimeController = OpenAIRealtimeLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
@@ -2992,6 +2999,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     if model.hasPrefix("modulate/") { return modulateController }
     if model.hasPrefix("elevenlabs/") { return elevenlabsController }
     if model.hasPrefix("soniox/") { return sonioxController }
+    if model.hasPrefix("openai/gpt-realtime-whisper") { return openAIRealtimeController }
     return nativeController
   }
 
@@ -3002,7 +3010,8 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       modulateController,
       assemblyAIController,
       elevenlabsController,
-      sonioxController
+      sonioxController,
+      openAIRealtimeController
     ]
     let model = currentModel ?? appSettings.liveTranscriptionModel
     for controller in controllers {
@@ -3051,6 +3060,12 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       secureStorage: secureStorage
     )
     sonioxController = SonioxLiveController(
+      appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    openAIRealtimeController = OpenAIRealtimeLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,

--- a/Sources/SpeakCore/LiveModelCapabilities.swift
+++ b/Sources/SpeakCore/LiveModelCapabilities.swift
@@ -90,6 +90,15 @@ extension ModelCatalog {
         "assemblyai/u3-rt-pro-streaming": LiveModelCapabilities(
             supportedSpeedModes: [.instant, .livePolish],
             postStopFinalizeBudget: 2.0
+        ),
+
+        // OpenAI Realtime gpt-realtime-whisper: emits incremental
+        // transcription deltas during the session and a per-item completed
+        // event. We use a small post-stop budget to wait for the in-flight
+        // commit to round-trip, then close the socket.
+        "openai/gpt-realtime-whisper-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish],
+            postStopFinalizeBudget: 0.5
         )
     ]
 }

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -137,7 +137,13 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             displayName: "ElevenLabs Scribe v2 (Streaming)",
             description: "ElevenLabs Scribe v2 real-time WebSocket transcription. Reuses your "
                 + "ElevenLabs API key — the key must have speech-to-text (Scribe) access.",
-            estimatedLatencyMs: 200, latencyTier: .fast)
+            estimatedLatencyMs: 200, latencyTier: .fast),
+        Option(
+            id: "openai/gpt-realtime-whisper-streaming",
+            displayName: "OpenAI Whisper Realtime (Streaming)",
+            description: "OpenAI's gpt-realtime-whisper — low-latency streaming transcription with "
+                + "built-in noise reduction. Reuses your OpenAI API key.",
+            estimatedLatencyMs: 250, latencyTier: .fast)
     ]
 
     public static let batchTranscription: [Option] = [

--- a/Tests/SpeakAppTests/OpenAIRealtimeProviderTests.swift
+++ b/Tests/SpeakAppTests/OpenAIRealtimeProviderTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+@testable import SpeakCore
+
+final class OpenAIRealtimeProviderTests: XCTestCase {
+
+    // MARK: - Catalogue + capabilities
+
+    func testModelCatalog_includesGPTRealtimeWhisperStreaming() {
+        let ids = ModelCatalog.liveTranscription.map(\.id)
+        XCTAssertTrue(
+            ids.contains("openai/gpt-realtime-whisper-streaming"),
+            "OpenAI gpt-realtime-whisper-streaming must be registered in ModelCatalog.liveTranscription"
+        )
+    }
+
+    func testCapabilities_supportsInstantAndLivePolish() {
+        let capabilities = ModelCatalog.liveCapabilities(for: "openai/gpt-realtime-whisper-streaming")
+        XCTAssertTrue(capabilities.supportedSpeedModes.contains(.instant))
+        XCTAssertTrue(capabilities.supportedSpeedModes.contains(.livePolish))
+    }
+
+    func testCapabilities_postStopFinalizeBudgetIsSmall() {
+        let capabilities = ModelCatalog.liveCapabilities(for: "openai/gpt-realtime-whisper-streaming")
+        // Per-segment .completed events arrive during the session, so the
+        // post-stop wait should be much smaller than AssemblyAI's 2s.
+        XCTAssertGreaterThan(capabilities.postStopFinalizeBudget, 0)
+        XCTAssertLessThanOrEqual(capabilities.postStopFinalizeBudget, 1.0)
+    }
+
+    // MARK: - Model name translation
+
+    func testRealtimeModelName_stripsStreamingSuffix() {
+        let name = OpenAIRealtimeTranscriptionProvider.realtimeModelName(
+            from: "openai/gpt-realtime-whisper-streaming"
+        )
+        XCTAssertEqual(name, "gpt-realtime-whisper")
+    }
+
+    func testRealtimeModelName_handlesIDWithoutSuffix() {
+        let name = OpenAIRealtimeTranscriptionProvider.realtimeModelName(
+            from: "openai/gpt-realtime-whisper"
+        )
+        XCTAssertEqual(name, "gpt-realtime-whisper")
+    }
+
+    // MARK: - Event parser
+
+    func testParser_decodesSessionCreatedAsSessionCreatedNotReady() {
+        let json = """
+        {"type":"transcription_session.created","session":{"id":"sess_1"}}
+        """
+        let outcomes = OpenAIRealtimeEventParser.parse(json)
+        XCTAssertEqual(outcomes.count, 1)
+        // `created` is informational only — readiness must wait for `updated`,
+        // which acknowledges *our* transcription_session.update payload.
+        guard case .event(.sessionCreated) = outcomes.first else {
+            return XCTFail("Expected .sessionCreated event, got \(outcomes)")
+        }
+    }
+
+    func testParser_decodesSessionUpdatedAsSessionReady() {
+        let json = #"{"type":"transcription_session.updated"}"#
+        let outcomes = OpenAIRealtimeEventParser.parse(json)
+        guard case .event(.sessionReady) = outcomes.first else {
+            return XCTFail("Expected .sessionReady event, got \(outcomes)")
+        }
+    }
+
+    func testParser_decodesTranscriptionDelta() {
+        let json = """
+        {"type":"conversation.item.input_audio_transcription.delta",\
+        "item_id":"item_42","delta":"hello"}
+        """
+        let outcomes = OpenAIRealtimeEventParser.parse(json)
+        guard case .event(.delta(let text, let itemId)) = outcomes.first else {
+            return XCTFail("Expected .delta event, got \(outcomes)")
+        }
+        XCTAssertEqual(text, "hello")
+        XCTAssertEqual(itemId, "item_42")
+    }
+
+    func testParser_dropsEmptyDelta() {
+        let json = """
+        {"type":"conversation.item.input_audio_transcription.delta",\
+        "item_id":"item_1","delta":""}
+        """
+        let outcomes = OpenAIRealtimeEventParser.parse(json)
+        guard case .ignored = outcomes.first else {
+            return XCTFail("Expected .ignored for empty delta, got \(outcomes)")
+        }
+    }
+
+    func testParser_decodesTranscriptionCompleted() {
+        let json = """
+        {"type":"conversation.item.input_audio_transcription.completed",\
+        "item_id":"item_42","transcript":"Hello there."}
+        """
+        let outcomes = OpenAIRealtimeEventParser.parse(json)
+        guard case .event(.completed(let transcript, let itemId)) = outcomes.first else {
+            return XCTFail("Expected .completed event, got \(outcomes)")
+        }
+        XCTAssertEqual(transcript, "Hello there.")
+        XCTAssertEqual(itemId, "item_42")
+    }
+
+    func testParser_decodesServerErrorIntoErrorOutcome() {
+        let json = """
+        {"type":"error","error":{"code":"invalid_request_error","message":"bad audio format"}}
+        """
+        let outcomes = OpenAIRealtimeEventParser.parse(json)
+        guard case .error(let error) = outcomes.first else {
+            return XCTFail("Expected .error outcome, got \(outcomes)")
+        }
+        let description = error.localizedDescription
+        XCTAssertTrue(description.contains("invalid_request_error"))
+        XCTAssertTrue(description.contains("bad audio format"))
+    }
+
+    func testParser_ignoresUnknownEventType() {
+        let json = #"{"type":"response.audio.delta","data":"..."}"#
+        let outcomes = OpenAIRealtimeEventParser.parse(json)
+        guard case .ignored = outcomes.first else {
+            return XCTFail("Expected .ignored for unknown event, got \(outcomes)")
+        }
+    }
+
+    func testParser_handlesGarbageJSONWithoutCrashing() {
+        XCTAssertEqual(OpenAIRealtimeEventParser.parse("not json").count, 0)
+        XCTAssertEqual(OpenAIRealtimeEventParser.parse("{}").count, 0)
+    }
+}


### PR DESCRIPTION
Adds OpenAI's newly-released **`gpt-realtime-whisper`** as a streaming live transcription provider, peer to AssemblyAI / Deepgram / Soniox.

## Model

- Catalogue id: `openai/gpt-realtime-whisper-streaming`
- API model name: `gpt-realtime-whisper`
- Endpoint: `wss://api.openai.com/v1/realtime?intent=transcription`
- Audio: PCM16 mono @ 24 kHz, base64 in `input_audio_buffer.append`
- Pricing: $0.017 / min audio

## Architecture

Mirrors the AssemblyAI provider/controller pair:

- **`OpenAIRealtimeTranscriptionProvider.swift`** — WebSocket client + pure event parser + factory. Buffers pre-ready audio, tracks pending sends, exposes `awaitSessionReady(timeout:)`.
- **`OpenAIRealtimeLiveController.swift`** — `@MainActor` controller. 24 kHz capture/resample, `item_id`-keyed segment tracking, `postStopFinalizeBudget` (0.5 s).
- **`ModelCatalog`** + **`LiveModelCapabilities`** — registry entries with `{.instant, .livePolish}`.
- **`SwitchingLiveTranscriber`** — routes by exact id.

## Stop sequence (rubber-duck reviewed)

On stop:

1. `awaitSessionReady(timeout: 1s)` — guard against stop-before-config-ack so buffered audio has somewhere correct to land.
2. Flush local resampler tail.
3. Await all pending audio appends.
4. Send `input_audio_buffer.commit`.
5. Await the commit's send completion (it's tracked in `pendingSendGroup`).
6. Wait up to `postStopFinalizeBudget` (0.5 s) for a **new** `.completed` event — completions for items that were already final pre-stop don't trigger early resume.
7. Close socket.

## Auth

Reuses the existing `openai.apiKey` Keychain entry — no new settings, no new secret.

## Caveat — needs live verification

We use `turn_detection: null` for push-to-talk parity with our other providers. With server VAD off, OpenAI may not stream `.delta` events during recording — they may only arrive after `commit`. If that turns out to be the case, follow-up: switch to `server_vad` or periodic commits.

## Tests

- 13 new tests in `OpenAIRealtimeProviderTests` (catalogue, capabilities, model name translation, event parser including the `.created` vs `.updated` distinction).
- Full suite: 381 / 381 passing.

## Follow-up

iOS parity in a separate PR mirroring `Sources/SpeakiOS/Services/DeepgramLiveTranscriber.swift`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenAI Whisper Realtime (Streaming) as a new live transcription model supporting instant and live polish speed modes for real-time speech-to-text capabilities.

* **Tests**
  * Added comprehensive test coverage for OpenAI Realtime transcription provider integration and event parsing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->