### PR TITLE
fix(mac,ios): unify OpenAI Realtime transcription on GA payload

### DIFF
--- a/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
@@ -101,14 +101,16 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
       currentOnError()?(OpenAIRealtimeError.invalidURL)
       return
     }
-    // GA Realtime models (e.g. `gpt-realtime-whisper`) reject the beta
-    // `?intent=transcription` endpoint with `invalid_model`. They must use
-    // the GA URL form `?model=<name>` and omit the `OpenAI-Beta` header.
-    if OpenAIRealtimeLiveTranscriber.isGARealtimeTranscriptionModel(model) {
-      components.queryItems = [URLQueryItem(name: "model", value: model)]
-    } else {
-      components.queryItems = [URLQueryItem(name: "intent", value: "transcription")]
-    }
+    // All GA transcription models — gpt-realtime-whisper, whisper-1,
+    // gpt-4o-transcribe, gpt-4o-mini-transcribe — use the same
+    // `?intent=transcription` URL with a unified `session.update` payload.
+    // The legacy `?model=<name>` URL creates a realtime *conversation*
+    // session and rejects transcription session.updates with
+    // `invalid_parameter: Passing a transcription session update event to
+    // a realtime session is not allowed.` The legacy `OpenAI-Beta:
+    // realtime=v1` header pins the server to the old schema and rejects
+    // `session.type`, so we omit it.
+    components.queryItems = [URLQueryItem(name: "intent", value: "transcription")]
     guard let url = components.url else {
       currentOnError()?(OpenAIRealtimeError.invalidURL)
       return
@@ -116,11 +118,6 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
 
     var request = URLRequest(url: url)
     request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-    if !OpenAIRealtimeLiveTranscriber.isGARealtimeTranscriptionModel(model) {
-      // Required by the Realtime API while it's in beta. GA endpoints reject
-      // this header, so only set it on the legacy beta path.
-      request.setValue("realtime=v1", forHTTPHeaderField: "OpenAI-Beta")
-    }
 
     let task = session.webSocketTask(with: request)
     let shouldReceive = withStateLock { () -> Bool in
@@ -253,40 +250,25 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
       transcription["prompt"] = prompt
     }
 
-    let payload: [String: Any]
-    if OpenAIRealtimeLiveTranscriber.isGARealtimeTranscriptionModel(model) {
-      // GA shape: single `session.update` event with `session.type =
-      // "transcription"`. Transcription config nests under
-      // `session.audio.input.transcription`. `turn_detection: null` keeps the
-      // session push-to-talk so we control commit boundaries.
-      payload = [
-        "type": "session.update",
-        "session": [
-          "type": "transcription",
-          "audio": [
-            "input": [
-              "format": ["type": "audio/pcm", "rate": sampleRate],
-              "transcription": transcription,
-              "noise_reduction": ["type": "near_field"],
-              "turn_detection": NSNull()
-            ]
+    let payload: [String: Any] = [
+      // Unified GA shape for all transcription models. The legacy
+      // `transcription_session.update` event was removed during GA.
+      // Transcription config nests under `session.audio.input.transcription`.
+      // `turn_detection: null` keeps the session push-to-talk so we control
+      // commit boundaries.
+      "type": "session.update",
+      "session": [
+        "type": "transcription",
+        "audio": [
+          "input": [
+            "format": ["type": "audio/pcm", "rate": sampleRate],
+            "transcription": transcription,
+            "noise_reduction": ["type": "near_field"],
+            "turn_detection": NSNull()
           ]
         ]
       ]
-    } else {
-      // Beta shape: dedicated `transcription_session.update` event with
-      // flat `input_audio_*` fields. Used by `whisper-1`, `gpt-4o-transcribe`,
-      // and `gpt-4o-mini-transcribe`.
-      payload = [
-        "type": "transcription_session.update",
-        "session": [
-          "input_audio_format": "pcm16",
-          "input_audio_transcription": transcription,
-          "input_audio_noise_reduction": ["type": "near_field"],
-          "turn_detection": NSNull()
-        ]
-      ]
-    }
+    ]
 
     guard let data = try? JSONSerialization.data(withJSONObject: payload),
       let json = String(data: data, encoding: .utf8)
@@ -587,16 +569,6 @@ extension OpenAIRealtimeLiveTranscriber {
   static func modelSupportsPrompt(_ realtimeModel: String) -> Bool {
     let name = realtimeModel.lowercased()
     return name.hasPrefix("gpt-4o-transcribe") || name.hasPrefix("gpt-4o-mini-transcribe")
-  }
-
-  /// Models that are only available on the GA Realtime endpoint and reject
-  /// the legacy `?intent=transcription` beta path with `invalid_model`. The
-  /// GA endpoint uses `?model=<name>`, drops the `OpenAI-Beta` header, and
-  /// uses the unified `session.update` event with `session.type =
-  /// "transcription"` instead of `transcription_session.update`.
-  static func isGARealtimeTranscriptionModel(_ realtimeModel: String) -> Bool {
-    let name = realtimeModel.lowercased()
-    return name.hasPrefix("gpt-realtime-whisper")
   }
 }
 

--- a/Sources/SpeakiOS/Services/OpenAIRealtimeLiveTranscriber.swift
+++ b/Sources/SpeakiOS/Services/OpenAIRealtimeLiveTranscriber.swift
@@ -539,14 +539,13 @@ final class OpenAIRealtimeWebSocketClient: @unchecked Sendable {
             onError(OpenAIRealtimeError.connectionFailed("Invalid URL"))
             return
         }
-        // GA Realtime models (e.g. `gpt-realtime-whisper`) reject the beta
-        // `?intent=transcription` endpoint with `invalid_model`. They must use
-        // `?model=<name>` and omit the `OpenAI-Beta` header.
-        if Self.isGARealtimeTranscriptionModel(model) {
-            components.queryItems = [URLQueryItem(name: "model", value: model)]
-        } else {
-            components.queryItems = [URLQueryItem(name: "intent", value: "transcription")]
-        }
+        // All GA transcription models share the same `?intent=transcription`
+        // URL with a unified `session.update` payload. The legacy
+        // `?model=<name>` URL creates a realtime conversation session and
+        // rejects transcription `session.update` events. The legacy
+        // `OpenAI-Beta: realtime=v1` header pins the server to the old
+        // schema and rejects `session.type`, so we omit it.
+        components.queryItems = [URLQueryItem(name: "intent", value: "transcription")]
         guard let url = components.url else {
             onError(OpenAIRealtimeError.connectionFailed("Invalid URL components"))
             return
@@ -554,9 +553,6 @@ final class OpenAIRealtimeWebSocketClient: @unchecked Sendable {
 
         var request = URLRequest(url: url)
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        if !Self.isGARealtimeTranscriptionModel(model) {
-            request.setValue("realtime=v1", forHTTPHeaderField: "OpenAI-Beta")
-        }
 
         let task = session.webSocketTask(with: request)
         withStateLock { webSocketTask = task }
@@ -586,41 +582,23 @@ final class OpenAIRealtimeWebSocketClient: @unchecked Sendable {
         transcription["model"] = model
         if let language { transcription["language"] = language }
 
-        let payload: [String: Any]
-        if Self.isGARealtimeTranscriptionModel(model) {
-            // GA shape: unified `session.update` with nested `audio.input`.
-            payload = [
-                "type": "session.update",
-                "session": [
-                    "type": "transcription",
-                    "audio": [
-                        "input": [
-                            "format": ["type": "audio/pcm", "rate": sampleRate],
-                            "transcription": transcription,
-                            "noise_reduction": ["type": "near_field"],
-                            "turn_detection": NSNull()
-                        ]
+        let payload: [String: Any] = [
+            // Unified GA shape for all transcription models. The legacy
+            // `transcription_session.update` event was removed during GA.
+            "type": "session.update",
+            "session": [
+                "type": "transcription",
+                "audio": [
+                    "input": [
+                        "format": ["type": "audio/pcm", "rate": sampleRate],
+                        "transcription": transcription,
+                        "noise_reduction": ["type": "near_field"],
+                        "turn_detection": NSNull()
                     ]
                 ]
             ]
-        } else {
-            payload = [
-                "type": "transcription_session.update",
-                "session": [
-                    "input_audio_format": "pcm16",
-                    "input_audio_transcription": transcription,
-                    "input_audio_noise_reduction": ["type": "near_field"],
-                    "turn_detection": NSNull()
-                ]
-            ]
-        }
+        ]
         sendJSON(payload)
-    }
-
-    /// Models only available on the GA Realtime endpoint. Mirrors the macOS
-    /// helper of the same name.
-    static func isGARealtimeTranscriptionModel(_ realtimeModel: String) -> Bool {
-        realtimeModel.lowercased().hasPrefix("gpt-realtime-whisper")
     }
 
     func sendAudio(_ pcmData: Data) {


### PR DESCRIPTION
## Bug

User reports `gpt-realtime-whisper` still failing with:

> OpenAI Realtime error (invalid_parameter): Passing a transcription session update event to a realtime session is not allowed.

## Root cause

The OpenAI Realtime API has fully migrated to the GA schema. Three things in our shipping code are now wrong:

1. **`?model=<name>` URL.** Creates a realtime *conversation* session. `session.update` with `session.type=transcription` is rejected with the user's error.
2. **`transcription_session.update` event.** Removed entirely. Server now responds `Invalid value: 'transcription_session.update'`.
3. **`OpenAI-Beta: realtime=v1` header.** Pins the server to the old schema and rejects `session.type`.

## Fix — validated against the live API before deploying

Probed all four transcription models (`whisper-1`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-realtime-whisper`) with the live OpenAI WebSocket. The unified GA shape works for all of them:

```
URL:     wss://api.openai.com/v1/realtime?intent=transcription
Headers: Authorization only (no OpenAI-Beta)
Payload: {"type":"session.update",
          "session":{"type":"transcription",
            "audio":{"input":{
              "format":{"type":"audio/pcm","rate":24000},
              "transcription":{"model":...,"language":...},
              "noise_reduction":{"type":"near_field"},
              "turn_detection":null}}}}
```

All four models reach `session.updated`. The two orphan `isGARealtimeTranscriptionModel` helpers are removed.

## Verification
- `swift build` clean
- `swift test`: 381 pass / 11 skip / 0 fail
- Live API probe: all four models accepted

## Related
Reverts and replaces the misdirected GA logic from #424 (mac) and #425 (iOS).