### PR TITLE
feat(mac): add history error issue reporting

### DIFF
--- a/Sources/SpeakApp/HistoryDiagnosticContext.swift
+++ b/Sources/SpeakApp/HistoryDiagnosticContext.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct HistoryDiagnosticContext: Codable, Hashable {
+  let capturedAt: Date
+  let appVersion: String
+  let appBuild: String
+  let operatingSystem: String
+  let processIdentifier: Int
+  let microphonePermission: String
+  let inputDeviceName: String
+  let providerLabel: String
+  let latencyTier: String
+  let transcriptionMode: String
+  let transcriptionModel: String
+  let postProcessingModel: String
+  let speedMode: String
+
+  init(
+    capturedAt: Date = .init(),
+    appVersion: String,
+    appBuild: String,
+    operatingSystem: String,
+    processIdentifier: Int,
+    microphonePermission: String,
+    inputDeviceName: String,
+    providerLabel: String,
+    latencyTier: String,
+    transcriptionMode: String,
+    transcriptionModel: String,
+    postProcessingModel: String,
+    speedMode: String
+  ) {
+    self.capturedAt = capturedAt
+    self.appVersion = appVersion
+    self.appBuild = appBuild
+    self.operatingSystem = operatingSystem
+    self.processIdentifier = processIdentifier
+    self.microphonePermission = microphonePermission
+    self.inputDeviceName = inputDeviceName
+    self.providerLabel = providerLabel
+    self.latencyTier = latencyTier
+    self.transcriptionMode = transcriptionMode
+    self.transcriptionModel = transcriptionModel
+    self.postProcessingModel = postProcessingModel
+    self.speedMode = speedMode
+  }
+}

