### PR TITLE
fix(mac): live stop UX (HUD timing, OpenAI prompt, generic stop grace)

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -805,7 +805,12 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       liveStopGracePeriod = stored
     } else {
       let legacy = defaults.object(forKey: DefaultsKey.deepgramStopGracePeriod.rawValue) as? Double
-      liveStopGracePeriod = legacy ?? 0
+      let migrated = legacy ?? 0
+      liveStopGracePeriod = migrated
+      // `didSet` does not fire during init, so persist the migrated value
+      // explicitly — otherwise the next launch would re-read the legacy key
+      // and the new key would never be populated.
+      defaults.set(migrated, forKey: DefaultsKey.liveStopGracePeriod.rawValue)
     }
     trackedAPIKeyIdentifiers =
       defaults.array(forKey: DefaultsKey.trackedKeyIdentifiers.rawValue) as? [String] ?? []

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -231,6 +231,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     case preferredLocale
     case postRecordingTailDuration
     case deepgramStopGracePeriod
+    case liveStopGracePeriod
     case preferredAudioInputUID
     case defaultTTSVoice
     case ttsSpeed
@@ -483,8 +484,13 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     didSet { store(postRecordingTailDuration, key: .postRecordingTailDuration) }
   }
 
-  @Published var deepgramStopGracePeriod: TimeInterval {
-    didSet { store(deepgramStopGracePeriod, key: .deepgramStopGracePeriod) }
+  /// Extra grace period (in seconds) the live controllers wait, on top of
+  /// each provider's hard-coded `postStopFinalizeBudget`, before tearing the
+  /// stream down. Useful when the user wants to capture the final word that
+  /// some providers (notably Deepgram) only finalise a beat after the audio
+  /// stops. Applied uniformly to every live transcription provider.
+  @Published var liveStopGracePeriod: TimeInterval {
+    didSet { store(liveStopGracePeriod, key: .liveStopGracePeriod) }
   }
 
   @Published private(set) var trackedAPIKeyIdentifiers: [String] {
@@ -790,8 +796,17 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     }
     postRecordingTailDuration =
       defaults.object(forKey: DefaultsKey.postRecordingTailDuration.rawValue) as? Double ?? 0.5
-    deepgramStopGracePeriod =
-      defaults.object(forKey: DefaultsKey.deepgramStopGracePeriod.rawValue) as? Double ?? 0
+    // Migration: reuse the legacy `deepgramStopGracePeriod` value the first
+    // time the user launches a build that has the generic
+    // `liveStopGracePeriod`. After this, the legacy key is left intact (not
+    // deleted) so a downgrade still has its setting; only the new key is
+    // written from now on.
+    if let stored = defaults.object(forKey: DefaultsKey.liveStopGracePeriod.rawValue) as? Double {
+      liveStopGracePeriod = stored
+    } else {
+      let legacy = defaults.object(forKey: DefaultsKey.deepgramStopGracePeriod.rawValue) as? Double
+      liveStopGracePeriod = legacy ?? 0
+    }
     trackedAPIKeyIdentifiers =
       defaults.array(forKey: DefaultsKey.trackedKeyIdentifiers.rawValue) as? [String] ?? []
 

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -288,6 +288,24 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
     }
   }
 
+  /// Sends `ForceEndpoint` to AssemblyAI without tearing down the socket so
+  /// the server flushes the in-flight turn as a final formatted Turn message
+  /// over the still-open WebSocket. The controller calls this, awaits the
+  /// final Turn (or its budget timeout), and only *then* invokes `stop()` to
+  /// send Terminate and close the socket. Sending ForceEndpoint and Terminate
+  /// in the same `stop()` call closed the socket before the formatted final
+  /// Turn could arrive — the budget burned on a dead socket.
+  func sendForceEndpoint() {
+    let task = withStateLock { webSocketTask }
+    guard let task, task.state == .running else { return }
+    let forceMsg = #"{"type":"ForceEndpoint"}"#
+    task.send(.string(forceMsg)) { [weak self] error in
+      if let error {
+        self?.logger.error("ForceEndpoint send failed: \(error.localizedDescription)")
+      }
+    }
+  }
+
   func stop() {
     let task = withStateLock { () -> URLSessionWebSocketTask? in
       guard !isStopping else { return nil }

--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -483,6 +483,14 @@ extension AssemblyAILiveTranscriber {
       }
     }
   }
