### PR TITLE
fix(mac,ios): validate ElevenLabs Scribe access

### DIFF
--- a/Sources/SpeakApp/ElevenLabsTranscriptionProvider.swift
+++ b/Sources/SpeakApp/ElevenLabsTranscriptionProvider.swift
@@ -80,36 +80,7 @@ struct ElevenLabsTranscriptionProvider: TranscriptionProvider {
     }
 
     func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
-        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return .failure(message: "API key is empty")
-        }
-
-        let url = baseURL.appendingPathComponent("user")
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue(trimmed, forHTTPHeaderField: "xi-api-key")
-
-        do {
-            let (data, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse else {
-                return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
-            }
-
-            let debug = debugSnapshot(request: request, response: http, data: data)
-
-            if (200..<300).contains(http.statusCode) {
-                return .success(message: "ElevenLabs API key validated", debug: debug)
-            }
-
-            let message = "HTTP \(http.statusCode) while validating key"
-            return .failure(message: message, debug: debug)
-        } catch {
-            return .failure(
-                message: "Validation failed: \(error.localizedDescription)",
-                debug: debugSnapshot(request: request, error: error)
-            )
-        }
+        await ElevenLabsSTTAPIKeyValidator(session: session).validate(key)
     }
 
     func requiresAPIKey(for model: String) -> Bool {
@@ -185,28 +156,6 @@ struct ElevenLabsTranscriptionProvider: TranscriptionProvider {
         )
     }
 
-    private func debugSnapshot(
-        request: URLRequest,
-        response: HTTPURLResponse? = nil,
-        data: Data? = nil,
-        error: Error? = nil
-    ) -> APIKeyValidationDebugSnapshot {
-        APIKeyValidationDebugSnapshot(
-            url: request.url?.absoluteString ?? "",
-            method: request.httpMethod ?? "GET",
-            requestHeaders: request.allHTTPHeaderFields ?? [:],
-            requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-            statusCode: response?.statusCode,
-            responseHeaders: response.map { headers in
-                headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
-                    guard let key = entry.key as? String else { return }
-                    partialResult[key] = String(describing: entry.value)
-                }
-            } ?? [:],
-            responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
-            errorDescription: error?.localizedDescription
-        )
-    }
 }
 
 // MARK: - Response Models

--- a/Sources/SpeakApp/TextToSpeech/ElevenLabsClient.swift
+++ b/Sources/SpeakApp/TextToSpeech/ElevenLabsClient.swift
@@ -105,50 +105,7 @@ actor ElevenLabsClient: TextToSpeechClient {
   }
 
   func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
-    // Step 1: verify the key is valid at all
-    let userURL = baseURL.appendingPathComponent("user")
-    var userRequest = URLRequest(url: userURL)
-    userRequest.setValue(key, forHTTPHeaderField: "xi-api-key")
-
-    do {
-      let (_, userResponse) = try await session.data(for: userRequest)
-      guard let userHTTP = userResponse as? HTTPURLResponse else {
-        return .failure(message: "Invalid response")
-      }
-      if userHTTP.statusCode == 401 {
-        return .failure(message: "Invalid API key")
-      }
-      guard userHTTP.statusCode == 200 else {
-        return .failure(message: "HTTP \(userHTTP.statusCode)")
-      }
-    } catch {
-      return .failure(message: error.localizedDescription)
-    }
-
-    // Step 2: probe Scribe capability — a TTS-only restricted key returns 403 here
-    let scribeURL = baseURL.appendingPathComponent("speech-to-text")
-    var scribeRequest = URLRequest(url: scribeURL)
-    scribeRequest.httpMethod = "POST"
-    scribeRequest.setValue(key, forHTTPHeaderField: "xi-api-key")
-    scribeRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    scribeRequest.httpBody = try? JSONSerialization.data(withJSONObject: [:])
-
-    do {
-      let (_, scribeResponse) = try await session.data(for: scribeRequest)
-      guard let scribeHTTP = scribeResponse as? HTTPURLResponse else {
-        return .failure(message: "Invalid Scribe response")
-      }
-      if scribeHTTP.statusCode == 403 {
-        return .failure(
-          message: "API key does not have Scribe (speech-to-text) access. Use a key with both "
-            + "TTS and Scribe permissions."
-        )
-      }
-      // 422 (missing required audio) and 400 (bad request) both indicate the key has Scribe access
-      return .success(message: "API key is valid for Text-to-Speech and Scribe transcription")
-    } catch {
-      return .failure(message: error.localizedDescription)
-    }
+    await ElevenLabsSTTAPIKeyValidator(session: session).validate(key)
   }
 
   // MARK: - Private Helpers

