### PR TITLE
fix(mac): remove sidebar focus ring

### DIFF
--- a/Sources/SpeakApp/SideBarView.swift
+++ b/Sources/SpeakApp/SideBarView.swift
@@ -130,6 +130,7 @@ struct SideBarView: View {
           }
           .buttonStyle(.plain)
           .focusable(true)
+          .focusEffectDisabled()
           .padding(.horizontal, 12)
           .padding(.vertical, 8)
           .background(
@@ -168,6 +169,7 @@ struct SideBarView: View {
           }
           .buttonStyle(.plain)
           .focusable(true)
+          .focusEffectDisabled()
           .padding(.horizontal, 12)
           .padding(.vertical, 8)
           .background(


### PR DESCRIPTION
## Summary
- Disable the SwiftUI focus effect on sidebar navigation rows so clicked menu items do not retain the blue focus border
- Keep the selected row background/highlight unchanged

## Validation
- swift build --target SpeakApp --quiet
- git diff --check