+
+  /// Whether the AssemblyAI server has acknowledged the session with a
+  /// `Begin` message. The post-stop finalisation budget is meaningless if
+  /// the session never began (no audio reached the server, no Turn will
+  /// ever be returned), so the controller can use this to skip the wait.
+  func didReceiveBegin() -> Bool {
+    withStateLock { sessionDidBegin }
+  }
 }
 
 private extension AssemblyAILiveTranscriber {

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -575,6 +575,14 @@ final class MainManager: ObservableObject {
 
     state = .processing
     session.recordingEnded = Date()
+    if appSettings.transcriptionMode == .liveNative {
+      // Move the HUD off the "Recording" timer immediately. Otherwise the
+      // user sees the recording timer frozen at the release time while we
+      // close the audio file and drain the live provider's finalisation
+      // budget — which on AssemblyAI can be ~2s and reads as a hang for
+      // very short presses where the WebSocket `Begin` never arrived.
+      hudManager.beginTranscribing(subheadline: "Finalising transcript")
+    }
     let stopDescription: String
     if tailDuration > 0 {
       let tailText = String(format: "%.1f", tailDuration)
@@ -598,7 +606,6 @@ final class MainManager: ObservableObject {
 
       if appSettings.transcriptionMode == .liveNative {
         session.transcriptionStarted = Date()
-        hudManager.beginTranscribing(subheadline: "Finalising transcript")
         let result = try await transcriptionManager.stopLiveTranscription()
         session.transcriptionEnded = Date()
         session.transcriptionResult = result

--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -180,7 +180,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
     if let transcriber {
       // 1. Make sure the OpenAI session has acknowledged our config so any
       //    pre-ready buffered audio has somewhere correct to land.
-      _ = await transcriber.awaitSessionReady(timeout: 1.0)
+      let sessionReady = await transcriber.awaitSessionReady(timeout: 1.0)
       // 2. Flush local resampler tail into the transcriber (which will send
       //    immediately now that the session is ready, or buffer briefly if
       //    the readiness timeout lapsed).
@@ -188,6 +188,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
       // 3. Await all pending audio appends so the server has the full tail.
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
+      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
       // 4. Commit; the commit send is also tracked by pendingSendGroup.
       transcriber.commitInputBuffer()
       // 5. Await the commit send completion before starting the finalize
@@ -197,8 +198,10 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
 
       // 6. Wait for a *new* `.completed` event triggered by our commit, or
       //    the model-specific finalize budget, whichever comes first.
+      //    Skip the wait entirely when the session never became ready —
+      //    no audio was ever processed and no `.completed` will arrive.
       let budget = appSettings.liveModelCapabilities.postStopFinalizeBudget
-      if budget > 0 {
+      if budget > 0, sessionReady {
         await withCheckedContinuation { continuation in
           stopContinuation = continuation
           Task { @MainActor [weak self] in

--- a/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
@@ -239,7 +239,7 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
     if let language, !language.isEmpty {
       transcription["language"] = language
     }
-    if let prompt, !prompt.isEmpty {
+    if let prompt, !prompt.isEmpty, OpenAIRealtimeLiveTranscriber.modelSupportsPrompt(model) {
       transcription["prompt"] = prompt
     }
 
@@ -542,6 +542,18 @@ struct OpenAIRealtimeTranscriptionProvider {
   static func realtimeModelName(from catalogID: String) -> String {
     let suffix = catalogID.split(separator: "/").last.map(String.init) ?? catalogID
     return suffix.replacingOccurrences(of: "-streaming", with: "")
+  }
+}
+
+extension OpenAIRealtimeLiveTranscriber {
+  /// OpenAI Realtime only accepts `input_audio_transcription.prompt` for the
+  /// GPT-4o transcription models. `gpt-realtime-whisper` (Whisper-1) rejects
+  /// the parameter with `invalid_value`. Returning false here means the
+  /// provider silently drops the prompt for unsupported models rather than
+  /// failing the whole session.
+  static func modelSupportsPrompt(_ realtimeModel: String) -> Bool {
+    let name = realtimeModel.lowercased()
+    return name.hasPrefix("gpt-4o-transcribe") || name.hasPrefix("gpt-4o-mini-transcribe")
   }
 }
 

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -814,20 +814,30 @@ struct SettingsView: View {
       }
       .speakTooltip("Decide how much breathing room Speak gives you after releasing your shortcut.")
 
-      SettingsCard(title: "Deepgram stop grace", systemImage: "waveform.and.mic", tint: Color.brandAccentDeep) {
+      SettingsCard(
+        title: "Live stop grace",
+        systemImage: "waveform.and.mic",
+        tint: Color.brandAccentDeep
+      ) {
         VStack(alignment: .leading, spacing: 12) {
-          Text("After stopping, keep the Deepgram stream open briefly to capture final words.")
+          Text(
+            """
+            After stopping, keep the live transcription stream open briefly so providers \
+            can flush their final words. Applied to every live model (Deepgram, AssemblyAI, \
+            OpenAI Realtime, ElevenLabs, Soniox, Modulate).
+            """
+          )
             .font(.caption)
             .foregroundStyle(.secondary)
           HStack {
             Slider(
-              value: settingsBinding(\AppSettings.deepgramStopGracePeriod),
+              value: settingsBinding(\AppSettings.liveStopGracePeriod),
               in: 0...2,
               step: 0.1
             )
-            .speakTooltip("Delay closing the Deepgram live stream after you stop recording.")
+            .speakTooltip("Extra delay before closing the live transcription stream after you stop recording.")
             Text(
-              settings.deepgramStopGracePeriod,
+              settings.liveStopGracePeriod,
               format: .number.precision(.fractionLength(1))
             )
             .font(.caption.monospacedDigit())
@@ -838,7 +848,7 @@ struct SettingsView: View {
           }
         }
       }
-      .speakTooltip("Helps reduce last-word cutoffs with Deepgram live transcription.")
+      .speakTooltip("Helps reduce last-word cutoffs across all live transcription providers.")
 
       SettingsCard(title: "Silence detection", systemImage: "waveform.slash", tint: Color.brandAccentWarm) {
         VStack(alignment: .leading, spacing: 12) {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -6,6 +6,17 @@ import Speech
 
 // swiftlint:disable file_length
 
+/// Applies the user-configured extra stop-grace period uniformly across all
+/// live transcription providers. This sits on top of each provider's
+/// hard-coded `LiveModelCapabilities.postStopFinalizeBudget` and lets the
+/// user buy themselves a bit of extra trailing-audio finalisation time
+/// (originally a Deepgram-only knob, now generalised).
+func applyLiveStopGrace(_ period: TimeInterval) async {
+  let grace = max(period, 0)
+  guard grace > 0 else { return }
+  try? await Task.sleep(nanoseconds: UInt64(grace * 1_000_000_000))
+}
+
 enum TranscriptionManagerError: LocalizedError {
   case liveSessionAlreadyRunning
   case liveSessionNotRunning
@@ -826,14 +837,7 @@ final class DeepgramLiveController: NSObject, LiveTranscriptionController {
 
     audioProcessor.setRunning(false)
 
-    let gracePeriod = max(appSettings.deepgramStopGracePeriod, 0)
-    if gracePeriod > 0 {
-      do {
-        try await Task.sleep(nanoseconds: UInt64(gracePeriod * 1_000_000_000))
-      } catch {
-        // Ignored: sleep cancellation simply means we stop immediately.
-      }
-    }
+    await applyLiveStopGrace(appSettings.liveStopGracePeriod)
 
     transcriber?.stop()
 
@@ -1407,13 +1411,20 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
       audioProcessor.flushPendingAudio(to: transcriber)
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
+      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
       transcriber.stop()
       // Wait for the final Turn response (resumed in handleTurn) or the
       // model-specific finalize budget, whichever comes first. Both paths
       // nil-out stopContinuation under the MainActor before resuming, so
       // resume is idempotent.
       let budget = appSettings.liveModelCapabilities.postStopFinalizeBudget
-      if budget > 0 {
+      // Skip the finalisation wait entirely when the AssemblyAI session
+      // never received its `Begin` ack — there is no Turn to wait for and
+      // the server has nothing to flush. This keeps very-short presses
+      // (sub-second) from blocking the HUD on "Finalising" for the full
+      // budget.
+      let serverBegan = transcriber.didReceiveBegin()
+      if budget > 0, serverBegan {
         await withCheckedContinuation { continuation in
           stopContinuation = continuation
           Task { @MainActor [weak self] in
@@ -1610,6 +1621,7 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
       audioProcessor.flushPendingAudio(to: transcriber)
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
+      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
       transcriber.signalEndOfStream()
 
       // Wait for the final response (resumed in finished/error callbacks) or a 2s timeout.
@@ -2168,6 +2180,7 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
       audioProcessor.flushPendingAudio(to: transcriber)
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
+      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
       // Manual commit flushes any VAD-buffered audio so the server emits
       // a final committed_transcript for the trailing words. Await that
       // event-driven (with timeout) instead of a fixed sleep so the HUD
@@ -2596,6 +2609,7 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
       audioProcessor.flushPendingAudio(to: transcriber)
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
+      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
       // Ask Soniox to finalize any in-flight non-final tokens so the trailing
       // words of the utterance get returned as final tokens. The server replies
       // with a `<fin>` marker token (handled in parseResponse) which fires the

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -1411,7 +1411,6 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
       audioProcessor.flushPendingAudio(to: transcriber)
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
-      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
       // Send ForceEndpoint *without* closing the socket so the formatted
       // final Turn can arrive on the same WebSocket while we wait below.
       // Skip the wait when the AssemblyAI session never received its
@@ -1436,6 +1435,10 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
           }
         }
       }
+      // Apply the user grace AFTER the finalisation budget but BEFORE
+      // tearing down the socket — extra trailing-finals window without
+      // delaying the ForceEndpoint signal.
+      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
       // Only now tear down the socket (sends Terminate + cancel).
       transcriber.stop()
     } else {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -14,7 +14,7 @@ import Speech
 func applyLiveStopGrace(_ period: TimeInterval) async {
   let grace = max(period, 0)
   guard grace > 0 else { return }
-  try? await Task.sleep(nanoseconds: UInt64(grace * 1_000_000_000))
+  try? await Task.sleep(for: .seconds(grace))
 }
 
 enum TranscriptionManagerError: LocalizedError {
@@ -1412,18 +1412,19 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
       await applyLiveStopGrace(appSettings.liveStopGracePeriod)
-      transcriber.stop()
+      // Send ForceEndpoint *without* closing the socket so the formatted
+      // final Turn can arrive on the same WebSocket while we wait below.
+      // Skip the wait when the AssemblyAI session never received its
+      // `Begin` ack — there is no Turn to wait for.
+      let serverBegan = transcriber.didReceiveBegin()
+      if serverBegan {
+        transcriber.sendForceEndpoint()
+      }
       // Wait for the final Turn response (resumed in handleTurn) or the
       // model-specific finalize budget, whichever comes first. Both paths
       // nil-out stopContinuation under the MainActor before resuming, so
       // resume is idempotent.
       let budget = appSettings.liveModelCapabilities.postStopFinalizeBudget
-      // Skip the finalisation wait entirely when the AssemblyAI session
-      // never received its `Begin` ack — there is no Turn to wait for and
-      // the server has nothing to flush. This keeps very-short presses
-      // (sub-second) from blocking the HUD on "Finalising" for the full
-      // budget.
-      let serverBegan = transcriber.didReceiveBegin()
       if budget > 0, serverBegan {
         await withCheckedContinuation { continuation in
           stopContinuation = continuation
@@ -1435,6 +1436,8 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
           }
         }
       }
+      // Only now tear down the socket (sends Terminate + cancel).
+      transcriber.stop()
     } else {
       audioProcessor.setRunning(false)
     }


### PR DESCRIPTION
## Summary

Three related fixes around the end-of-recording experience.

### 1. HUD: no more frozen 'Recording 00.65s' (the screenshot bug)

`MainManager.endSession` was setting `state = .processing` immediately but the HUD's `beginTranscribing(subheadline: "Finalising transcript")` call only fired *after* `stopRecordingWithTimeout()` returned. On AssemblyAI the controller then waits up to 2 s (`postStopFinalizeBudget`) for the formatted final turn — during which the HUD just kept showing the last 'Recording' frame, which read as a frozen UI.

The HUD transition now fires the moment we flip into the `.processing` state, so the user sees 'Finalising transcript' for the duration of any post-stop wait.

Also: AssemblyAI / OpenAI Realtime now **skip the post-stop wait entirely** when the WebSocket never reached its handshake (Begin / Ready). Tap-and-instantly-release no longer blocks for 2 s with nothing to flush.

### 2. OpenAI Realtime: drop `prompt` for models that reject it

`gpt-realtime-whisper` (Whisper-1 backend) rejects `input_audio_transcription.prompt` with `invalid_value`, breaking the session entirely. We now only forward the prompt for the GPT-4o transcription models (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`). Other models silently drop the prompt instead of failing.

### 3. Generalise `deepgramStopGracePeriod` → `liveStopGracePeriod`

The 'Deepgram stop grace' slider is now 'Live stop grace' and applies to every live provider (Deepgram, AssemblyAI, OpenAI Realtime, ElevenLabs, Soniox, Modulate). The setting is migrated from the old key on first launch.

## Test plan
- `swift build` ✅
- `swift test` — 381 tests, 0 failures
- `swiftlint --strict` ✅

## Notes
- Out of scope (queued for follow-ups): controller `isRunning` race fix, OpenAI feature additions (model picker, server VAD, custom prompt UI). Tracked in the session plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Live stop grace period" setting now applies universally across all live transcription providers (Deepgram, AssemblyAI, OpenAI Realtime, ElevenLabs, Soniox, Modulate) instead of Deepgram only.

* **Bug Fixes**
  * Improved live transcription shutdown handling across all providers for more reliable session finalization.
  * Enhanced transcript finalization UI feedback timing.
  * Better handling of OpenAI Realtime sessions that fail to establish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->