### PR TITLE
fix(mac): recover from stale audio input device on capture start

### DIFF
--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -26,7 +26,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
   private var currentModel: String?
   private var currentLanguage: String?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
-  private let audioEngine = AVAudioEngine()
+  private var audioEngine = AVAudioEngine()
   private let logger = Logger(subsystem: "com.speak.app", category: "OpenAIRealtimeLiveController")
   private let audioProcessor = OpenAIRealtimeAudioProcessor(targetSampleRate: 24_000)
   private var hasFinished: Bool = false
@@ -76,6 +76,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
 
     let sessionContext = await audioDeviceManager.beginUsingPreferredInput()
     activeInputSession = sessionContext
+    audioEngine = AVAudioEngine()
 
     transcriber = nil
     targetFormat = nil
@@ -92,6 +93,9 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
       let inputNode = audioEngine.inputNode
       inputNode.removeTap(onBus: 0)
       let inputFormat = inputNode.outputFormat(forBus: 0)
+      guard audioInputFormatIsUsable(inputFormat) else {
+        throw TranscriptionManagerError.noUsableAudioInput
+      }
 
       guard let outputFormat = AVAudioFormat(
         commonFormat: .pcmFormatInt16,

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -24,6 +24,7 @@ enum TranscriptionManagerError: LocalizedError, Equatable {
   case permissionsMissing
   case localLiveStreamingUnsupported
   case invalidLocalStreamingSource(String)
+  case noUsableAudioInput
 
   var errorDescription: String? {
     switch self {
@@ -40,8 +41,18 @@ enum TranscriptionManagerError: LocalizedError, Equatable {
     case .invalidLocalStreamingSource(let sourceID):
       return "Local streaming source is not available: \(sourceID). " +
         "Choose or download a local streaming model in Settings."
+    case .noUsableAudioInput:
+      return "The selected microphone is unavailable. Pick a different input device in Settings and try again."
     }
   }
+}
+
+/// Returns `true` when an `AVAudioEngine` input format describes a usable capture
+/// device. A stale or disconnected input device reports zero channels or a zero
+/// sample rate, which would otherwise surface as `kAudioHardwareBadDeviceError`
+/// (`com.apple.coreaudio.avfaudio error 560227702`) when starting the engine.
+func audioInputFormatIsUsable(_ format: AVAudioFormat) -> Bool {
+  format.channelCount > 0 && format.sampleRate > 0
 }
 
 @MainActor
@@ -330,7 +341,7 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
   private let appSettings: AppSettings
   private let audioDeviceManager: AudioInputDeviceManager
   private var speechRecognizer: SFSpeechRecognizer?
-  private let audioEngine = AVAudioEngine()
+  private var audioEngine = AVAudioEngine()
   private var recognitionTask: SFSpeechRecognitionTask?
   private var request: SFSpeechAudioBufferRecognitionRequest?
   private var currentLocaleIdentifier: String?
@@ -370,6 +381,11 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
 
     let sessionContext = await audioDeviceManager.beginUsingPreferredInput()
 
+    // Bind a fresh engine to the now-selected default input device. Reusing a
+    // long-lived engine across device changes leaves it pointing at a stale HAL
+    // device and `start()` then fails with kAudioHardwareBadDeviceError.
+    audioEngine = AVAudioEngine()
+
     let localeIdentifier = currentLocaleIdentifier ?? appSettings.preferredLocaleIdentifier
 
     guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: localeIdentifier)) else {
@@ -383,6 +399,10 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
     let inputNode = audioEngine.inputNode
     inputNode.removeTap(onBus: 0)
     let format = inputNode.outputFormat(forBus: 0)
+    guard audioInputFormatIsUsable(format) else {
+      await audioDeviceManager.endUsingPreferredInput(session: sessionContext)
+      throw TranscriptionManagerError.noUsableAudioInput
+    }
     inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
       self?.request?.append(buffer)
     }