--- a/Sources/SpeakCore/ElevenLabsLiveClient.swift
+++ b/Sources/SpeakCore/ElevenLabsLiveClient.swift
@@ -365,7 +365,7 @@ public struct ElevenLabsSTTAPIKeyValidator {
     }
 
     private func isAcceptedScribeProbeStatus(_ statusCode: Int) -> Bool {
-        (200..<300).contains(statusCode) || statusCode == 400 || statusCode == 422
+        (200..<300).contains(statusCode) || statusCode == 400 || statusCode == 415 || statusCode == 422
     }
 
     private func debugSnapshot(

--- a/Sources/SpeakCore/ElevenLabsLiveClient.swift
+++ b/Sources/SpeakCore/ElevenLabsLiveClient.swift
@@ -257,37 +257,128 @@ public enum ElevenLabsLiveError: LocalizedError {
 
 public struct ElevenLabsSTTAPIKeyValidator {
     private let session: URLSession
+    private let baseURL = URL(string: "https://api.elevenlabs.io/v1")!
 
     public init(session: URLSession = .shared) {
         self.session = session
     }
 
-    /// Validates an ElevenLabs API key by calling the user endpoint.
+    /// Validates that an ElevenLabs API key is valid and has Scribe speech-to-text access.
     public func validate(_ key: String) async -> APIKeyValidationResult {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             return .failure(message: "API key is empty")
         }
 
-        let url = URL(string: "https://api.elevenlabs.io/v1/user")!
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue(trimmed, forHTTPHeaderField: "xi-api-key")
+        let request = makeUserRequest(apiKey: trimmed)
 
         do {
             let (data, response) = try await session.data(for: request)
             guard let http = response as? HTTPURLResponse else {
-                return .failure(message: "Received a non-HTTP response")
+                return .failure(
+                    message: "Received a non-HTTP response",
+                    debug: debugSnapshot(request: request)
+                )
             }
 
-            if (200..<300).contains(http.statusCode) {
-                return .success(message: "ElevenLabs API key validated")
+            let debug = debugSnapshot(request: request, response: http, data: data)
+            guard http.statusCode != 401 else {
+                return .failure(message: "Invalid API key", debug: debug)
             }
-
-            let body = String(data: data, encoding: .utf8) ?? ""
-            return .failure(message: "HTTP \(http.statusCode): \(body)")
+            guard (200..<300).contains(http.statusCode) else {
+                return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
+            }
         } catch {
-            return .failure(message: "Validation failed: \(error.localizedDescription)")
+            return .failure(
+                message: "Validation failed: \(error.localizedDescription)",
+                debug: debugSnapshot(request: request, error: error)
+            )
         }
+
+        return await validateScribeAccess(apiKey: trimmed)
+    }
+
+    private func makeUserRequest(apiKey: String) -> URLRequest {
+        let url = baseURL.appendingPathComponent("user")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+        return request
+    }
+
+    private func makeScribeProbeRequest(apiKey: String) -> URLRequest {
+        let url = baseURL.appendingPathComponent("speech-to-text")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data("{}".utf8)
+        return request
+    }
+
+    private func validateScribeAccess(apiKey: String) async -> APIKeyValidationResult {
+        let request = makeScribeProbeRequest(apiKey: apiKey)
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .failure(
+                    message: "Received a non-HTTP response from Scribe",
+                    debug: debugSnapshot(request: request)
+                )
+            }
+
+            let debug = debugSnapshot(request: request, response: http, data: data)
+            if http.statusCode == 403 {
+                return .failure(
+                    message: "API key does not have Scribe (speech-to-text) access. Use a key with both "
+                        + "TTS and Scribe permissions.",
+                    debug: debug
+                )
+            }
+            if http.statusCode == 401 {
+                return .failure(message: "Invalid API key", debug: debug)
+            }
+            if isAcceptedScribeProbeStatus(http.statusCode) {
+                return .success(
+                    message: "ElevenLabs API key is valid for Text-to-Speech and Scribe transcription",
+                    debug: debug
+                )
+            }
+
+            return .failure(message: "HTTP \(http.statusCode) while probing Scribe access", debug: debug)
+        } catch {
+            return .failure(
+                message: "Scribe validation failed: \(error.localizedDescription)",
+                debug: debugSnapshot(request: request, error: error)
+            )
+        }
+    }
+
+    private func isAcceptedScribeProbeStatus(_ statusCode: Int) -> Bool {
+        (200..<300).contains(statusCode) || statusCode == 400 || statusCode == 422
+    }
+
+    private func debugSnapshot(
+        request: URLRequest,
+        response: HTTPURLResponse? = nil,
+        data: Data? = nil,
+        error: Error? = nil
+    ) -> APIKeyValidationDebugSnapshot {
+        APIKeyValidationDebugSnapshot(
+            url: request.url?.absoluteString ?? "",
+            method: request.httpMethod ?? "GET",
+            requestHeaders: request.allHTTPHeaderFields ?? [:],
+            requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
+            statusCode: response?.statusCode,
+            responseHeaders: response.map { headers in
+                headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
+                    guard let key = entry.key as? String else { return }
+                    partialResult[key] = String(describing: entry.value)
+                }
+            } ?? [:],
+            responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
+            errorDescription: error?.localizedDescription
+        )
     }
 }

