### PR TITLE
fix(ios): unbreak Release archive — IntentDescription needs literal

### DIFF
--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -35,8 +35,7 @@ private func stopResultDialog(
 public struct StartTranscriptionIntent: AudioRecordingIntent {
     public static var title: LocalizedStringResource = "Start Recording"
     public static var description = IntentDescription(
-        "Start a fresh transcription. If one is already in progress, this does nothing. "
-            + "Pair it with the Stop Recording shortcut to finish."
+        "Start a fresh transcription. No-op if already recording. Pair with Stop Recording to finish."
     )
 
     public static var openAppWhenRun: Bool = false
@@ -61,8 +60,7 @@ public struct StartTranscriptionIntent: AudioRecordingIntent {
 public struct StartTranscriptionRecordingIntent: AudioRecordingIntent {
     public static var title: LocalizedStringResource = "Toggle Recording"
     public static var description = IntentDescription(
-        "Start or stop voice transcription. Each invocation flips between the two states. "
-            + "The result lands in the destination you chose in Settings (clipboard by default)."
+        "Start or stop voice transcription. Result lands in the destination you chose in Settings."
     )
 
     public static var openAppWhenRun: Bool = false


### PR DESCRIPTION
## Summary

The TestFlight build kicked off after #464 merged **failed** with:

```
TranscriptionIntents.swift:37:37: error: no exact matches in call to initializer
TranscriptionIntents.swift:63:37: error: no exact matches in call to initializer
```

Both lines are `IntentDescription(...)` calls I added in #464.

## Root cause

`IntentDescription.init(_:)` takes a `LocalizedStringResource`. `LocalizedStringResource` is constructible from `ExpressibleByStringLiteral` literals — **not** from a `String` expression built with `+`.

In Debug the SPM build was lenient and accepted the concatenation. The Release archive build (Xcode 26.3 / iOS 17 deployment / `-O`) rejects it because the result isn't a single static literal.

## Fix

Inline both strings as single string literals. Shortened the wording slightly so each line stays under the 120/160-char SwiftLint limit without losing meaning:

- `Start fresh transcription. If one is already in progress, this does nothing. Pair it with the Stop Recording shortcut to finish.` → `Start a fresh transcription. No-op if already recording. Pair with Stop Recording to finish.`
- `Start or stop voice transcription. Each invocation flips between the two states. The result lands in the destination you chose in Settings (clipboard by default).` → `Start or stop voice transcription. Result lands in the destination you chose in Settings.`

The user-facing dialogs and short titles are unchanged — this only affects the long description shown in the Shortcuts editor.

## Verification

- `swift build` — clean
- `swift test` — passes
- `swift package plugin swiftlint --strict --baseline .swiftlint-baseline.json` — 0 violations
- **Reproduced the original failure locally first**, then confirmed the fix:
  ```
  xcodebuild -workspace "Just Speak to It.xcworkspace" -scheme SpeakiOS \
    -configuration Release -destination "generic/platform=iOS" archive
  ```
  → `** ARCHIVE SUCCEEDED **`

## Notes for next time

`IntentDescription`, `LocalizedStringResource`, and related `@AppShortcut` macro APIs all require **literal** strings — adjacent literal concatenation with `+` won't compile in Release. Always test the Release archive locally before relying on TestFlight to catch this class of error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the descriptions for two transcription recording actions to make their behavior clearer to users.
  * Clarified that starting a transcription begins a new recording only when needed, and that results are saved to the destination chosen in Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->