### PR TITLE
fix(ios): surface raw audio session error code and state on record failure

### DIFF
--- a/Sources/SpeakiOS/Services/AudioSessionDiagnostics.swift
+++ b/Sources/SpeakiOS/Services/AudioSessionDiagnostics.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Immutable snapshot of the audio session state captured at the moment audio
+/// configuration fails.
+///
+/// Deliberately free of AVFoundation so it compiles and is unit-testable on
+/// every platform; `AudioSessionManager` populates it from the live
+/// `AVAudioSession` on iOS. Modelled as a Data Transfer Object: a plain carrier
+/// of already-resolved primitive values, not a live view onto the session.
+public struct AudioSessionDiagnostics: Sendable, Equatable {
+    public let category: String
+    public let mode: String
+    public let options: String
+    public let isOtherAudioPlaying: Bool
+    public let inputRoute: String
+    public let outputRoute: String
+
+    public init(
+        category: String,
+        mode: String,
+        options: String,
+        isOtherAudioPlaying: Bool,
+        inputRoute: String,
+        outputRoute: String
+    ) {
+        self.category = category
+        self.mode = mode
+        self.options = options
+        self.isOtherAudioPlaying = isOtherAudioPlaying
+        self.inputRoute = inputRoute
+        self.outputRoute = outputRoute
+    }
+
+    /// One-line, log-friendly description of the captured session state.
+    public var summary: String {
+        "category=\(category) mode=\(mode) options=[\(options)] "
+            + "otherAudioPlaying=\(isOtherAudioPlaying) "
+            + "input=\(inputRoute) output=\(outputRoute)"
+    }
+}
+
+/// Rich diagnostic error thrown when the audio session cannot be configured for
+/// recording.
+///
+/// The previous behaviour wrapped the raw `NSError` and only surfaced its
+/// generic `localizedDescription`, which discarded the useful `OSStatus` code
+/// that `AVAudioSession` reports. This type preserves the underlying error and
+/// renders it as a decoded FourCC (e.g. `561145187` → `'!rec'` →
+/// `cannotStartRecording`) alongside a snapshot of the session state, so
+/// hard-to-reproduce "why did recording fail" reports are diagnosable from
+/// logs alone.
+public struct AudioSessionConfigurationError: LocalizedError {
+    /// The `AVAudioSession` call that threw.
+    public enum Operation: String, Sendable {
+        case setCategory
+        case setActive
+    }
+
+    public let operation: Operation
+    public let underlying: NSError
+    public let diagnostics: AudioSessionDiagnostics
+
+    public init(operation: Operation, underlying: NSError, diagnostics: AudioSessionDiagnostics) {
+        self.operation = operation
+        self.underlying = underlying
+        self.diagnostics = diagnostics
+    }
+
+    /// Decoded description of the underlying error code, including its FourCC
+    /// interpretation and a known `AVAudioSession.ErrorCode` name where one is
+    /// recognised.
+    public var codeSummary: String {
+        var parts: [String] = []
+        if let fourCC = Self.fourCharCode(from: underlying.code) {
+            if let name = Self.knownErrorName(forFourCC: fourCC) {
+                parts.append(name)
+            }
+            parts.append("'\(fourCC)'")
+        }
+        parts.append("code \(underlying.code)")
+        parts.append("domain \(underlying.domain)")
+        return parts.joined(separator: ", ")
+    }
+
+    public var errorDescription: String? {
+        "Audio session \(operation.rawValue) failed [\(codeSummary)]. "
+            + "State: \(diagnostics.summary). "
+            + "Underlying: \(underlying.localizedDescription)"
+    }
+
+    public var recoverySuggestion: String? {
+        "Another app may own the microphone. Close music, podcast, call or "
+            + "voice apps, disconnect Bluetooth audio, then try again."
+    }
+
+    // MARK: - OSStatus decoding
+
+    /// Decodes an `OSStatus`/`NSError` code as a four-character code when its
+    /// bytes are printable ASCII. `AVAudioSession` reports errors this way
+    /// (e.g. `'!rec'`), whereas plain numeric codes such as `-50` are not
+    /// FourCCs and return `nil`.
+    public static func fourCharCode(from code: Int) -> String? {
+        let value = UInt32(truncatingIfNeeded: code)
+        let bytes = [
+            UInt8((value >> 24) & 0xFF),
+            UInt8((value >> 16) & 0xFF),
+            UInt8((value >> 8) & 0xFF),
+            UInt8(value & 0xFF)
+        ]
+        // Require every byte to be printable ASCII (space…tilde); otherwise the
+        // code is a plain integer, not a FourCC.
+        guard bytes.allSatisfy({ (32...126).contains($0) }) else { return nil }
+        return String(bytes: bytes, encoding: .ascii)
+    }
+
+    /// Human-readable name for the well-known `AVAudioSession.ErrorCode` FourCCs
+    /// most relevant to a failed recording start.
+    public static func knownErrorName(forFourCC fourCC: String) -> String? {
+        knownErrorNames[fourCC]
+    }
+
+    private static let knownErrorNames: [String: String] = [
+        "!int": "cannotInterruptOthers",
+        "!pla": "cannotStartPlaying",
+        "!rec": "cannotStartRecording",
+        "!pri": "insufficientPriority",
+        "siri": "siriIsRecording",
+        "msrv": "mediaServicesFailed",
+        "what": "unspecified"
+    ]
+}

