### PR TITLE
fix(mac): pre-warm AudioToolbox component registry off-main

### DIFF
--- a/Sources/SpeakApp/SpeakApp.swift
+++ b/Sources/SpeakApp/SpeakApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 #if canImport(Sentry)
 import Sentry
 #endif
@@ -167,8 +168,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.activate(ignoringOtherApps: true)
             NSApp.windows.first?.makeKeyAndOrderFront(nil)
         }
-        
-        // Check if running from DMG and offer to move to Applications
+        DispatchQueue.global(qos: .utility).async { _ = AVAudioEngine() } // Sentry JUSTSPEAKTOIT-A
         checkAndOfferDMGCleanup()
     }
     


### PR DESCRIPTION
## AudioToolbox first-record hang — Sentry JUSTSPEAKTOIT-A (16 events)

First `AVAudioEngine()` after launch can block ~2s in `AudioComponentFindNext` while AudioToolbox boots its plug-in registry over XPC. Pre-warm an `AVAudioEngine` on a utility-QoS background queue in `applicationDidFinishLaunching` so the registry is hydrated before the first record-tap.

## Notes
This PR originally also enabled `SUEnableInstallerLauncherService=YES` to fix the 390-event Sparkle main-thread auth hang (JUSTSPEAKTOIT-6). CodeRabbit correctly pointed out Sparkle's docs explicitly say "Do not enable this XPC Service if your application is not sandboxed." Removed that change — Sparkle hang needs a separate, supported approach (SPUUpdaterDelegate off-main dispatch, or upstream issue).

## Verification
- swift build clean
- swift test: 381 pass / 11 skip / 0 fail