### PR TITLE
fix(mac): use OpenAI Realtime GA endpoint for gpt-realtime-whisper

### DIFF
--- a/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
@@ -101,7 +101,14 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
       currentOnError()?(OpenAIRealtimeError.invalidURL)
       return
     }
-    components.queryItems = [URLQueryItem(name: "intent", value: "transcription")]
+    // GA Realtime models (e.g. `gpt-realtime-whisper`) reject the beta
+    // `?intent=transcription` endpoint with `invalid_model`. They must use
+    // the GA URL form `?model=<name>` and omit the `OpenAI-Beta` header.
+    if OpenAIRealtimeLiveTranscriber.isGARealtimeTranscriptionModel(model) {
+      components.queryItems = [URLQueryItem(name: "model", value: model)]
+    } else {
+      components.queryItems = [URLQueryItem(name: "intent", value: "transcription")]
+    }
     guard let url = components.url else {
       currentOnError()?(OpenAIRealtimeError.invalidURL)
       return
@@ -109,8 +116,11 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
 
     var request = URLRequest(url: url)
     request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-    // Required by the Realtime API while it's in beta.
-    request.setValue("realtime=v1", forHTTPHeaderField: "OpenAI-Beta")
+    if !OpenAIRealtimeLiveTranscriber.isGARealtimeTranscriptionModel(model) {
+      // Required by the Realtime API while it's in beta. GA endpoints reject
+      // this header, so only set it on the legacy beta path.
+      request.setValue("realtime=v1", forHTTPHeaderField: "OpenAI-Beta")
+    }
 
     let task = session.webSocketTask(with: request)
     let shouldReceive = withStateLock { () -> Bool in
@@ -243,18 +253,40 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
       transcription["prompt"] = prompt
     }
 
-    // `turn_detection: null` keeps the session push-to-talk: the server won't
-    // auto-finalise on silence; we explicitly commit on stop. This mirrors
-    // the AssemblyAI / Deepgram UX where the user controls the boundaries.
-    let payload: [String: Any] = [
-      "type": "transcription_session.update",
-      "session": [
-        "input_audio_format": "pcm16",
-        "input_audio_transcription": transcription,
-        "input_audio_noise_reduction": ["type": "near_field"],
-        "turn_detection": NSNull()
+    let payload: [String: Any]
+    if OpenAIRealtimeLiveTranscriber.isGARealtimeTranscriptionModel(model) {
+      // GA shape: single `session.update` event with `session.type =
+      // "transcription"`. Transcription config nests under
+      // `session.audio.input.transcription`. `turn_detection: null` keeps the
+      // session push-to-talk so we control commit boundaries.
+      payload = [
+        "type": "session.update",
+        "session": [
+          "type": "transcription",
+          "audio": [
+            "input": [
+              "format": ["type": "audio/pcm", "rate": 24_000],
+              "transcription": transcription,
+              "noise_reduction": ["type": "near_field"],
+              "turn_detection": NSNull()
+            ]
+          ]
+        ]
       ]
-    ]
+    } else {
+      // Beta shape: dedicated `transcription_session.update` event with
+      // flat `input_audio_*` fields. Used by `whisper-1`, `gpt-4o-transcribe`,
+      // and `gpt-4o-mini-transcribe`.
+      payload = [
+        "type": "transcription_session.update",
+        "session": [
+          "input_audio_format": "pcm16",
+          "input_audio_transcription": transcription,
+          "input_audio_noise_reduction": ["type": "near_field"],
+          "turn_detection": NSNull()
+        ]
+      ]
+    }
 
     guard let data = try? JSONSerialization.data(withJSONObject: payload),
       let json = String(data: data, encoding: .utf8)
@@ -554,6 +586,16 @@ extension OpenAIRealtimeLiveTranscriber {
   static func modelSupportsPrompt(_ realtimeModel: String) -> Bool {
     let name = realtimeModel.lowercased()
     return name.hasPrefix("gpt-4o-transcribe") || name.hasPrefix("gpt-4o-mini-transcribe")
+  }
+
+  /// Models that are only available on the GA Realtime endpoint and reject
+  /// the legacy `?intent=transcription` beta path with `invalid_model`. The
+  /// GA endpoint uses `?model=<name>`, drops the `OpenAI-Beta` header, and
+  /// uses the unified `session.update` event with `session.type =
+  /// "transcription"` instead of `transcription_session.update`.
+  static func isGARealtimeTranscriptionModel(_ realtimeModel: String) -> Bool {
+    let name = realtimeModel.lowercased()
+    return name.hasPrefix("gpt-realtime-whisper")
   }
 }
 

--- a/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
@@ -265,7 +265,7 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
           "type": "transcription",
           "audio": [
             "input": [
-              "format": ["type": "audio/pcm", "rate": 24_000],
+              "format": ["type": "audio/pcm", "rate": sampleRate],
               "transcription": transcription,
               "noise_reduction": ["type": "near_field"],
               "turn_detection": NSNull()
@@ -493,12 +493,13 @@ enum OpenAIRealtimeEventParser {
     guard let type = object["type"] as? String else { return [] }
 
     switch type {
-    case "transcription_session.created":
+    case "transcription_session.created", "session.created":
       // `created` confirms the socket is open with default config; we still
       // need to wait for `updated` (the ack of *our* session.update) before
-      // sending audio.
+      // sending audio. GA Realtime emits the unprefixed `session.*` names;
+      // beta emits `transcription_session.*`.
       return [.event(.sessionCreated)]
-    case "transcription_session.updated":
+    case "transcription_session.updated", "session.updated":
       return [.event(.sessionReady)]
     case "conversation.item.input_audio_transcription.delta":
       let delta = (object["delta"] as? String) ?? ""


### PR DESCRIPTION
## Problem

After releasing `gpt-realtime-whisper` as a streaming option (mac-v0.32.1), users hit:

> OpenAI Realtime error (invalid_model): Model "gpt-realtime-whisper" is only available on the GA API.

The provider was hard-coded to the legacy beta Realtime endpoint (`?intent=transcription` + `OpenAI-Beta: realtime=v1` header + `transcription_session.update` event), which the Whisper-based GA model rejects.

## Fix

Detect GA-only models via a new `OpenAIRealtimeLiveTranscriber.isGARealtimeTranscriptionModel(_:)` helper (currently matches `gpt-realtime-whisper*`) and:

- Connect to `wss://api.openai.com/v1/realtime?model=<name>` (no `intent=transcription`).
- Omit the `OpenAI-Beta: realtime=v1` header.
- Send the unified `session.update` event with `session.type = "transcription"` and the nested `session.audio.input.{format,transcription,noise_reduction,turn_detection}` shape (per [openai-python](https://github.com/openai/openai-python/blob/main/src/openai/types/realtime/realtime_transcription_session_create_request.py)).

Existing beta models (`whisper-1`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`) keep their current path unchanged so this can't regress them.

## Verification

- `swift build` — clean
- `swift test` — 381 passed (11 skipped, 0 failures)
- SwiftLint strict + baseline — clean

## Follow-ups (already tracked)

- iOS mirror of the same fix.
- Optional GA `delay` field as a user setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced transcription support with compatibility for both OpenAI's latest API endpoints and legacy versions, enabling access to newer transcription models while maintaining stability with current implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->