### PR TITLE
feat(mac): add Deepgram Flux streaming models

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Just Speak to It supports multiple live and batch transcription backends on macO
 
 ### macOS
 
-- **Live**: Apple Speech (`apple/local/SFSpeechRecognizer`), Apple Dictation (`apple/local/Dictation`), Deepgram (`deepgram/nova-3-streaming`), Modulate (`modulate/velma-2-stt-streaming`), AssemblyAI (`assemblyai/universal-streaming`, `assemblyai/universal-streaming-english`, `assemblyai/universal-streaming-multilingual`, `assemblyai/u3-rt-pro-streaming`), and ElevenLabs Scribe (`elevenlabs/scribe-v2-streaming`).
+- **Live**: Apple Speech (`apple/local/SFSpeechRecognizer`), Apple Dictation (`apple/local/Dictation`), Deepgram (`deepgram/nova-3-streaming`, `deepgram/flux-general-en-streaming`, `deepgram/flux-general-multi-streaming`), Modulate (`modulate/velma-2-stt-streaming`), AssemblyAI (`assemblyai/universal-streaming`, `assemblyai/universal-streaming-english`, `assemblyai/universal-streaming-multilingual`, `assemblyai/u3-rt-pro-streaming`), and ElevenLabs Scribe (`elevenlabs/scribe-v2-streaming`).
 - **Batch**: OpenAI Whisper / GPT-4o Transcribe (`openai/whisper-1`, `openai/gpt-4o-mini-transcribe`, `openai/gpt-4o-transcribe`, `openai/gpt-4o-transcribe-diarize`), Groq Whisper (`groq/whisper-large-v3-turbo`), Rev.ai (`revai/default`), Deepgram (`deepgram/nova-3`), Modulate (`modulate/velma-2-stt-batch`, `modulate/velma-2-stt-batch-english-vfast`), AssemblyAI (`assemblyai/universal-3-pro`, `assemblyai/universal-2`), ElevenLabs Scribe (`elevenlabs/scribe_v1`, `elevenlabs/scribe_v1_experimental`), and OpenRouter audio models such as `google/gemini-2.0-flash-001`, `google/gemini-2.0-flash-lite-001`, and `openai/gpt-4o-audio-preview-2024-12-17`.
 - API keys are stored in the Keychain. The same ElevenLabs key is reused for both TTS and Scribe STT.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Just Speak to It supports multiple live and batch transcription backends on macO
 
 ### macOS
 
-- **Live**: Apple Speech (`apple/local/SFSpeechRecognizer`), Apple Dictation (`apple/local/Dictation`), Deepgram (`deepgram/nova-3-streaming`, `deepgram/flux-general-en-streaming`, `deepgram/flux-general-multi-streaming`), Modulate (`modulate/velma-2-stt-streaming`), AssemblyAI (`assemblyai/universal-streaming`, `assemblyai/universal-streaming-english`, `assemblyai/universal-streaming-multilingual`, `assemblyai/u3-rt-pro-streaming`), and ElevenLabs Scribe (`elevenlabs/scribe-v2-streaming`).
+- **Live**: Apple Speech (`apple/local/SFSpeechRecognizer`), Apple Dictation (`apple/local/Dictation`), Deepgram (`deepgram/nova-3-streaming`, `deepgram/flux-general-en-streaming`, `deepgram/flux-general-multi-streaming`), Modulate (`modulate/velma-2-stt-streaming`), AssemblyAI (`assemblyai/u3-rt-pro-streaming`), and ElevenLabs Scribe (`elevenlabs/scribe-v2-streaming`).
 - **Batch**: OpenAI Whisper / GPT-4o Transcribe (`openai/whisper-1`, `openai/gpt-4o-mini-transcribe`, `openai/gpt-4o-transcribe`, `openai/gpt-4o-transcribe-diarize`), Groq Whisper (`groq/whisper-large-v3-turbo`), Rev.ai (`revai/default`), Deepgram (`deepgram/nova-3`), Modulate (`modulate/velma-2-stt-batch`, `modulate/velma-2-stt-batch-english-vfast`), AssemblyAI (`assemblyai/universal-3-pro`, `assemblyai/universal-2`), ElevenLabs Scribe (`elevenlabs/scribe_v1`, `elevenlabs/scribe_v1_experimental`), and OpenRouter audio models such as `google/gemini-2.0-flash-001`, `google/gemini-2.0-flash-lite-001`, and `openai/gpt-4o-audio-preview-2024-12-17`.
 - API keys are stored in the Keychain. The same ElevenLabs key is reused for both TTS and Scribe STT.
 

