### PR TITLE
perf: integrate validated remote optimisation branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ logs/
 .dolt/
 *.db
 .beads-credential-key
+issues.jsonl
 
 # Quality Software conformance derived evidence
 .conformance/

--- a/Sources/SpeakApp/AudioBufferPool.swift
+++ b/Sources/SpeakApp/AudioBufferPool.swift
@@ -12,9 +12,27 @@ final class AudioBufferPool: @unchecked Sendable {
     private let logger = Logger(subsystem: "com.speak.app", category: "AudioBufferPool")
 
     // Metrics
-    private(set) var poolHits: Int = 0
-    private(set) var poolMisses: Int = 0
-    private(set) var growthCount: Int = 0
+    private var _poolHits: Int = 0
+    private var _poolMisses: Int = 0
+    private var _growthCount: Int = 0
+
+    var poolHits: Int {
+        os_unfair_lock_lock(&unfairLock)
+        defer { os_unfair_lock_unlock(&unfairLock) }
+        return _poolHits
+    }
+
+    var poolMisses: Int {
+        os_unfair_lock_lock(&unfairLock)
+        defer { os_unfair_lock_unlock(&unfairLock) }
+        return _poolMisses
+    }
+
+    var growthCount: Int {
+        os_unfair_lock_lock(&unfairLock)
+        defer { os_unfair_lock_unlock(&unfairLock) }
+        return _growthCount
+    }
 
     /// Creates a new buffer pool.
     /// - Parameters:
@@ -42,15 +60,15 @@ final class AudioBufferPool: @unchecked Sendable {
         defer { os_unfair_lock_unlock(&unfairLock) }
 
         if let buffer = availableBuffers.popLast() {
-            poolHits += 1
+            _poolHits += 1
             return buffer
         }
 
         // Pool exhausted - grow by creating a new buffer
-        poolMisses += 1
-        growthCount += 1
+        _poolMisses += 1
+        _growthCount += 1
         logger.warning(
-            "AudioBufferPool exhausted, growing pool. Hits: \(self.poolHits), Misses: \(self.poolMisses), Growth: \(self.growthCount)"
+            "Pool exhausted. Hits: \(self._poolHits), Misses: \(self._poolMisses), Growth: \(self._growthCount)"
         )
 
         var newBuffer = Data()
@@ -78,9 +96,9 @@ final class AudioBufferPool: @unchecked Sendable {
         defer { os_unfair_lock_unlock(&unfairLock) }
 
         return [
-            "poolHits": poolHits,
-            "poolMisses": poolMisses,
-            "growthCount": growthCount,
+            "poolHits": _poolHits,
+            "poolMisses": _poolMisses,
+            "growthCount": _growthCount,
             "availableBuffers": availableBuffers.count,
             "initialPoolSize": initialPoolSize
         ]
@@ -91,16 +109,21 @@ final class AudioBufferPool: @unchecked Sendable {
         os_unfair_lock_lock(&unfairLock)
         defer { os_unfair_lock_unlock(&unfairLock) }
 
-        poolHits = 0
-        poolMisses = 0
-        growthCount = 0
+        _poolHits = 0
+        _poolMisses = 0
+        _growthCount = 0
     }
 
     /// Logs current pool metrics.
     func logMetrics() {
         let metrics = metricsSnapshot()
+        let hits = metrics["poolHits"] ?? 0
+        let misses = metrics["poolMisses"] ?? 0
+        let growth = metrics["growthCount"] ?? 0
+        let available = metrics["availableBuffers"] ?? 0
+
         logger.info(
-            "AudioBufferPool metrics - Hits: \(metrics["poolHits"] ?? 0), Misses: \(metrics["poolMisses"] ?? 0), Growth: \(metrics["growthCount"] ?? 0), Available: \(metrics["availableBuffers"] ?? 0)"
+            "Pool metrics. Hits: \(hits), Misses: \(misses), Growth: \(growth), Available: \(available)"
         )
     }
 }

--- a/Sources/SpeakApp/PersonalLexiconService.swift
+++ b/Sources/SpeakApp/PersonalLexiconService.swift
@@ -3,10 +3,13 @@ import os.log
 
 @MainActor
 final class PersonalLexiconService: ObservableObject {
-  @Published private(set) var rules: [PersonalLexiconRule] = []
+  @Published private(set) var rules: [PersonalLexiconRule] = [] {
+    didSet { regexCache.removeAll() }
+  }
 
   private let store: PersonalLexiconStore
   private let log = Logger(subsystem: "com.github.speakapp", category: "PersonalLexicon")
+  private var regexCache: [String: NSRegularExpression] = [:]
 
   init(store: PersonalLexiconStore) {
     self.store = store
@@ -193,10 +196,17 @@ final class PersonalLexiconService: ObservableObject {
   }
 
   private func apply(alias: String, with canonical: String, to text: String) -> (Int, String) {
-    let escapedAlias = NSRegularExpression.escapedPattern(for: alias)
-    let pattern = "(?i)\\b\(escapedAlias)\\b"
-    guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
-      return (0, text)
+    let regex: NSRegularExpression
+    if let cached = regexCache[alias] {
+      regex = cached
+    } else {
+      let escapedAlias = NSRegularExpression.escapedPattern(for: alias)
+      let pattern = "(?i)\\b\(escapedAlias)\\b"
+      guard let compiled = try? NSRegularExpression(pattern: pattern, options: []) else {
+        return (0, text)
+      }
+      regexCache[alias] = compiled
+      regex = compiled
     }
     let fullRange = NSRange(location: 0, length: text.utf16.count)
     let matches = regex.numberOfMatches(in: text, options: [], range: fullRange)

--- a/Sources/SpeakApp/WordDiffer.swift
+++ b/Sources/SpeakApp/WordDiffer.swift
@@ -15,8 +15,12 @@ struct WordDiffer {
     // If the text is completely different, don't try to extract corrections
     guard !originalWords.isEmpty, !editedWords.isEmpty else { return [] }
 
+    // Precompute lowercased words once; reused by findCommonEnds comparisons.
+    let originalLower = originalWords.map { $0.lowercased() }
+    let editedLower = editedWords.map { $0.lowercased() }
+
     // Find the longest common prefix and suffix to isolate the changed region
-    let (prefixLen, suffixLen) = findCommonEnds(originalWords, editedWords)
+    let (prefixLen, suffixLen) = findCommonEnds(originalLower, editedLower)
 
     // Extract the changed portions
     let originalMiddle = Array(
@@ -43,11 +47,12 @@ struct WordDiffer {
   }
 
   /// Find the length of common prefix and suffix in word arrays.
+  /// Expects pre-lowercased arrays so no per-element lowercasing is needed.
   private static func findCommonEnds(_ a: [String], _ b: [String]) -> (prefix: Int, suffix: Int) {
     // Find common prefix length
     var prefixLen = 0
     let minLen = min(a.count, b.count)
-    while prefixLen < minLen && a[prefixLen].lowercased() == b[prefixLen].lowercased() {
+    while prefixLen < minLen && a[prefixLen] == b[prefixLen] {
       prefixLen += 1
     }
 
@@ -55,7 +60,7 @@ struct WordDiffer {
     var suffixLen = 0
     let maxSuffix = minLen - prefixLen
     while suffixLen < maxSuffix
-      && a[a.count - 1 - suffixLen].lowercased() == b[b.count - 1 - suffixLen].lowercased()
+      && a[a.count - 1 - suffixLen] == b[b.count - 1 - suffixLen]
     {
       suffixLen += 1
     }
@@ -116,9 +121,14 @@ struct WordDiffer {
   private static func extractViaLCS(original: [String], edited: [String]) -> [WordChange] {
     guard !original.isEmpty, !edited.isEmpty else { return [] }
 
-    let table = buildLCSTable(original: original, edited: edited)
+    // Precompute lowercased arrays once; passed to buildLCSTable and backtrackLCS
+    // to avoid O(rows × cols) repeated .lowercased() calls in the inner loop.
+    let originalLower = original.map { $0.lowercased() }
+    let editedLower = edited.map { $0.lowercased() }
+
+    let table = buildLCSTable(originalLower: originalLower, editedLower: editedLower)
     let (commonOriginalIndices, commonEditedIndices) = backtrackLCS(
-      table: table, original: original, edited: edited
+      table: table, originalLower: originalLower, editedLower: editedLower
     )
 
     // Find words that are not in common
@@ -145,13 +155,13 @@ struct WordDiffer {
     return changes
   }
 
-  private static func buildLCSTable(original: [String], edited: [String]) -> [[Int]] {
-    let rows = original.count
-    let cols = edited.count
+  private static func buildLCSTable(originalLower: [String], editedLower: [String]) -> [[Int]] {
+    let rows = originalLower.count
+    let cols = editedLower.count
     var table = [[Int]](repeating: [Int](repeating: 0, count: cols + 1), count: rows + 1)
     for rowIndex in 0..<rows {
       for columnIndex in 0..<cols {
-        if original[rowIndex].lowercased() == edited[columnIndex].lowercased() {
+        if originalLower[rowIndex] == editedLower[columnIndex] {
           table[rowIndex + 1][columnIndex + 1] = table[rowIndex][columnIndex] + 1
         } else {
           table[rowIndex + 1][columnIndex + 1] = max(
@@ -165,13 +175,13 @@ struct WordDiffer {
   }
 
   private static func backtrackLCS(
-    table: [[Int]], original: [String], edited: [String]
+    table: [[Int]], originalLower: [String], editedLower: [String]
   ) -> (Set<Int>, Set<Int>) {
     var commonOriginalIndices = Set<Int>()
     var commonEditedIndices = Set<Int>()
-    var row = original.count, col = edited.count
+    var row = originalLower.count, col = editedLower.count
     while row > 0 && col > 0 {
-      if original[row - 1].lowercased() == edited[col - 1].lowercased() {
+      if originalLower[row - 1] == editedLower[col - 1] {
         commonOriginalIndices.insert(row - 1)
         commonEditedIndices.insert(col - 1)
         row -= 1

--- a/Sources/SpeakCore/AudioBufferPool.swift
+++ b/Sources/SpeakCore/AudioBufferPool.swift
@@ -11,9 +11,27 @@ public final class AudioBufferPool: @unchecked Sendable {
     private let logger = Logger(subsystem: "com.speak.app", category: "AudioBufferPool")
 
     // Metrics
-    public private(set) var poolHits: Int = 0
-    public private(set) var poolMisses: Int = 0
-    public private(set) var growthCount: Int = 0
+    private var _poolHits: Int = 0
+    private var _poolMisses: Int = 0
+    private var _growthCount: Int = 0
+
+    public var poolHits: Int {
+        os_unfair_lock_lock(&unfairLock)
+        defer { os_unfair_lock_unlock(&unfairLock) }
+        return _poolHits
+    }
+
+    public var poolMisses: Int {
+        os_unfair_lock_lock(&unfairLock)
+        defer { os_unfair_lock_unlock(&unfairLock) }
+        return _poolMisses
+    }
+
+    public var growthCount: Int {
+        os_unfair_lock_lock(&unfairLock)
+        defer { os_unfair_lock_unlock(&unfairLock) }
+        return _growthCount
+    }
 
     /// Creates a new buffer pool.
     /// - Parameters:
@@ -41,15 +59,15 @@ public final class AudioBufferPool: @unchecked Sendable {
         defer { os_unfair_lock_unlock(&unfairLock) }
 
         if let buffer = availableBuffers.popLast() {
-            poolHits += 1
+            _poolHits += 1
             return buffer
         }
 
         // Pool exhausted - grow by creating a new buffer
-        poolMisses += 1
-        growthCount += 1
+        _poolMisses += 1
+        _growthCount += 1
         logger.warning(
-            "AudioBufferPool exhausted, growing pool. Hits: \(self.poolHits), Misses: \(self.poolMisses), Growth: \(self.growthCount)"
+            "Pool exhausted. Hits: \(self._poolHits), Misses: \(self._poolMisses), Growth: \(self._growthCount)"
         )
 
         var newBuffer = Data()
@@ -77,9 +95,9 @@ public final class AudioBufferPool: @unchecked Sendable {
         defer { os_unfair_lock_unlock(&unfairLock) }
 
         return [
-            "poolHits": poolHits,
-            "poolMisses": poolMisses,
-            "growthCount": growthCount,
+            "poolHits": _poolHits,
+            "poolMisses": _poolMisses,
+            "growthCount": _growthCount,
             "availableBuffers": availableBuffers.count,
             "initialPoolSize": initialPoolSize
         ]
@@ -90,16 +108,21 @@ public final class AudioBufferPool: @unchecked Sendable {
         os_unfair_lock_lock(&unfairLock)
         defer { os_unfair_lock_unlock(&unfairLock) }
 
-        poolHits = 0
-        poolMisses = 0
-        growthCount = 0
+        _poolHits = 0
+        _poolMisses = 0
+        _growthCount = 0
     }
 
     /// Logs current pool metrics.
     public func logMetrics() {
         let metrics = metricsSnapshot()
+        let hits = metrics["poolHits"] ?? 0
+        let misses = metrics["poolMisses"] ?? 0
+        let growth = metrics["growthCount"] ?? 0
+        let available = metrics["availableBuffers"] ?? 0
+
         logger.info(
-            "AudioBufferPool metrics - Hits: \(metrics["poolHits"] ?? 0), Misses: \(metrics["poolMisses"] ?? 0), Growth: \(metrics["growthCount"] ?? 0), Available: \(metrics["availableBuffers"] ?? 0)"
+            "Pool metrics. Hits: \(hits), Misses: \(misses), Growth: \(growth), Available: \(available)"
         )
     }
 }

--- a/Sources/SpeakiOS/Services/OpenClawChatCoordinator+HandsFree.swift
+++ b/Sources/SpeakiOS/Services/OpenClawChatCoordinator+HandsFree.swift
@@ -190,9 +190,16 @@ extension OpenClawChatCoordinator {
         let keyword = settings.keywordAcknowledgePhrase.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !keyword.isEmpty else { return trimmed }
 
-        let pattern = "(?i)[\\s\\p{P}]*\(NSRegularExpression.escapedPattern(for: keyword))[\\s\\p{P}]*$"
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            return trimmed
+        let regex: NSRegularExpression
+        if let cached = cachedKeywordRegex, cached.keyword == keyword {
+            regex = cached.regex
+        } else {
+            let pattern = "(?i)[\\s\\p{P}]*\(NSRegularExpression.escapedPattern(for: keyword))[\\s\\p{P}]*$"
+            guard let compiled = try? NSRegularExpression(pattern: pattern) else {
+                return trimmed
+            }
+            cachedKeywordRegex = (keyword: keyword, regex: compiled)
+            regex = compiled
         }
 
         let range = NSRange(trimmed.startIndex..<trimmed.endIndex, in: trimmed)

--- a/Sources/SpeakiOS/Services/OpenClawChatCoordinator.swift
+++ b/Sources/SpeakiOS/Services/OpenClawChatCoordinator.swift
@@ -126,6 +126,7 @@ public final class OpenClawChatCoordinator: ObservableObject {
     var settingsCancellables = Set<AnyCancellable>()
     var headsetToggleTarget: Any?
     var headsetPauseTarget: Any?
+    var cachedKeywordRegex: (keyword: String, regex: NSRegularExpression)?
 
     let logger = Logger(subsystem: "com.justspeaktoit.ios", category: "OpenClawChat")
 

--- a/Tests/SpeakCoreTests/AudioBufferPoolTests.swift
+++ b/Tests/SpeakCoreTests/AudioBufferPoolTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+
+@testable import SpeakCore
+
+final class AudioBufferPoolTests: XCTestCase {
+
+    // MARK: - Initial State
+
+    func testInit_defaultPoolSize_preAllocatesBuffers() {
+        let pool = AudioBufferPool(poolSize: 5, bufferSize: 512)
+        let metrics = pool.metricsSnapshot()
+        XCTAssertEqual(metrics["availableBuffers"], 5, "Should pre-allocate the requested number of buffers")
+        XCTAssertEqual(metrics["initialPoolSize"], 5)
+    }
+
+    func testInit_metricsStartAtZero() {
+        let pool = AudioBufferPool(poolSize: 3, bufferSize: 256)
+        XCTAssertEqual(pool.poolHits, 0)
+        XCTAssertEqual(pool.poolMisses, 0)
+        XCTAssertEqual(pool.growthCount, 0)
+    }
+
+    // MARK: - Checkout from pool
+
+    func testCheckout_fromNonEmptyPool_incrementsHits() {
+        let pool = AudioBufferPool(poolSize: 2, bufferSize: 64)
+        _ = pool.checkout()
+        XCTAssertEqual(pool.poolHits, 1, "Checkout from non-empty pool should increment hits")
+        XCTAssertEqual(pool.poolMisses, 0)
+    }
+
+    func testCheckout_reducesAvailableBufferCount() {
+        let pool = AudioBufferPool(poolSize: 3, bufferSize: 64)
+        _ = pool.checkout()
+        _ = pool.checkout()
+        let metrics = pool.metricsSnapshot()
+        XCTAssertEqual(metrics["availableBuffers"], 1, "Two checkouts from a 3-buffer pool should leave 1 available")
+    }
+
+    func testCheckout_returnsDataWithReservedCapacity() {
+        let pool = AudioBufferPool(poolSize: 1, bufferSize: 1024)
+        var buffer = pool.checkout()
+        XCTAssertTrue(buffer.isEmpty, "Should return an empty Data buffer")
+
+        buffer.append(contentsOf: [0x01, 0x02])
+        XCTAssertEqual(buffer, Data([0x01, 0x02]), "Checked-out buffers should be usable")
+    }
+
+    // MARK: - Pool exhaustion (miss path)
+
+    func testCheckout_exhaustedPool_incrementsMissesAndGrowth() {
+        let pool = AudioBufferPool(poolSize: 1, bufferSize: 64)
+        _ = pool.checkout() // drains the pool
+        _ = pool.checkout() // pool is empty - should miss
+        XCTAssertEqual(pool.poolMisses, 1, "Checkout from empty pool should increment misses")
+        XCTAssertEqual(pool.growthCount, 1, "Growth count should increment on miss")
+    }
+
+    func testCheckout_exhaustedPool_returnsValidBuffer() {
+        let pool = AudioBufferPool(poolSize: 0, bufferSize: 64)
+        var buffer = pool.checkout()
+        XCTAssertTrue(buffer.isEmpty, "Even an exhausted pool should return an empty usable buffer")
+
+        buffer.append(contentsOf: [0x01, 0x02])
+        XCTAssertEqual(buffer, Data([0x01, 0x02]))
+        XCTAssertEqual(pool.poolMisses, 1)
+    }
+
+    // MARK: - Return buffer
+
+    func testReturnBuffer_increasesAvailableCount() {
+        let pool = AudioBufferPool(poolSize: 1, bufferSize: 64)
+        var buffer = pool.checkout()
+        XCTAssertEqual(pool.metricsSnapshot()["availableBuffers"], 0, "Pool should be empty after checkout")
+        pool.returnBuffer(&buffer)
+        XCTAssertEqual(pool.metricsSnapshot()["availableBuffers"], 1, "Pool should have 1 buffer after return")
+    }
+
+    func testReturnBuffer_clearsBufferContents() {
+        let pool = AudioBufferPool(poolSize: 1, bufferSize: 64)
+        var buffer = pool.checkout()
+        buffer.append(contentsOf: [0x01, 0x02, 0x03, 0x04])
+        XCTAssertFalse(buffer.isEmpty, "Buffer should have contents before return")
+        pool.returnBuffer(&buffer)
+        XCTAssertTrue(buffer.isEmpty, "returnBuffer should clear the buffer contents for security")
+    }
+
+    func testReturnBuffer_returnedBufferIsReusable() {
+        let pool = AudioBufferPool(poolSize: 1, bufferSize: 64)
+        var buffer = pool.checkout()
+        buffer.append(contentsOf: [0xFF, 0xAA])
+        pool.returnBuffer(&buffer)
+
+        // Second checkout should reuse the returned buffer (pool hit)
+        _ = pool.checkout()
+        XCTAssertEqual(pool.poolHits, 2, "Second checkout should be a pool hit (buffer was returned)")
+    }
+
+    // MARK: - Checkout/Return cycles
+
+    func testCheckoutReturn_multipleRoundTrips_noBufferLeak() {
+        let pool = AudioBufferPool(poolSize: 3, bufferSize: 128)
+        for _ in 0..<5 {
+            var buf = pool.checkout()
+            buf.append(contentsOf: [0x01])
+            pool.returnBuffer(&buf)
+        }
+        let metrics = pool.metricsSnapshot()
+        XCTAssertEqual(metrics["availableBuffers"], 3, "Round-trips should not change pool size")
+    }
+
+    // MARK: - Metrics snapshot
+
+    func testMetricsSnapshot_containsExpectedKeys() {
+        let pool = AudioBufferPool(poolSize: 2, bufferSize: 64)
+        let metrics = pool.metricsSnapshot()
+        XCTAssertNotNil(metrics["poolHits"])
+        XCTAssertNotNil(metrics["poolMisses"])
+        XCTAssertNotNil(metrics["growthCount"])
+        XCTAssertNotNil(metrics["availableBuffers"])
+        XCTAssertNotNil(metrics["initialPoolSize"])
+    }
+
+    func testMetricsSnapshot_afterMixedOperations_reflectsCorrectCounts() {
+        let pool = AudioBufferPool(poolSize: 2, bufferSize: 64)
+        _ = pool.checkout() // hit 1
+        _ = pool.checkout() // hit 2
+        _ = pool.checkout() // miss 1 (pool exhausted)
+
+        XCTAssertEqual(pool.poolHits, 2)
+        XCTAssertEqual(pool.poolMisses, 1)
+        XCTAssertEqual(pool.growthCount, 1)
+    }
+
+    // MARK: - Reset metrics
+
+    func testResetMetrics_clearsAllCounters() {
+        let pool = AudioBufferPool(poolSize: 1, bufferSize: 64)
+        _ = pool.checkout()
+        _ = pool.checkout() // forces a miss
+        XCTAssertGreaterThan(pool.poolHits + pool.poolMisses, 0, "Should have some metrics before reset")
+
+        pool.resetMetrics()
+
+        XCTAssertEqual(pool.poolHits, 0, "poolHits should be 0 after reset")
+        XCTAssertEqual(pool.poolMisses, 0, "poolMisses should be 0 after reset")
+        XCTAssertEqual(pool.growthCount, 0, "growthCount should be 0 after reset")
+    }
+
+    func testResetMetrics_doesNotAffectAvailableBuffers() {
+        let pool = AudioBufferPool(poolSize: 3, bufferSize: 64)
+        _ = pool.checkout()
+        pool.resetMetrics()
+        let metrics = pool.metricsSnapshot()
+        XCTAssertEqual(metrics["availableBuffers"], 2, "resetMetrics should not affect the buffer pool itself")
+    }
+
+    // MARK: - Thread safety
+
+    func testCheckout_concurrentAccess_metricsRemainConsistent() {
+        let pool = AudioBufferPool(poolSize: 10, bufferSize: 64)
+        let iterations = 50
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            _ = pool.checkout()
+        }
+
+        let totalOps = pool.poolHits + pool.poolMisses
+        XCTAssertEqual(totalOps, iterations, "Total ops (hits + misses) should equal number of checkouts")
+    }
+
+    func testReturnBuffer_concurrentReturns_noDeadlock() {
+        let pool = AudioBufferPool(poolSize: 5, bufferSize: 64)
+
+        DispatchQueue.concurrentPerform(iterations: 20) { _ in
+            var buf = pool.checkout()
+            buf.append(contentsOf: [0x01, 0x02])
+            pool.returnBuffer(&buf)
+        }
+
+        // No assertion beyond "no deadlock / no crash"
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary
- cache compiled regular expressions in the personal lexicon and iOS OpenClaw keyword acknowledgement paths
- precompute lowercased WordDiffer tokens to avoid repeated work in prefix/suffix and LCS comparisons
- add AudioBufferPool coverage from the remote test-assist branch, with a compile-safe checkout assertion

## Remote branch review
Selected and integrated:
- `origin/perf-assist/cache-nsregularexpression-4798d0d5abe1e0e5`
- `origin/perf-assist/worddifer-lcs-precompute-v3-4023396b2a7548da`
- `origin/test-assist/audio-buffer-pool-c458f9204b31f1c6`

Skipped for now:
- no open GitHub PR objects exist for this repo
- memory branches have unrelated histories
- agentic workflow branches conflict heavily with current workflow files
- duplicate/stale test branches either already exist on `main` or conflict with current tests
- `origin/test-assist/transcription-provider-error-tests-20260401-e1350b566d08a76f` adds a duplicate `TranscriptionProviderErrorTests` class
- HistoryManager perf branches need dedicated behavioural coverage before merging because they alter persistence/statistics semantics

## Conformance
No findings from the conformance profile check. The changes stay inside existing module homes and reuse existing abstractions.

## Validation
- `swift test --disable-automatic-resolution --filter AudioBufferPoolTests`
- `swift test --disable-automatic-resolution --filter WordDifferTests`
- `swift test --disable-automatic-resolution --filter PersonalLexiconServiceTests`
- `swift build --disable-automatic-resolution --target SpeakiOSLib`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved alias and keyword matching performance for faster, more responsive interactions.
  * Added a new issue-tracking data set to support broader project tracking.

* **Bug Fixes**
  * Kept word comparison behavior case-insensitive while reducing unnecessary processing.
  * Improved buffer handling and reuse for more reliable audio operations.

* **Tests**
  * Added coverage for audio buffer pooling, including reuse, metrics, and concurrency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->