### PR TITLE
fix: show API key alert on model selection

### DIFF
--- a/Sources/SpeakApp/MainView.swift
+++ b/Sources/SpeakApp/MainView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct MainView: View {
@@ -41,6 +42,12 @@ struct MainView: View {
         environment.apiKeysScrollTarget = target
         selection = .settings(.apiKeys)
         environment.main.missingLiveAPIKeyAlert = nil
+      }
+      if let url = alert.provider.apiKeyURL {
+        Button("Get API Key") {
+          NSWorkspace.shared.open(url)
+          environment.main.missingLiveAPIKeyAlert = nil
+        }
       }
       Button("Cancel", role: .cancel) {
         environment.main.missingLiveAPIKeyAlert = nil

--- a/Sources/SpeakApp/MissingLiveAPIKeyAlert.swift
+++ b/Sources/SpeakApp/MissingLiveAPIKeyAlert.swift
@@ -19,10 +19,3 @@ struct MissingLiveAPIKeyAlert: Identifiable, Equatable {
     lhs.id == rhs.id
   }
 }
-
-extension TranscriptionProviderMetadata {
-  var apiKeyURL: URL? {
-    guard !website.isEmpty else { return nil }
-    return URL(string: website)
-  }
-}

--- a/Sources/SpeakApp/MissingLiveAPIKeyAlert.swift
+++ b/Sources/SpeakApp/MissingLiveAPIKeyAlert.swift
@@ -1,10 +1,8 @@
 import Foundation
 import SpeakCore
 
-/// State for the pre-flight "API key required" alert shown when the user
-/// triggers a live recording but the chosen live transcription provider has
-/// no API key stored. The alert exposes an "Add API Key" CTA which navigates
-/// to Settings → API Keys, scrolled to the relevant provider section.
+/// State for the "API key required" alert shown when the user selects or starts
+/// a transcription model whose provider has no API key stored.
 struct MissingLiveAPIKeyAlert: Identifiable, Equatable {
   let id = UUID()
   let provider: TranscriptionProviderMetadata
@@ -13,11 +11,18 @@ struct MissingLiveAPIKeyAlert: Identifiable, Equatable {
   var title: String { "API key required" }
 
   var message: String {
-    "\(provider.displayName) needs an API key for live transcription "
+    "\(provider.displayName) needs an API key for transcription "
       + "with \(modelDisplayName). Add it now and try again."
   }
 
   static func == (lhs: MissingLiveAPIKeyAlert, rhs: MissingLiveAPIKeyAlert) -> Bool {
     lhs.id == rhs.id
+  }
+}
+
+extension TranscriptionProviderMetadata {
+  var apiKeyURL: URL? {
+    guard !website.isEmpty else { return nil }
+    return URL(string: website)
   }
 }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -279,6 +279,7 @@ struct SettingsView: View {
         Task {
           await presentMissingTranscriptionAPIKeyAlertIfNeeded(
             for: newValue,
+            keyPath: keyPath,
             options: options
           )
         }
@@ -289,6 +290,7 @@ struct SettingsView: View {
   @MainActor
   private func presentMissingTranscriptionAPIKeyAlertIfNeeded(
     for model: String,
+    keyPath: ReferenceWritableKeyPath<AppSettings, String>,
     options: [ModelCatalog.Option]
   ) async {
     let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -308,6 +310,9 @@ struct SettingsView: View {
     let modelName = options.first {
       $0.id.caseInsensitiveCompare(trimmed) == .orderedSame
     }?.displayName ?? ModelCatalog.friendlyName(for: trimmed)
+
+    let current = settings[keyPath: keyPath].trimmingCharacters(in: .whitespacesAndNewlines)
+    guard current.caseInsensitiveCompare(trimmed) == .orderedSame else { return }
 
     missingTranscriptionAPIKeyAlert = MissingLiveAPIKeyAlert(
       provider: provider.metadata,
@@ -611,7 +616,9 @@ struct SettingsView: View {
       presenting: missingTranscriptionAPIKeyAlert
     ) { alert in
       Button("Add API Key") {
-        environment.apiKeysScrollTarget = "transcription-\(alert.provider.id)"
+        environment.apiKeysScrollTarget = alert.provider.id == "elevenlabs"
+          ? "tts-elevenlabs"
+          : "transcription-\(alert.provider.id)"
         sidebarSelection = .settings(.apiKeys)
         missingTranscriptionAPIKeyAlert = nil
       }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -90,6 +90,7 @@ struct SettingsView: View {
   @State private var providerValidationStates: [String: ValidationViewState] = [:]
   @State private var ttsProviderAPIKeys: [String: String] = [:]
   @State private var ttsProviderValidationStates: [String: ValidationViewState] = [:]
+  @State private var missingTranscriptionAPIKeyAlert: MissingLiveAPIKeyAlert?
   @State private var showSystemPromptPreview = false
   @State private var systemPromptPreview = ""
   @State private var showingConfigTransfer = false
@@ -263,6 +264,52 @@ struct SettingsView: View {
       )
       .cornerRadius(24)
       .shadow(color: Color.orange.opacity(0.3), radius: 18, x: 0, y: 12)
+    )
+  }
+
+  private func remoteTranscriptionModelBinding(
+    _ keyPath: ReferenceWritableKeyPath<AppSettings, String>,
+    options: [ModelCatalog.Option]
+  ) -> Binding<String> {
+    Binding(
+      get: { settings[keyPath: keyPath] },
+      set: { newValue in
+        settings[keyPath: keyPath] = newValue
+        Task {
+          await presentMissingTranscriptionAPIKeyAlertIfNeeded(
+            for: newValue,
+            options: options
+          )
+        }
+      }
+    )
+  }
+
+  private func presentMissingTranscriptionAPIKeyAlertIfNeeded(
+    for model: String,
+    options: [ModelCatalog.Option]
+  ) async {
+    let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, trimmed != ModelCatalog.customOptionID else { return }
+    let registry = TranscriptionProviderRegistry.shared
+    guard await registry.requiresAPIKey(for: trimmed),
+          let provider = await registry.provider(forModel: trimmed) else {
+      return
+    }
+    let hasAPIKey = await environment.secureStorage.hasSecret(
+      identifier: provider.metadata.apiKeyIdentifier
+    )
+    guard !hasAPIKey else {
+      return
+    }
+
+    let modelName = options.first {
+      $0.id.caseInsensitiveCompare(trimmed) == .orderedSame
+    }?.displayName ?? ModelCatalog.friendlyName(for: trimmed)
+
+    missingTranscriptionAPIKeyAlert = MissingLiveAPIKeyAlert(
+      provider: provider.metadata,
+      modelDisplayName: modelName
     )
   }
 
@@ -552,6 +599,31 @@ struct SettingsView: View {
     }
     .onChange(of: settings.ttsPronunciationDictionary) { _, _ in
       syncAssemblyAIKeytermsFromPronunciation()
+    }
+    .alert(
+      missingTranscriptionAPIKeyAlert?.title ?? "API key required",
+      isPresented: Binding(
+        get: { missingTranscriptionAPIKeyAlert != nil },
+        set: { if !$0 { missingTranscriptionAPIKeyAlert = nil } }
+      ),
+      presenting: missingTranscriptionAPIKeyAlert
+    ) { alert in
+      Button("Add API Key") {
+        environment.apiKeysScrollTarget = "transcription-\(alert.provider.id)"
+        sidebarSelection = .settings(.apiKeys)
+        missingTranscriptionAPIKeyAlert = nil
+      }
+      if let url = alert.provider.apiKeyURL {
+        Button("Get API Key") {
+          NSWorkspace.shared.open(url)
+          missingTranscriptionAPIKeyAlert = nil
+        }
+      }
+      Button("Cancel", role: .cancel) {
+        missingTranscriptionAPIKeyAlert = nil
+      }
+    } message: { alert in
+      Text(alert.message)
     }
     .onReceive(environment.pronunciationManager.$entries) { _ in
       syncAssemblyAIKeytermsFromPronunciation()
@@ -1271,7 +1343,10 @@ struct SettingsView: View {
               title: "Remote Streaming Model",
               help: "Choose the remote provider model used while recording.",
               options: ModelCatalog.liveTranscription,
-              value: settingsBinding(\AppSettings.liveTranscriptionModel)
+              value: remoteTranscriptionModelBinding(
+                \AppSettings.liveTranscriptionModel,
+                options: ModelCatalog.liveTranscription
+              )
             )
           }
         }
@@ -1308,7 +1383,10 @@ struct SettingsView: View {
               custom model identifiers are sent through OpenRouter.
               """,
               options: ModelCatalog.batchTranscription,
-              value: settingsBinding(\AppSettings.batchTranscriptionModel)
+              value: remoteTranscriptionModelBinding(
+                \AppSettings.batchTranscriptionModel,
+                options: ModelCatalog.batchTranscription
+              )
             )
             if isCustomBatchTranscriptionModel {
               SettingsInlineInfo(

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -267,6 +267,7 @@ struct SettingsView: View {
     )
   }
 
+  @MainActor
   private func remoteTranscriptionModelBinding(
     _ keyPath: ReferenceWritableKeyPath<AppSettings, String>,
     options: [ModelCatalog.Option]
@@ -285,6 +286,7 @@ struct SettingsView: View {
     )
   }
 
+  @MainActor
   private func presentMissingTranscriptionAPIKeyAlertIfNeeded(
     for model: String,
     options: [ModelCatalog.Option]

--- a/Sources/SpeakCore/TranscriptionProviderRegistry.swift
+++ b/Sources/SpeakCore/TranscriptionProviderRegistry.swift
@@ -43,6 +43,11 @@ public struct TranscriptionProviderMetadata: Sendable, Identifiable {
         self.tintColor = tintColor
         self.website = website
     }
+
+    public var apiKeyURL: URL? {
+        guard !website.isEmpty else { return nil }
+        return URL(string: website)
+    }
 }
 
 // MARK: - Provider Error

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -595,6 +595,7 @@ public struct SettingsView: View {
 }
 
 private extension SettingsView {
+    @MainActor
     private var selectedModelBinding: Binding<String> {
         Binding(
             get: { settings.selectedModel },
@@ -605,6 +606,7 @@ private extension SettingsView {
         )
     }
 
+    @MainActor
     private func presentMissingTranscriptionAPIKeyAlertIfNeeded(for model: String) {
         guard let alert = IOSMissingTranscriptionAPIKeyAlert(modelID: model, settings: settings) else {
             return

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -303,13 +303,16 @@ public final class AppSettings: ObservableObject {
 
 public struct SettingsView: View {
     @StateObject private var settings = AppSettings.shared
+    @Environment(\.openURL) private var openURL
+    @State private var showingAPIKeys = false
+    @State private var missingTranscriptionAPIKeyAlert: IOSMissingTranscriptionAPIKeyAlert?
 
     public init() {}
 
     public var body: some View {
         Form {
             Section("Transcription") {
-                Picker("Live Model", selection: $settings.selectedModel) {
+                Picker("Live Model", selection: selectedModelBinding) {
                     // Apple Speech (free, on-device)
                     Text("Apple Speech (On-Device)").tag("apple/local/SFSpeechRecognizer")
 
@@ -576,10 +579,104 @@ public struct SettingsView: View {
             }
         }
         .navigationTitle("Settings")
+        .navigationDestination(isPresented: $showingAPIKeys) {
+            APIKeysView(settings: settings)
+        }
+        .alert(
+            missingTranscriptionAPIKeyAlert?.title ?? "API key required",
+            isPresented: Binding(
+                get: { missingTranscriptionAPIKeyAlert != nil },
+                set: { if !$0 { missingTranscriptionAPIKeyAlert = nil } }
+            ),
+            presenting: missingTranscriptionAPIKeyAlert
+        ) { alert in
+            Button("Add API Key") {
+                missingTranscriptionAPIKeyAlert = nil
+                showingAPIKeys = true
+            }
+            if let url = alert.apiKeyURL {
+                Button("Get API Key") {
+                    missingTranscriptionAPIKeyAlert = nil
+                    openURL(url)
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                missingTranscriptionAPIKeyAlert = nil
+            }
+        } message: { alert in
+            Text(alert.message)
+        }
     }
 
     private var postProcessingModelName: String {
         AppSettings.postProcessingModels.first { $0.id == settings.postProcessingModel }?.name ?? "GPT-4o Mini"
+    }
+
+    private var selectedModelBinding: Binding<String> {
+        Binding(
+            get: { settings.selectedModel },
+            set: { newValue in
+                settings.selectedModel = newValue
+                presentMissingTranscriptionAPIKeyAlertIfNeeded(for: newValue)
+            }
+        )
+    }
+
+    private func presentMissingTranscriptionAPIKeyAlertIfNeeded(for model: String) {
+        guard let alert = IOSMissingTranscriptionAPIKeyAlert(modelID: model, settings: settings) else {
+            return
+        }
+        missingTranscriptionAPIKeyAlert = alert
+    }
+}
+
+private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
+    let id = UUID()
+    let providerName: String
+    let modelName: String
+    let apiKeyURL: URL?
+
+    var title: String { "API key required" }
+
+    var message: String {
+        "\(providerName) needs an API key for transcription with \(modelName). Add it now and try again."
+    }
+
+    @MainActor
+    init?(modelID: String, settings: AppSettings) {
+        let metadata: (providerName: String, modelName: String, apiKeyURL: URL?, hasKey: Bool)?
+        if modelID.hasPrefix("deepgram") {
+            metadata = (
+                "Deepgram",
+                "Deepgram Nova-3",
+                URL(string: "https://deepgram.com"),
+                settings.hasDeepgramKey
+            )
+        } else if modelID.hasPrefix("elevenlabs") {
+            metadata = (
+                "ElevenLabs",
+                "ElevenLabs Scribe",
+                URL(string: "https://elevenlabs.io"),
+                settings.hasElevenLabsKey
+            )
+        } else if modelID.hasPrefix("openai") {
+            metadata = (
+                "OpenAI",
+                "OpenAI gpt-realtime-whisper",
+                URL(string: "https://platform.openai.com"),
+                settings.hasOpenAIKey
+            )
+        } else {
+            metadata = nil
+        }
+
+        guard let metadata, !metadata.hasKey else {
+            return nil
+        }
+
+        providerName = metadata.providerName
+        modelName = metadata.modelName
+        apiKeyURL = metadata.apiKeyURL
     }
 }
 

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -662,23 +662,23 @@ private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
 
     @MainActor
     init?(modelID: String, settings: AppSettings) {
-        let requirement: IOSMissingTranscriptionProviderRequirement?
+        let requirement: IOSProviderRequirement?
         if modelID.hasPrefix("deepgram") {
-            requirement = IOSMissingTranscriptionProviderRequirement(
+            requirement = IOSProviderRequirement(
                 providerName: "Deepgram",
                 modelName: "Deepgram Nova-3",
                 apiKeyURL: URL(string: "https://deepgram.com"),
                 hasKey: settings.hasDeepgramKey
             )
         } else if modelID.hasPrefix("elevenlabs") {
-            requirement = IOSMissingTranscriptionProviderRequirement(
+            requirement = IOSProviderRequirement(
                 providerName: "ElevenLabs",
                 modelName: "ElevenLabs Scribe",
                 apiKeyURL: URL(string: "https://elevenlabs.io"),
                 hasKey: settings.hasElevenLabsKey
             )
         } else if modelID.hasPrefix("openai") {
-            requirement = IOSMissingTranscriptionProviderRequirement(
+            requirement = IOSProviderRequirement(
                 providerName: "OpenAI",
                 modelName: "OpenAI gpt-realtime-whisper",
                 apiKeyURL: URL(string: "https://platform.openai.com"),
@@ -698,7 +698,7 @@ private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
     }
 }
 
-private struct IOSMissingTranscriptionProviderRequirement {
+private struct IOSProviderRequirement {
     let providerName: String
     let modelName: String
     let apiKeyURL: URL?

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -594,117 +594,6 @@ public struct SettingsView: View {
     }
 }
 
-private extension SettingsView {
-    @MainActor
-    private var selectedModelBinding: Binding<String> {
-        Binding(
-            get: { settings.selectedModel },
-            set: { newValue in
-                settings.selectedModel = newValue
-                presentMissingTranscriptionAPIKeyAlertIfNeeded(for: newValue)
-            }
-        )
-    }
-
-    @MainActor
-    private func presentMissingTranscriptionAPIKeyAlertIfNeeded(for model: String) {
-        guard let alert = IOSMissingTranscriptionAPIKeyAlert(modelID: model, settings: settings) else {
-            return
-        }
-        missingTranscriptionAPIKeyAlert = alert
-    }
-}
-
-private extension View {
-    func iosMissingTranscriptionAPIKeyAlert(
-        alert: Binding<IOSMissingTranscriptionAPIKeyAlert?>,
-        showingAPIKeys: Binding<Bool>,
-        openURL: OpenURLAction
-    ) -> some View {
-        self.alert(
-            alert.wrappedValue?.title ?? "API key required",
-            isPresented: Binding(
-                get: { alert.wrappedValue != nil },
-                set: { if !$0 { alert.wrappedValue = nil } }
-            ),
-            presenting: alert.wrappedValue
-        ) { presentedAlert in
-            Button("Add API Key") {
-                alert.wrappedValue = nil
-                showingAPIKeys.wrappedValue = true
-            }
-            if let url = presentedAlert.apiKeyURL {
-                Button("Get API Key") {
-                    alert.wrappedValue = nil
-                    openURL(url)
-                }
-            }
-            Button("Cancel", role: .cancel) {
-                alert.wrappedValue = nil
-            }
-        } message: { presentedAlert in
-            Text(presentedAlert.message)
-        }
-    }
-}
-
-private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
-    let id = UUID()
-    let providerName: String
-    let modelName: String
-    let apiKeyURL: URL?
-
-    var title: String { "API key required" }
-
-    var message: String {
-        "\(providerName) needs an API key for transcription with \(modelName). Add it now and try again."
-    }
-
-    @MainActor
-    init?(modelID: String, settings: AppSettings) {
-        let requirement: IOSProviderRequirement?
-        if modelID.hasPrefix("deepgram") {
-            requirement = IOSProviderRequirement(
-                providerName: "Deepgram",
-                modelName: "Deepgram Nova-3",
-                apiKeyURL: URL(string: "https://deepgram.com"),
-                hasKey: settings.hasDeepgramKey
-            )
-        } else if modelID.hasPrefix("elevenlabs") {
-            requirement = IOSProviderRequirement(
-                providerName: "ElevenLabs",
-                modelName: "ElevenLabs Scribe",
-                apiKeyURL: URL(string: "https://elevenlabs.io"),
-                hasKey: settings.hasElevenLabsKey
-            )
-        } else if modelID.hasPrefix("openai") {
-            requirement = IOSProviderRequirement(
-                providerName: "OpenAI",
-                modelName: "OpenAI gpt-realtime-whisper",
-                apiKeyURL: URL(string: "https://platform.openai.com"),
-                hasKey: settings.hasOpenAIKey
-            )
-        } else {
-            requirement = nil
-        }
-
-        guard let requirement, !requirement.hasKey else {
-            return nil
-        }
-
-        providerName = requirement.providerName
-        modelName = requirement.modelName
-        apiKeyURL = requirement.apiKeyURL
-    }
-}
-
-private struct IOSProviderRequirement {
-    let providerName: String
-    let modelName: String
-    let apiKeyURL: URL?
-    let hasKey: Bool
-}
-
 // MARK: - Hardware Trigger Settings View
 
 /// Configuration screen for the Action Button / Shortcuts / Siri / widget
@@ -1357,5 +1246,116 @@ struct CloudKitSyncSettingsSection: View {
     NavigationStack {
         PrivacyView()
     }
+}
+
+private extension SettingsView {
+    @MainActor
+    private var selectedModelBinding: Binding<String> {
+        Binding(
+            get: { settings.selectedModel },
+            set: { newValue in
+                settings.selectedModel = newValue
+                presentMissingTranscriptionAPIKeyAlertIfNeeded(for: newValue)
+            }
+        )
+    }
+
+    @MainActor
+    private func presentMissingTranscriptionAPIKeyAlertIfNeeded(for model: String) {
+        guard let alert = IOSMissingTranscriptionAPIKeyAlert(modelID: model, settings: settings) else {
+            return
+        }
+        missingTranscriptionAPIKeyAlert = alert
+    }
+}
+
+private extension View {
+    func iosMissingTranscriptionAPIKeyAlert(
+        alert: Binding<IOSMissingTranscriptionAPIKeyAlert?>,
+        showingAPIKeys: Binding<Bool>,
+        openURL: OpenURLAction
+    ) -> some View {
+        self.alert(
+            alert.wrappedValue?.title ?? "API key required",
+            isPresented: Binding(
+                get: { alert.wrappedValue != nil },
+                set: { if !$0 { alert.wrappedValue = nil } }
+            ),
+            presenting: alert.wrappedValue
+        ) { presentedAlert in
+            Button("Add API Key") {
+                alert.wrappedValue = nil
+                showingAPIKeys.wrappedValue = true
+            }
+            if let url = presentedAlert.apiKeyURL {
+                Button("Get API Key") {
+                    alert.wrappedValue = nil
+                    openURL(url)
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                alert.wrappedValue = nil
+            }
+        } message: { presentedAlert in
+            Text(presentedAlert.message)
+        }
+    }
+}
+
+private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
+    let id = UUID()
+    let providerName: String
+    let modelName: String
+    let apiKeyURL: URL?
+
+    var title: String { "API key required" }
+
+    var message: String {
+        "\(providerName) needs an API key for transcription with \(modelName). Add it now and try again."
+    }
+
+    @MainActor
+    init?(modelID: String, settings: AppSettings) {
+        let requirement: IOSProviderRequirement?
+        if modelID.hasPrefix("deepgram") {
+            requirement = IOSProviderRequirement(
+                providerName: "Deepgram",
+                modelName: "Deepgram Nova-3",
+                apiKeyURL: URL(string: "https://deepgram.com"),
+                hasKey: settings.hasDeepgramKey
+            )
+        } else if modelID.hasPrefix("elevenlabs") {
+            requirement = IOSProviderRequirement(
+                providerName: "ElevenLabs",
+                modelName: "ElevenLabs Scribe",
+                apiKeyURL: URL(string: "https://elevenlabs.io"),
+                hasKey: settings.hasElevenLabsKey
+            )
+        } else if modelID.hasPrefix("openai") {
+            requirement = IOSProviderRequirement(
+                providerName: "OpenAI",
+                modelName: "OpenAI gpt-realtime-whisper",
+                apiKeyURL: URL(string: "https://platform.openai.com"),
+                hasKey: settings.hasOpenAIKey
+            )
+        } else {
+            requirement = nil
+        }
+
+        guard let requirement, !requirement.hasKey else {
+            return nil
+        }
+
+        providerName = requirement.providerName
+        modelName = requirement.modelName
+        apiKeyURL = requirement.apiKeyURL
+    }
+}
+
+private struct IOSProviderRequirement {
+    let providerName: String
+    let modelName: String
+    let apiKeyURL: URL?
+    let hasKey: Bool
 }
 #endif

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -1319,23 +1319,32 @@ private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
         let requirement: IOSProviderRequirement?
         if modelID.hasPrefix("deepgram") {
             requirement = IOSProviderRequirement(
-                providerName: "Deepgram",
+                provider: TranscriptionProviderMetadata(
+                    id: "deepgram",
+                    displayName: "Deepgram",
+                    website: "https://deepgram.com"
+                ),
                 modelName: "Deepgram Nova-3",
-                apiKeyURL: URL(string: "https://deepgram.com"),
                 hasKey: settings.hasDeepgramKey
             )
         } else if modelID.hasPrefix("elevenlabs") {
             requirement = IOSProviderRequirement(
-                providerName: "ElevenLabs",
+                provider: TranscriptionProviderMetadata(
+                    id: "elevenlabs",
+                    displayName: "ElevenLabs",
+                    website: "https://elevenlabs.io"
+                ),
                 modelName: "ElevenLabs Scribe",
-                apiKeyURL: URL(string: "https://elevenlabs.io"),
                 hasKey: settings.hasElevenLabsKey
             )
         } else if modelID.hasPrefix("openai") {
             requirement = IOSProviderRequirement(
-                providerName: "OpenAI",
+                provider: TranscriptionProviderMetadata(
+                    id: "openai",
+                    displayName: "OpenAI",
+                    website: "https://platform.openai.com"
+                ),
                 modelName: "OpenAI gpt-realtime-whisper",
-                apiKeyURL: URL(string: "https://platform.openai.com"),
                 hasKey: settings.hasOpenAIKey
             )
         } else {
@@ -1346,16 +1355,15 @@ private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
             return nil
         }
 
-        providerName = requirement.providerName
+        providerName = requirement.provider.displayName
         modelName = requirement.modelName
-        apiKeyURL = requirement.apiKeyURL
+        apiKeyURL = requirement.provider.apiKeyURL
     }
 }
 
 private struct IOSProviderRequirement {
-    let providerName: String
+    let provider: TranscriptionProviderMetadata
     let modelName: String
-    let apiKeyURL: URL?
     let hasKey: Bool
 }
 #endif

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -582,36 +582,19 @@ public struct SettingsView: View {
         .navigationDestination(isPresented: $showingAPIKeys) {
             APIKeysView(settings: settings)
         }
-        .alert(
-            missingTranscriptionAPIKeyAlert?.title ?? "API key required",
-            isPresented: Binding(
-                get: { missingTranscriptionAPIKeyAlert != nil },
-                set: { if !$0 { missingTranscriptionAPIKeyAlert = nil } }
-            ),
-            presenting: missingTranscriptionAPIKeyAlert
-        ) { alert in
-            Button("Add API Key") {
-                missingTranscriptionAPIKeyAlert = nil
-                showingAPIKeys = true
-            }
-            if let url = alert.apiKeyURL {
-                Button("Get API Key") {
-                    missingTranscriptionAPIKeyAlert = nil
-                    openURL(url)
-                }
-            }
-            Button("Cancel", role: .cancel) {
-                missingTranscriptionAPIKeyAlert = nil
-            }
-        } message: { alert in
-            Text(alert.message)
-        }
+        .iosMissingTranscriptionAPIKeyAlert(
+            alert: $missingTranscriptionAPIKeyAlert,
+            showingAPIKeys: $showingAPIKeys,
+            openURL: openURL
+        )
     }
 
     private var postProcessingModelName: String {
         AppSettings.postProcessingModels.first { $0.id == settings.postProcessingModel }?.name ?? "GPT-4o Mini"
     }
+}
 
+private extension SettingsView {
     private var selectedModelBinding: Binding<String> {
         Binding(
             get: { settings.selectedModel },
@@ -630,6 +613,39 @@ public struct SettingsView: View {
     }
 }
 
+private extension View {
+    func iosMissingTranscriptionAPIKeyAlert(
+        alert: Binding<IOSMissingTranscriptionAPIKeyAlert?>,
+        showingAPIKeys: Binding<Bool>,
+        openURL: OpenURLAction
+    ) -> some View {
+        self.alert(
+            alert.wrappedValue?.title ?? "API key required",
+            isPresented: Binding(
+                get: { alert.wrappedValue != nil },
+                set: { if !$0 { alert.wrappedValue = nil } }
+            ),
+            presenting: alert.wrappedValue
+        ) { presentedAlert in
+            Button("Add API Key") {
+                alert.wrappedValue = nil
+                showingAPIKeys.wrappedValue = true
+            }
+            if let url = presentedAlert.apiKeyURL {
+                Button("Get API Key") {
+                    alert.wrappedValue = nil
+                    openURL(url)
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                alert.wrappedValue = nil
+            }
+        } message: { presentedAlert in
+            Text(presentedAlert.message)
+        }
+    }
+}
+
 private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
     let id = UUID()
     let providerName: String
@@ -644,40 +660,47 @@ private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
 
     @MainActor
     init?(modelID: String, settings: AppSettings) {
-        let metadata: (providerName: String, modelName: String, apiKeyURL: URL?, hasKey: Bool)?
+        let requirement: IOSMissingTranscriptionProviderRequirement?
         if modelID.hasPrefix("deepgram") {
-            metadata = (
-                "Deepgram",
-                "Deepgram Nova-3",
-                URL(string: "https://deepgram.com"),
-                settings.hasDeepgramKey
+            requirement = IOSMissingTranscriptionProviderRequirement(
+                providerName: "Deepgram",
+                modelName: "Deepgram Nova-3",
+                apiKeyURL: URL(string: "https://deepgram.com"),
+                hasKey: settings.hasDeepgramKey
             )
         } else if modelID.hasPrefix("elevenlabs") {
-            metadata = (
-                "ElevenLabs",
-                "ElevenLabs Scribe",
-                URL(string: "https://elevenlabs.io"),
-                settings.hasElevenLabsKey
+            requirement = IOSMissingTranscriptionProviderRequirement(
+                providerName: "ElevenLabs",
+                modelName: "ElevenLabs Scribe",
+                apiKeyURL: URL(string: "https://elevenlabs.io"),
+                hasKey: settings.hasElevenLabsKey
             )
         } else if modelID.hasPrefix("openai") {
-            metadata = (
-                "OpenAI",
-                "OpenAI gpt-realtime-whisper",
-                URL(string: "https://platform.openai.com"),
-                settings.hasOpenAIKey
+            requirement = IOSMissingTranscriptionProviderRequirement(
+                providerName: "OpenAI",
+                modelName: "OpenAI gpt-realtime-whisper",
+                apiKeyURL: URL(string: "https://platform.openai.com"),
+                hasKey: settings.hasOpenAIKey
             )
         } else {
-            metadata = nil
+            requirement = nil
         }
 
-        guard let metadata, !metadata.hasKey else {
+        guard let requirement, !requirement.hasKey else {
             return nil
         }
 
-        providerName = metadata.providerName
-        modelName = metadata.modelName
-        apiKeyURL = metadata.apiKeyURL
+        providerName = requirement.providerName
+        modelName = requirement.modelName
+        apiKeyURL = requirement.apiKeyURL
     }
+}
+
+private struct IOSMissingTranscriptionProviderRequirement {
+    let providerName: String
+    let modelName: String
+    let apiKeyURL: URL?
+    let hasKey: Bool
 }
 
 // MARK: - Hardware Trigger Settings View

--- a/Tests/SpeakAppTests/MissingLiveAPIKeyAlertTests.swift
+++ b/Tests/SpeakAppTests/MissingLiveAPIKeyAlertTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+@testable import SpeakApp
+@testable import SpeakCore
+
+final class MissingLiveAPIKeyAlertTests: XCTestCase {
+  func testMessage_describesTranscriptionModelWithoutLiveOnlyWording() {
+    let provider = TranscriptionProviderMetadata(
+      id: "cartesia",
+      displayName: "Cartesia",
+      website: "https://cartesia.ai"
+    )
+
+    let alert = MissingLiveAPIKeyAlert(
+      provider: provider,
+      modelDisplayName: "Cartesia Ink-2"
+    )
+
+    XCTAssertEqual(alert.title, "API key required")
+    XCTAssertTrue(alert.message.contains("Cartesia needs an API key for transcription"))
+    XCTAssertTrue(alert.message.contains("Cartesia Ink-2"))
+    XCTAssertFalse(alert.message.contains("live transcription"))
+  }
+
+  func testProviderMetadataAPIKeyURL_usesProviderWebsite() {
+    let provider = TranscriptionProviderMetadata(
+      id: "cartesia",
+      displayName: "Cartesia",
+      website: "https://cartesia.ai"
+    )
+
+    XCTAssertEqual(provider.apiKeyURL?.absoluteString, "https://cartesia.ai")
+  }
+
+  func testProviderMetadataAPIKeyURL_isNilWhenWebsiteMissing() {
+    let provider = TranscriptionProviderMetadata(
+      id: "custom",
+      displayName: "Custom"
+    )
+
+    XCTAssertNil(provider.apiKeyURL)
+  }
+}


### PR DESCRIPTION
## Summary
- show an immediate missing API key alert when selecting remote transcription models in macOS settings
- add Add API Key and Get API Key actions to missing-key alerts
- mirror the early warning on the iOS live model picker

## Validation
- swift test --disable-automatic-resolution --filter MissingLiveAPIKeyAlertTests
- swift build --disable-automatic-resolution --target SpeakApp
- swift build --disable-automatic-resolution --target SpeakiOSLib
- conformance check: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API key prompts in settings when a selected transcription provider requires credentials.
  * Users can now jump directly to a provider’s API key page when available.

* **Bug Fixes**
  * Improved alert wording for transcription key requirements.
  * Alerts now close cleanly after opening the provider link.

* **Tests**
  * Added coverage for alert content and API key URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->