### PR TITLE
feat(mac): update sherpa streaming recommendations

### DIFF
--- a/Sources/SpeakApp/LocalModelManager.swift
+++ b/Sources/SpeakApp/LocalModelManager.swift
@@ -25,7 +25,7 @@ enum LocalModelError: LocalizedError {
     case .invalidHuggingFaceModel:
       return """
       Enter a supported local model name. Local Batch expects a WhisperKit variant; \
-      Local Streaming expects a sherpa-onnx Zipformer source.
+      Local Streaming expects a sherpa-onnx streaming ASR source.
       """
     }
   }
@@ -49,10 +49,36 @@ final class LocalModelManager: ObservableObject {
 
   static let recommendedStreamingModelSources: [LocalStreamingModelSource] = [
     LocalStreamingModelSource(
+      repoID: "k2-fsa/sherpa-onnx",
+      modelName: "sherpa-onnx-nemotron-speech-streaming-en-0.6b-1120ms-int8-2026-04-25",
+      runtime: "sherpa-onnx streaming runtime",
+      approximateSizeMB: 632,
+      archiveURL: URL(
+        string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/"
+          + "sherpa-onnx-nemotron-speech-streaming-en-0.6b-1120ms-int8-2026-04-25.tar.bz2"
+      )
+    ),
+    LocalStreamingModelSource(
+      repoID: "k2-fsa/sherpa-onnx",
+      modelName: "sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25",
+      runtime: "sherpa-onnx streaming runtime",
+      approximateSizeMB: 632,
+      archiveURL: URL(
+        string: "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/"
+          + "sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25.tar.bz2"
+      )
+    ),
+    LocalStreamingModelSource(
       repoID: "csukuangfj/sherpa-onnx-streaming-zipformer-en-kroko-2025-08-06",
       modelName: "streaming-zipformer-en-kroko-2025-08-06",
       runtime: "sherpa-onnx streaming runtime",
       approximateSizeMB: 71
+    ),
+    LocalStreamingModelSource(
+      repoID: "csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-21",
+      modelName: "streaming-zipformer-en-2023-06-21",
+      runtime: "sherpa-onnx streaming runtime",
+      approximateSizeMB: 181
     ),
     LocalStreamingModelSource(
       repoID: "csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26",
@@ -403,7 +429,8 @@ final class LocalModelManager: ObservableObject {
       modelName: source.modelName,
       runtime: streamingRuntimeHint(for: source.repoID, modelName: source.modelName),
       approximateSizeMB: source.approximateSizeMB
-        ?? streamingApproximateSizeMB(repoID: source.repoID, modelName: source.modelName)
+        ?? streamingApproximateSizeMB(repoID: source.repoID, modelName: source.modelName),
+      archiveURL: source.archiveURL
     )
   }
 
@@ -441,6 +468,12 @@ final class LocalModelManager: ObservableObject {
     if searchText.contains("en-kroko-2025-08-06") {
       return 71
     }
+    if searchText.contains("nemotron-speech-streaming-en-0.6b") {
+      return 632
+    }
+    if searchText.contains("en-2023-06-21") {
+      return 181
+    }
     if searchText.contains("en-20m-2023-02-17") {
       return 44
     }
@@ -452,10 +485,11 @@ final class LocalModelManager: ObservableObject {
 
   nonisolated static func isSupportedStreamingSource(_ source: LocalStreamingModelSource) -> Bool {
     let text = "\(source.id) \(source.repoID) \(source.modelName) \(source.runtime)".lowercased()
-    guard !text.contains("parakeet"), !text.contains("nemo"), !text.contains("nvidia") else {
+    let isNemotron = text.contains("nemotron")
+    guard !text.contains("parakeet"), !text.contains("nvidia"), isNemotron || !text.contains("nemo") else {
       return false
     }
-    return text.contains("sherpa") && text.contains("zipformer")
+    return text.contains("sherpa") && (text.contains("zipformer") || text.contains("nemotron"))
   }
 
   nonisolated static func resolveHuggingFaceModel(repoID: String, modelName: String) -> ResolvedHuggingFaceModel {
@@ -577,8 +611,15 @@ struct LocalStreamingModelSource: Codable, Equatable, Identifiable, Sendable {
   let modelName: String
   let runtime: String
   let approximateSizeMB: Int?
+  let archiveURL: URL?
 
-  init(repoID: String, modelName: String, runtime: String? = nil, approximateSizeMB: Int? = nil) {
+  init(
+    repoID: String,
+    modelName: String,
+    runtime: String? = nil,
+    approximateSizeMB: Int? = nil,
+    archiveURL: URL? = nil
+  ) {
     let repoID = repoID.trimmingCharacters(in: .whitespacesAndNewlines)
     let modelName = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
     self.id = "local/streaming/huggingface/\(LocalModelManager.slug(repoID))/\(LocalModelManager.slug(modelName))"
@@ -587,6 +628,7 @@ struct LocalStreamingModelSource: Codable, Equatable, Identifiable, Sendable {
     self.runtime = runtime ?? LocalModelManager.streamingRuntimeHint(for: repoID, modelName: modelName)
     self.approximateSizeMB = approximateSizeMB
       ?? LocalModelManager.streamingApproximateSizeMB(repoID: repoID, modelName: modelName)
+    self.archiveURL = archiveURL
   }
 
   var displayName: String {

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -1672,7 +1672,7 @@ struct SettingsView: View {
       localStreamingSetupSection(
         title: "2. Browse for more local streaming models",
         subtitle: """
-        Open Hugging Face search for sherpa-onnx Zipformer models. \
+        Open Hugging Face search for sherpa-onnx streaming ASR models. \
         Only compatible sources can be added here.
         """,
         systemImage: "magnifyingglass",
@@ -1687,7 +1687,10 @@ struct SettingsView: View {
 
       localStreamingSetupSection(
         title: "3. Add a source manually",
-        subtitle: "Use this when you already know the Hugging Face repo and model name. The model still stays local-only.",
+        subtitle: """
+        Use this when you already know the Hugging Face repo and model name. \
+        The model still stays local-only.
+        """,
         systemImage: "keyboard",
         tint: .purple
       ) {
@@ -2078,7 +2081,7 @@ struct SettingsView: View {
   private func openLocalStreamingModelSearch() {
     guard let url = URL(
       string: "https://huggingface.co/models?pipeline_tag=automatic-speech-recognition&sort=downloads"
-        + "&search=sherpa-onnx%20streaming%20zipformer"
+        + "&search=sherpa-onnx%20streaming"
     ) else { return }
     NSWorkspace.shared.open(url)
   }

--- a/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
+++ b/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
@@ -285,10 +285,16 @@ final class SherpaOnnxRuntimeManager: ObservableObject {
         "Download returned HTTP \(http.statusCode) for \(url.lastPathComponent)."
       )
     }
-    _ = try await Self.runProcess(
-      executableURL: URL(fileURLWithPath: "/usr/bin/tar"),
-      arguments: ["-xjf", downloadedURL.path, "-C", destination.path]
-    )
+    do {
+      _ = try await Self.runProcess(
+        executableURL: URL(fileURLWithPath: "/usr/bin/tar"),
+        arguments: ["-xf", downloadedURL.path, "-C", destination.path]
+      )
+    } catch {
+      throw SherpaOnnxRuntimeError.downloadFailed(
+        "Failed to extract model archive: \(error.localizedDescription)"
+      )
+    }
   }
 
   private nonisolated static func runProcess(executableURL: URL, arguments: [String]) async throws -> String {

--- a/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
+++ b/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
@@ -32,6 +32,7 @@ struct SherpaOnnxModelBundle: Equatable, Sendable {
   let encoder: URL
   let decoder: URL
   let joiner: URL
+  let featureDim: Int
 }
 
 @MainActor
@@ -141,9 +142,13 @@ final class SherpaOnnxRuntimeManager: ObservableObject {
       }
       try fileManager.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
 
-      for file in spec.files {
-        let destination = tempDirectory.appendingPathComponent(file)
-        try await downloadFile(repoID: source.repoID, filename: file, to: destination)
+      if let archiveURL = spec.archiveURL {
+        try await downloadArchive(from: archiveURL, to: tempDirectory)
+      } else {
+        for file in spec.files {
+          let destination = tempDirectory.appendingPathComponent(file)
+          try await downloadFile(repoID: source.repoID, filename: file, to: destination)
+        }
       }
 
       if fileManager.fileExists(atPath: finalDirectory.path) {
@@ -165,7 +170,8 @@ final class SherpaOnnxRuntimeManager: ObservableObject {
       tokens: directory.appendingPathComponent(spec.tokens),
       encoder: directory.appendingPathComponent(spec.encoder),
       decoder: directory.appendingPathComponent(spec.decoder),
-      joiner: directory.appendingPathComponent(spec.joiner)
+      joiner: directory.appendingPathComponent(spec.joiner),
+      featureDim: spec.featureDim
     )
     guard fileManager.fileExists(atPath: bundle.tokens.path),
       fileManager.fileExists(atPath: bundle.encoder.path),
@@ -271,6 +277,20 @@ final class SherpaOnnxRuntimeManager: ObservableObject {
     try fileManager.moveItem(at: downloadedURL, to: destination)
   }
 
+  private func downloadArchive(from url: URL, to destination: URL) async throws {
+    let (downloadedURL, response) = try await URLSession.shared.download(from: url)
+    defer { try? fileManager.removeItem(at: downloadedURL) }
+    if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+      throw SherpaOnnxRuntimeError.downloadFailed(
+        "Download returned HTTP \(http.statusCode) for \(url.lastPathComponent)."
+      )
+    }
+    _ = try await Self.runProcess(
+      executableURL: URL(fileURLWithPath: "/usr/bin/tar"),
+      arguments: ["-xjf", downloadedURL.path, "-C", destination.path]
+    )
+  }
+
   private nonisolated static func runProcess(executableURL: URL, arguments: [String]) async throws -> String {
     try await withCheckedThrowingContinuation { continuation in
       DispatchQueue.global(qos: .utility).async {
@@ -346,6 +366,26 @@ final class SherpaOnnxRuntimeManager: ObservableObject {
         joiner: "joiner.onnx"
       )
     }
+    if repo.contains("nemotron-speech-streaming-en-0.6b")
+      || source.modelName.lowercased().contains("nemotron-speech-streaming-en-0.6b") {
+      let root = source.modelName
+      return ModelSpecification(
+        tokens: "\(root)/tokens.txt",
+        encoder: "\(root)/encoder.int8.onnx",
+        decoder: "\(root)/decoder.int8.onnx",
+        joiner: "\(root)/joiner.int8.onnx",
+        featureDim: 128,
+        archiveURL: source.archiveURL
+      )
+    }
+    if repo.contains("en-2023-06-21") {
+      return ModelSpecification(
+        tokens: "tokens.txt",
+        encoder: "encoder-epoch-99-avg-1.int8.onnx",
+        decoder: "decoder-epoch-99-avg-1.onnx",
+        joiner: "joiner-epoch-99-avg-1.int8.onnx"
+      )
+    }
     if repo.contains("en-2023-06-26") {
       return ModelSpecification(
         tokens: "tokens.txt",
@@ -362,6 +402,8 @@ final class SherpaOnnxRuntimeManager: ObservableObject {
     let encoder: String
     let decoder: String
     let joiner: String
+    var featureDim: Int = 80
+    var archiveURL: URL?
 
     var files: [String] { [tokens, encoder, decoder, joiner] }
   }
@@ -386,6 +428,7 @@ def main():
     parser.add_argument("--encoder", required=True)
     parser.add_argument("--decoder", required=True)
     parser.add_argument("--joiner", required=True)
+    parser.add_argument("--feature-dim", type=int, default=80)
     args = parser.parse_args()
 
     recognizer = sherpa_onnx.OnlineRecognizer.from_transducer(
@@ -395,7 +438,7 @@ def main():
         joiner=args.joiner,
         num_threads=2,
         sample_rate=16000,
-        feature_dim=80,
+        feature_dim=args.feature_dim,
         decoding_method="greedy_search",
         provider="cpu",
     )

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -791,7 +791,8 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
       "--tokens", bundle.tokens.path,
       "--encoder", bundle.encoder.path,
       "--decoder", bundle.decoder.path,
-      "--joiner", bundle.joiner.path
+      "--joiner", bundle.joiner.path,
+      "--feature-dim", "\(bundle.featureDim)"
     ]
     return process
   }

--- a/Tests/SpeakAppTests/LocalModelManagerTests.swift
+++ b/Tests/SpeakAppTests/LocalModelManagerTests.swift
@@ -103,6 +103,20 @@ final class LocalModelManagerTests: XCTestCase {
         )
         XCTAssertEqual(
             LocalModelManager.streamingApproximateSizeMB(
+                repoID: "k2-fsa/sherpa-onnx",
+                modelName: "sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25"
+            ),
+            632
+        )
+        XCTAssertEqual(
+            LocalModelManager.streamingApproximateSizeMB(
+                repoID: "csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-21",
+                modelName: "streaming-zipformer-en-2023-06-21"
+            ),
+            181
+        )
+        XCTAssertEqual(
+            LocalModelManager.streamingApproximateSizeMB(
                 repoID: "csukuangfj/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17",
                 modelName: "streaming-zipformer-en-20M-2023-02-17"
             ),
@@ -111,7 +125,19 @@ final class LocalModelManagerTests: XCTestCase {
     }
 
     @MainActor
-    func testRecommendedStreamingSources_includeSelectableSherpaCandidate() {
+    func testRecommendedStreamingSources_prioritizeLatestNemotronCandidates() {
+        let sources = LocalModelManager.recommendedStreamingModelSources
+        XCTAssertEqual(
+            sources.first?.modelName,
+            "sherpa-onnx-nemotron-speech-streaming-en-0.6b-1120ms-int8-2026-04-25"
+        )
+        XCTAssertEqual(sources.first?.approximateSizeMB, 632)
+        XCTAssertNotNil(sources.first?.archiveURL)
+        XCTAssertTrue(sources.prefix(2).allSatisfy { $0.modelName.contains("nemotron-speech-streaming-en-0.6b") })
+    }
+
+    @MainActor
+    func testRecommendedStreamingSources_keepLightweightSherpaCandidate() {
         let sources = LocalModelManager.recommendedStreamingModelSources
         let hasSherpa = sources.contains {
             $0.repoID == "csukuangfj/sherpa-onnx-streaming-zipformer-en-kroko-2025-08-06"
@@ -131,13 +157,27 @@ final class LocalModelManagerTests: XCTestCase {
         XCTAssertFalse(LocalModelManager.isSupportedStreamingSource(source))
     }
 
+    func testSupportedStreamingSource_acceptsSherpaNemotronSource() {
+        let source = LocalStreamingModelSource(
+            repoID: "k2-fsa/sherpa-onnx",
+            modelName: "sherpa-onnx-nemotron-speech-streaming-en-0.6b-560ms-int8-2026-04-25",
+            runtime: "sherpa-onnx streaming runtime"
+        )
+
+        XCTAssertTrue(LocalModelManager.isSupportedStreamingSource(source))
+    }
+
     @MainActor
-    func testRecommendedStreamingSources_onlyIncludeDownloadableZipformerModels() {
+    func testRecommendedStreamingSources_onlyIncludeDownloadableSherpaModels() {
         let sources = LocalModelManager.recommendedStreamingModelSources
 
-        XCTAssertFalse(sources.contains { $0.repoID == "k2-fsa/sherpa-onnx" })
         XCTAssertTrue(sources.allSatisfy(LocalModelManager.isSupportedStreamingSource))
         XCTAssertTrue(sources.allSatisfy { ($0.approximateSizeMB ?? 0) > 0 })
+        XCTAssertTrue(
+            sources.allSatisfy {
+                $0.repoID.split(separator: "/").count == 2 || $0.archiveURL != nil
+            }
+        )
     }
 
     func testNormalizedStreamingModelSourceBackfillsKnownSize() {


### PR DESCRIPTION
## Summary
- add the 2026 sherpa-onnx Nemotron 0.6B streaming models to the recommended Local Streaming list
- support recommended GitHub release archive downloads for sherpa-onnx model bundles
- pass model feature dimensions through to the sherpa sidecar so Nemotron can use 128-dim features
- keep lightweight Zipformer options as fallbacks and update regression coverage

## Validation
- swift test --filter LocalModelManagerTests --quiet
- swift build --target SpeakApp --quiet
- git diff --check
- verified Nemotron 560ms/1120ms archive URLs return HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nemotron streaming speech recognition models from the Sherpa-ONNX framework.
  * Enhanced model installation with archive download and extraction capabilities.

* **Bug Fixes**
  * Fixed transcription process argument handling to properly format command-line parameters.

* **Documentation**
  * Updated settings UI descriptions for improved clarity regarding streaming ASR model types and sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crmitchelmore/justspeaktoit/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->