### PR TITLE
fix(mac): retry stale audio input engine start

### DIFF
--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -156,8 +156,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
         )
       }
 
-      audioEngine.prepare()
-      try audioEngine.start()
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
       isRunning = true
       streamingStartTime = Date()
     } catch {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -55,6 +55,51 @@ func audioInputFormatIsUsable(_ format: AVAudioFormat) -> Bool {
   format.channelCount > 0 && format.sampleRate > 0
 }
 
+private let coreAudioBadDeviceErrorCode = 560_227_702
+private let avfaudioErrorDomain = "com.apple.coreaudio.avfaudio"
+private let staleInputDeviceRetryDelay: Duration = .milliseconds(200)
+
+@MainActor
+func startAudioEngineAfterInputDeviceSettles(_ audioEngine: AVAudioEngine) async throws {
+  do {
+    audioEngine.prepare()
+    try audioEngine.start()
+  } catch {
+    guard audioInputStartErrorIsBadDevice(error) else {
+      throw error
+    }
+
+    audioEngine.stop()
+    try? await Task.sleep(for: staleInputDeviceRetryDelay)
+
+    do {
+      audioEngine.prepare()
+      try audioEngine.start()
+    } catch {
+      throw normalisedAudioInputStartError(error)
+    }
+  }
+}
+
+func normalisedAudioInputStartError(_ error: Error) -> Error {
+  audioInputStartErrorIsBadDevice(error)
+    ? TranscriptionManagerError.noUsableAudioInput
+    : error
+}
+
+func audioInputStartErrorIsBadDevice(_ error: Error) -> Bool {
+  let nsError = error as NSError
+  if nsError.code == coreAudioBadDeviceErrorCode,
+    nsError.domain == avfaudioErrorDomain || nsError.domain == NSOSStatusErrorDomain
+  {
+    return true
+  }
+  if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+    return audioInputStartErrorIsBadDevice(underlying)
+  }
+  return false
+}
+
 @MainActor
 final class TranscriptionManager: ObservableObject {
   @Published private(set) var livePartialText: String = ""
@@ -407,12 +452,11 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
       self?.request?.append(buffer)
     }
 
-    audioEngine.prepare()
     do {
-      try audioEngine.start()
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
     } catch {
       await audioDeviceManager.endUsingPreferredInput(session: sessionContext)
-      throw error
+      throw normalisedAudioInputStartError(error)
     }
 
     latestResult = nil
@@ -762,8 +806,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
           logger: log
         )
       }
-      audioEngine.prepare()
-      try audioEngine.start()
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
       streamingStartTime = Date()
       isRunning = true
     } catch {
@@ -1122,8 +1165,7 @@ final class DeepgramLiveController: NSObject, LiveTranscriptionController {
         transcriber: transcriber
       )
 
-      audioEngine.prepare()
-      try audioEngine.start()
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
       isRunning = true
       streamingStartTime = Date()
       print("[DeepgramLiveController] Started successfully")
@@ -1643,8 +1685,7 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
         )
       }
 
-      audioEngine.prepare()
-      try audioEngine.start()
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
       isRunning = true
       streamingStartTime = Date()
     } catch {
@@ -2075,8 +2116,7 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
         transcriber: transcriber
       )
 
-      audioEngine.prepare()
-      try audioEngine.start()
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
       isRunning = true
       streamingStartTime = Date()
     } catch {
@@ -2622,8 +2662,7 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
         )
       }
 
-      audioEngine.prepare()
-      try audioEngine.start()
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
       isRunning = true
       streamingStartTime = Date()
     } catch {
@@ -3037,8 +3076,7 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
         )
       }
 
