### PR TITLE
feat(mac): add OpenAI GPT-4o diarized transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Just Speak to It supports multiple live and batch transcription backends on macO
 ### macOS
 
 - **Live**: Apple Speech (`apple/local/SFSpeechRecognizer`), Apple Dictation (`apple/local/Dictation`), Deepgram (`deepgram/nova-3-streaming`), Modulate (`modulate/velma-2-stt-streaming`), AssemblyAI (`assemblyai/universal-streaming`, `assemblyai/universal-streaming-english`, `assemblyai/universal-streaming-multilingual`, `assemblyai/u3-rt-pro-streaming`), and ElevenLabs Scribe (`elevenlabs/scribe-v2-streaming`).
-- **Batch**: OpenAI Whisper (`openai/whisper-1`), Rev.ai (`revai/default`), Deepgram (`deepgram/nova-3`), Modulate (`modulate/velma-2-stt-batch`, `modulate/velma-2-stt-batch-english-vfast`), AssemblyAI (`assemblyai/universal-3-pro`, `assemblyai/universal-2`), ElevenLabs Scribe (`elevenlabs/scribe_v1`, `elevenlabs/scribe_v1_experimental`), and OpenRouter audio models such as `google/gemini-2.0-flash-001`, `google/gemini-2.0-flash-lite-001`, and `openai/gpt-4o-audio-preview-2024-12-17`.
+- **Batch**: OpenAI Whisper / GPT-4o Transcribe (`openai/whisper-1`, `openai/gpt-4o-mini-transcribe`, `openai/gpt-4o-transcribe`, `openai/gpt-4o-transcribe-diarize`), Rev.ai (`revai/default`), Deepgram (`deepgram/nova-3`), Modulate (`modulate/velma-2-stt-batch`, `modulate/velma-2-stt-batch-english-vfast`), AssemblyAI (`assemblyai/universal-3-pro`, `assemblyai/universal-2`), ElevenLabs Scribe (`elevenlabs/scribe_v1`, `elevenlabs/scribe_v1_experimental`), and OpenRouter audio models such as `google/gemini-2.0-flash-001`, `google/gemini-2.0-flash-lite-001`, and `openai/gpt-4o-audio-preview-2024-12-17`.
 - API keys are stored in the Keychain. The same ElevenLabs key is reused for both TTS and Scribe STT.
 
 ### iOS

--- a/Sources/SpeakApp/OpenAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAITranscriptionProvider.swift
@@ -196,7 +196,7 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
     if let duration = response.duration, duration > 0 {
       return duration
     }
-    if let lastSegmentEnd = response.segments?.map(\.end).max(), lastSegmentEnd > 0 {
+    if let lastSegmentEnd = response.segments?.last?.end, lastSegmentEnd > 0 {
       return lastSegmentEnd
     }
     let asset = AVURLAsset(url: audioURL)

--- a/Sources/SpeakApp/OpenAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAITranscriptionProvider.swift
@@ -38,14 +38,11 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
     // Extract model name without provider prefix
     let modelName = model.split(separator: "/").last.map(String.init) ?? model
 
-    // Only Whisper models support "verbose_json" (with per-segment timestamps).
-    // The gpt-* transcription models (and likely future OpenAI models) only
-    // support "json" or "text", so default everything that isn't a Whisper
-    // family model to "json".
-    let responseFormat = modelName.hasPrefix("whisper") ? "verbose_json" : "json"
-
     body.appendFormField(named: "model", value: modelName, boundary: boundary)
-    body.appendFormField(named: "response_format", value: responseFormat, boundary: boundary)
+    body.appendFormField(named: "response_format", value: responseFormat(for: modelName), boundary: boundary)
+    if requiresChunkingStrategy(modelName) {
+      body.appendFormField(named: "chunking_strategy", value: "auto", boundary: boundary)
+    }
 
     if let language {
       // OpenAI expects ISO-639-1 (2-letter code), not full locale (e.g., "en" not "en_GB")
@@ -135,8 +132,27 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
         id: "openai/gpt-4o-transcribe",
         displayName: "GPT-4o Transcribe",
         description: "Flagship transcription model with strong accuracy on noisy, accented audio."
+      ),
+      ModelCatalog.Option(
+        id: "openai/gpt-4o-transcribe-diarize",
+        displayName: "GPT-4o Transcribe Diarize",
+        description: "Speaker-aware GPT-4o transcription model with diarized JSON segments."
       )
     ]