--- a/Sources/SpeakCore/ElevenLabsLiveClient.swift
+++ b/Sources/SpeakCore/ElevenLabsLiveClient.swift
@@ -308,11 +308,20 @@ public struct ElevenLabsSTTAPIKeyValidator {
 
     private func makeScribeProbeRequest(apiKey: String) -> URLRequest {
         let url = baseURL.appendingPathComponent("speech-to-text")
+        let boundary = "Boundary-\(UUID().uuidString)"
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = Data("{}".utf8)
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data(
+            """
+            --\(boundary)\r
+            Content-Disposition: form-data; name="model_id"\r
+            \r
+            scribe_v1\r
+            --\(boundary)--\r
+            """.utf8
+        )
         return request
     }
 
@@ -376,6 +385,7 @@ public struct ElevenLabsSTTAPIKeyValidator {
                     guard let key = entry.key as? String else { return }
                     partialResult[key] = String(describing: entry.value)
                 }
+
             } ?? [:],
             responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
             errorDescription: error?.localizedDescription

--- a/Tests/SpeakAppTests/ElevenLabsTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/ElevenLabsTranscriptionProviderTests.swift
@@ -216,11 +216,12 @@ final class ElevenLabsTranscriptionProviderTests: XCTestCase {
 
     // MARK: - API Key Validation
 
-    func testValidateAPIKey_returnsSuccess_on200() async {
+    func testValidateAPIKey_returnsSuccess_whenUserKeyHasScribeAccess() async {
         MockURLProtocol.requestHandler = { request in
+            let statusCode = request.url?.path == "/v1/speech-to-text" ? 422 : 200
             let response = HTTPURLResponse(
                 url: try XCTUnwrap(request.url),
-                statusCode: 200,
+                statusCode: statusCode,
                 httpVersion: nil,
                 headerFields: nil
             )!
@@ -236,6 +237,30 @@ final class ElevenLabsTranscriptionProviderTests: XCTestCase {
             // pass
         } else {
             XCTFail("Expected validation success for 200 response")
+        }
+    }
+
+    func testValidateAPIKey_returnsFailure_whenScribeAccessForbidden() async {
+        MockURLProtocol.requestHandler = { request in
+            let statusCode = request.url?.path == "/v1/speech-to-text" ? 403 : 200
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("{}".utf8))
+        }
+        defer { MockURLProtocol.requestHandler = nil }
+
+        let session = makeMockSession()
+        let provider = ElevenLabsTranscriptionProvider(session: session)
+        let result = await provider.validateAPIKey("tts-only-key")
+
+        if case .failure(let message) = result.outcome {
+            XCTAssertTrue(message.contains("Scribe"), "Expected missing Scribe access message")
+        } else {
+            XCTFail("Expected validation failure for a key without Scribe access")
         }
     }
 

--- a/Tests/SpeakAppTests/ElevenLabsTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/ElevenLabsTranscriptionProviderTests.swift
@@ -251,6 +251,7 @@ final class ElevenLabsTranscriptionProviderTests: XCTestCase {
             )!
             return (response, Data("{}".utf8))
         }
+
         defer { MockURLProtocol.requestHandler = nil }
 
         let session = makeMockSession()

--- a/Tests/SpeakCoreTests/ElevenLabsSTTAPIKeyValidatorTests.swift
+++ b/Tests/SpeakCoreTests/ElevenLabsSTTAPIKeyValidatorTests.swift
@@ -35,7 +35,10 @@ final class ElevenLabsSTTAPIKeyValidatorTests: XCTestCase {
         XCTAssertEqual(requests.map(\.path), ["/v1/user", "/v1/speech-to-text"])
         XCTAssertEqual(requests.last?.method, "POST")
         XCTAssertEqual(requests.last?.apiKeyHeader, "full-access-key")
-        XCTAssertEqual(requests.last?.body, "{}")
+        XCTAssertTrue(requests.last?.contentType?.hasPrefix("multipart/form-data; boundary=") == true)
+        XCTAssertTrue(requests.last?.body?.contains(#"name="model_id""#) == true)
+        XCTAssertTrue(requests.last?.body?.contains("\r\nscribe_v1\r\n") == true)
+        XCTAssertFalse(requests.last?.body == "{}")
     }
 
     func testValidate_rejectsTTSOnlyKeyWhenScribeAccessIsForbidden() async {
@@ -100,6 +103,7 @@ private actor ElevenLabsSTTValidationRequestRecorder {
                 path: request.url?.path,
                 method: request.httpMethod,
                 apiKeyHeader: request.value(forHTTPHeaderField: "xi-api-key"),
+                contentType: request.value(forHTTPHeaderField: "Content-Type"),
                 body: requestBody(for: request).flatMap { String(data: $0, encoding: .utf8) }
             )
         )
@@ -144,6 +148,7 @@ private struct RecordedRequest: Equatable {
     let path: String?
     let method: String?
     let apiKeyHeader: String?
+    let contentType: String?
     let body: String?
 }
 

--- a/Tests/SpeakCoreTests/ElevenLabsSTTAPIKeyValidatorTests.swift
+++ b/Tests/SpeakCoreTests/ElevenLabsSTTAPIKeyValidatorTests.swift
@@ -63,6 +63,27 @@ final class ElevenLabsSTTAPIKeyValidatorTests: XCTestCase {
         XCTAssertEqual(result.debug?.statusCode, 403)
     }
 
+    func testValidate_acceptsUnsupportedMediaTypeAfterUserCheck() async {
+        ElevenLabsSTTValidationMockURLProtocol.handler = { request in
+            let statusCode = request.url?.path == "/v1/speech-to-text" ? 415 : 200
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let validator = ElevenLabsSTTAPIKeyValidator(session: makeMockSession())
+        let result = await validator.validate("full-access-key")
+
+        guard case .success = result.outcome else {
+            return XCTFail("Expected validation success for a post-auth Scribe probe response, got \(result)")
+        }
+        XCTAssertEqual(result.debug?.statusCode, 415)
+    }
+
     func testValidate_doesNotProbeScribeWhenUserCheckRejectsKey() async throws {
         let recorder = ElevenLabsSTTValidationRequestRecorder()
         ElevenLabsSTTValidationMockURLProtocol.handler = { request in

--- a/Tests/SpeakCoreTests/ElevenLabsSTTAPIKeyValidatorTests.swift
+++ b/Tests/SpeakCoreTests/ElevenLabsSTTAPIKeyValidatorTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import XCTest
+
+@testable import SpeakCore
+
+final class ElevenLabsSTTAPIKeyValidatorTests: XCTestCase {
+    override func tearDown() {
+        ElevenLabsSTTValidationMockURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    func testValidate_probesUserThenScribeAndSucceedsOnMissingAudioResponse() async throws {
+        let recorder = ElevenLabsSTTValidationRequestRecorder()
+        ElevenLabsSTTValidationMockURLProtocol.handler = { request in
+            await recorder.record(request)
+            let path = request.url?.path
+            let statusCode = path == "/v1/speech-to-text" ? 422 : 200
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let validator = ElevenLabsSTTAPIKeyValidator(session: makeMockSession())
+        let result = await validator.validate("full-access-key")
+
+        guard case .success = result.outcome else {
+            return XCTFail("Expected validation success for a key with Scribe access, got \(result)")
+        }
+
+        let requests = await recorder.requests()
+        XCTAssertEqual(requests.map(\.path), ["/v1/user", "/v1/speech-to-text"])
+        XCTAssertEqual(requests.last?.method, "POST")
+        XCTAssertEqual(requests.last?.apiKeyHeader, "full-access-key")
+        XCTAssertEqual(requests.last?.body, "{}")
+    }
+
+    func testValidate_rejectsTTSOnlyKeyWhenScribeAccessIsForbidden() async {
+        ElevenLabsSTTValidationMockURLProtocol.handler = { request in
+            let statusCode = request.url?.path == "/v1/speech-to-text" ? 403 : 200
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let validator = ElevenLabsSTTAPIKeyValidator(session: makeMockSession())
+        let result = await validator.validate("tts-only-key")
+
+        guard case .failure(let message) = result.outcome else {
+            return XCTFail("Expected validation failure for a TTS-only key, got \(result)")
+        }
+        XCTAssertTrue(message.contains("Scribe"), "Expected Scribe access guidance, got: \(message)")
+        XCTAssertEqual(result.debug?.statusCode, 403)
+    }
+
+    func testValidate_doesNotProbeScribeWhenUserCheckRejectsKey() async throws {
+        let recorder = ElevenLabsSTTValidationRequestRecorder()
+        ElevenLabsSTTValidationMockURLProtocol.handler = { request in
+            await recorder.record(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: request.url?.path == "/v1/user" ? 401 : 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let validator = ElevenLabsSTTAPIKeyValidator(session: makeMockSession())
+        let result = await validator.validate("invalid-key")
+
+        guard case .failure = result.outcome else {
+            return XCTFail("Expected validation failure for an invalid key, got \(result)")
+        }
+
+        let requests = await recorder.requests()
+        XCTAssertEqual(requests.map(\.path), ["/v1/user"])
+    }
+
+    private func makeMockSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ElevenLabsSTTValidationMockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
+private actor ElevenLabsSTTValidationRequestRecorder {
+    private var recordedRequests: [RecordedRequest] = []
+
+    func record(_ request: URLRequest) {
+        recordedRequests.append(
+            RecordedRequest(
+                path: request.url?.path,
+                method: request.httpMethod,
+                apiKeyHeader: request.value(forHTTPHeaderField: "xi-api-key"),
+                body: requestBody(for: request).flatMap { String(data: $0, encoding: .utf8) }
+            )
+        )
+    }
+
+    func requests() -> [RecordedRequest] {
+        recordedRequests
+    }
+
+    private func requestBody(for request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: bufferSize)
+            if count < 0 {
+                return nil
+            }
+            if count == 0 {
+                break
+            }
+            data.append(buffer, count: count)
+        }
+
+        return data.isEmpty ? nil : data
+    }
+}
+
+private struct RecordedRequest: Equatable {
+    let path: String?
+    let method: String?
+    let apiKeyHeader: String?
+    let body: String?
+}
+
+private final class ElevenLabsSTTValidationMockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            XCTFail("ElevenLabsSTTValidationMockURLProtocol.handler was not set")
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        Task {
+            do {
+                let (response, data) = try await handler(request)
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Summary
- centralise ElevenLabs STT/Scribe key validation in the shared SpeakCore validator
- reuse it from macOS transcription and TTS validation paths
- add behavioural coverage for full-access, TTS-only, and invalid-key probes

Fixes #346.

## Validation
- `swift test --disable-automatic-resolution --filter 'ElevenLabs(STTAPIKeyValidator|TranscriptionProvider|ClientValidation)Tests'`
- `swift build --disable-automatic-resolution --target SpeakiOSLib`
- `conformance check --event PR_REVIEW --base origin/main`
