### PR TITLE
fix: label GPT realtime whisper explicitly

### DIFF
--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -165,7 +165,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             estimatedLatencyMs: 200, latencyTier: .fast),
         Option(
             id: "openai/gpt-realtime-whisper-streaming",
-            displayName: "OpenAI Whisper Realtime (Streaming)",
+            displayName: "OpenAI GPT Realtime Whisper (Streaming)",
             description: "OpenAI's gpt-realtime-whisper — low-latency streaming transcription with "
                 + "built-in noise reduction. Reuses your OpenAI API key.",
             estimatedLatencyMs: 250, latencyTier: .fast),

--- a/Tests/SpeakAppTests/OpenAIRealtimeProviderTests.swift
+++ b/Tests/SpeakAppTests/OpenAIRealtimeProviderTests.swift
@@ -9,11 +9,11 @@ final class OpenAIRealtimeProviderTests: XCTestCase {
     // MARK: - Catalogue + capabilities
 
     func testModelCatalog_includesGPTRealtimeWhisperStreaming() {
-        let ids = ModelCatalog.liveTranscription.map(\.id)
-        XCTAssertTrue(
-            ids.contains("openai/gpt-realtime-whisper-streaming"),
-            "OpenAI gpt-realtime-whisper-streaming must be registered in ModelCatalog.liveTranscription"
-        )
+        let option = ModelCatalog.liveTranscription.first {
+            $0.id == "openai/gpt-realtime-whisper-streaming"
+        }
+
+        XCTAssertEqual(option?.displayName, "OpenAI GPT Realtime Whisper (Streaming)")
     }
 
     func testCapabilities_supportsInstantAndLivePolish() {

--- a/Tests/SpeakAppTests/OpenAIRealtimeProviderTests.swift
+++ b/Tests/SpeakAppTests/OpenAIRealtimeProviderTests.swift
@@ -8,12 +8,15 @@ final class OpenAIRealtimeProviderTests: XCTestCase {
 
     // MARK: - Catalogue + capabilities
 
-    func testModelCatalog_includesGPTRealtimeWhisperStreaming() {
-        let option = ModelCatalog.liveTranscription.first {
-            $0.id == "openai/gpt-realtime-whisper-streaming"
-        }
+    func testModelCatalog_includesGPTRealtimeWhisperStreaming() throws {
+        let option = try XCTUnwrap(
+            ModelCatalog.liveTranscription.first {
+                $0.id == "openai/gpt-realtime-whisper-streaming"
+            },
+            "Expected to find openai/gpt-realtime-whisper-streaming in liveTranscription"
+        )
 
-        XCTAssertEqual(option?.displayName, "OpenAI GPT Realtime Whisper (Streaming)")
+        XCTAssertEqual(option.displayName, "OpenAI GPT Realtime Whisper (Streaming)")
     }
 
     func testCapabilities_supportsInstantAndLivePolish() {


### PR DESCRIPTION
## Summary
- make the existing OpenAI realtime Whisper live model obvious in the Mac/shared catalogue by labelling it `OpenAI GPT Realtime Whisper (Streaming)`
- tighten the realtime provider regression test so this model stays listed with the expected picker label

## Notes
- `openai/gpt-realtime-whisper-streaming` was already wired through the OpenAI Realtime live controller; this is a discoverability fix, not a new transport.

## Validation
- swift test --disable-automatic-resolution --filter OpenAIRealtimeProviderTests
- swift build --disable-automatic-resolution --target SpeakApp
- conformance check: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the label for the realtime whisper streaming model to **“OpenAI GPT Realtime Whisper (Streaming)”** for clearer, more accurate naming in the app.
  * Improved coverage to verify the catalog entry now shows the updated display name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->