--- a/Sources/SpeakApp/HistoryIssueReporter.swift
+++ b/Sources/SpeakApp/HistoryIssueReporter.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+enum HistoryIssueReporter {
+  static let repositoryIssueURL = URL(string: "https://github.com/crmitchelmore/justspeaktoit/issues/new")!
+  static let maximumBodyLength = 6_000
+  static let maximumURLLength = 7_500
+
+  static func issueURL(for item: HistoryItem) -> URL? {
+    var body = truncated(issueBody(for: item), limit: maximumBodyLength)
+    var components = URLComponents(url: repositoryIssueURL, resolvingAgainstBaseURL: false)
+    components?.queryItems = queryItems(for: item, body: body)
+
+    while let url = components?.url,
+      url.absoluteString.count > maximumURLLength,
+      body.count > 1_500
+    {
+      body = truncated(body, limit: body.count - 750)
+      components?.queryItems = queryItems(for: item, body: body)
+    }
+
+    return components?.url
+  }
+
+  static func issueTitle(for item: HistoryItem) -> String {
+    let phase = item.errors.first?.phase.rawValue ?? "session"
+    let message = item.errors.first?.message ?? "Session error"
+    return "[Bug] \(phase.capitalized) error: \(truncated(publicSafe(message), limit: 72))"
+  }
+
+  static func issueBody(for item: HistoryItem) -> String {
+    let diagnostics = item.diagnosticContext.map(diagnosticLines) ?? ["- Not captured"]
+    let errorLines = item.errors.isEmpty
+      ? ["- No structured errors recorded"]
+      : item.errors.enumerated().map { index, error in
+        let debug = error.debugDescription.map { "\n  - Debug: `\(publicSafe($0))`" } ?? ""
+        return """
+        \(index + 1). **\(error.phase.rawValue)** at \(iso8601(error.occurredAt))
+          - Message: \(publicSafe(error.message))\(debug)
+        """
+      }
+    let eventLines = item.events.isEmpty
+      ? ["- No events recorded"]
+      : item.events.map { event in
+        "- \(iso8601(event.timestamp)) [\(event.kind.rawValue)] \(publicSafe(event.description))"
+      }
+    let networkLines = item.networkExchanges.isEmpty
+      ? ["- No network exchanges recorded"]
+      : item.networkExchanges.map { exchange in
+        let requestHeaderKeys = exchange.requestHeaders.keys.sorted().joined(separator: ", ")
+        let responseHeaderKeys = exchange.responseHeaders.keys.sorted().joined(separator: ", ")
+        return """
+        - \(exchange.method) \(publicSafe(exchange.url.host ?? exchange.url.absoluteString))\(exchange.url.path) -> HTTP \(exchange.responseCode)
+          - Request headers: \(requestHeaderKeys.isEmpty ? "none" : requestHeaderKeys)
+          - Response headers: \(responseHeaderKeys.isEmpty ? "none" : responseHeaderKeys)
+          - Payload previews omitted from public issue prefill for privacy.
+        """
+      }
+
+    let audioReference = item.audioFileURL?.lastPathComponent ?? "none"
+    let models = item.modelUsages.isEmpty
+      ? item.modelsUsed.sorted().joined(separator: ", ")
+      : item.modelUsages.map { "\($0.phase.rawValue): \($0.modelIdentifier)" }.joined(separator: ", ")
+    let recordingDuration = item.recordingDuration > 0
+      ? String(format: "%.2fs", item.recordingDuration)
+      : "unknown"
+
+    return """
+    ## Description
+    An in-app error was recorded by JustSpeakToIt. Please describe what you were doing when this happened:
+
+    ## History reference
+    - History ID: `\(item.id.uuidString)`
+    - Created: \(iso8601(item.createdAt))
+    - Updated: \(iso8601(item.updatedAt))
+    - Recording duration: \(recordingDuration)
+    - Audio file: \(publicSafe(audioReference))
+    - Models: \(models.isEmpty ? "none recorded" : publicSafe(models))
+
+    ## Errors
+    \(errorLines.joined(separator: "\n"))
+
+    ## Diagnostic context
+    \(diagnostics.joined(separator: "\n"))
+
+    ## Event timeline
+    \(eventLines.joined(separator: "\n"))
+
+    ## Network metadata
+    \(networkLines.joined(separator: "\n"))
+
+    ## Privacy note
+    This prefilled issue intentionally omits transcript text, API payload bodies, full local file paths, destination app names, and secrets because GitHub issues are public. Add any extra private context manually only if you are comfortable publishing it.
+    """
+  }
+
+  private static func queryItems(for item: HistoryItem, body: String) -> [URLQueryItem] {
+    [
+      URLQueryItem(name: "title", value: issueTitle(for: item)),
+      URLQueryItem(name: "body", value: body),
+      URLQueryItem(name: "labels", value: "bug")
+    ]
+  }
+
+  private static func diagnosticLines(_ context: HistoryDiagnosticContext) -> [String] {
+    [
+      "- Captured: \(iso8601(context.capturedAt))",
+      "- App: \(context.appVersion) (\(context.appBuild))",
+      "- macOS: \(publicSafe(context.operatingSystem))",
+      "- Process ID: \(context.processIdentifier)",
+      "- Microphone permission: \(context.microphonePermission)",
+      "- Input device: \(publicSafe(context.inputDeviceName))",
+      "- Provider: \(publicSafe(context.providerLabel))",
+      "- Latency: \(context.latencyTier)",
+      "- Transcription mode: \(context.transcriptionMode)",
+      "- Transcription model: \(publicSafe(context.transcriptionModel))",
+      "- Post-processing model: \(publicSafe(context.postProcessingModel))",
+      "- Speed mode: \(context.speedMode)"
+    ]
+  }
+
+  private static func truncated(_ value: String, limit: Int) -> String {
+    guard value.count > limit else { return value }
+    let suffix = "\n\n[Report truncated to keep the GitHub issue URL within a safe length.]"
+    let prefixLimit = max(0, limit - suffix.count)
+    return String(value.prefix(prefixLimit)) + suffix
+  }
+
+  private static func publicSafe(_ value: String) -> String {
+    var result = replacing(pattern: #"/Users/[^/\s]+"#, in: value, with: "/Users/<redacted>")
+    result = replacing(pattern: #"(?i)(authorization|api[-_ ]?key|token|secret)\s*[:=]\s*\S+"#, in: result, with: "$1=<redacted>")
+    return result
+  }
+
+  private static func replacing(pattern: String, in value: String, with replacement: String) -> String {
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return value }
+    let range = NSRange(value.startIndex..<value.endIndex, in: value)
+    return regex.stringByReplacingMatches(in: value, range: range, withTemplate: replacement)
+  }
+
+  private static func iso8601(_ date: Date) -> String {
+    ISO8601DateFormatter().string(from: date)
+  }
+}

--- a/Sources/SpeakApp/HistoryIssueReporter.swift
+++ b/Sources/SpeakApp/HistoryIssueReporter.swift
@@ -13,8 +13,7 @@ enum HistoryIssueReporter {
 
     while let url = components?.url,
       url.absoluteString.count > maximumURLLength,
-      body.count > 1_500
-    {
+      body.count > 1_500 {
       body = truncated(body, limit: body.count - 750)
       components?.queryItems = queryItems(for: item, body: body)
     }
@@ -30,67 +29,30 @@ enum HistoryIssueReporter {
 
   static func issueBody(for item: HistoryItem) -> String {
     let diagnostics = item.diagnosticContext.map(diagnosticLines) ?? ["- Not captured"]
-    let errorLines = item.errors.isEmpty
-      ? ["- No structured errors recorded"]
-      : item.errors.enumerated().map { index, error in
-        let debug = error.debugDescription.map { "\n  - Debug: `\(publicSafe($0))`" } ?? ""
-        return """
-        \(index + 1). **\(error.phase.rawValue)** at \(iso8601(error.occurredAt))
-          - Message: \(publicSafe(error.message))\(debug)
-        """
-      }
-    let eventLines = item.events.isEmpty
-      ? ["- No events recorded"]
-      : item.events.map { event in
-        "- \(iso8601(event.timestamp)) [\(event.kind.rawValue)] \(publicSafe(event.description))"
-      }
-    let networkLines = item.networkExchanges.isEmpty
-      ? ["- No network exchanges recorded"]
-      : item.networkExchanges.map { exchange in
-        let requestHeaderKeys = exchange.requestHeaders.keys.sorted().joined(separator: ", ")
-        let responseHeaderKeys = exchange.responseHeaders.keys.sorted().joined(separator: ", ")
-        return """
-        - \(exchange.method) \(publicSafe(exchange.url.host ?? exchange.url.absoluteString))\(exchange.url.path) -> HTTP \(exchange.responseCode)
-          - Request headers: \(requestHeaderKeys.isEmpty ? "none" : requestHeaderKeys)
-          - Response headers: \(responseHeaderKeys.isEmpty ? "none" : responseHeaderKeys)
-          - Payload previews omitted from public issue prefill for privacy.
-        """
-      }
-
-    let audioReference = item.audioFileURL?.lastPathComponent ?? "none"
-    let models = item.modelUsages.isEmpty
-      ? item.modelsUsed.sorted().joined(separator: ", ")
-      : item.modelUsages.map { "\($0.phase.rawValue): \($0.modelIdentifier)" }.joined(separator: ", ")
-    let recordingDuration = item.recordingDuration > 0
-      ? String(format: "%.2fs", item.recordingDuration)
-      : "unknown"
 
     return """
     ## Description
     An in-app error was recorded by JustSpeakToIt. Please describe what you were doing when this happened:
 
     ## History reference
-    - History ID: `\(item.id.uuidString)`
-    - Created: \(iso8601(item.createdAt))
-    - Updated: \(iso8601(item.updatedAt))
-    - Recording duration: \(recordingDuration)
-    - Audio file: \(publicSafe(audioReference))
-    - Models: \(models.isEmpty ? "none recorded" : publicSafe(models))
+    \(historyReferenceLines(for: item).joined(separator: "\n"))
 
     ## Errors
-    \(errorLines.joined(separator: "\n"))
+    \(errorLines(for: item).joined(separator: "\n"))
 
     ## Diagnostic context
     \(diagnostics.joined(separator: "\n"))
 
     ## Event timeline
-    \(eventLines.joined(separator: "\n"))
+    \(eventLines(for: item).joined(separator: "\n"))
 
     ## Network metadata
-    \(networkLines.joined(separator: "\n"))
+    \(networkLines(for: item).joined(separator: "\n"))
 
     ## Privacy note
-    This prefilled issue intentionally omits transcript text, API payload bodies, full local file paths, destination app names, and secrets because GitHub issues are public. Add any extra private context manually only if you are comfortable publishing it.
+    This prefilled issue intentionally omits transcript text, API payload bodies, full local file paths,
+    destination app names, and secrets because GitHub issues are public. Add any extra private context manually
+    only if you are comfortable publishing it.
     """
   }
 
@@ -100,6 +62,58 @@ enum HistoryIssueReporter {
       URLQueryItem(name: "body", value: body),
       URLQueryItem(name: "labels", value: "bug")
     ]
+  }
+
+  private static func historyReferenceLines(for item: HistoryItem) -> [String] {
+    let audioReference = item.audioFileURL?.lastPathComponent ?? "none"
+    let models = item.modelUsages.isEmpty
+      ? item.modelsUsed.sorted().joined(separator: ", ")
+      : item.modelUsages.map { "\($0.phase.rawValue): \($0.modelIdentifier)" }.joined(separator: ", ")
+    let recordingDuration = item.recordingDuration > 0
+      ? String(format: "%.2fs", item.recordingDuration)
+      : "unknown"
+
+    return [
+      "- History ID: `\(item.id.uuidString)`",
+      "- Created: \(iso8601(item.createdAt))",
+      "- Updated: \(iso8601(item.updatedAt))",
+      "- Recording duration: \(recordingDuration)",
+      "- Audio file: \(publicSafe(audioReference))",
+      "- Models: \(models.isEmpty ? "none recorded" : publicSafe(models))"
+    ]
+  }
+
+  private static func errorLines(for item: HistoryItem) -> [String] {
+    guard !item.errors.isEmpty else { return ["- No structured errors recorded"] }
+    return item.errors.enumerated().map { index, error in
+      let debug = error.debugDescription.map { "\n  - Debug: `\(publicSafe($0))`" } ?? ""
+      return """
+      \(index + 1). **\(error.phase.rawValue)** at \(iso8601(error.occurredAt))
+        - Message: \(publicSafe(error.message))\(debug)
+      """
+    }
+  }
+
+  private static func eventLines(for item: HistoryItem) -> [String] {
+    guard !item.events.isEmpty else { return ["- No events recorded"] }
+    return item.events.map { event in
+      "- \(iso8601(event.timestamp)) [\(event.kind.rawValue)] \(publicSafe(event.description))"
+    }
+  }
+
+  private static func networkLines(for item: HistoryItem) -> [String] {
+    guard !item.networkExchanges.isEmpty else { return ["- No network exchanges recorded"] }
+    return item.networkExchanges.map { exchange in
+      let requestHeaderKeys = exchange.requestHeaders.keys.sorted().joined(separator: ", ")
+      let responseHeaderKeys = exchange.responseHeaders.keys.sorted().joined(separator: ", ")
+      let target = "\(publicSafe(exchange.url.host ?? exchange.url.absoluteString))\(exchange.url.path)"
+      return """
+      - \(exchange.method) \(target) -> HTTP \(exchange.responseCode)
+        - Request headers: \(requestHeaderKeys.isEmpty ? "none" : requestHeaderKeys)
+        - Response headers: \(responseHeaderKeys.isEmpty ? "none" : responseHeaderKeys)
+        - Payload previews omitted from public issue prefill for privacy.
+      """
+    }
   }
 
   private static func diagnosticLines(_ context: HistoryDiagnosticContext) -> [String] {

--- a/Sources/SpeakApp/HistoryIssueReporter.swift
+++ b/Sources/SpeakApp/HistoryIssueReporter.swift
@@ -4,6 +4,7 @@ enum HistoryIssueReporter {
   static let repositoryIssueURL = URL(string: "https://github.com/crmitchelmore/justspeaktoit/issues/new")!
   static let maximumBodyLength = 6_000
   static let maximumURLLength = 7_500
+  private static let iso8601Formatter = ISO8601DateFormatter()
 
   static func issueURL(for item: HistoryItem) -> URL? {
     var body = truncated(issueBody(for: item), limit: maximumBodyLength)
@@ -24,7 +25,7 @@ enum HistoryIssueReporter {
   static func issueTitle(for item: HistoryItem) -> String {
     let phase = item.errors.first?.phase.rawValue ?? "session"
     let message = item.errors.first?.message ?? "Session error"
-    return "[Bug] \(phase.capitalized) error: \(truncated(publicSafe(message), limit: 72))"
+    return "[Bug] \(phase.capitalized) error: \(truncated(publicSafe(message), limit: 72, suffix: "..."))"
   }
 
   static func issueBody(for item: HistoryItem) -> String {
@@ -118,16 +119,23 @@ enum HistoryIssueReporter {
     ]
   }
 
-  private static func truncated(_ value: String, limit: Int) -> String {
+  private static func truncated(
+    _ value: String,
+    limit: Int,
+    suffix: String = "\n\n[Report truncated to keep the GitHub issue URL within a safe length.]"
+  ) -> String {
     guard value.count > limit else { return value }
-    let suffix = "\n\n[Report truncated to keep the GitHub issue URL within a safe length.]"
     let prefixLimit = max(0, limit - suffix.count)
     return String(value.prefix(prefixLimit)) + suffix
   }
 
   private static func publicSafe(_ value: String) -> String {
     var result = replacing(pattern: #"/Users/[^/\s]+"#, in: value, with: "/Users/<redacted>")
-    result = replacing(pattern: #"(?i)(authorization|api[-_ ]?key|token|secret)\s*[:=]\s*\S+"#, in: result, with: "$1=<redacted>")
+    result = replacing(
+      pattern: #"(?i)(authorization|api[-_ ]?key|token|secret)\s*[:=]\s*(?:bearer\s+)?\S+"#,
+      in: result,
+      with: "$1=<redacted>"
+    )
     return result
   }
 
@@ -138,6 +146,6 @@ enum HistoryIssueReporter {
   }
 
   private static func iso8601(_ date: Date) -> String {
-    ISO8601DateFormatter().string(from: date)
+    iso8601Formatter.string(from: date)
   }
 }

--- a/Sources/SpeakApp/HistoryItem.swift
+++ b/Sources/SpeakApp/HistoryItem.swift
@@ -183,6 +183,7 @@ struct HistoryItem: Codable, Identifiable, Hashable {
   let errors: [HistoryError]
   let source: HistoryItemSource?
   let postProcessingPrompt: PostProcessingPromptPayload?
+  let diagnosticContext: HistoryDiagnosticContext?
 
   init(
     id: UUID = UUID(), createdAt: Date = .init(), updatedAt: Date = .init(), modelsUsed: [String],
@@ -192,7 +193,8 @@ struct HistoryItem: Codable, Identifiable, Hashable {
     events: [HistoryEvent], phaseTimestamps: PhaseTimestamps, trigger: HistoryTrigger,
     personalCorrections: PersonalLexiconHistorySummary?, errors: [HistoryError],
     source: HistoryItemSource? = nil,
-    postProcessingPrompt: PostProcessingPromptPayload? = nil
+    postProcessingPrompt: PostProcessingPromptPayload? = nil,
+    diagnosticContext: HistoryDiagnosticContext? = nil
   ) {
     self.id = id
     self.createdAt = createdAt
@@ -212,6 +214,7 @@ struct HistoryItem: Codable, Identifiable, Hashable {
     self.errors = errors
     self.source = source
     self.postProcessingPrompt = postProcessingPrompt
+    self.diagnosticContext = diagnosticContext
   }
 
   static let placeholder: HistoryItem = .init(

--- a/Sources/SpeakApp/HistoryView.swift
+++ b/Sources/SpeakApp/HistoryView.swift
@@ -711,6 +711,22 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
       }
     }
 
+    if !item.errors.isEmpty {
+      Divider()
+
+      Button {
+        openGitHubIssue()
+      } label: {
+        Label("Open GitHub Issue", systemImage: "ladybug")
+      }
+
+      Button {
+        copyIssueReport()
+      } label: {
+        Label("Copy Issue Report", systemImage: "doc.on.clipboard")
+      }
+    }
+
     Divider()
 
     if item.audioFileURL != nil {
@@ -1168,9 +1184,30 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
   }
 
   private var errorSection: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      Text("Errors")
-        .font(.subheadline.bold())
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(alignment: .firstTextBaseline, spacing: 12) {
+        Text("Errors")
+          .font(.subheadline.bold())
+
+        Spacer()
+
+        Button {
+          openGitHubIssue()
+        } label: {
+          Label("Open GitHub Issue", systemImage: "ladybug")
+        }
+        .speakTooltip("Open a prefilled public GitHub issue with safe diagnostics for this failed session.")
+
+        Button {
+          copyIssueReport()
+        } label: {
+          Label("Copy Report", systemImage: "doc.on.clipboard")
+        }
+        .speakTooltip("Copy the same safe diagnostic report without opening GitHub.")
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+
       ForEach(item.errors) { error in
         VStack(alignment: .leading, spacing: 2) {
           Text(error.phase.rawValue.capitalized)
@@ -1424,6 +1461,20 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
     let board = NSPasteboard.general
     board.clearContents()
     board.setString(text, forType: .string)
+  }
+
+  private func copyIssueReport() {
+    copyToPasteboard(HistoryIssueReporter.issueBody(for: item))
+  }
+
+  private func openGitHubIssue() {
+    guard let url = HistoryIssueReporter.issueURL(for: item) else {
+      copyIssueReport()
+      return
+    }
+    if !NSWorkspace.shared.open(url) {
+      copyIssueReport()
+    }
   }
 
   private func formatDuration(_ duration: TimeInterval) -> String {

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -374,6 +374,58 @@ final class MainManager: ObservableObject {
     )
   }
 
+  private func currentTranscriptionModelIdentifier() -> String {
+    switch appSettings.transcriptionMode {
+    case .liveNative:
+      return appSettings.liveTranscriptionModel
+    case .batchRemote:
+      return appSettings.batchTranscriptionModel
+    case .localModel:
+      return appSettings.localTranscriptionMode == .streaming
+        ? appSettings.localStreamingModelSource
+        : appSettings.localTranscriptionModel
+    }
+  }
+
+  private func makeHistoryDiagnosticContext() -> HistoryDiagnosticContext {
+    let health = buildCaptureHealthSnapshot()
+    let info = Bundle.main.infoDictionary
+    let appVersion = info?["CFBundleShortVersionString"] as? String ?? "unknown"
+    let appBuild = info?["CFBundleVersion"] as? String ?? "unknown"
+    let microphonePermission: String
+    switch health.microphonePermission {
+    case .granted:
+      microphonePermission = "granted"
+    case .denied:
+      microphonePermission = "denied"
+    case .notDetermined:
+      microphonePermission = "notDetermined"
+    }
+
+    return HistoryDiagnosticContext(
+      appVersion: appVersion,
+      appBuild: appBuild,
+      operatingSystem: ProcessInfo.processInfo.operatingSystemVersionString,
+      processIdentifier: Int(ProcessInfo.processInfo.processIdentifier),
+      microphonePermission: microphonePermission,
+      inputDeviceName: health.inputDeviceName,
+      providerLabel: health.providerLabel,
+      latencyTier: health.latencyTier.displayName,
+      transcriptionMode: appSettings.transcriptionMode.displayName,
+      transcriptionModel: currentTranscriptionModelIdentifier(),
+      postProcessingModel: appSettings.postProcessingModel,
+      speedMode: appSettings.speedMode.displayName
+    )
+  }
+
+  private func attachFailureDiagnostics(to session: ActiveSession) {
+    session.diagnosticContext = makeHistoryDiagnosticContext()
+    let description = "Diagnostic snapshot captured for issue report"
+    if !session.events.contains(where: { $0.kind == .error && $0.description == description }) {
+      session.events.append(HistoryEvent(kind: .error, description: description))
+    }
+  }
+
   private func captureHealthProviderLabel(for modelID: String) -> String {
     guard appSettings.transcriptionMode == .localModel else {
       return ModelCatalog.friendlyName(for: modelID)
@@ -542,6 +594,7 @@ final class MainManager: ObservableObject {
 
     let gesture = trigger.historyGesture
     let session = ActiveSession(gesture: gesture, hotKeyDescription: appSettings.selectedHotKey.displayString)
+    session.diagnosticContext = makeHistoryDiagnosticContext()
     activeSession = session
     state = .recording
 
@@ -869,6 +922,7 @@ final class MainManager: ObservableObject {
             )
           )
           session.events.append(HistoryEvent(kind: .error, description: friendly))
+          attachFailureDiagnostics(to: session)
           postProcessingFailureNotice = (headline: "Post-processing failed", message: friendly)
 
           if let transcriptionResult = session.transcriptionResult {
@@ -918,6 +972,9 @@ final class MainManager: ObservableObject {
           hudManager.finishFailure(headline: "Delivery failed", message: error.localizedDescription)
           state = .failed(error.localizedDescription)
           lastErrorMessage = error.localizedDescription
+          attachFailureDiagnostics(to: session)
+          let historyItem = session.buildHistoryItem(finalText: finalText)
+          await historyManager.append(historyItem)
           livePolishManager.reset()
           liveTextInserter.reset()
           activeSession = nil
@@ -934,6 +991,9 @@ final class MainManager: ObservableObject {
         hudManager.finishFailure(headline: "Delivery failed", message: error.localizedDescription)
         state = .failed(error.localizedDescription)
         lastErrorMessage = error.localizedDescription
+        attachFailureDiagnostics(to: session)
+        let historyItem = session.buildHistoryItem(finalText: finalText)
+        await historyManager.append(historyItem)
         livePolishManager.reset()
         liveTextInserter.reset()
         activeSession = nil
@@ -990,6 +1050,7 @@ final class MainManager: ObservableObject {
     hudManager.beginPostProcessing()
 
     let session = ActiveSession(gesture: .uiButton, hotKeyDescription: appSettings.selectedHotKey.displayString)
+    session.diagnosticContext = makeHistoryDiagnosticContext()
     activeSession = session
     session.transcriptionResult = retryData.transcriptionResult
     session.recordingSummary = retryData.recordingSummary
@@ -1079,6 +1140,9 @@ final class MainManager: ObservableObject {
         hudManager.finishFailure(headline: "Delivery failed", message: error.localizedDescription)
         state = .failed(error.localizedDescription)
         lastErrorMessage = error.localizedDescription
+        attachFailureDiagnostics(to: session)
+        let historyItem = session.buildHistoryItem(finalText: finalText)
+        await historyManager.append(historyItem)
       } else {
         session.events.append(
           HistoryEvent(kind: .outputDelivered, description: "Retry output delivered successfully")
@@ -1109,6 +1173,9 @@ final class MainManager: ObservableObject {
       hudManager.finishFailure(headline: "Retry post-processing failed", message: friendly, showRetryHint: true)
       state = .failed(friendly)
       lastErrorMessage = friendly
+      attachFailureDiagnostics(to: session)
+      let historyItem = session.buildHistoryItem(finalText: finalText)
+      await historyManager.append(historyItem)
     }
 
     activeSession = nil
@@ -1124,6 +1191,7 @@ final class MainManager: ObservableObject {
 
     let session = ActiveSession(
       gesture: .uiButton, hotKeyDescription: item.trigger.hotKeyDescription)
+    session.diagnosticContext = makeHistoryDiagnosticContext()
     activeSession = session
 
     let summary = makeRecordingSummary(from: url, fallbackDuration: item.recordingDuration)
@@ -1320,6 +1388,7 @@ final class MainManager: ObservableObject {
       )
       hudManager.finishFailure(message: error.localizedDescription)
       state = .failed(error.localizedDescription)
+      attachFailureDiagnostics(to: session)
       let historyItem = session.buildHistoryItem(
         finalText: session.transcriptionResult?.text,
         source: item.source
@@ -1363,6 +1432,7 @@ final class MainManager: ObservableObject {
     hudManager.finishFailure(message: message)
     state = .failed(message)
     lastErrorMessage = message
+    attachFailureDiagnostics(to: session)
     let historyItem = session.buildHistoryItem(finalText: session.transcriptionResult?.text)
     await historyManager.append(historyItem)
     activeSession = nil
@@ -1487,6 +1557,10 @@ final class MainManager: ObservableObject {
 
     if isStreamingTranscriptionMode {
       transcriptionManager.cancelLiveTranscription()
+    }
+
+    if let session = activeSession {
+      attachFailureDiagnostics(to: session)
     }
 
     Task { [failedSession = activeSession] in
@@ -1689,6 +1763,7 @@ private final class ActiveSession {
   var destination: String?
   var personalCorrections: PersonalLexiconHistorySummary?
   var lexiconContext: PersonalLexiconContext = .empty
+  var diagnosticContext: HistoryDiagnosticContext?
 
   init(gesture: HistoryTrigger.HotKeyGesture, hotKeyDescription: String) {
     self.gesture = gesture
@@ -1750,7 +1825,8 @@ private final class ActiveSession {
       personalCorrections: personalCorrections,
       errors: errors,
       source: source,
-      postProcessingPrompt: postProcessingOutcome?.promptPayload
+      postProcessingPrompt: postProcessingOutcome?.promptPayload,
+      diagnosticContext: diagnosticContext
     )
   }
 }

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -579,6 +579,7 @@ final class MainManager: ObservableObject {
     return "Loading local model and transcribing. First run can take a minute."
   }
 
+  // swiftlint:disable:next function_body_length
   private func startSession(trigger: SessionTriggerSource) async {
     guard activeSession == nil else { return }
     if await presentMissingLiveAPIKeyAlertIfNeeded() { return }
@@ -1044,6 +1045,7 @@ final class MainManager: ObservableObject {
   }
   // swiftlint:enable cyclomatic_complexity function_body_length
 
+  // swiftlint:disable:next function_body_length
   private func performRetryPostProcessing(with retryData: RetryData) async {
     state = .processing
     lastErrorMessage = nil

--- a/Tests/SpeakAppTests/HistoryIssueReporterTests.swift
+++ b/Tests/SpeakAppTests/HistoryIssueReporterTests.swift
@@ -45,6 +45,7 @@ final class HistoryIssueReporterTests: XCTestCase {
     XCTAssertTrue(title.hasSuffix("..."))
   }
 
+  // swiftlint:disable:next function_body_length
   private func makeErrorItem(errorMessage: String = "The selected microphone is unavailable") -> HistoryItem {
     let date = Date(timeIntervalSince1970: 1_717_171_717)
     let diagnostic = HistoryDiagnosticContext(
@@ -109,7 +110,9 @@ final class HistoryIssueReporterTests: XCTestCase {
         HistoryError(
           phase: .recording,
           message: errorMessage,
-          debugDescription: "com.apple.coreaudio.avfaudio error 560227702 with Authorization: Bearer real-token-value at /Users/cm/private"
+          debugDescription: """
+          com.apple.coreaudio.avfaudio error 560227702 with Authorization: Bearer real-token-value at /Users/cm/private
+          """
         )
       ],
       diagnosticContext: diagnostic

--- a/Tests/SpeakAppTests/HistoryIssueReporterTests.swift
+++ b/Tests/SpeakAppTests/HistoryIssueReporterTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+@testable import SpeakApp
+
+final class HistoryIssueReporterTests: XCTestCase {
+  func testIssueURL_targetsGitHubIssueCreationWithBugLabel() throws {
+    let item = makeErrorItem()
+    let url = try XCTUnwrap(HistoryIssueReporter.issueURL(for: item))
+    let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+      item.value.map { (item.name, $0) }
+    })
+
+    XCTAssertEqual(components.scheme, "https")
+    XCTAssertEqual(components.host, "github.com")
+    XCTAssertEqual(components.path, "/crmitchelmore/justspeaktoit/issues/new")
+    XCTAssertEqual(query["labels"], "bug")
+    XCTAssertTrue(query["title"]?.contains("[Bug]") == true)
+    XCTAssertTrue(url.absoluteString.count <= HistoryIssueReporter.maximumURLLength)
+  }
+
+  func testIssueBody_includesDiagnosticsAndOmitsPrivatePayloads() {
+    let item = makeErrorItem()
+    let body = HistoryIssueReporter.issueBody(for: item)
+
+    XCTAssertTrue(body.contains(item.id.uuidString))
+    XCTAssertTrue(body.contains("The selected microphone is unavailable"))
+    XCTAssertTrue(body.contains("MacBook Pro Microphone"))
+    XCTAssertTrue(body.contains("Deepgram Nova-3"))
+    XCTAssertTrue(body.contains("HTTP 500"))
+
+    XCTAssertFalse(body.contains("secret dictated transcript"))
+    XCTAssertFalse(body.contains("corrected private transcript"))
+    XCTAssertFalse(body.contains("payload with private transcript"))
+    XCTAssertFalse(body.contains("/Users/cm"))
+    XCTAssertFalse(body.contains("real-token-value"))
+  }
+
+  private func makeErrorItem() -> HistoryItem {
+    let date = Date(timeIntervalSince1970: 1_717_171_717)
+    let diagnostic = HistoryDiagnosticContext(
+      capturedAt: date,
+      appVersion: "2.1.3",
+      appBuild: "202606030123",
+      operatingSystem: "Version 15.5 (Build 24F74)",
+      processIdentifier: 1234,
+      microphonePermission: "granted",
+      inputDeviceName: "MacBook Pro Microphone",
+      providerLabel: "Deepgram Nova-3",
+      latencyTier: "Fast",
+      transcriptionMode: "Remote Streaming",
+      transcriptionModel: "deepgram/nova-3-streaming",
+      postProcessingModel: "inception/mercury",
+      speedMode: "Instant"
+    )
+
+    return HistoryItem(
+      id: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+      createdAt: date,
+      updatedAt: date,
+      modelsUsed: ["deepgram/nova-3-streaming"],
+      modelUsages: [ModelUsage(modelIdentifier: "deepgram/nova-3-streaming", phase: .transcriptionLive)],
+      rawTranscription: "secret dictated transcript",
+      postProcessedTranscription: "corrected private transcript",
+      recordingDuration: 3.4,
+      cost: nil,
+      audioFileURL: URL(fileURLWithPath: "/Users/cm/Library/Application Support/SpeakApp/Recordings/private.m4a"),
+      networkExchanges: [
+        HistoryNetworkExchange(
+          url: URL(string: "wss://api.deepgram.com/v1/listen")!,
+          method: "WebSocket",
+          requestHeaders: ["Authorization": "Bearer real-token-value", "Model": "nova-3"],
+          requestBodyPreview: "payload with private transcript",
+          responseCode: 500,
+          responseHeaders: ["Request-ID": "abc123"],
+          responseBodyPreview: "payload with private transcript"
+        )
+      ],
+      events: [
+        HistoryEvent(kind: .recordingStarted, timestamp: date, description: "Recording started"),
+        HistoryEvent(kind: .error, timestamp: date, description: "Diagnostic snapshot captured for issue report")
+      ],
+      phaseTimestamps: PhaseTimestamps(
+        recordingStarted: date,
+        recordingEnded: date.addingTimeInterval(3.4),
+        transcriptionStarted: date.addingTimeInterval(3.5),
+        transcriptionEnded: nil,
+        postProcessingStarted: nil,
+        postProcessingEnded: nil,
+        outputDelivered: nil
+      ),
+      trigger: HistoryTrigger(
+        gesture: .doubleTap,
+        hotKeyDescription: "Fn",
+        outputMethod: .none,
+        destinationApplication: "Private Notes"
+      ),
+      personalCorrections: nil,
+      errors: [
+        HistoryError(
+          phase: .recording,
+          message: "The selected microphone is unavailable",
+          debugDescription: "com.apple.coreaudio.avfaudio error 560227702 at /Users/cm/private"
+        )
+      ],
+      diagnosticContext: diagnostic
+    )
+  }
+}

--- a/Tests/SpeakAppTests/HistoryIssueReporterTests.swift
+++ b/Tests/SpeakAppTests/HistoryIssueReporterTests.swift
@@ -36,7 +36,16 @@ final class HistoryIssueReporterTests: XCTestCase {
     XCTAssertFalse(body.contains("real-token-value"))
   }
 
-  private func makeErrorItem() -> HistoryItem {
+  func testIssueTitle_preservesErrorContextWhenLongMessageIsTruncated() {
+    let longMessage = String(repeating: "microphone unavailable ", count: 8)
+    let item = makeErrorItem(errorMessage: longMessage)
+    let title = HistoryIssueReporter.issueTitle(for: item)
+
+    XCTAssertTrue(title.contains("microphone unavailable"))
+    XCTAssertTrue(title.hasSuffix("..."))
+  }
+
+  private func makeErrorItem(errorMessage: String = "The selected microphone is unavailable") -> HistoryItem {
     let date = Date(timeIntervalSince1970: 1_717_171_717)
     let diagnostic = HistoryDiagnosticContext(
       capturedAt: date,
@@ -99,8 +108,8 @@ final class HistoryIssueReporterTests: XCTestCase {
       errors: [
         HistoryError(
           phase: .recording,
-          message: "The selected microphone is unavailable",
-          debugDescription: "com.apple.coreaudio.avfaudio error 560227702 at /Users/cm/private"
+          message: errorMessage,
+          debugDescription: "com.apple.coreaudio.avfaudio error 560227702 with Authorization: Bearer real-token-value at /Users/cm/private"
         )
       ],
       diagnosticContext: diagnostic


### PR DESCRIPTION
## Summary
- persist safe diagnostic context with history items so red HUD failures have app/version/device/provider metadata available later
- fill failure-path gaps where delivery/retry/reprocess errors showed red but did not append a history item
- add History actions to open a prefilled GitHub bug report or copy the same report
- keep public issue prefill privacy-safe: transcripts, API payload bodies, full local paths, destination app names, and secrets are omitted/redacted

## Verification
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all swift test --filter HistoryIssueReporterTests`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all make test`