--- a/Sources/SpeakApp/DeepgramTranscriptionProvider.swift
+++ b/Sources/SpeakApp/DeepgramTranscriptionProvider.swift
@@ -49,27 +49,7 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
         self.onTranscript = onTranscript
         self.onError = onError
 
-        var urlComponents = URLComponents(string: "wss://api.deepgram.com/v1/listen")!
-        var queryItems = [
-            URLQueryItem(name: "model", value: model),
-            URLQueryItem(name: "punctuate", value: "true"),
-            URLQueryItem(name: "smart_format", value: "true"),
-            URLQueryItem(name: "numerals", value: "true"),
-            URLQueryItem(name: "interim_results", value: "true"),
-            URLQueryItem(name: "encoding", value: "linear16"),
-            URLQueryItem(name: "sample_rate", value: String(sampleRate)),
-            URLQueryItem(name: "channels", value: "1"),
-            URLQueryItem(name: "endpointing", value: "300"),
-            URLQueryItem(name: "vad_events", value: "true")
-        ]
-        if let language {
-            let languageCode = extractLanguageCode(from: language)
-            queryItems.append(URLQueryItem(name: "language", value: languageCode))
-        }
-
-        urlComponents.queryItems = queryItems
-
-        guard let url = urlComponents.url else {
+        guard let url = Self.webSocketURL(model: model, language: language, sampleRate: sampleRate) else {
             onError(DeepgramError.invalidURL)
             return
         }
@@ -219,26 +199,82 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
 
     private func parseTranscriptResponse(_ json: String) {
         logger.debug("Received Deepgram response (length: \(json.count))")
-        guard let data = json.data(using: .utf8) else { return }
-
-        do {
-            let response = try JSONDecoder().decode(DeepgramStreamResponse.self, from: data)
-
-            guard let channel = response.channel,
-                  let alternative = channel.alternatives.first,
-                  !alternative.transcript.isEmpty else {
-                return
-            }
-
-            let isFinal = response.is_final ?? false
-            onTranscript?(alternative.transcript, isFinal)
-
-        } catch {
-            logger.debug("Failed to parse transcript response: \(error.localizedDescription)")
+        guard let event = Self.transcriptEvent(from: json, model: model) else {
+            logger.debug("Failed to parse transcript response")
+            return
         }
+        onTranscript?(event.text, event.isFinal)
+    }
+
+    nonisolated static func transcriptEvent(from json: String, model: String) -> (text: String, isFinal: Bool)? {
+        guard let data = json.data(using: .utf8) else { return nil }
+
+        if model.hasPrefix("flux-") {
+            guard
+                let response = try? JSONDecoder().decode(DeepgramFluxResponse.self, from: data),
+                !response.transcript.isEmpty
+            else {
+                return nil
+            }
+            return (response.transcript, response.event == .endOfTurn)
+        }
+
+        guard
+            let response = try? JSONDecoder().decode(DeepgramStreamResponse.self, from: data),
+            let channel = response.channel,
+            let alternative = channel.alternatives.first,
+            !alternative.transcript.isEmpty
+        else {
+            return nil
+        }
+        return (alternative.transcript, response.is_final ?? false)
+    }
+
+    nonisolated static func webSocketURL(model: String, language: String?, sampleRate: Int) -> URL? {
+        let isFlux = model.hasPrefix("flux-")
+        var urlComponents = URLComponents(
+            string: isFlux
+                ? "wss://api.deepgram.com/v2/listen"
+                : "wss://api.deepgram.com/v1/listen"
+        )!
+        var queryItems = [
+            URLQueryItem(name: "model", value: model),
+            URLQueryItem(name: "encoding", value: "linear16"),
+            URLQueryItem(name: "sample_rate", value: String(sampleRate))
+        ]
+
+        if isFlux {
+            if model == "flux-general-multi", let language {
+                queryItems.append(URLQueryItem(name: "language_hint", value: extractLanguageCode(from: language)))
+            }
+        } else {
+            queryItems.append(contentsOf: [
+                URLQueryItem(name: "punctuate", value: "true"),
+                URLQueryItem(name: "smart_format", value: "true"),
+                URLQueryItem(name: "numerals", value: "true"),
+                URLQueryItem(name: "interim_results", value: "true"),
+                URLQueryItem(name: "channels", value: "1"),
+                URLQueryItem(name: "endpointing", value: "300"),
+                URLQueryItem(name: "vad_events", value: "true")
+            ])
+            if let language {
+                queryItems.append(URLQueryItem(name: "language", value: extractLanguageCode(from: language)))
+            }
+        }
+
+        urlComponents.queryItems = queryItems
+        return urlComponents.url
+    }
+
+    private var isFluxModel: Bool {
+        model.hasPrefix("flux-")
     }
 
     private func extractLanguageCode(from locale: String) -> String {
+        Self.extractLanguageCode(from: locale)
+    }
+
+    private nonisolated static func extractLanguageCode(from locale: String) -> String {
         let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
         return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
     }
@@ -503,6 +539,24 @@ private struct DeepgramStreamResponse: Decodable {
 
     let channel: Channel?
     let is_final: Bool?
+}
+
+private struct DeepgramFluxResponse: Decodable {
+    enum Event: String, Decodable {
+        case update = "Update"
+        case startOfTurn = "StartOfTurn"
+        case eagerEndOfTurn = "EagerEndOfTurn"
+        case turnResumed = "TurnResumed"
+        case endOfTurn = "EndOfTurn"
+    }
+
+    let event: Event
+    let transcript: String
+
+    private enum CodingKeys: String, CodingKey {
+        case event
+        case transcript
+    }
 }
 
 private struct DeepgramBatchResponse: Decodable {

--- a/Sources/SpeakApp/DeepgramTranscriptionProvider.swift
+++ b/Sources/SpeakApp/DeepgramTranscriptionProvider.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import SpeakCore
 import AVFoundation
 import Foundation

--- a/Sources/SpeakApp/DeepgramTranscriptionProvider.swift
+++ b/Sources/SpeakApp/DeepgramTranscriptionProvider.swift
@@ -199,10 +199,7 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
 
     private func parseTranscriptResponse(_ json: String) {
         logger.debug("Received Deepgram response (length: \(json.count))")
-        guard let event = Self.transcriptEvent(from: json, model: model) else {
-            logger.debug("Failed to parse transcript response")
-            return
-        }
+        guard let event = Self.transcriptEvent(from: json, model: model) else { return }
         onTranscript?(event.text, event.isFinal)
     }
 
@@ -216,7 +213,7 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
             else {
                 return nil
             }
-            return (response.transcript, response.event == .endOfTurn)
+            return (response.transcript, response.event == "EndOfTurn")
         }
 
         guard
@@ -264,14 +261,6 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
 
         urlComponents.queryItems = queryItems
         return urlComponents.url
-    }
-
-    private var isFluxModel: Bool {
-        model.hasPrefix("flux-")
-    }
-
-    private func extractLanguageCode(from locale: String) -> String {
-        Self.extractLanguageCode(from: locale)
     }
 
     private nonisolated static func extractLanguageCode(from locale: String) -> String {
@@ -542,21 +531,8 @@ private struct DeepgramStreamResponse: Decodable {
 }
 
 private struct DeepgramFluxResponse: Decodable {
-    enum Event: String, Decodable {
-        case update = "Update"
-        case startOfTurn = "StartOfTurn"
-        case eagerEndOfTurn = "EagerEndOfTurn"
-        case turnResumed = "TurnResumed"
-        case endOfTurn = "EndOfTurn"
-    }
-
-    let event: Event
+    let event: String
     let transcript: String
-
-    private enum CodingKeys: String, CodingKey {
-        case event
-        case transcript
-    }
 }
 
 private struct DeepgramBatchResponse: Decodable {

--- a/Sources/SpeakCore/LiveModelCapabilities.swift
+++ b/Sources/SpeakCore/LiveModelCapabilities.swift
@@ -72,6 +72,12 @@ extension ModelCatalog {
         "deepgram/nova-3-streaming": LiveModelCapabilities(
             supportedSpeedModes: [.instant, .livePolish]
         ),
+        "deepgram/flux-general-en-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish]
+        ),
+        "deepgram/flux-general-multi-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish]
+        ),
         "modulate/velma-2-stt-streaming": LiveModelCapabilities(
             supportedSpeedModes: [.instant, .livePolish]
         ),

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -129,6 +129,16 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             description: "Real-time WebSocket streaming transcription with interim results.",
             estimatedLatencyMs: 200, latencyTier: .fast),
         Option(
+            id: "deepgram/flux-general-en-streaming",
+            displayName: "Deepgram Flux (English Streaming)",
+            description: "Conversational streaming model with integrated end-of-turn detection.",
+            estimatedLatencyMs: 180, latencyTier: .fast),
+        Option(
+            id: "deepgram/flux-general-multi-streaming",
+            displayName: "Deepgram Flux (Multilingual Streaming)",
+            description: "Flux conversational streaming with multilingual detection and language hints.",
+            estimatedLatencyMs: 220, latencyTier: .fast),
+        Option(
             id: "modulate/velma-2-stt-streaming", displayName: "Modulate Velma-2 (Streaming)",
             description: "Real-time multilingual WebSocket transcription with diarization and signal detection.",
             estimatedLatencyMs: 220, latencyTier: .fast),

--- a/Tests/SpeakAppTests/DeepgramFluxTranscriptionTests.swift
+++ b/Tests/SpeakAppTests/DeepgramFluxTranscriptionTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+@testable import SpeakCore
+
+final class DeepgramFluxTranscriptionTests: XCTestCase {
+  func testModelCatalogLiveTranscription_includesFluxModels() {
+    let ids = ModelCatalog.liveTranscription.map(\.id)
+
+    XCTAssertTrue(ids.contains("deepgram/flux-general-en-streaming"))
+    XCTAssertTrue(ids.contains("deepgram/flux-general-multi-streaming"))
+  }
+
+  func testFluxModelsSupportLivePolish() {
+    let english = ModelCatalog.liveCapabilities(for: "deepgram/flux-general-en-streaming")
+    let multilingual = ModelCatalog.liveCapabilities(for: "deepgram/flux-general-multi-streaming")
+
+    XCTAssertTrue(english.supportedSpeedModes.contains(.livePolish))
+    XCTAssertTrue(multilingual.supportedSpeedModes.contains(.livePolish))
+  }
+
+  func testWebSocketURL_fluxUsesV2EndpointAndFluxParameters() throws {
+    let url = try XCTUnwrap(
+      DeepgramLiveTranscriber.webSocketURL(
+        model: "flux-general-en",
+        language: "en_GB",
+        sampleRate: 16_000
+      )
+    )
+    let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let query = Dictionary(uniqueKeysWithValues: try XCTUnwrap(components.queryItems).map { ($0.name, $0.value ?? "") })
+
+    XCTAssertEqual(components.scheme, "wss")
+    XCTAssertEqual(components.host, "api.deepgram.com")
+    XCTAssertEqual(components.path, "/v2/listen")
+    XCTAssertEqual(query["model"], "flux-general-en")
+    XCTAssertEqual(query["encoding"], "linear16")
+    XCTAssertEqual(query["sample_rate"], "16000")
+    XCTAssertNil(query["language"])
+    XCTAssertNil(query["language_hint"])
+  }
+
+  func testWebSocketURL_fluxMultilingualUsesLanguageHint() throws {
+    let url = try XCTUnwrap(
+      DeepgramLiveTranscriber.webSocketURL(
+        model: "flux-general-multi",
+        language: "es_ES",
+        sampleRate: 16_000
+      )
+    )
+    let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let query = Dictionary(uniqueKeysWithValues: try XCTUnwrap(components.queryItems).map { ($0.name, $0.value ?? "") })
+
+    XCTAssertEqual(components.path, "/v2/listen")
+    XCTAssertEqual(query["model"], "flux-general-multi")
+    XCTAssertEqual(query["language_hint"], "es")
+  }
+
+  func testWebSocketURL_novaKeepsV1EndpointAndLanguageParameter() throws {
+    let url = try XCTUnwrap(
+      DeepgramLiveTranscriber.webSocketURL(model: "nova-3", language: "en_GB", sampleRate: 16_000)
+    )
+    let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let query = Dictionary(uniqueKeysWithValues: try XCTUnwrap(components.queryItems).map { ($0.name, $0.value ?? "") })
+
+    XCTAssertEqual(components.path, "/v1/listen")
+    XCTAssertEqual(query["model"], "nova-3")
+    XCTAssertEqual(query["interim_results"], "true")
+    XCTAssertEqual(query["language"], "en")
+  }
+
+  func testTranscriptEvent_fluxUpdateProducesPartial() {
+    let json = #"{"event":"Update","transcript":"Hello there"}"#
+    let event = DeepgramLiveTranscriber.transcriptEvent(from: json, model: "flux-general-en")
+
+    XCTAssertEqual(event?.text, "Hello there")
+    XCTAssertEqual(event?.isFinal, false)
+  }
+
+  func testTranscriptEvent_fluxEndOfTurnProducesFinal() {
+    let json = #"{"event":"EndOfTurn","transcript":"Hello there."}"#
+    let event = DeepgramLiveTranscriber.transcriptEvent(from: json, model: "flux-general-en")
+
+    XCTAssertEqual(event?.text, "Hello there.")
+    XCTAssertEqual(event?.isFinal, true)
+  }
+
+  func testTranscriptEvent_fluxEmptyTranscriptIsIgnored() {
+    let json = #"{"event":"Update","transcript":""}"#
+    let event = DeepgramLiveTranscriber.transcriptEvent(from: json, model: "flux-general-en")
+
+    XCTAssertNil(event)
+  }
+
+  func testTranscriptEvent_novaResponseStillParses() {
+    let json = """
+    {
+      "channel": {
+        "alternatives": [
+          {"transcript": "Nova transcript", "confidence": 0.9}
+        ]
+      },
+      "is_final": true
+    }
+    """
+
+    let event = DeepgramLiveTranscriber.transcriptEvent(from: json, model: "nova-3")
+
+    XCTAssertEqual(event?.text, "Nova transcript")
+    XCTAssertEqual(event?.isFinal, true)
+  }
+}


### PR DESCRIPTION
## Summary
- add Deepgram Flux English and multilingual live transcription options
- route Flux model IDs to Deepgram's required `/v2/listen` WebSocket endpoint
- parse Flux turn-state events so `EndOfTurn` commits final transcript segments
- keep Nova-3 on the existing `/v1/listen` path and preserve existing language/query behaviour

## Worthiness check
Flux is worthy and distinct from Nova-3 because Deepgram built it specifically for conversational speech recognition, with model-integrated turn detection and the `/v2/listen` state-machine events. It reuses the existing Deepgram API key and live-controller pipeline, so users get a voice-agent-oriented option without new credentials.

## Validation
- `swift test --disable-automatic-resolution --filter DeepgramFluxTranscriptionTests`
- `swift test --disable-automatic-resolution --filter ModelCatalogTests`
- `swift test --disable-automatic-resolution --filter TranscriptionManagerRoutingTests`
- conformance check: no findings

Fixes #451


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional Deepgram live transcription models, including English and multilingual Flux streaming options.
  * Live transcription now recognizes these models with faster, more capable real-time behavior.
* **Bug Fixes**
  * Improved Deepgram live transcription handling so model-specific streaming responses are parsed correctly.
  * Fixed endpoint selection and language handling for supported live models, helping transcripts return more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->