@@ -639,7 +659,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
   private let permissionsManager: PermissionsManager
   private let audioDeviceManager: AudioInputDeviceManager
   private let runtimeManager: SherpaOnnxRuntimeManager
-  private let audioEngine = AVAudioEngine()
+  private var audioEngine = AVAudioEngine()
   private let audioProcessor = SherpaOnnxAudioProcessor()
   private let targetSampleRate: Double = 16000
   private let logger = Logger(subsystem: "com.github.speakapp", category: "SherpaOnnxLiveController")
@@ -711,11 +731,15 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
 
     let sessionContext = await audioDeviceManager.beginUsingPreferredInput()
     activeInputSession = sessionContext
+    audioEngine = AVAudioEngine()
 
     do {
       let inputNode = audioEngine.inputNode
       inputNode.removeTap(onBus: 0)
       let inputFormat = inputNode.outputFormat(forBus: 0)
+      guard audioInputFormatIsUsable(inputFormat) else {
+        throw TranscriptionManagerError.noUsableAudioInput
+      }
       guard let outputFormat = AVAudioFormat(
         commonFormat: .pcmFormatFloat32,
         sampleRate: targetSampleRate,
@@ -1028,7 +1052,7 @@ final class DeepgramLiveController: NSObject, LiveTranscriptionController {
   private var currentLanguage: String?
   private var currentModel: String?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
-  private let audioEngine = AVAudioEngine()
+  private var audioEngine = AVAudioEngine()
   private let logger = Logger(subsystem: "com.speak.app", category: "DeepgramLiveController")
   private let audioProcessor = DeepgramAudioProcessor()
   /// Guards against calling didFinishWith more than once per session.
@@ -1076,12 +1100,16 @@ final class DeepgramLiveController: NSObject, LiveTranscriptionController {
 
     let apiKey = try await deepgramAPIKey()
     activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    audioEngine = AVAudioEngine()
     resetStartState()
 
     do {
       let inputNode = audioEngine.inputNode
       inputNode.removeTap(onBus: 0)
       let inputFormat = inputNode.outputFormat(forBus: 0)
+      guard audioInputFormatIsUsable(inputFormat) else {
+        throw TranscriptionManagerError.noUsableAudioInput
+      }
       print("[DeepgramLiveController] Input format: \(inputFormat.sampleRate)Hz, \(inputFormat.channelCount) channels")
 
       let outputFormat = try makeDeepgramOutputFormat()
@@ -1490,7 +1518,7 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
   private var currentModel: String?
   private var currentLanguage: String?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
-  private let audioEngine = AVAudioEngine()
+  private var audioEngine = AVAudioEngine()
   private let logger = Logger(subsystem: "com.speak.app", category: "AssemblyAILiveController")
   private let audioProcessor = AssemblyAIAudioProcessor()
   private var hasFinished: Bool = false
@@ -1535,6 +1563,7 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
 
     let sessionContext = await audioDeviceManager.beginUsingPreferredInput()
     activeInputSession = sessionContext
+    audioEngine = AVAudioEngine()
 
     transcriber = nil
     targetFormat = nil
@@ -1552,6 +1581,9 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
       let inputNode = audioEngine.inputNode
       inputNode.removeTap(onBus: 0)
       let inputFormat = inputNode.outputFormat(forBus: 0)
+      guard audioInputFormatIsUsable(inputFormat) else {
+        throw TranscriptionManagerError.noUsableAudioInput
+      }
 
       guard let outputFormat = AVAudioFormat(
         commonFormat: .pcmFormatInt16,
@@ -1981,7 +2013,7 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
   private var currentModel: String?
   private var currentLanguage: String?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
-  private let audioEngine = AVAudioEngine()
+  private var audioEngine = AVAudioEngine()
   private let logger = Logger(subsystem: "com.speak.app", category: "ModulateLiveController")
   private let audioProcessor = ModulateAudioProcessor()
   private var hasFinished: Bool = false
@@ -2023,12 +2055,16 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
 
     let apiKey = try await modulateAPIKey()
     activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    audioEngine = AVAudioEngine()
     resetStartState()
 
     do {
       let inputNode = audioEngine.inputNode
       inputNode.removeTap(onBus: 0)
       let inputFormat = inputNode.outputFormat(forBus: 0)
+      guard audioInputFormatIsUsable(inputFormat) else {
+        throw TranscriptionManagerError.noUsableAudioInput
+      }
       let outputFormat = try makeModulateOutputFormat()
       let transcriber = try makeModulateTranscriber(apiKey: apiKey)
       installModulateTap(
@@ -2487,7 +2523,7 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
   private var currentLanguage: String?
   private var currentModel: String?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
-  private let audioEngine = AVAudioEngine()
+  private var audioEngine = AVAudioEngine()
   private let logger = Logger(subsystem: "com.speak.app", category: "ElevenLabsLiveController")
   private let audioProcessor = ElevenLabsAudioProcessor()
   private var hasFinished: Bool = false
@@ -2525,12 +2561,16 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
 
     let apiKey = try await elevenLabsAPIKey()
     activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    audioEngine = AVAudioEngine()
     resetStartState()
 
     do {
       let inputNode = audioEngine.inputNode
       inputNode.removeTap(onBus: 0)
       let inputFormat = inputNode.outputFormat(forBus: 0)
+      guard audioInputFormatIsUsable(inputFormat) else {
+        throw TranscriptionManagerError.noUsableAudioInput
+      }
 
       guard let outputFormat = AVAudioFormat(
         commonFormat: .pcmFormatInt16,
@@ -2885,7 +2925,7 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
   private var currentLanguage: String?
   private var currentModel: String?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
-  private let audioEngine = AVAudioEngine()
+  private var audioEngine = AVAudioEngine()
   private let logger = Logger(subsystem: "com.speak.app", category: "SonioxLiveController")
   private let audioProcessor = SonioxAudioProcessor()
   private var hasFinished: Bool = false
@@ -2924,12 +2964,16 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
 
     let apiKey = try await sonioxAPIKey()
     activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    audioEngine = AVAudioEngine()
     resetStartState()
 
     do {
       let inputNode = audioEngine.inputNode
       inputNode.removeTap(onBus: 0)
       let inputFormat = inputNode.outputFormat(forBus: 0)
+      guard audioInputFormatIsUsable(inputFormat) else {
+        throw TranscriptionManagerError.noUsableAudioInput
+      }
 
       guard let outputFormat = AVAudioFormat(
         commonFormat: .pcmFormatInt16,

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -692,6 +692,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
     currentModel = model
   }
 
+  // swiftlint:disable:next function_body_length
   func start() async throws {
     guard !isRunning, !isStopping else {
       throw TranscriptionManagerError.liveSessionAlreadyRunning

--- a/Tests/SpeakAppTests/AudioInputFormatTests.swift
+++ b/Tests/SpeakAppTests/AudioInputFormatTests.swift
@@ -18,18 +18,28 @@ final class AudioInputFormatTests: XCTestCase {
   }
 
   func testUsableFormat_zeroSampleRate_isNotUsable() {
-    guard
-      let format = AVAudioFormat(
-        commonFormat: .pcmFormatFloat32,
-        sampleRate: 0,
-        channels: 1,
-        interleaved: false
-      )
-    else {
-      // A zero sample rate is itself rejected by AVAudioFormat, which already
-      // protects the engine start path, so there is nothing further to assert.
-      return
-    }
-    XCTAssertFalse(audioInputFormatIsUsable(format))
+    // A stale HAL input node reports a 0 Hz format. AVAudioFormat does build
+    // such an instance, so the helper must reject it.
+    let format = AVAudioFormat(standardFormatWithSampleRate: 0, channels: 1)
+    XCTAssertNotNil(format)
+    XCTAssertFalse(audioInputFormatIsUsable(format!))
+  }
+
+  func testUsableFormat_zeroChannels_isNotUsable() {
+    // A stale input node can also report 0 channels; build one via an ASBD.
+    var asbd = AudioStreamBasicDescription(
+      mSampleRate: 48_000,
+      mFormatID: kAudioFormatLinearPCM,
+      mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+      mBytesPerPacket: 4,
+      mFramesPerPacket: 1,
+      mBytesPerFrame: 4,
+      mChannelsPerFrame: 0,
+      mBitsPerChannel: 32,
+      mReserved: 0
+    )
+    let format = AVAudioFormat(streamDescription: &asbd)
+    XCTAssertNotNil(format)
+    XCTAssertFalse(audioInputFormatIsUsable(format!))
   }
 }

--- a/Tests/SpeakAppTests/AudioInputFormatTests.swift
+++ b/Tests/SpeakAppTests/AudioInputFormatTests.swift
@@ -1,0 +1,35 @@
+import AVFoundation
+import XCTest
+
+@testable import SpeakApp
+
+final class AudioInputFormatTests: XCTestCase {
+
+  func testUsableFormat_standardMic_isUsable() {
+    let format = AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 1)
+    XCTAssertNotNil(format)
+    XCTAssertTrue(audioInputFormatIsUsable(format!))
+  }
+
+  func testUsableFormat_stereo_isUsable() {
+    let format = AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 2)
+    XCTAssertNotNil(format)
+    XCTAssertTrue(audioInputFormatIsUsable(format!))
+  }
+
+  func testUsableFormat_zeroSampleRate_isNotUsable() {
+    guard
+      let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: 0,
+        channels: 1,
+        interleaved: false
+      )
+    else {
+      // A zero sample rate is itself rejected by AVAudioFormat, which already
+      // protects the engine start path, so there is nothing further to assert.
+      return
+    }
+    XCTAssertFalse(audioInputFormatIsUsable(format))
+  }
+}


### PR DESCRIPTION
## Problem

Users hit a runtime error sheet when starting dictation:

> **Something went wrong** — The operation couldn't be completed. (com.apple.coreaudio.avfaudio error 560227702.)

`560227702` decodes to the Core Audio FourCC `'!dev'` = `kAudioHardwareBadDeviceError`, thrown by `AVAudioEngine.start()`.

## Root cause

Every live-transcription controller (Apple Speech, Sherpa, Deepgram, AssemblyAI, Modulate, ElevenLabs, Soniox, OpenAI Realtime) held a **single long-lived** `AVAudioEngine` created once at init and reused for every recording.

`AVAudioEngine` binds to the default input device when its `inputNode` is first realised. The system default input changes over time — both from device hot-plug/removal (this app's users commonly have webcam mics, Continuity iPhone mics, virtual Teams devices) **and because the app itself switches the default in `beginUsingPreferredInput()`** before each session. The reused engine then points at a stale/removed HAL device and `start()` fails with `kAudioHardwareBadDeviceError`.

## Fix

- Recreate a fresh `AVAudioEngine` at the start of each session, **after** `beginUsingPreferredInput()` has selected the device, so the engine always binds to the current default input. Applied to all 8 controllers.
- Validate the input format (non-zero channels and sample rate) before installing the tap; if the selected device is genuinely unusable, throw a new `TranscriptionManagerError.noUsableAudioInput` that shows *"The selected microphone is unavailable. Pick a different input device in Settings and try again."* instead of the raw Core Audio error.
- Add `AudioInputFormatTests` covering the format-validation helper.

## Verification

- The identical change pattern was built (`swift build --target SpeakApp`) and the new tests pass (`swift test --filter AudioInputFormatTests`) on a structurally-equivalent base. CI will validate the full latest-main build.

Fixes the `avfaudio error 560227702` reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate microphone audio input formats before starting live processing to prevent failures with incompatible devices
  * Provide a clearer user-facing error when the selected microphone format is unusable
  * Recreate the audio engine when starting sessions to avoid using stale hardware paths and improve reliability when devices change

* **Tests**
  * Added tests covering audio format validation scenarios (usable and unusable formats)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->