-      audioEngine.prepare()
-      try audioEngine.start()
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
       isRunning = true
       streamingStartTime = Date()
     } catch {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -90,8 +90,7 @@ func normalisedAudioInputStartError(_ error: Error) -> Error {
 func audioInputStartErrorIsBadDevice(_ error: Error) -> Bool {
   let nsError = error as NSError
   if nsError.code == coreAudioBadDeviceErrorCode,
-    nsError.domain == avfaudioErrorDomain || nsError.domain == NSOSStatusErrorDomain
-  {
+    nsError.domain == avfaudioErrorDomain || nsError.domain == NSOSStatusErrorDomain {
     return true
   }
   if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
@@ -1062,9 +1061,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
 struct RemoteAudioTranscriber: BatchTranscriptionClient {
   let client: OpenRouterAPIClient
 
-  func transcribeFile(at url: URL, model: String, language: String?) async throws
-    -> TranscriptionResult
-  {
+  func transcribeFile(at url: URL, model: String, language: String?) async throws -> TranscriptionResult {
     try await client.transcribeFile(at: url, model: model, language: language)
   }
 }

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -59,7 +59,6 @@ private let coreAudioBadDeviceErrorCode = 560_227_702
 private let avfaudioErrorDomain = "com.apple.coreaudio.avfaudio"
 private let staleInputDeviceRetryDelay: Duration = .milliseconds(200)
 
-@MainActor
 func startAudioEngineAfterInputDeviceSettles(_ audioEngine: AVAudioEngine) async throws {
   do {
     audioEngine.prepare()
@@ -70,7 +69,7 @@ func startAudioEngineAfterInputDeviceSettles(_ audioEngine: AVAudioEngine) async
     }
 
     audioEngine.stop()
-    try? await Task.sleep(for: staleInputDeviceRetryDelay)
+    try await Task.sleep(for: staleInputDeviceRetryDelay)
 
     do {
       audioEngine.prepare()
@@ -454,6 +453,8 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
     do {
       try await startAudioEngineAfterInputDeviceSettles(audioEngine)
     } catch {
+      audioEngine.stop()
+      audioEngine.inputNode.removeTap(onBus: 0)
       await audioDeviceManager.endUsingPreferredInput(session: sessionContext)
       throw normalisedAudioInputStartError(error)
     }

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -456,7 +456,7 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
       audioEngine.stop()
       audioEngine.inputNode.removeTap(onBus: 0)
       await audioDeviceManager.endUsingPreferredInput(session: sessionContext)
-      throw normalisedAudioInputStartError(error)
+      throw error
     }
 
     latestResult = nil

--- a/Tests/SpeakAppTests/AudioInputFormatTests.swift
+++ b/Tests/SpeakAppTests/AudioInputFormatTests.swift
@@ -42,4 +42,27 @@ final class AudioInputFormatTests: XCTestCase {
     XCTAssertNotNil(format)
     XCTAssertFalse(audioInputFormatIsUsable(format!))
   }
+
+  func testAudioInputStartError_avfaudioBadDevice_mapsToNoUsableInput() {
+    let error = NSError(domain: "com.apple.coreaudio.avfaudio", code: 560_227_702)
+    let normalised = normalisedAudioInputStartError(error)
+
+    XCTAssertEqual(normalised as? TranscriptionManagerError, .noUsableAudioInput)
+  }
+
+  func testAudioInputStartError_underlyingBadDevice_mapsToNoUsableInput() {
+    let underlying = NSError(domain: NSOSStatusErrorDomain, code: 560_227_702)
+    let error = NSError(domain: "wrapper", code: 1, userInfo: [NSUnderlyingErrorKey: underlying])
+    let normalised = normalisedAudioInputStartError(error)
+
+    XCTAssertEqual(normalised as? TranscriptionManagerError, .noUsableAudioInput)
+  }
+
+  func testAudioInputStartError_unrelatedError_isPreserved() {
+    let error = NSError(domain: "com.apple.coreaudio.avfaudio", code: -1)
+    let normalised = normalisedAudioInputStartError(error) as NSError
+
+    XCTAssertEqual(normalised.domain, error.domain)
+    XCTAssertEqual(normalised.code, error.code)
+  }
 }


### PR DESCRIPTION
## Summary
- retry AVAudioEngine start once after a stale HAL input-device (`!dev` / 560227702) failure so pending input-device reconfiguration can settle
- normalise persistent AVFAudio/OSStatus bad-device failures to the existing actionable microphone-unavailable message
- cover exact AVFAudio and underlying OSStatus error mapping in AudioInputFormatTests

## Device log evidence
The installed 2.1.3 app already included PR #439, but the local device still logged the same failure at 2026-06-03 20:33:37:

```
JustSpeakToIt AUHAL connecting device 267
JustSpeakToIt AUHAL Device ID: 267 (Input:No | Output:No): true
JustSpeakToIt ca_verify_noerr: [err, 560227702]
JustSpeakToIt AVAudioIONodeImpl.mm Error setting device on iounit, err = 560227702
JustSpeakToIt AVAudioEngineGraph Failed to create tap, config change pending!
JustSpeakToIt AVAEInternal CheckCanPerformIO false
```

That points to a HAL config-change race after the fresh-engine fix, not a provider/API issue.

## Verification
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all swift test --filter AudioInputFormatTests`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio engine startup to detect and recover from temporarily unavailable or stale/disconnected input devices with an automatic retry and clearer "no usable input" errors.
  * Aligned startup timing and error behavior across live transcription providers for more consistent reliability.

* **Tests**
  * Added unit tests that verify normalization and handling of audio-input start errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->