+  }
+
+  private func responseFormat(for modelName: String) -> String {
+    if modelName == "gpt-4o-transcribe-diarize" {
+      return "diarized_json"
+    }
+    if modelName.hasPrefix("whisper") {
+      return "verbose_json"
+    }
+    return "json"
+  }
+
+  private func requiresChunkingStrategy(_ modelName: String) -> Bool {
+    modelName == "gpt-4o-transcribe-diarize"
   }
 
   private func extractLanguageCode(from locale: String) -> String {
@@ -152,21 +168,20 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
     model: String,
     payload: Data
   ) async throws -> TranscriptionResult {
-    let asset = AVURLAsset(url: audioURL)
-    let durationTime = try await asset.load(.duration)
-    let duration = durationTime.seconds
+    let duration = await resolvedDuration(for: audioURL, response: response)
+    let transcriptText = response.transcriptText
 
     let segments =
       response.segments?.map { segment in
         TranscriptionSegment(
           startTime: segment.start,
           endTime: segment.end,
-          text: segment.text
+          text: response.segmentText(for: segment)
         )
-      } ?? [TranscriptionSegment(startTime: 0, endTime: duration, text: response.text)]
+      } ?? [TranscriptionSegment(startTime: 0, endTime: duration, text: transcriptText)]
 
     return TranscriptionResult(
-      text: response.text,
+      text: transcriptText,
       segments: segments,
       confidence: nil,
       duration: duration,
@@ -175,6 +190,20 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
       rawPayload: String(data: payload, encoding: .utf8),
       debugInfo: nil
     )
+  }
+
+  private func resolvedDuration(for audioURL: URL, response: OpenAITranscriptionResponse) async -> TimeInterval {
+    if let duration = response.duration, duration > 0 {
+      return duration
+    }
+    if let lastSegmentEnd = response.segments?.map(\.end).max(), lastSegmentEnd > 0 {
+      return lastSegmentEnd
+    }
+    let asset = AVURLAsset(url: audioURL)
+    guard let durationTime = try? await asset.load(.duration), durationTime.seconds.isFinite else {
+      return 0
+    }
+    return durationTime.seconds
   }
 
   private func debugSnapshot(
@@ -208,12 +237,47 @@ private struct OpenAITranscriptionResponse: Decodable {
     let start: TimeInterval
     let end: TimeInterval
     let text: String
+    let speaker: String?
   }
 
-  let text: String
+  let text: String?
   let language: String?
   let duration: TimeInterval?
   let segments: [Segment]?
+
+  var transcriptText: String {
+    if shouldLabelSpeakers {
+      return segments?.map(segmentText(for:)).joined(separator: "\n") ?? (text ?? "")
+    }
+    return text ?? segments?.map(\.text).joined(separator: " ") ?? ""
+  }
+
+  func segmentText(for segment: Segment) -> String {
+    guard shouldLabelSpeakers, let label = speakerLabel(from: segment.speaker) else {
+      return segment.text
+    }
+    return "\(label): \(segment.text)"
+  }
+
+  private var shouldLabelSpeakers: Bool {
+    let speakers = Set((segments ?? []).compactMap { speakerLabel(from: $0.speaker) })
+    return speakers.count > 1
+  }
+
+  private func speakerLabel(from value: String?) -> String? {
+    guard let raw = value?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+      return nil
+    }
+    let uppercased = raw.uppercased()
+    if uppercased.hasPrefix("SPEAKER_") || uppercased.hasPrefix("SPEAKER ") {
+      let digits = raw.filter(\.isNumber)
+      if let index = Int(digits) {
+        return "Speaker \(index + 1)"
+      }
+      return raw.replacingOccurrences(of: "_", with: " ").capitalized
+    }
+    return raw
+  }
 }
 
 // MARK: - Error Types

