### PR TITLE
fix(mac): label Soniox Real-time v5 as (Streaming) in model selector

### DIFF
--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -153,7 +153,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             estimatedLatencyMs: 250, latencyTier: .fast),
         Option(
             id: "soniox/stt-rt-v5-streaming",
-            displayName: "Soniox Real-time v5",
+            displayName: "Soniox Real-time v5 (Streaming)",
             description: "Soniox v5 real-time WebSocket STT with reinvented speaker separation, "
                 + "faster semantic endpointing, and improved multilingual recognition across 60+ languages.",
             estimatedLatencyMs: 220, latencyTier: .fast),


### PR DESCRIPTION
The Soniox v5 real-time streaming model (`soniox/stt-rt-v5-streaming`) was labelled `Soniox Real-time v5` in the transcription model selector, missing the `(Streaming)` suffix that every other streaming entry in `ModelCatalog.swift` uses (Deepgram, Cartesia, AssemblyAI, ElevenLabs, OpenAI, etc.). This restores consistency in the selector.

Introduced in #473.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the label for the Soniox Real-time v5 live transcription option to clearly indicate it is a streaming model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->