### PR TITLE
feat(ios): configurable Action Button & Shortcuts trigger

### DIFF
--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -6,22 +6,32 @@ import UIKit
 // MARK: - Audio Recording Intent (Action Button / Shortcuts)
 
 @available(iOS 18, *)
-private func stopResultDialog(for result: TranscriptionResult) -> IntentDialog {
+private func stopResultDialog(
+    for result: TranscriptionResult,
+    destination: HardwareTriggerDestination
+) -> IntentDialog {
     let wordCount = result.text.split(separator: " ").count
     if result.text.isEmpty {
         return "Recording stopped. No speech detected."
     }
-    return "Copied \(wordCount) words to clipboard."
+    switch destination {
+    case .clipboard:
+        return "Copied \(wordCount) words to clipboard."
+    case .clipboardAndPostProcess:
+        return "Copied \(wordCount) words. Polishing in the background."
+    case .historyOnly:
+        return "Saved \(wordCount) words to history."
+    }
 }
 
-/// Toggle intent for starting/stopping transcription via Action Button, Siri, or Shortcuts.
-/// Conforms to AudioRecordingIntent so the system allows background audio recording
-/// and shows the recording indicator. Requires iOS 18+.
+/// Idempotent start intent for users who wire their Action Button / Shortcut
+/// to a one-shot start (and a separate one to stop). If a recording is already
+/// in progress this intent leaves it running and reports the state.
 @available(iOS 18, *)
-public struct StartTranscriptionRecordingIntent: AudioRecordingIntent {
-    public static var title: LocalizedStringResource = "Transcribe Voice"
+public struct StartTranscriptionIntent: AudioRecordingIntent {
+    public static var title: LocalizedStringResource = "Start Recording"
     public static var description = IntentDescription(
-        "Start or stop voice transcription. The transcript is copied to your clipboard automatically."
+        "Start a fresh transcription. If one is already in progress, this does nothing."
     )
 
     public static var openAppWhenRun: Bool = false
@@ -31,22 +41,52 @@ public struct StartTranscriptionRecordingIntent: AudioRecordingIntent {
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let service = await TranscriptionRecordingService.shared
         let isRunning = await service.isRunning
+        if isRunning {
+            return .result(dialog: "Recording already in progress.")
+        }
+        try await service.startRecording()
+        return .result(dialog: "Recording started. Run \"Stop Recording\" or press your Action Button again to finish.")
+    }
+}
+
+/// Toggle intent for starting/stopping transcription via Action Button, Siri, or Shortcuts.
+/// Conforms to AudioRecordingIntent so the system allows background audio recording
+/// and shows the recording indicator. Requires iOS 18+.
+@available(iOS 18, *)
+public struct StartTranscriptionRecordingIntent: AudioRecordingIntent {
+    public static var title: LocalizedStringResource = "Toggle Recording"
+    public static var description = IntentDescription(
+        "Start or stop voice transcription. Each invocation flips between the two states. "
+            + "The result lands in the destination you chose in Settings (clipboard by default)."
+    )
+
+    public static var openAppWhenRun: Bool = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        let service = await TranscriptionRecordingService.shared
+        let isRunning = await service.isRunning
+        let destination = await AppSettings.shared.hardwareTriggerDestination
 
         if isRunning {
-            let result = await service.stopRecording()
-            return .result(dialog: stopResultDialog(for: result))
+            let result = await service.stopRecording(destination: destination)
+            return .result(dialog: stopResultDialog(for: result, destination: destination))
         } else {
             try await service.startRecording()
-            return .result(dialog: "Recording started. Press again to stop and copy.")
+            return .result(dialog: "Recording started. Press again to stop.")
         }
     }
 }
 
-/// Intent to stop an active recording from a Live Activity button.
+/// Intent to stop an active recording from a Live Activity button or a dedicated
+/// Shortcut paired with `StartTranscriptionIntent`.
 @available(iOS 18, *)
 public struct StopTranscriptionRecordingIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Stop Transcription"
-    public static var description = IntentDescription("Stops the current transcription and copies it to clipboard")
+    public static var title: LocalizedStringResource = "Stop Recording"
+    public static var description = IntentDescription(
+        "Stops the current transcription and routes the result to the destination you chose in Settings."
+    )
 
     public static var openAppWhenRun: Bool = false
 
@@ -60,8 +100,9 @@ public struct StopTranscriptionRecordingIntent: AppIntent {
             return .result(dialog: "No active recording.")
         }
 
-        let result = await service.stopRecording()
-        return .result(dialog: stopResultDialog(for: result))
+        let destination = await AppSettings.shared.hardwareTriggerDestination
+        let result = await service.stopRecording(destination: destination)
+        return .result(dialog: stopResultDialog(for: result, destination: destination))
     }
 }
 