--- a/Sources/SpeakApp/OpenAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAITranscriptionProvider.swift
@@ -171,14 +171,18 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
     let duration = await resolvedDuration(for: audioURL, response: response)
     let transcriptText = response.transcriptText
 
-    let segments =
+    let mappedSegments =
       response.segments?.map { segment in
         TranscriptionSegment(
           startTime: segment.start,
           endTime: segment.end,
           text: response.segmentText(for: segment)
         )
-      } ?? [TranscriptionSegment(startTime: 0, endTime: duration, text: transcriptText)]
+      } ?? []
+    let segments =
+      mappedSegments.isEmpty
+      ? [TranscriptionSegment(startTime: 0, endTime: duration, text: transcriptText)]
+      : mappedSegments
 
     return TranscriptionResult(
       text: transcriptText,
@@ -261,7 +265,7 @@ private struct OpenAITranscriptionResponse: Decodable {
 
   private var shouldLabelSpeakers: Bool {
     let speakers = Set((segments ?? []).compactMap { speakerLabel(from: $0.speaker) })
-    return speakers.count > 1
+    return !speakers.isEmpty
   }
 
   private func speakerLabel(from value: String?) -> String? {

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -184,6 +184,11 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             description: "OpenAI's flagship transcription model with strong accuracy on noisy, accented audio.",
             estimatedLatencyMs: 900, latencyTier: .fast),
         Option(
+            id: "openai/gpt-4o-transcribe-diarize",
+            displayName: "GPT-4o Transcribe Diarize (OpenAI)",
+            description: "OpenAI's speaker-aware GPT-4o transcription model with diarized JSON segments.",
+            estimatedLatencyMs: 1100, latencyTier: .medium),
+        Option(
             id: "revai/default", displayName: "Rev.ai",
             description: "Rev.ai's speech recognition. High accuracy with speaker identification.",
             estimatedLatencyMs: 1500, latencyTier: .medium),

--- a/Tests/SpeakAppTests/OpenAITranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/OpenAITranscriptionProviderTests.swift
@@ -95,6 +95,49 @@ final class OpenAITranscriptionProviderTests: XCTestCase {
     XCTAssertEqual(result.segments.map(\.text), ["Speaker 1: Hello there.", "Speaker 2: Hi back."])
   }
 
+  func testTranscribeFileWithDiarize_preservesSingleSpeakerLabels() async throws {
+    let responseBody = """
+    {
+      "text": "Only me.",
+      "segments": [
+        {"speaker": "SPEAKER_00", "start": 0.0, "end": 1.0, "text": "Only me."}
+      ]
+    }
+    """
+    OpenAIMockURLProtocol.requestHandler = { request in
+      try Self.makeResponse(for: request, body: responseBody)
+    }
+    defer { OpenAIMockURLProtocol.requestHandler = nil }
+
+    let result = try await makeProvider().transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-openai-key",
+      model: "openai/gpt-4o-transcribe-diarize",
+      language: nil
+    )
+
+    XCTAssertEqual(result.text, "Speaker 1: Only me.")
+    XCTAssertEqual(result.segments.map(\.text), ["Speaker 1: Only me."])
+  }
+
+  func testTranscribeFileWithEmptySegments_fallsBackToTranscriptText() async throws {
+    OpenAIMockURLProtocol.requestHandler = { request in
+      try Self.makeResponse(for: request, body: #"{"text":"fallback transcript","segments":[]}"#)
+    }
+    defer { OpenAIMockURLProtocol.requestHandler = nil }
+
+    let result = try await makeProvider().transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-openai-key",
+      model: "openai/gpt-4o-transcribe",
+      language: nil
+    )
+
+    XCTAssertEqual(result.text, "fallback transcript")
+    XCTAssertEqual(result.segments.count, 1)
+    XCTAssertEqual(result.segments.first?.text, "fallback transcript")
+  }
+
   private func makeProvider() -> OpenAITranscriptionProvider {
     OpenAITranscriptionProvider(session: makeMockSession())
   }

--- a/Tests/SpeakAppTests/OpenAITranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/OpenAITranscriptionProviderTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+@testable import SpeakCore
+
+final class OpenAITranscriptionProviderTests: XCTestCase {
+  func testModelCatalogBatchTranscription_includesGPT4oTranscribeDiarize() {
+    let ids = ModelCatalog.batchTranscription.map(\.id)
+
+    XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe-diarize"))
+  }
+
+  func testSupportedModels_includeGPT4oTranscriptionFamily() {
+    let ids = OpenAITranscriptionProvider().supportedModels().map(\.id)
+
+    XCTAssertTrue(ids.contains("openai/whisper-1"))
+    XCTAssertTrue(ids.contains("openai/gpt-4o-mini-transcribe"))
+    XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe"))
+    XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe-diarize"))
+  }
+
+  func testProviderRegistry_routesGPT4oTranscriptionFamilyToOpenAIProvider() async {
+    for model in [
+      "openai/gpt-4o-mini-transcribe",
+      "openai/gpt-4o-transcribe",
+      "openai/gpt-4o-transcribe-diarize"
+    ] {
+      let provider = await TranscriptionProviderRegistry.shared.provider(forModel: model)
+      XCTAssertEqual(provider?.metadata.id, "openai", "\(model) should route to OpenAI provider")
+    }
+  }
+
+  func testTranscribeFileWithGPT4oTranscribe_usesJSONResponseFormat() async throws {
+    let requestObserver = OpenAIRequestObserver()
+    OpenAIMockURLProtocol.requestHandler = { request in
+      await requestObserver.store(request: request)
+      return try Self.makeResponse(for: request, body: #"{"text":"hello world","duration":1.25}"#)
+    }
+    defer { OpenAIMockURLProtocol.requestHandler = nil }
+
+    let result = try await makeProvider().transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-openai-key",
+      model: "openai/gpt-4o-transcribe",
+      language: "en_GB"
+    )
+
+    let capturedBody = await requestObserver.capturedBodyString()
+    let body = try XCTUnwrap(capturedBody)
+    XCTAssertTrue(body.contains(#"name="model""#))
+    XCTAssertTrue(body.contains("gpt-4o-transcribe"))
+    XCTAssertTrue(body.contains(#"name="response_format""#))
+    XCTAssertTrue(body.contains("json"))
+    XCTAssertFalse(body.contains("verbose_json"))
+    XCTAssertFalse(body.contains("chunking_strategy"))
+    XCTAssertTrue(body.contains(#"name="language""#))
+    XCTAssertTrue(body.contains("\r\nen\r\n"))
+    XCTAssertEqual(result.text, "hello world")
+    XCTAssertEqual(result.duration, 1.25)
+  }
+
+  func testTranscribeFileWithDiarize_usesDiarizedJSONAndLabelsSpeakers() async throws {
+    let requestObserver = OpenAIRequestObserver()
+    let responseBody = """
+    {
+      "text": "Hello there. Hi back.",
+      "segments": [
+        {"speaker": "SPEAKER_00", "start": 0.0, "end": 1.0, "text": "Hello there."},
+        {"speaker": "SPEAKER_01", "start": 1.1, "end": 2.0, "text": "Hi back."}
+      ]
+    }
+    """
+    OpenAIMockURLProtocol.requestHandler = { request in
+      await requestObserver.store(request: request)
+      return try Self.makeResponse(for: request, body: responseBody)
+    }
+    defer { OpenAIMockURLProtocol.requestHandler = nil }
+
+    let result = try await makeProvider().transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-openai-key",
+      model: "openai/gpt-4o-transcribe-diarize",
+      language: nil
+    )
+
+    let capturedBody = await requestObserver.capturedBodyString()
+    let body = try XCTUnwrap(capturedBody)
+    XCTAssertTrue(body.contains("gpt-4o-transcribe-diarize"))
+    XCTAssertTrue(body.contains("diarized_json"))
+    XCTAssertTrue(body.contains(#"name="chunking_strategy""#))
+    XCTAssertTrue(body.contains("\r\nauto\r\n"))
+    XCTAssertEqual(result.text, "Speaker 1: Hello there.\nSpeaker 2: Hi back.")
+    XCTAssertEqual(result.duration, 2.0)
+    XCTAssertEqual(result.segments.map(\.text), ["Speaker 1: Hello there.", "Speaker 2: Hi back."])
+  }
+
+  private func makeProvider() -> OpenAITranscriptionProvider {
+    OpenAITranscriptionProvider(session: makeMockSession())
+  }
+
+  private func makeMockSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [OpenAIMockURLProtocol.self]
+    return URLSession(configuration: configuration)
+  }
+
+  private func makeAudioFile() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("openai-transcription-\(UUID().uuidString).m4a")
+    try Data("fake-audio".utf8).write(to: url)
+    addTeardownBlock {
+      try? FileManager.default.removeItem(at: url)
+    }
+    return url
+  }
+
+  private static func makeResponse(for request: URLRequest, body: String) throws -> (HTTPURLResponse, Data) {
+    let response = HTTPURLResponse(
+      url: try XCTUnwrap(request.url),
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: ["Content-Type": "application/json"]
+    )!
+    return (response, Data(body.utf8))
+  }
+}
+
+private actor OpenAIRequestObserver {
+  private var request: URLRequest?
+  private var body: Data?
+
+  func store(request: URLRequest) {
+    self.request = request
+    body = request.httpBody ?? readBody(from: request.httpBodyStream)
+  }
+
+  func capturedBodyString() -> String? {
+    body.flatMap { String(data: $0, encoding: .utf8) }
+  }
+
+  private func readBody(from stream: InputStream?) -> Data? {
+    guard let stream else { return nil }
+    stream.open()
+    defer { stream.close() }
+
+    var data = Data()
+    let bufferSize = 4096
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+
+    while stream.hasBytesAvailable {
+      let readCount = stream.read(buffer, maxLength: bufferSize)
+      if readCount <= 0 { break }
+      data.append(buffer, count: readCount)
+    }
+    return data.isEmpty ? nil : data
+  }
+}
+
+private final class OpenAIMockURLProtocol: URLProtocol {
+  nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+
+  override static func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    guard let handler = Self.requestHandler else {
+      XCTFail("OpenAIMockURLProtocol.requestHandler was not set")
+      return
+    }
+
+    Task {
+      do {
+        let (response, data) = try await handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+      } catch {
+        client?.urlProtocol(self, didFailWithError: error)
+      }
+    }
+  }
+
+  override func stopLoading() {}
+}


### PR DESCRIPTION
## Summary
- add `openai/gpt-4o-transcribe-diarize` to the batch transcription catalogue
- route the full OpenAI GPT-4o transcription family through the existing OpenAI provider
- use the correct OpenAI response formats: `json` for GPT-4o, `diarized_json` + `chunking_strategy=auto` for diarize
- surface diarized speaker labels in transcript text/segments where the current DTO can carry them

## Worthiness check
This is worth shipping and distinct from existing `openai/whisper-1`: OpenAI documents GPT-4o Transcribe as higher quality than Whisper, and the diarize model adds speaker-aware output that the current OpenAI provider does not expose. It reuses the existing OpenAI API key/provider, so the integration cost is low.

## Validation
- `swift test --disable-automatic-resolution --filter OpenAITranscriptionProviderTests`
- `swift test --disable-automatic-resolution --filter ModelCatalogTests`
- conformance check: no findings

Fixes #452


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new GPT-4o diarized transcription option with speaker-aware output.
  * Expanded the available batch transcription model list to include additional OpenAI models.

* **Bug Fixes**
  * Improved transcription result handling for more reliable duration detection and cleaner text output.
  * Added speaker labeling to multi-speaker transcripts when multiple speakers are detected.

* **Tests**
  * Added coverage for request formatting, model routing, and diarized response parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->