### PR TITLE
fix(mac): include WhisperKit in release project

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -43,7 +43,8 @@ let project = Project(
     packages: [
         .package(path: .relativeToRoot(".")),
         .remote(url: "https://github.com/sparkle-project/Sparkle.git", requirement: .upToNextMajor(from: "2.6.0")),
-        .remote(url: "https://github.com/getsentry/sentry-cocoa.git", requirement: .upToNextMajor(from: "9.3.0"))
+        .remote(url: "https://github.com/getsentry/sentry-cocoa.git", requirement: .upToNextMajor(from: "9.3.0")),
+        .remote(url: "https://github.com/argmaxinc/argmax-oss-swift.git", requirement: .upToNextMajor(from: "0.9.0"))
     ],
     settings: .settings(
         base: [
@@ -70,6 +71,7 @@ let project = Project(
                 .package(product: "SpeakCore"),
                 .package(product: "SpeakSync"),
                 .package(product: "SpeakHotKeys"),
+                .package(product: "WhisperKit"),
                 .package(product: "Sparkle"),
                 .package(product: "Sentry")
             ],


### PR DESCRIPTION
## Summary\n- add the argmax/WhisperKit package to the Tuist macOS app project\n- link WhisperKit for Xcode archive builds used by the macOS release workflow\n\n## Validation\n- tuist generate --no-open completed locally\n- xcodebuild package resolution is blocked locally by the machine's Xcode plug-in mismatch; CI release runner is the target validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sentry error tracking library to version 9.3.0
  * Added Argmax OSS Swift library (version 0.9.0) as a new dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crmitchelmore/justspeaktoit/pull/432)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->