@@ -124,13 +165,32 @@ struct TranscriptionShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: StartTranscriptionRecordingIntent(),
             phrases: [
-                "Record with \(.applicationName)",
+                "Toggle recording with \(.applicationName)",
                 "Transcribe with \(.applicationName)",
+                "Record with \(.applicationName)"
+            ],
+            shortTitle: "Toggle Recording",
+            systemImageName: "mic.fill"
+        )
+
+        AppShortcut(
+            intent: StartTranscriptionIntent(),
+            phrases: [
                 "Start recording with \(.applicationName)",
                 "Start transcription with \(.applicationName)"
             ],
-            shortTitle: "Transcribe Voice",
-            systemImageName: "mic.fill"
+            shortTitle: "Start Recording",
+            systemImageName: "mic.badge.plus"
+        )
+
+        AppShortcut(
+            intent: StopTranscriptionRecordingIntent(),
+            phrases: [
+                "Stop recording with \(.applicationName)",
+                "Stop transcription with \(.applicationName)"
+            ],
+            shortTitle: "Stop Recording",
+            systemImageName: "stop.fill"
         )
 
         AppShortcut(
@@ -142,7 +202,7 @@ struct TranscriptionShortcuts: AppShortcutsProvider {
             shortTitle: "Copy Last Sentence",
             systemImageName: "doc.on.doc"
         )
-        
+
         AppShortcut(
             intent: CopyFullTranscriptIntent(),
             phrases: [

--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -8,7 +8,8 @@ import UIKit
 @available(iOS 18, *)
 private func stopResultDialog(
     for result: TranscriptionResult,
-    destination: HardwareTriggerDestination
+    destination: HardwareTriggerDestination,
+    canPostProcess: Bool = true
 ) -> IntentDialog {
     let wordCount = result.text.split(separator: " ").count
     if result.text.isEmpty {
@@ -18,7 +19,10 @@ private func stopResultDialog(
     case .clipboard:
         return "Copied \(wordCount) words to clipboard."
     case .clipboardAndPostProcess:
-        return "Copied \(wordCount) words. Polishing in the background."
+        if canPostProcess {
+            return "Copied \(wordCount) words. Polishing in the background."
+        }
+        return "Copied \(wordCount) words. Add an OpenRouter API key to polish future recordings."
     case .historyOnly:
         return "Saved \(wordCount) words to history."
     }
@@ -31,7 +35,8 @@ private func stopResultDialog(
 public struct StartTranscriptionIntent: AudioRecordingIntent {
     public static var title: LocalizedStringResource = "Start Recording"
     public static var description = IntentDescription(
-        "Start a fresh transcription. If one is already in progress, this does nothing."
+        "Start a fresh transcription. If one is already in progress, this does nothing. "
+            + "Pair it with the Stop Recording shortcut to finish."
     )
 
     public static var openAppWhenRun: Bool = false
@@ -45,7 +50,7 @@ public struct StartTranscriptionIntent: AudioRecordingIntent {
             return .result(dialog: "Recording already in progress.")
         }
         try await service.startRecording()
-        return .result(dialog: "Recording started. Run \"Stop Recording\" or press your Action Button again to finish.")
+        return .result(dialog: "Recording started. Run \"Stop Recording\" to finish.")
     }
 }
 
@@ -68,10 +73,15 @@ public struct StartTranscriptionRecordingIntent: AudioRecordingIntent {
         let service = await TranscriptionRecordingService.shared
         let isRunning = await service.isRunning
         let destination = await AppSettings.shared.hardwareTriggerDestination
+        let canPostProcess = await AppSettings.shared.hasOpenRouterKey
 
         if isRunning {
             let result = await service.stopRecording(destination: destination)
-            return .result(dialog: stopResultDialog(for: result, destination: destination))
+            return .result(dialog: stopResultDialog(
+                for: result,
+                destination: destination,
+                canPostProcess: canPostProcess
+            ))
         } else {
             try await service.startRecording()
             return .result(dialog: "Recording started. Press again to stop.")
@@ -101,8 +111,13 @@ public struct StopTranscriptionRecordingIntent: AppIntent {
         }
 
         let destination = await AppSettings.shared.hardwareTriggerDestination
+        let canPostProcess = await AppSettings.shared.hasOpenRouterKey
         let result = await service.stopRecording(destination: destination)
-        return .result(dialog: stopResultDialog(for: result, destination: destination))
+        return .result(dialog: stopResultDialog(
+            for: result,
+            destination: destination,
+            canPostProcess: canPostProcess
+        ))
     }
 }
 

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -278,26 +278,28 @@ private extension TranscriptionRecordingService {
     /// Stops whichever transcriber is currently active and returns its result.
     /// Falls back to a synthetic `TranscriptionResult` built from `partialText`
     /// if no transcriber is wired up (defensive — shouldn't happen in practice).
+    ///
+    /// We null out the transcriber property **before** awaiting `stop()` to be
+    /// safe under `@MainActor` reentrancy: a rapid double-press of the Action
+    /// Button can re-enter `stopRecording` while the first stop is suspended,
+    /// and otherwise both calls would see the same non-nil transcriber and try
+    /// to stop it twice.
     func drainActiveTranscriber(duration: Int) async -> TranscriptionResult {
         if let deepgram = deepgramTranscriber {
-            let result = await deepgram.stop()
             deepgramTranscriber = nil
-            return result
+            return await deepgram.stop()
         }
         if let elevenlabs = elevenLabsTranscriber {
-            let result = await elevenlabs.stop()
             elevenLabsTranscriber = nil
-            return result
+            return await elevenlabs.stop()
         }
         if let openai = openAITranscriber {
-            let result = await openai.stop()
             openAITranscriber = nil
-            return result
+            return await openai.stop()
         }
         if let apple = appleTranscriber {
-            let result = await apple.stop()
             appleTranscriber = nil
-            return result
+            return await apple.stop()
         }
         return TranscriptionResult(
             text: partialText,

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -168,52 +168,32 @@ public final class TranscriptionRecordingService: ObservableObject {
         }
     }
 
-    /// Stops recording, copies transcript to clipboard, and returns the result.
+    /// Stops recording, applies the requested result destination, and returns the result.
+    ///
+    /// - Parameter destination: Where the transcript should go. When `nil`, defaults
+    ///   to `.clipboardAndPostProcess` if the user has post-processing turned on,
+    ///   else `.clipboard` — i.e., the original behaviour before destinations
+    ///   were configurable. Hardware-trigger callers (Action Button, Siri,
+    ///   Shortcuts) pass `AppSettings.shared.hardwareTriggerDestination`.
     @discardableResult
-    public func stopRecording() async -> TranscriptionResult {
+    public func stopRecording(destination: HardwareTriggerDestination? = nil) async -> TranscriptionResult {
         isRunning = false
         let duration = elapsedSeconds
 
-        let result: TranscriptionResult
-        if let deepgram = deepgramTranscriber {
-            result = await deepgram.stop()
-            deepgramTranscriber = nil
-        } else if let elevenlabs = elevenLabsTranscriber {
-            result = await elevenlabs.stop()
-            elevenLabsTranscriber = nil
-        } else if let openai = openAITranscriber {
-            result = await openai.stop()
-            openAITranscriber = nil
-        } else if let apple = appleTranscriber {
-            result = await apple.stop()
-            appleTranscriber = nil
-        } else {
-            result = TranscriptionResult(
-                text: partialText,
-                segments: [],
-                confidence: nil,
-                duration: TimeInterval(duration),
-                modelIdentifier: currentModel,
-                cost: nil,
-                rawPayload: nil,
-                debugInfo: nil
-            )
-        }
-
+        let result = await drainActiveTranscriber(duration: duration)
         startTime = nil
 
-        // Record to history
+        // Record to history (always, regardless of destination).
         iOSHistoryManager.shared.recordTranscription(
             text: result.text,
             model: currentModel,
             duration: result.duration
         )
 
-        // Copy to clipboard immediately
-        if !result.text.isEmpty {
-            UIPasteboard.general.string = result.text
-            sharedState.lastCompletedTranscript = result.text
-        }
+        // Resolve the destination. When nil (legacy callers), preserve the
+        // pre-destination behaviour: clipboard + post-process if user opted in.
+        let resolvedDestination: HardwareTriggerDestination = destination ?? .clipboard
+        applyDestinationSideEffects(result: result, destination: resolvedDestination)
 
         // Update shared state
         sharedState.clearRecordingState()
@@ -221,10 +201,12 @@ public final class TranscriptionRecordingService: ObservableObject {
         // Complete Live Activity with clipboard confirmation
         activityManager.completeActivity(finalWordCount: wordCount, duration: duration)
 
-        // Post-process in background if enabled
-        if AppSettings.shared.autoPostProcess && AppSettings.shared.hasOpenRouterKey && !result.text.isEmpty {
-            Task {
-                await postProcess(text: result.text)
+        // Kick off background post-processing if the chosen destination + user
+        // settings call for it.
+        if shouldPostProcess(destination: resolvedDestination, isLegacyCaller: destination == nil)
+            && !result.text.isEmpty {
+            Task { [resolvedDestination] in
+                await postProcess(text: result.text, replacingClipboard: resolvedDestination != .historyOnly)
             }
         }
 
@@ -268,7 +250,7 @@ public final class TranscriptionRecordingService: ObservableObject {
         activityManager.reportError(error.localizedDescription)
     }
 
-    private func postProcess(text: String) async {
+    private func postProcess(text: String, replacingClipboard: Bool = true) async {
         let settings = AppSettings.shared
         let processor = iOSPostProcessingManager.shared
 
@@ -279,10 +261,93 @@ public final class TranscriptionRecordingService: ObservableObject {
             apiKey: settings.openRouterAPIKey
         )
 
-        // Replace clipboard with processed text
+        // Replace clipboard with processed text (unless caller asked us not to).
         if !processor.processedText.isEmpty {
-            UIPasteboard.general.string = processor.processedText
+            if replacingClipboard {
+                UIPasteboard.general.string = processor.processedText
+            }
             sharedState.lastCompletedTranscript = processor.processedText
+        }
+    }
+}
+
+// MARK: - Stop helpers
+
+@MainActor
+private extension TranscriptionRecordingService {
+    /// Stops whichever transcriber is currently active and returns its result.
+    /// Falls back to a synthetic `TranscriptionResult` built from `partialText`
+    /// if no transcriber is wired up (defensive — shouldn't happen in practice).
+    func drainActiveTranscriber(duration: Int) async -> TranscriptionResult {
+        if let deepgram = deepgramTranscriber {
+            let result = await deepgram.stop()
+            deepgramTranscriber = nil
+            return result
+        }
+        if let elevenlabs = elevenLabsTranscriber {
+            let result = await elevenlabs.stop()
+            elevenLabsTranscriber = nil
+            return result
+        }
+        if let openai = openAITranscriber {
+            let result = await openai.stop()
+            openAITranscriber = nil
+            return result
+        }
+        if let apple = appleTranscriber {
+            let result = await apple.stop()
+            appleTranscriber = nil
+            return result
+        }
+        return TranscriptionResult(
+            text: partialText,
+            segments: [],
+            confidence: nil,
+            duration: TimeInterval(duration),
+            modelIdentifier: currentModel,
+            cost: nil,
+            rawPayload: nil,
+            debugInfo: nil
+        )
+    }
+
+    /// Applies the destination's side-effects (clipboard write, shared state
+    /// update). History recording is handled by the caller because it always
+    /// happens regardless of destination.
+    func applyDestinationSideEffects(
+        result: TranscriptionResult,
+        destination: HardwareTriggerDestination
+    ) {
+        guard !result.text.isEmpty else { return }
+        switch destination {
+        case .clipboard, .clipboardAndPostProcess:
+            UIPasteboard.general.string = result.text
+            sharedState.lastCompletedTranscript = result.text
+        case .historyOnly:
+            // Don't touch the pasteboard. We still record `lastCompletedTranscript`
+            // because the Live Activity / shared state UI shows it.
+            sharedState.lastCompletedTranscript = result.text
+        }
+    }
+
+    /// Decides whether to run the background post-processor.
+    ///
+    /// Two paths trigger it:
+    /// 1. Legacy callers (no explicit destination) honour the global
+    ///    `autoPostProcess` toggle for backwards compatibility.
+    /// 2. Hardware-trigger callers explicitly choose `.clipboardAndPostProcess`.
+    func shouldPostProcess(
+        destination: HardwareTriggerDestination,
+        isLegacyCaller: Bool
+    ) -> Bool {
+        let settings = AppSettings.shared
+        switch destination {
+        case .clipboardAndPostProcess:
+            return settings.hasOpenRouterKey
+        case .clipboard:
+            return isLegacyCaller && settings.autoPostProcess && settings.hasOpenRouterKey
+        case .historyOnly:
+            return false
         }
     }
 }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -14,6 +14,52 @@ public struct PostProcessingModelInfo: Identifiable {
     public let description: String
 }
 
+// MARK: - Hardware Trigger Destination
+
+/// What happens to the transcript after a hardware-triggered recording stops.
+///
+/// Used by every "headless" entry point: Action Button (iPhone 15 Pro+),
+/// Siri voice commands, the Shortcuts app, Lock Screen / Home Screen widget,
+/// Control Center, Back Tap. The main in-app record-and-stop flow is
+/// unaffected — it always shows the result on screen.
+public enum HardwareTriggerDestination: String, CaseIterable, Identifiable, Sendable {
+    /// Copy the transcript to the clipboard. Default — matches behaviour
+    /// prior to the destination setting being added.
+    case clipboard
+
+    /// Copy to clipboard and run the configured post-processor (OpenRouter)
+    /// in the background, replacing the clipboard with the polished version
+    /// when it lands. Falls back to plain `.clipboard` if no OpenRouter key.
+    case clipboardAndPostProcess
+
+    /// Save to history only — don't touch the clipboard, don't post-process.
+    /// Useful if the user wants to capture a thought without polluting the
+    /// pasteboard with something they didn't choose to paste.
+    case historyOnly
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .clipboard: return "Copy to Clipboard"
+        case .clipboardAndPostProcess: return "Copy & Polish"
+        case .historyOnly: return "Save to History Only"
+        }
+    }
+
+    public var summary: String {
+        switch self {
+        case .clipboard:
+            return "Transcript is copied to the clipboard immediately when recording stops."
+        case .clipboardAndPostProcess:
+            return "Transcript is copied to the clipboard, then re-cleaned with your post-processing model "
+                + "and the polished version is re-copied."
+        case .historyOnly:
+            return "Transcript is saved to history. Clipboard and post-processing are skipped."
+        }
+    }
+}
+
 // MARK: - Settings Storage
 
 /// Simple UserDefaults-based settings for iOS app.
@@ -63,6 +109,14 @@ public final class AppSettings: ObservableObject {
 
     @Published public var autoStartRecording: Bool {
         didSet { UserDefaults.standard.set(autoStartRecording, forKey: "autoStartRecording") }
+    }
+
+    /// What happens to the transcript when a hardware-triggered recording (Action Button,
+    /// Siri, Shortcuts, Lock Screen widget, Back Tap, Control Center) stops.
+    @Published public var hardwareTriggerDestination: HardwareTriggerDestination {
+        didSet {
+            UserDefaults.standard.set(hardwareTriggerDestination.rawValue, forKey: "hardwareTriggerDestination")
+        }
     }
 
     // MARK: - Post-Processing Settings
@@ -128,6 +182,11 @@ public final class AppSettings: ObservableObject {
         let liveActivities = UserDefaults.standard.object(forKey: "liveActivitiesEnabled") as? Bool ?? true
         let autoStart = UserDefaults.standard.bool(forKey: "autoStartRecording")
 
+        // Hardware trigger destination (Action Button, Siri, Shortcuts).
+        // Default to .clipboard for backwards compatibility with prior versions.
+        let hardwareDestRaw = UserDefaults.standard.string(forKey: "hardwareTriggerDestination")
+        let hardwareDest = HardwareTriggerDestination(rawValue: hardwareDestRaw ?? "") ?? .clipboard
+
         // Post-processing settings
         let postEnabled = UserDefaults.standard.bool(forKey: "postProcessingEnabled")
         let postModel = UserDefaults.standard.string(forKey: "postProcessingModel") ?? "openai/gpt-4o-mini"
@@ -141,6 +200,7 @@ public final class AppSettings: ObservableObject {
         self.elevenLabsAPIKey = ""
         self.liveActivitiesEnabled = liveActivities
         self.autoStartRecording = autoStart
+        self.hardwareTriggerDestination = hardwareDest
         self.postProcessingEnabled = postEnabled
         self.postProcessingModel = postModel
         self.postProcessingPrompt = postPrompt
@@ -307,6 +367,24 @@ public struct SettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+            }
+
+            Section("Hardware Trigger") {
+                NavigationLink {
+                    HardwareTriggerSettingsView(settings: settings)
+                } label: {
+                    HStack {
+                        Label("Action Button & Shortcuts", systemImage: "button.programmable")
+                        Spacer()
+                        Text(settings.hardwareTriggerDestination.displayName)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Text("Trigger transcription from the Action Button, Siri, Lock Screen, Control Center, or Back Tap.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Post-Processing") {
@@ -502,6 +580,145 @@ public struct SettingsView: View {
 
     private var postProcessingModelName: String {
         AppSettings.postProcessingModels.first { $0.id == settings.postProcessingModel }?.name ?? "GPT-4o Mini"
+    }
+}
+
+// MARK: - Hardware Trigger Settings View
+
+/// Configuration screen for the Action Button / Shortcuts / Siri / widget
+/// recording entry points. Lets the user pick what happens to the transcript
+/// when recording stops and explains how to wire each entry point.
+struct HardwareTriggerSettingsView: View {
+    @ObservedObject var settings: AppSettings
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        Form {
+            Section("When Recording Stops") {
+                Picker("Destination", selection: $settings.hardwareTriggerDestination) {
+                    ForEach(HardwareTriggerDestination.allCases) { destination in
+                        Text(destination.displayName).tag(destination)
+                    }
+                }
+                .pickerStyle(.inline)
+                .labelsHidden()
+
+                Text(settings.hardwareTriggerDestination.summary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if settings.hardwareTriggerDestination == .clipboardAndPostProcess
+                    && !settings.hasOpenRouterKey {
+                    Label(
+                        "Add an OpenRouter API key under API Keys to enable polishing. "
+                            + "Without it, polishing falls back to plain clipboard.",
+                        systemImage: "exclamationmark.triangle"
+                    )
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            Section("Set Up the Action Button") {
+                Text(
+                    "On iPhone 15 Pro and later you can map the Action Button to start recording in one press — "
+                        + "even from the Lock Screen."
+                )
+                    .font(.callout)
+
+                StepRow(number: 1, text: "Open the Shortcuts app and tap the + button.")
+                StepRow(
+                    number: 2,
+                    text: "Search for JustSpeakToIt and choose Toggle Recording "
+                        + "(or Start Recording if you prefer a one-shot start)."
+                )
+                StepRow(number: 3, text: "Name the shortcut and tap Done.")
+                StepRow(
+                    number: 4,
+                    text: "Open Settings → Action Button, swipe to Shortcut, and pick the shortcut you just made."
+                )
+
+                Button {
+                    if let url = URL(string: "shortcuts://") {
+                        openURL(url)
+                    }
+                } label: {
+                    Label("Open Shortcuts App", systemImage: "arrow.up.right.square")
+                }
+            }
+
+            Section("Other Trigger Options") {
+                BulletRow(
+                    icon: "mic.fill",
+                    title: "Siri",
+                    detail: "Say \"Toggle Recording with JustSpeakToIt\" or \"Start Recording with JustSpeakToIt\"."
+                )
+                BulletRow(
+                    icon: "square.grid.2x2.fill",
+                    title: "Control Center",
+                    detail: "On iOS 18 and later add the Shortcut control via Customise Controls → Add a Control."
+                )
+                BulletRow(
+                    icon: "lock.iphone",
+                    title: "Lock Screen / Home Screen widget",
+                    detail: "Add a Shortcuts widget and pick your Toggle Recording shortcut."
+                )
+                BulletRow(
+                    icon: "hand.tap.fill",
+                    title: "Back Tap",
+                    detail: "Settings → Accessibility → Touch → Back Tap. "
+                        + "Assign your shortcut to a double or triple tap."
+                )
+            }
+
+            Section("What Runs") {
+                Label("Live model: \(settings.selectedModel)", systemImage: "waveform")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(
+                    "Recording uses the live model from the Transcription section above. "
+                        + "If the chosen model needs an API key that isn't set, JustSpeakToIt "
+                        + "falls back to Apple Speech (on-device) so the trigger still works."
+                )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Action Button & Shortcuts")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct StepRow: View {
+    let number: Int
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text("\(number)")
+                .font(.headline)
+                .frame(width: 24, height: 24)
+                .background(Color.accentColor.opacity(0.15), in: Circle())
+                .foregroundStyle(Color.accentColor)
+            Text(text)
+                .font(.callout)
+        }
+    }
+}
+
+private struct BulletRow: View {
+    let icon: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(title, systemImage: icon)
+                .font(.callout.weight(.medium))
+            Text(detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -629,8 +629,8 @@ struct HardwareTriggerSettingsView: View {
                 StepRow(number: 1, text: "Open the Shortcuts app and tap the + button.")
                 StepRow(
                     number: 2,
-                    text: "Search for JustSpeakToIt and choose Toggle Recording "
-                        + "(or Start Recording if you prefer a one-shot start)."
+                    text: "Search for JustSpeakToIt and choose Toggle Recording for a single-button flow. "
+                        + "Use Start Recording only if you also create a separate Stop Recording shortcut."
                 )
                 StepRow(number: 3, text: "Name the shortcut and tap Done.")
                 StepRow(

--- a/Tests/SpeakiOSTests/HardwareTriggerDestinationTests.swift
+++ b/Tests/SpeakiOSTests/HardwareTriggerDestinationTests.swift
@@ -1,0 +1,92 @@
+#if os(iOS)
+import Foundation
+import XCTest
+
+@testable import SpeakiOSLib
+
+/// Verifies the new `HardwareTriggerDestination` enum and its UserDefaults
+/// round-trip through `AppSettings`. These are the only pieces of the
+/// Action Button feature that are reasonable to exercise in unit tests
+/// without spinning up the live recording stack (transcribers, audio
+/// session, Live Activity, etc.).
+@MainActor
+final class HardwareTriggerDestinationTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suiteName = "HardwareTriggerDestinationTests"
+
+    override func setUp() async throws {
+        try await super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Enum surface
+
+    func testAllCasesHaveStableRawValues() {
+        // Stability matters because the raw value is what we persist to
+        // UserDefaults. Changing these strings would silently reset
+        // existing users' choices back to the default.
+        XCTAssertEqual(HardwareTriggerDestination.clipboard.rawValue, "clipboard")
+        XCTAssertEqual(HardwareTriggerDestination.clipboardAndPostProcess.rawValue, "clipboardAndPostProcess")
+        XCTAssertEqual(HardwareTriggerDestination.historyOnly.rawValue, "historyOnly")
+    }
+
+    func testAllCasesHaveNonEmptyDisplayName() {
+        for destination in HardwareTriggerDestination.allCases {
+            XCTAssertFalse(destination.displayName.isEmpty, "\(destination) should have a display name")
+            XCTAssertFalse(destination.summary.isEmpty, "\(destination) should have a summary")
+        }
+    }
+
+    func testIdentifiableUsesRawValue() {
+        for destination in HardwareTriggerDestination.allCases {
+            XCTAssertEqual(destination.id, destination.rawValue)
+        }
+    }
+
+    // MARK: - UserDefaults persistence
+
+    /// `AppSettings.shared` is a singleton bound to `UserDefaults.standard`,
+    /// so we can't safely swap its backing store. Instead this test verifies
+    /// the persistence contract directly against UserDefaults the same way
+    /// `AppSettings` reads/writes it, using an isolated suite.
+    func testDestinationRoundTripsThroughUserDefaults() {
+        let key = "hardwareTriggerDestination"
+
+        for destination in HardwareTriggerDestination.allCases {
+            defaults.set(destination.rawValue, forKey: key)
+
+            let raw = defaults.string(forKey: key) ?? ""
+            let restored = HardwareTriggerDestination(rawValue: raw) ?? .clipboard
+
+            XCTAssertEqual(restored, destination, "Round-trip failed for \(destination)")
+        }
+    }
+
+    func testMissingDefaultsValueFallsBackToClipboard() {
+        // Mirrors the init logic in AppSettings: when the key is absent
+        // (fresh install / pre-feature user) we fall back to `.clipboard`
+        // so the previous behaviour is preserved.
+        let raw = defaults.string(forKey: "hardwareTriggerDestination") ?? ""
+        let restored = HardwareTriggerDestination(rawValue: raw) ?? .clipboard
+        XCTAssertEqual(restored, .clipboard)
+    }
+
+    func testUnknownRawValueFallsBackToClipboard() {
+        // Defensive: if a future build wrote an unknown raw value (e.g. a
+        // case that has since been removed), the loader should not crash
+        // and should fall back to `.clipboard`.
+        defaults.set("nonsense", forKey: "hardwareTriggerDestination")
+        let raw = defaults.string(forKey: "hardwareTriggerDestination") ?? ""
+        let restored = HardwareTriggerDestination(rawValue: raw) ?? .clipboard
+        XCTAssertEqual(restored, .clipboard)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Closes #463.

Adds a **Hardware Trigger** section to Settings letting users choose where the transcript goes when recording is started/stopped from outside the main UI:

- **Copy to Clipboard** (default — matches existing behaviour)
- **Copy & Polish** — clipboard → post-process → re-copy polished
- **Save to History Only** — never touches the clipboard

Used by every "headless" entry point: Action Button (iPhone 15 Pro+), Siri, Shortcuts app, Lock Screen / Home Screen widgets, Control Center, Back Tap.

## How competing apps do it (research)

Whisper Memos, Voicenotes, Wispr Flow, AudioPen, MacWhisper for iOS all share the same Apple-blessed plumbing:

1. Conform an `AppIntent` to `AudioRecordingIntent` (iOS 18+) so the system grants mic access from anywhere — including the Lock Screen.
2. Start a Live Activity for the lifetime of the recording so iOS keeps the audio session alive when the app is backgrounded.
3. Register the intent through `AppShortcutsProvider` so it shows up in the Shortcuts app and can be picked from **Settings → Action Button → Shortcut**.

JSTI already had #1 and #2 — only #3's discoverability and the result-destination choice were missing.

## Changes

- **`HardwareTriggerDestination`** enum (Sendable, persisted via UserDefaults, defaults to `.clipboard`).
- **`TranscriptionRecordingService.stopRecording(destination:)`** — accepts an optional destination; legacy callers (`nil`) get the original behaviour. Extracted `drainActiveTranscriber`, `applyDestinationSideEffects`, and `shouldPostProcess` helpers to stay under the lint complexity/body-length thresholds.
- **`StartTranscriptionIntent`** — new idempotent start intent for users who'd rather use two shortcuts (start + stop) than one toggle.
- **`StartTranscriptionRecordingIntent`** — renamed from "Transcribe Voice" to "Toggle Recording" so the Shortcuts UI shows what it actually does.
- **`StopTranscriptionRecordingIntent`** — promoted to a first-class App Shortcut.
- **`HardwareTriggerSettingsView`** — destination picker + step-by-step Action Button setup guide + "Open Shortcuts App" deep link + helper rows for Siri / Control Center / widgets / Back Tap.

## Tests

- `HardwareTriggerDestinationTests` covers raw-value stability (so we don't silently reset users' choices on rename), UserDefaults round-trip for every case, missing-value fallback to `.clipboard`, and unknown-raw-value fallback.

## Out of scope (intentionally)

- True press-and-hold mode — Action Button + Shortcuts only fires on tap.
- A bespoke `PushToTalkTransmissionIntent` — that's for VoIP only.
- iPhone 14 and earlier (no Action Button) — Shortcuts/Siri/Back Tap still work.

## Verification

- `swift build` — clean
- `swift test` — passes
- `swift package plugin swiftlint --strict --baseline .swiftlint-baseline.json` — 0 violations
- `xcodebuild -scheme SpeakiOS -destination "generic/platform=iOS Simulator" build` — no new errors (pre-existing widget-extension `SpeakCore`/`SpeakiOSLib` dependency errors on `main` are unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Hardware Trigger setting to choose what happens when hardware-triggered recording stops.
  * Added destination-aware recording actions, including iOS 18+ one-tap start behavior and updated stop/start prompts.
  * Refreshed shortcut titles, phrases, and icons for the recording actions.

* **Bug Fixes**
  * Stop behavior now follows the selected destination (clipboard, clipboard + post-process, or history-only).
  * Clipboard overwrites and post-processing are applied only when appropriate.

* **Tests**
  * Added coverage for destination persistence and enum stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->