--- a/Sources/SpeakiOS/Services/AudioSessionManager.swift
+++ b/Sources/SpeakiOS/Services/AudioSessionManager.swift
@@ -8,17 +8,17 @@ public final class AudioSessionManager: ObservableObject {
     @Published private(set) public var isConfigured = false
     @Published private(set) public var currentRoute: String = "Unknown"
     @Published private(set) public var lastError: Error?
-    
+
     private var interruptionObserver: NSObjectProtocol?
     private var routeChangeObserver: NSObjectProtocol?
-    
+
     public var onInterruption: ((Bool) -> Void)?
     public var onRouteChange: (() -> Void)?
-    
+
     public init() {
         setupNotificationObservers()
     }
-    
+
     deinit {
         if let observer = interruptionObserver {
             NotificationCenter.default.removeObserver(observer)
@@ -27,11 +27,16 @@ public final class AudioSessionManager: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
         }
     }
-    
+
     /// Configure audio session for recording with speech recognition.
+    ///
+    /// The two configuration calls are attempted separately so a failure can be
+    /// attributed to the exact step, and both throw an
+    /// ``AudioSessionConfigurationError`` carrying the decoded `OSStatus` code
+    /// plus a snapshot of the live session state.
     public func configureForRecording() throws {
         let session = AVAudioSession.sharedInstance()
-        
+
         do {
             // Category: playAndRecord allows simultaneous input/output
             // Mode: measurement for high-quality audio capture
@@ -41,21 +46,78 @@ public final class AudioSessionManager: ObservableObject {
                 mode: .measurement,
                 options: [.allowBluetooth, .defaultToSpeaker, .allowBluetoothA2DP]
             )
-            
+        } catch {
+            throw configurationFailure(.setCategory, error, session)
+        }
+
+        do {
             // Activate the session
             try session.setActive(true, options: .notifyOthersOnDeactivation)
-            
-            isConfigured = true
-            updateCurrentRoute()
-            
-            print("[AudioSessionManager] Configured for recording: \(session.currentRoute.inputs.first?.portName ?? "unknown")")
         } catch {
-            lastError = error
-            isConfigured = false
-            throw error
+            throw configurationFailure(.setActive, error, session)
         }
+
+        isConfigured = true
+        updateCurrentRoute()
+
+        let inputRoute = Self.routeDescription(ports: session.currentRoute.inputs)
+        print("[AudioSessionManager] Configured for recording: \(inputRoute)")
     }
-    
+
+    /// Builds a diagnostic error for a failed configuration step, snapshotting
+    /// the live session state so production failures are traceable from logs.
+    private func configurationFailure(
+        _ operation: AudioSessionConfigurationError.Operation,
+        _ error: Error,
+        _ session: AVAudioSession
+    ) -> AudioSessionConfigurationError {
+        let failure = AudioSessionConfigurationError(
+            operation: operation,
+            underlying: error as NSError,
+            diagnostics: Self.diagnostics(for: session)
+        )
+        lastError = failure
+        isConfigured = false
+        return failure
+    }
+
+    /// Snapshots the current audio session state into a transferable value.
+    static func diagnostics(for session: AVAudioSession) -> AudioSessionDiagnostics {
+        AudioSessionDiagnostics(
+            category: session.category.rawValue,
+            mode: session.mode.rawValue,
+            options: describe(options: session.categoryOptions),
+            isOtherAudioPlaying: session.isOtherAudioPlaying,
+            inputRoute: routeDescription(ports: session.currentRoute.inputs),
+            outputRoute: routeDescription(ports: session.currentRoute.outputs)
+        )
+    }
+
+    /// Describes the audio route using stable, non-localised `portType`
+    /// identifiers (e.g. `MicrophoneBuiltIn`, `BluetoothHFP`, `Speaker`) rather
+    /// than `portName`, which can leak personal device names (e.g. a user's
+    /// AirPods) into logs and is localised.
+    private static func routeDescription(ports: [AVAudioSessionPortDescription]) -> String {
+        ports.isEmpty ? "none" : ports.map(\.portType.rawValue).joined(separator: "+")
+    }
+
+    private static func describe(options: AVAudioSession.CategoryOptions) -> String {
+        var names: [String] = []
+        if options.contains(.mixWithOthers) { names.append("mixWithOthers") }
+        if options.contains(.duckOthers) { names.append("duckOthers") }
+        if options.contains(.allowBluetooth) { names.append("allowBluetooth") }
+        if options.contains(.defaultToSpeaker) { names.append("defaultToSpeaker") }
+        if options.contains(.interruptSpokenAudioAndMixWithOthers) {
+            names.append("interruptSpokenAudioAndMixWithOthers")
+        }
+        if options.contains(.allowBluetoothA2DP) { names.append("allowBluetoothA2DP") }
+        if options.contains(.allowAirPlay) { names.append("allowAirPlay") }
+        if #available(iOS 14.5, *), options.contains(.overrideMutedMicrophoneInterruption) {
+            names.append("overrideMutedMicrophoneInterruption")
+        }
+        return names.isEmpty ? "none" : names.joined(separator: ",")
+    }
+
     /// Deactivate audio session when done recording.
     public func deactivate() {
         do {
@@ -66,12 +128,12 @@ public final class AudioSessionManager: ObservableObject {
             print("[AudioSessionManager] Failed to deactivate: \(error.localizedDescription)")
         }
     }
-    
+
     /// Check if microphone permission is granted.
     public func hasMicrophonePermission() -> Bool {
         AVAudioSession.sharedInstance().recordPermission == .granted
     }
-    
+
     /// Request microphone permission.
     public func requestMicrophonePermission() async -> Bool {
         await withCheckedContinuation { continuation in
@@ -80,9 +142,9 @@ public final class AudioSessionManager: ObservableObject {
             }
         }
     }
-    
+
     // MARK: - Private
-    
+
     private func setupNotificationObservers() {
         // Interruption observer (phone calls, Siri, etc.)
         interruptionObserver = NotificationCenter.default.addObserver(
@@ -92,7 +154,7 @@ public final class AudioSessionManager: ObservableObject {
         ) { [weak self] notification in
             self?.handleInterruption(notification)
         }
-        
+
         // Route change observer (headphones plugged/unplugged, Bluetooth changes)
         routeChangeObserver = NotificationCenter.default.addObserver(
             forName: AVAudioSession.routeChangeNotification,
@@ -102,18 +164,18 @@ public final class AudioSessionManager: ObservableObject {
             self?.handleRouteChange(notification)
         }
     }
-    
+
     private func handleInterruption(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
               let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
               let type = AVAudioSession.InterruptionType(rawValue: typeValue)
         else { return }
-        
+
         switch type {
         case .began:
             print("[AudioSessionManager] Interruption began")
             onInterruption?(true)
-            
+
         case .ended:
             print("[AudioSessionManager] Interruption ended")
             // Check if we should resume
@@ -124,23 +186,23 @@ public final class AudioSessionManager: ObservableObject {
                 }
             }
             onInterruption?(false)
-            
+
         @unknown default:
             break
         }
     }
-    
+
     private func handleRouteChange(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
               let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
               let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue)
         else { return }
-        
+
         print("[AudioSessionManager] Route changed: \(reason)")
         updateCurrentRoute()
         onRouteChange?()
     }
-    
+
     private func updateCurrentRoute() {
         let route = AVAudioSession.sharedInstance().currentRoute
         if let input = route.inputs.first {

--- a/Tests/SpeakiOSTests/AudioSessionDiagnosticsTests.swift
+++ b/Tests/SpeakiOSTests/AudioSessionDiagnosticsTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+
+@testable import SpeakiOSLib
+
+final class AudioSessionDiagnosticsTests: XCTestCase {
+
+    // MARK: - FourCC decoding
+
+    func testFourCharCode_cannotStartRecording_decodesToBangRec() {
+        // Arrange
+        let code = 561_145_187 // '!rec'
+
+        // Act
+        let fourCC = AudioSessionConfigurationError.fourCharCode(from: code)
+
+        // Assert
+        XCTAssertEqual(fourCC, "!rec")
+    }
+
+    func testFourCharCode_siriIsRecording_decodesToSiri() {
+        // Arrange
+        let code = 1_936_290_409 // 'siri'
+
+        // Act
+        let fourCC = AudioSessionConfigurationError.fourCharCode(from: code)
+
+        // Assert
+        XCTAssertEqual(fourCC, "siri")
+    }
+
+    func testFourCharCode_negativeParamError_isNotAFourCC() {
+        // Arrange
+        let code = -50 // kAudio_ParamError, not a printable FourCC
+
+        // Act
+        let fourCC = AudioSessionConfigurationError.fourCharCode(from: code)
+
+        // Assert
+        XCTAssertNil(fourCC)
+    }
+
+    // MARK: - Known error names
+
+    func testKnownErrorName_bangRec_mapsToCannotStartRecording() {
+        // Arrange
+        let fourCC = "!rec"
+
+        // Act
+        let name = AudioSessionConfigurationError.knownErrorName(forFourCC: fourCC)
+
+        // Assert
+        XCTAssertEqual(name, "cannotStartRecording")
+    }
+
+    func testKnownErrorName_unknownFourCC_isNil() {
+        // Arrange
+        let fourCC = "zzzz"
+
+        // Act
+        let name = AudioSessionConfigurationError.knownErrorName(forFourCC: fourCC)
+
+        // Assert
+        XCTAssertNil(name)
+    }
+
+    // MARK: - Error description composition
+
+    func testErrorDescription_setActiveInsufficientPriority_surfacesCodeAndState() {
+        // Arrange
+        let underlying = NSError(domain: NSOSStatusErrorDomain, code: 561_017_449) // '!pri'
+        let diagnostics = AudioSessionDiagnostics(
+            category: "AVAudioSessionCategoryPlayAndRecord",
+            mode: "AVAudioSessionModeMeasurement",
+            options: "allowBluetooth,defaultToSpeaker",
+            isOtherAudioPlaying: true,
+            inputRoute: "None",
+            outputRoute: "Speaker"
+        )
+        let error = AudioSessionConfigurationError(
+            operation: .setActive,
+            underlying: underlying,
+            diagnostics: diagnostics
+        )
+
+        // Act
+        let description = error.errorDescription ?? ""
+
+        // Assert
+        XCTAssertTrue(description.contains("setActive"), description)
+        XCTAssertTrue(description.contains("insufficientPriority"), description)
+        XCTAssertTrue(description.contains("'!pri'"), description)
+        XCTAssertTrue(description.contains("561017449"), description)
+        XCTAssertTrue(description.contains("otherAudioPlaying=true"), description)
+    }
+
+    func testErrorDescription_nonFourCCCode_stillSurfacesRawCode() {
+        // Arrange
+        let underlying = NSError(domain: NSOSStatusErrorDomain, code: -50)
+        let diagnostics = AudioSessionDiagnostics(
+            category: "AVAudioSessionCategoryPlayAndRecord",
+            mode: "AVAudioSessionModeMeasurement",
+            options: "none",
+            isOtherAudioPlaying: false,
+            inputRoute: "MicrophoneBuiltIn",
+            outputRoute: "Speaker"
+        )
+        let error = AudioSessionConfigurationError(
+            operation: .setCategory,
+            underlying: underlying,
+            diagnostics: diagnostics
+        )
+
+        // Act
+        let description = error.errorDescription ?? ""
+
+        // Assert
+        XCTAssertTrue(description.contains("setCategory"), description)
+        XCTAssertTrue(description.contains("code -50"), description)
+        XCTAssertFalse(
+            description.contains("'"),
+            "Non-FourCC codes should not render quoted characters: \(description)"
+        )
+    }
+
+    // MARK: - Summary
+
+    func testSummary_includesAllCapturedFields() {
+        // Arrange
+        let diagnostics = AudioSessionDiagnostics(
+            category: "cat",
+            mode: "mode",
+            options: "allowBluetooth",
+            isOtherAudioPlaying: true,
+            inputRoute: "in",
+            outputRoute: "out"
+        )
+
+        // Act
+        let summary = diagnostics.summary
+
+        // Assert
+        XCTAssertEqual(
+            summary,
+            "category=cat mode=mode options=[allowBluetooth] otherAudioPlaying=true input=in output=out"
+        )
+    }
+}


### PR DESCRIPTION
## Motivation

Starting a recording via Shortcuts / Action Button occasionally fails with a
generic "Failed to configure audio" message. The real cause is an
`AVAudioSession` `OSStatus` error (commonly another app owning the session, or
a `.measurement` + Bluetooth route combination), but that code was swallowed:
every live transcriber wraps the failure in
`iOSTranscriptionError.audioSessionFailed(error)`, which only surfaced the
underlying `NSError.localizedDescription`.

## Change

- **`AudioSessionManager.configureForRecording()`** now attempts `setCategory`
  and `setActive` as separate steps so a failure is attributed to the exact
  call, and throws a new `AudioSessionConfigurationError`.
- **`AudioSessionConfigurationError`** (new, pure-Foundation DTO + `LocalizedError`)
  decodes the raw `OSStatus` as a FourCC (e.g. `561145187` → `'!rec'` →
  `cannotStartRecording`) and carries an `AudioSessionDiagnostics` snapshot of
  the live session: category, mode, options, `isOtherAudioPlaying`, and
  input/output routes.
- No transcriber changes required: the richer `errorDescription` flows unchanged
  through the existing `audioSessionFailed` wrapping to the UI, Live Activity,
  and `SpeakLogger`, so future "why did recording fail" reports are diagnosable
  from logs alone.

## User-visible change

The audio-failure message now includes the decoded error code and session state
instead of a generic string.

## Tests

New `AudioSessionDiagnosticsTests` (Arrange-Act-Assert) cover FourCC decoding of
known `AVAudioSession` error codes, the non-FourCC fallback (`-50`), known-name
mapping, and error-description composition.

- `swift test --filter AudioSessionDiagnosticsTests` — 8 passed
- iOS typecheck of the changed files against the iOS 17 simulator SDK — clean

## Conformance

- Information Hiding: `AVAudioSession` specifics stay inside `AudioSessionManager`;
  callers receive a resolved DTO + error.
- DTO / Adapter / Facade / Guard Clause: `AudioSessionDiagnostics` is a plain
  carrier; `AudioSessionManager` remains the adapter over `AVAudioSession`.
- Design for Production / Stability: adds observability without changing the
  recording behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer audio recording diagnostics to capture session details like category, mode, routes, and whether other audio is playing.
  * Recording setup errors now surface clearer, human-readable messages with decoded audio error codes and recovery guidance.

* **Bug Fixes**
  * Improved handling when audio session setup fails, making it easier to understand which configuration step caused the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->