### PR TITLE
feat(mac): add Speechmatics live transcription

### DIFF
--- a/Sources/SpeakApp/SpeechmaticsLiveController.swift
+++ b/Sources/SpeakApp/SpeechmaticsLiveController.swift
@@ -2,13 +2,11 @@
 import Foundation
 import os.log
 import SpeakCore
-
 // swiftlint:disable type_body_length
 @MainActor
 final class SpeechmaticsLiveController: NSObject, LiveTranscriptionController {
   weak var delegate: LiveTranscriptionSessionDelegate?
   private(set) var isRunning = false
-
   private let appSettings: AppSettings
   private let permissionsManager: PermissionsManager
   private let audioDeviceManager: AudioInputDeviceManager
@@ -21,7 +19,6 @@ final class SpeechmaticsLiveController: NSObject, LiveTranscriptionController {
   private let logger = Logger(subsystem: "com.speak.app", category: "SpeechmaticsLiveController")
   private let audioProcessor = SpeechmaticsAudioProcessor()
   private var hasFinished = false
-
   private let targetSampleRate: Double = 16000
   private var targetFormat: AVAudioFormat?
   private var streamingStartTime: Date?
@@ -263,6 +260,7 @@ final class SpeechmaticsLiveController: NSObject, LiveTranscriptionController {
       return copy
     }
 
+    // swiftlint:disable:next function_body_length
     private func processAndSendAudio(
       _ buffer: AVAudioPCMBuffer,
       from inputFormat: AVAudioFormat,
@@ -301,11 +299,16 @@ final class SpeechmaticsLiveController: NSObject, LiveTranscriptionController {
 
       converter.reset()
       var error: NSError?
+      var suppliedInput = false
       let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+        guard !suppliedInput else {
+          outStatus.pointee = .noDataNow
+          return nil
+        }
+        suppliedInput = true
         outStatus.pointee = .haveData
         return buffer
       }
-
       guard status != .error, error == nil else { return }
       guard let int16Data = outputBuffer.int16ChannelData else { return }
       let frameLength = Int(outputBuffer.frameLength)
@@ -325,7 +328,6 @@ final class SpeechmaticsLiveController: NSObject, LiveTranscriptionController {
   }
 }
 // swiftlint:enable type_body_length
-
 private extension SpeechmaticsLiveController {
   func ensurePermissions() async -> Bool {
     let microphone = await permissionsManager.ensureGranted(.microphone)

--- a/Sources/SpeakApp/SpeechmaticsLiveController.swift
+++ b/Sources/SpeakApp/SpeechmaticsLiveController.swift
@@ -1,0 +1,393 @@
+@preconcurrency import AVFoundation
+import Foundation
+import os.log
+import SpeakCore
+
+// swiftlint:disable type_body_length
+@MainActor
+final class SpeechmaticsLiveController: NSObject, LiveTranscriptionController {
+  weak var delegate: LiveTranscriptionSessionDelegate?
+  private(set) var isRunning = false
+
+  private let appSettings: AppSettings
+  private let permissionsManager: PermissionsManager
+  private let audioDeviceManager: AudioInputDeviceManager
+  private let secureStorage: SecureAppStorage
+  private var transcriber: SpeechmaticsLiveTranscriber?
+  private var currentLanguage: String?
+  private var currentModel: String?
+  private var activeInputSession: AudioInputDeviceManager.SessionContext?
+  private var audioEngine = AVAudioEngine()
+  private let logger = Logger(subsystem: "com.speak.app", category: "SpeechmaticsLiveController")
+  private let audioProcessor = SpeechmaticsAudioProcessor()
+  private var hasFinished = false
+
+  private let targetSampleRate: Double = 16000
+  private var targetFormat: AVAudioFormat?
+  private var streamingStartTime: Date?
+  private var finalSegments: [TranscriptionSegment] = []
+  private var currentInterim = ""
+  private var fullTranscript = ""
+
+  init(
+    appSettings: AppSettings,
+    permissionsManager: PermissionsManager,
+    audioDeviceManager: AudioInputDeviceManager,
+    secureStorage: SecureAppStorage
+  ) {
+    self.appSettings = appSettings
+    self.permissionsManager = permissionsManager
+    self.audioDeviceManager = audioDeviceManager
+    self.secureStorage = secureStorage
+  }
+
+  func configure(language: String?, model: String) {
+    self.currentLanguage = language
+    self.currentModel = model
+    self.logger.info("Configured Speechmatics with model: \(model, privacy: .public)")
+  }
+
+  // swiftlint:disable:next function_body_length
+  func start() async throws {
+    guard await ensurePermissions() else {
+      throw TranscriptionManagerError.permissionsMissing
+    }
+
+    let apiKey = try await speechmaticsAPIKey()
+    self.activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    self.audioEngine = AVAudioEngine()
+    resetStartState()
+
+    do {
+      let inputNode = audioEngine.inputNode
+      inputNode.removeTap(onBus: 0)
+      let inputFormat = inputNode.outputFormat(forBus: 0)
+      guard audioInputFormatIsUsable(inputFormat) else {
+        throw TranscriptionManagerError.noUsableAudioInput
+      }
+
+      guard let outputFormat = AVAudioFormat(
+        commonFormat: .pcmFormatInt16,
+        sampleRate: targetSampleRate,
+        channels: 1,
+        interleaved: true
+      ) else {
+        throw SpeechmaticsLiveError.encodingFailed
+      }
+      self.targetFormat = outputFormat
+
+      let provider = SpeechmaticsTranscriptionProvider()
+      let newTranscriber = provider.createLiveTranscriber(
+        apiKey: apiKey,
+        model: currentModel ?? appSettings.liveTranscriptionModel,
+        language: currentLanguage,
+        sampleRate: 16000
+      )
+      self.transcriber = newTranscriber
+
+      newTranscriber.start(
+        onTranscript: { [weak self] event in
+          Task { @MainActor [weak self] in
+            self?.handleTranscript(event)
+          }
+        },
+        onError: { [weak self] error in
+          Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard !self.hasFinished else { return }
+            self.delegate?.liveTranscriber(self, didFail: error)
+          }
+        }
+      )
+
+      audioProcessor.setRunning(true)
+      let processor = audioProcessor
+      let log = logger
+      inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { buffer, _ in
+        processor.handleAudioTap(
+          buffer,
+          inputFormat: inputFormat,
+          outputFormat: outputFormat,
+          transcriber: newTranscriber,
+          logger: log
+        )
+      }
+
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
+      self.isRunning = true
+      self.streamingStartTime = Date()
+    } catch {
+      await cleanupAfterFailedStart()
+      throw error
+    }
+  }
+
+  func stop() async {
+    guard isRunning else { return }
+    guard !hasFinished else { return }
+    self.hasFinished = true
+
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    self.isRunning = false
+
+    if let transcriber {
+      audioProcessor.flushPendingAudio(to: transcriber)
+      await transcriber.waitForPendingSends()
+      audioProcessor.setRunning(false)
+      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
+      transcriber.sendEndOfStream()
+      await transcriber.waitForPendingSends()
+      await transcriber.awaitEndOfTranscript(timeout: appSettings.liveModelCapabilities.postStopFinalizeBudget)
+      transcriber.stop()
+    } else {
+      audioProcessor.setRunning(false)
+    }
+
+    let result = buildFinalResult()
+    delegate?.liveTranscriber(self, didFinishWith: result)
+
+    await endActiveInputSession()
+    self.transcriber = nil
+  }
+
+  private func handleTranscript(_ event: SpeechmaticsTranscriptEvent) {
+    if event.isFinal {
+      let segment = TranscriptionSegment(
+        startTime: event.startTime,
+        endTime: event.endTime,
+        text: event.text,
+        isFinal: true,
+        confidence: event.confidence
+      )
+      finalSegments.append(segment)
+      fullTranscript = finalSegments.map(\.text).joined(separator: " ")
+      currentInterim = ""
+      delegate?.liveTranscriber(self, didUpdatePartial: fullTranscript)
+      delegate?.liveTranscriber(
+        self,
+        didUpdateWith: LiveTranscriptionUpdate(text: fullTranscript, isFinal: true, confidence: event.confidence)
+      )
+    } else {
+      currentInterim = event.text
+      let displayText = fullTranscript.isEmpty ? currentInterim : fullTranscript + " " + currentInterim
+      delegate?.liveTranscriber(self, didUpdatePartial: displayText)
+      delegate?.liveTranscriber(self, didUpdateWith: LiveTranscriptionUpdate(text: displayText, isFinal: false))
+    }
+  }
+
+  private final class SpeechmaticsAudioProcessor: @unchecked Sendable {
+    private static let preferredChunkBytes = SpeechmaticsLiveTranscriber.preferredChunkBytes
+    private static let minimumChunkBytes = SpeechmaticsLiveTranscriber.minimumChunkBytes
+
+    private let queue = DispatchQueue(label: "com.speak.app.speechmatics.audioProcessing")
+    private var isRunning = false
+    private var cachedConverter: AVAudioConverter?
+    private var cachedInputFormat: AVAudioFormat?
+    private var reusableOutputBuffer: AVAudioPCMBuffer?
+    private var pendingPCMData = Data()
+
+    func setRunning(_ running: Bool) {
+      queue.sync {
+        self.isRunning = running
+        if !running {
+          self.cachedConverter = nil
+          self.cachedInputFormat = nil
+          self.reusableOutputBuffer = nil
+          self.pendingPCMData.removeAll(keepingCapacity: false)
+        }
+      }
+    }
+
+    func flushPendingAudio(to transcriber: SpeechmaticsLiveTranscriber) {
+      queue.sync {
+        guard !self.pendingPCMData.isEmpty else { return }
+        var offset = 0
+        while self.pendingPCMData.count - offset >= Self.preferredChunkBytes {
+          let chunk = self.pendingPCMData.subdata(in: offset..<(offset + Self.preferredChunkBytes))
+          transcriber.sendAudio(chunk)
+          offset += Self.preferredChunkBytes
+        }
+        if offset > 0 {
+          self.pendingPCMData = Data(self.pendingPCMData.dropFirst(offset))
+        }
+        guard !self.pendingPCMData.isEmpty else { return }
+        if self.pendingPCMData.count < Self.minimumChunkBytes {
+          self.pendingPCMData.append(
+            contentsOf: repeatElement(0, count: Self.minimumChunkBytes - self.pendingPCMData.count))
+        }
+        transcriber.sendAudio(self.pendingPCMData)
+        self.pendingPCMData.removeAll(keepingCapacity: false)
+      }
+    }
+
+    func handleAudioTap(
+      _ buffer: AVAudioPCMBuffer,
+      inputFormat: AVAudioFormat,
+      outputFormat: AVAudioFormat,
+      transcriber: SpeechmaticsLiveTranscriber,
+      logger: Logger
+    ) {
+      guard let copied = copyPCMBuffer(buffer) else { return }
+      queue.async { [weak self] in
+        guard let self, self.isRunning else { return }
+        self.processAndSendAudio(
+          copied,
+          from: inputFormat,
+          to: outputFormat,
+          transcriber: transcriber,
+          logger: logger
+        )
+      }
+    }
+
+    private func copyPCMBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+      let frameLength = buffer.frameLength
+      guard let copy = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: frameLength) else {
+        return nil
+      }
+      copy.frameLength = frameLength
+      let src = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: buffer.audioBufferList))
+      let dst = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: copy.audioBufferList))
+      for idx in 0..<min(src.count, dst.count) {
+        let srcBuf = src[idx]
+        guard let srcData = srcBuf.mData, let dstData = dst[idx].mData else { continue }
+        dstData.copyMemory(from: srcData, byteCount: Int(srcBuf.mDataByteSize))
+        dst[idx].mDataByteSize = srcBuf.mDataByteSize
+      }
+      return copy
+    }
+
+    private func processAndSendAudio(
+      _ buffer: AVAudioPCMBuffer,
+      from inputFormat: AVAudioFormat,
+      to outputFormat: AVAudioFormat,
+      transcriber: SpeechmaticsLiveTranscriber,
+      logger: Logger
+    ) {
+      let converter: AVAudioConverter
+      if let cached = cachedConverter, cachedInputFormat == inputFormat {
+        converter = cached
+      } else {
+        guard let newConverter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+          logger.error("Failed to create audio converter")
+          return
+        }
+        self.cachedConverter = newConverter
+        self.cachedInputFormat = inputFormat
+        converter = newConverter
+      }
+
+      let ratio = outputFormat.sampleRate / inputFormat.sampleRate
+      let outputFrameCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
+
+      let outputBuffer: AVAudioPCMBuffer
+      if let reusableOutputBuffer, reusableOutputBuffer.frameCapacity >= outputFrameCapacity {
+        reusableOutputBuffer.frameLength = 0
+        outputBuffer = reusableOutputBuffer
+      } else {
+        guard let newBuffer = AVAudioPCMBuffer(
+          pcmFormat: outputFormat,
+          frameCapacity: outputFrameCapacity
+        ) else { return }
+        self.reusableOutputBuffer = newBuffer
+        outputBuffer = newBuffer
+      }
+
+      converter.reset()
+      var error: NSError?
+      let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+        outStatus.pointee = .haveData
+        return buffer
+      }
+
+      guard status != .error, error == nil else { return }
+      guard let int16Data = outputBuffer.int16ChannelData else { return }
+      let frameLength = Int(outputBuffer.frameLength)
+      let data = Data(bytes: int16Data[0], count: frameLength * 2)
+      pendingPCMData.append(data)
+
+      var offset = 0
+      while pendingPCMData.count - offset >= Self.preferredChunkBytes {
+        let chunk = pendingPCMData.subdata(in: offset..<(offset + Self.preferredChunkBytes))
+        transcriber.sendAudio(chunk)
+        offset += Self.preferredChunkBytes
+      }
+      if offset > 0 {
+        pendingPCMData = Data(pendingPCMData.dropFirst(offset))
+      }
+    }
+  }
+}
+// swiftlint:enable type_body_length
+
+private extension SpeechmaticsLiveController {
+  func ensurePermissions() async -> Bool {
+    let microphone = await permissionsManager.ensureGranted(.microphone)
+    let speech = await permissionsManager.ensureGranted(.speechRecognition)
+    return microphone.isGranted && speech.isGranted
+  }
+
+  func speechmaticsAPIKey() async throws -> String {
+    do {
+      let apiKey = try await secureStorage.secret(identifier: "speechmatics.apiKey")
+      guard !apiKey.isEmpty else { throw SpeechmaticsLiveError.missingAPIKey }
+      return apiKey
+    } catch let error as SecureAppStorageError {
+      if case .valueNotFound = error { throw SpeechmaticsLiveError.missingAPIKey }
+      throw error
+    }
+  }
+
+  func resetStartState() {
+    self.transcriber = nil
+    self.targetFormat = nil
+    self.finalSegments = []
+    self.currentInterim = ""
+    self.fullTranscript = ""
+    self.streamingStartTime = nil
+    self.hasFinished = false
+    self.isRunning = false
+  }
+
+  func cleanupAfterFailedStart() async {
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    self.isRunning = false
+    audioProcessor.setRunning(false)
+    transcriber?.stop()
+    self.transcriber = nil
+    self.targetFormat = nil
+    self.streamingStartTime = nil
+    self.currentInterim = ""
+    self.finalSegments = []
+    self.fullTranscript = ""
+    await endActiveInputSession()
+  }
+
+  func buildFinalResult() -> TranscriptionResult {
+    var text = finalSegments.map(\.text).joined(separator: " ")
+    let trimmedInterim = currentInterim.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmedInterim.isEmpty {
+      if !text.isEmpty { text += " " }
+      text += trimmedInterim
+    }
+    let streamingDuration = streamingStartTime.map { Date().timeIntervalSince($0) } ?? 0
+    return TranscriptionResult(
+      text: text,
+      segments: finalSegments,
+      confidence: nil,
+      duration: streamingDuration,
+      modelIdentifier: currentModel ?? "speechmatics/enhanced-streaming",
+      cost: nil,
+      rawPayload: nil,
+      debugInfo: nil
+    )
+  }
+
+  func endActiveInputSession() async {
+    guard let session = activeInputSession else { return }
+    self.activeInputSession = nil
+    await audioDeviceManager.endUsingPreferredInput(session: session)
+  }
+}

--- a/Sources/SpeakApp/SpeechmaticsLiveController.swift
+++ b/Sources/SpeakApp/SpeechmaticsLiveController.swift
@@ -133,12 +133,17 @@ final class SpeechmaticsLiveController: NSObject, LiveTranscriptionController {
 
     if let transcriber {
       audioProcessor.flushPendingAudio(to: transcriber)
+      let recognitionStarted = await transcriber.waitForRecognitionStarted(
+        timeout: appSettings.liveModelCapabilities.postStopFinalizeBudget
+      )
       await transcriber.waitForPendingSends()
       audioProcessor.setRunning(false)
-      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
-      transcriber.sendEndOfStream()
-      await transcriber.waitForPendingSends()
-      await transcriber.awaitEndOfTranscript(timeout: appSettings.liveModelCapabilities.postStopFinalizeBudget)
+      if recognitionStarted {
+        await applyLiveStopGrace(appSettings.liveStopGracePeriod)
+        transcriber.sendEndOfStream()
+        await transcriber.waitForPendingSends()
+        await transcriber.awaitEndOfTranscript(timeout: appSettings.liveModelCapabilities.postStopFinalizeBudget)
+      }
       transcriber.stop()
     } else {
       audioProcessor.setRunning(false)

--- a/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
@@ -66,7 +66,7 @@ struct SpeechmaticsTranscriptionProvider: TranscriptionProvider {
 
     var request = URLRequest(url: validationURL)
     request.httpMethod = "GET"
-    request.setValue(trimmed, forHTTPHeaderField: "Authorization")
+    request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
 
     do {
       let (data, response) = try await session.data(for: request)
@@ -215,6 +215,12 @@ private struct SpeechmaticsAudioAddedMessage: Decodable {
   }
 }
 
+private struct SpeechmaticsPreStartAudioFlush {
+  let task: URLSessionWebSocketTask?
+  let frames: [Data]
+  let continuation: CheckedContinuation<Bool, Never>?
+}
+
 private struct SpeechmaticsErrorMessage: Decodable {
   let type: String?
   let reason: String?
@@ -289,20 +295,32 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
   }
 
   func sendAudio(_ audioData: Data) {
-    let snapshot = withStateLock { () -> (URLSessionWebSocketTask?, Bool) in
-      (self.webSocketTask, self.recognitionStarted)
+    enum SendAction {
+      case sendDirectly(URLSessionWebSocketTask)
+      case buffered
     }
-    guard let task = snapshot.0, task.state == .running, snapshot.1 else {
-      withStateLock {
+
+    let action = withStateLock { () -> SendAction in
+      if self.recognitionStarted,
+         let task = self.webSocketTask,
+         task.state == .running {
+        return .sendDirectly(task)
+      } else {
         self.preStartAudioBuffer.append(audioData)
         var totalBytes = self.preStartAudioBuffer.reduce(0) { $0 + $1.count }
         while totalBytes > Self.preStartByteLimit, !self.preStartAudioBuffer.isEmpty {
           totalBytes -= self.preStartAudioBuffer.removeFirst().count
         }
+        return .buffered
       }
+    }
+
+    switch action {
+    case .sendDirectly(let task):
+      sendAudioFrame(audioData, on: task)
+    case .buffered:
       return
     }
-    sendAudioFrame(audioData, on: task)
   }
 
   func sendEndOfStream() {
@@ -471,7 +489,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
     }
 
     var request = URLRequest(url: url)
-    request.setValue(apiKey, forHTTPHeaderField: "Authorization")
+    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
 
     let task = session.webSocketTask(with: request)
     let shouldReceive = withStateLock { () -> Bool in
@@ -545,19 +563,6 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
     }
   }
 
-  private func flushPreStartAudio() {
-    let (task, frames) = withStateLock { () -> (URLSessionWebSocketTask?, [Data]) in
-      let pending = self.preStartAudioBuffer
-      self.preStartAudioBuffer = []
-      return (self.webSocketTask, pending)
-    }
-    guard let task, task.state == .running, !frames.isEmpty else { return }
-    logger.info("Flushing \(frames.count) pre-start audio frames to Speechmatics")
-    for frame in frames {
-      sendAudioFrame(frame, on: task)
-    }
-  }
-
   private func receiveMessages() {
     guard let task = currentWebSocketTask() else { return }
     task.receive { [weak self] result in
@@ -594,14 +599,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
 
     switch envelope.message {
     case "RecognitionStarted":
-      let pending = withStateLock { () -> CheckedContinuation<Bool, Never>? in
-        self.recognitionStarted = true
-        let saved = self.recognitionStartedContinuation
-        self.recognitionStartedContinuation = nil
-        return saved
-      }
-      flushPreStartAudio()
-      pending?.resume(returning: true)
+      handleRecognitionStarted()
     case "AudioAdded":
       if let message = try? JSONDecoder().decode(SpeechmaticsAudioAddedMessage.self, from: data) {
         withStateLock { self.lastAcknowledgedSeqNo = max(self.lastAcknowledgedSeqNo, message.seqNo) }
@@ -624,6 +622,28 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
     default:
       break
     }
+  }
+
+  private func handleRecognitionStarted() {
+    let flush = withStateLock { () -> SpeechmaticsPreStartAudioFlush in
+      self.recognitionStarted = true
+      let frames = self.preStartAudioBuffer
+      self.preStartAudioBuffer = []
+      let continuation = self.recognitionStartedContinuation
+      self.recognitionStartedContinuation = nil
+      return SpeechmaticsPreStartAudioFlush(
+        task: self.webSocketTask,
+        frames: frames,
+        continuation: continuation
+      )
+    }
+    if let task = flush.task, task.state == .running, !flush.frames.isEmpty {
+      logger.info("Flushing \(flush.frames.count) pre-start audio frames to Speechmatics")
+      for frame in flush.frames {
+        sendAudioFrame(frame, on: task)
+      }
+    }
+    flush.continuation?.resume(returning: true)
   }
 
   private static func segments(from results: [SpeechmaticsResult]) -> [TranscriptionSegment] {

--- a/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
@@ -1,0 +1,662 @@
+// swiftlint:disable file_length
+import Foundation
+import os.log
+import SpeakCore
+
+// MARK: - Errors
+
+enum SpeechmaticsLiveError: LocalizedError {
+  case missingAPIKey
+  case invalidURL
+  case invalidAPIKey
+  case batchNotSupported
+  case encodingFailed
+  case serverError(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .missingAPIKey:
+      "Speechmatics API key is missing. Please add it in Settings → Speechmatics."
+    case .invalidURL:
+      "Failed to construct Speechmatics WebSocket URL."
+    case .invalidAPIKey:
+      "Speechmatics API key is invalid. Check your key in Settings → Speechmatics."
+    case .batchNotSupported:
+      "Speechmatics is currently only available for live streaming in Speak."
+    case .encodingFailed:
+      "Failed to encode the Speechmatics realtime request."
+    case .serverError(let message):
+      "Speechmatics realtime error: \(message)"
+    }
+  }
+}
+
+// MARK: - Provider
+
+struct SpeechmaticsTranscriptionProvider: TranscriptionProvider {
+  let metadata = TranscriptionProviderMetadata(
+    id: "speechmatics",
+    displayName: "Speechmatics",
+    systemImage: "waveform.and.magnifyingglass",
+    tintColor: "cyan",
+    website: "https://www.speechmatics.com"
+  )
+
+  private let validationURL = URL(string: "https://eu1.asr.api.speechmatics.com/v2/jobs/")!
+  private let session: URLSession
+
+  init(session: URLSession = .shared) {
+    self.session = session
+  }
+
+  func transcribeFile(
+    at url: URL,
+    apiKey: String,
+    model: String,
+    language: String?
+  ) async throws -> TranscriptionResult {
+    throw SpeechmaticsLiveError.batchNotSupported
+  }
+
+  func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
+    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return .failure(message: "API key is empty")
+    }
+
+    var request = URLRequest(url: validationURL)
+    request.httpMethod = "GET"
+    request.setValue(trimmed, forHTTPHeaderField: "Authorization")
+
+    do {
+      let (data, response) = try await session.data(for: request)
+      guard let http = response as? HTTPURLResponse else {
+        return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
+      }
+
+      let debug = debugSnapshot(request: request, response: http, data: data)
+      if (200..<300).contains(http.statusCode) {
+        return .success(message: "Speechmatics API key validated", debug: debug)
+      }
+      if http.statusCode == 401 || http.statusCode == 403 {
+        return .failure(message: "Speechmatics rejected the key (HTTP \(http.statusCode))", debug: debug)
+      }
+      return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
+    } catch {
+      return .failure(
+        message: "Validation failed: \(error.localizedDescription)",
+        debug: debugSnapshot(request: request, error: error)
+      )
+    }
+  }
+
+  func requiresAPIKey(for model: String) -> Bool {
+    true
+  }
+
+  func supportedModels() -> [ModelCatalog.Option] {
+    [
+      ModelCatalog.Option(
+        id: "speechmatics/enhanced-streaming",
+        displayName: "Speechmatics Enhanced (Streaming)",
+        description: "Speechmatics realtime WebSocket transcription with partial and final results."
+      )
+    ]
+  }
+
+  func createLiveTranscriber(
+    apiKey: String,
+    model: String = "speechmatics/enhanced-streaming",
+    language: String? = nil,
+    sampleRate: Int = 16000
+  ) -> SpeechmaticsLiveTranscriber {
+    SpeechmaticsLiveTranscriber(
+      apiKey: apiKey,
+      model: Self.realtimeModelName(from: model),
+      language: language.map(Self.extractLanguageCode(from:)),
+      sampleRate: sampleRate
+    )
+  }
+
+  static func realtimeModelName(from modelID: String) -> String {
+    let raw = modelID
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: "speechmatics/", with: "")
+      .replacingOccurrences(of: "-streaming", with: "")
+    return raw.isEmpty ? "enhanced" : raw
+  }
+
+  static func extractLanguageCode(from locale: String) -> String {
+    let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
+    return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
+  }
+
+  private func debugSnapshot(
+    request: URLRequest,
+    response: HTTPURLResponse? = nil,
+    data: Data? = nil,
+    error: Error? = nil
+  ) -> APIKeyValidationDebugSnapshot {
+    APIKeyValidationDebugSnapshot(
+      url: request.url?.absoluteString ?? "",
+      method: request.httpMethod ?? "GET",
+      requestHeaders: request.allHTTPHeaderFields ?? [:],
+      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
+      statusCode: response?.statusCode,
+      responseHeaders: response?.allHeaderFields.reduce(into: [String: String]()) { result, pair in
+        if let key = pair.key as? String {
+          result[key] = String(describing: pair.value)
+        }
+      } ?? [:],
+      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
+      errorDescription: error?.localizedDescription
+    )
+  }
+}
+
+// MARK: - WebSocket response types
+
+struct SpeechmaticsTranscriptEvent: Sendable {
+  let text: String
+  let isFinal: Bool
+  let startTime: TimeInterval
+  let endTime: TimeInterval
+  let segments: [TranscriptionSegment]
+  let confidence: Double?
+}
+
+private struct SpeechmaticsEnvelope: Decodable {
+  let message: String
+}
+
+private struct SpeechmaticsTranscriptMetadata: Decodable {
+  let startTime: TimeInterval
+  let endTime: TimeInterval
+  let transcript: String
+
+  private enum CodingKeys: String, CodingKey {
+    case startTime = "start_time"
+    case endTime = "end_time"
+    case transcript
+  }
+}
+
+private struct SpeechmaticsTranscriptResponse: Decodable {
+  let message: String
+  let metadata: SpeechmaticsTranscriptMetadata
+  let results: [SpeechmaticsResult]
+}
+
+private struct SpeechmaticsResult: Decodable {
+  let type: String
+  let startTime: TimeInterval?
+  let endTime: TimeInterval?
+  let alternatives: [SpeechmaticsAlternative]
+
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case startTime = "start_time"
+    case endTime = "end_time"
+    case alternatives
+  }
+}
+
+private struct SpeechmaticsAlternative: Decodable {
+  let content: String
+  let confidence: Double?
+  let speaker: String?
+}
+
+private struct SpeechmaticsAudioAddedMessage: Decodable {
+  let seqNo: Int
+
+  private enum CodingKeys: String, CodingKey {
+    case seqNo = "seq_no"
+  }
+}
+
+private struct SpeechmaticsErrorMessage: Decodable {
+  let type: String?
+  let reason: String?
+}
+
+// MARK: - Live Transcriber
+
+// swiftlint:disable type_body_length
+final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
+  static let minimumChunkBytes = 3_200
+  static let preferredChunkBytes = 3_200
+
+  private static let websocketHost = "eu.rt.speechmatics.com"
+  private static let websocketPath = "/v2/"
+  private static let preStartByteLimit = 16_000 * 2 * 5
+
+  private let apiKey: String
+  private let model: String
+  private let language: String?
+  private let sampleRate: Int
+  private let session: URLSession
+  private let bufferPool: AudioBufferPool
+  private let logger = Logger(subsystem: "com.speak.app", category: "SpeechmaticsLiveTranscriber")
+  private let stateLock = NSLock()
+  private let pendingSendGroup = DispatchGroup()
+
+  private var webSocketTask: URLSessionWebSocketTask?
+  private var onTranscript: ((SpeechmaticsTranscriptEvent) -> Void)?
+  private var onError: ((Error) -> Void)?
+  private var isStopping = false
+  private var recognitionStarted = false
+  private var preStartAudioBuffer: [Data] = []
+  private var sentAudioFrameCount = 0
+  private var lastAcknowledgedSeqNo = -1
+  private var endOfTranscriptReceived = false
+  private var endOfTranscriptContinuation: CheckedContinuation<Void, Never>?
+
+  init(
+    apiKey: String,
+    model: String = "enhanced",
+    language: String? = nil,
+    sampleRate: Int = 16000,
+    session: URLSession = .shared,
+    bufferPool: AudioBufferPool = AudioBufferPool(poolSize: 10, bufferSize: 4096)
+  ) {
+    self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    self.model = model
+    self.language = language
+    self.sampleRate = sampleRate
+    self.session = session
+    self.bufferPool = bufferPool
+  }
+
+  func start(
+    onTranscript: @escaping (SpeechmaticsTranscriptEvent) -> Void,
+    onError: @escaping (Error) -> Void
+  ) {
+    withStateLock {
+      self.isStopping = false
+      self.recognitionStarted = false
+      self.preStartAudioBuffer = []
+      self.sentAudioFrameCount = 0
+      self.lastAcknowledgedSeqNo = -1
+      self.endOfTranscriptReceived = false
+      self.endOfTranscriptContinuation = nil
+      self.onTranscript = onTranscript
+      self.onError = onError
+    }
+    connectWebSocket()
+  }
+
+  func sendAudio(_ audioData: Data) {
+    let snapshot = withStateLock { () -> (URLSessionWebSocketTask?, Bool) in
+      (self.webSocketTask, self.recognitionStarted)
+    }
+    guard let task = snapshot.0, task.state == .running, snapshot.1 else {
+      withStateLock {
+        self.preStartAudioBuffer.append(audioData)
+        var totalBytes = self.preStartAudioBuffer.reduce(0) { $0 + $1.count }
+        while totalBytes > Self.preStartByteLimit, !self.preStartAudioBuffer.isEmpty {
+          totalBytes -= self.preStartAudioBuffer.removeFirst().count
+        }
+      }
+      return
+    }
+    sendAudioFrame(audioData, on: task)
+  }
+
+  func sendEndOfStream() {
+    guard let task = currentWebSocketTask(), task.state == .running else { return }
+    let lastSeqNo = withStateLock {
+      max(self.lastAcknowledgedSeqNo, self.sentAudioFrameCount - 1, 0)
+    }
+    let payload: [String: Any] = [
+      "message": "EndOfStream",
+      "last_seq_no": lastSeqNo
+    ]
+    sendJSONPayload(payload, on: task)
+  }
+
+  func awaitEndOfTranscript(timeout: TimeInterval = 2.0) async {
+    await withCheckedContinuation { continuation in
+      let shouldWait = withStateLock { () -> Bool in
+        guard !self.isStopping, !self.endOfTranscriptReceived else { return false }
+        self.endOfTranscriptContinuation = continuation
+        return true
+      }
+      if !shouldWait {
+        continuation.resume()
+        return
+      }
+      Task { [weak self] in
+        try? await Task.sleep(for: .seconds(timeout))
+        guard let self else { return }
+        let pending = self.withStateLock { () -> CheckedContinuation<Void, Never>? in
+          let saved = self.endOfTranscriptContinuation
+          self.endOfTranscriptContinuation = nil
+          return saved
+        }
+        pending?.resume()
+      }
+    }
+  }
+
+  func waitForPendingSends(timeout: TimeInterval = 1.5) async {
+    let sendGroup = pendingSendGroup
+    await withCheckedContinuation { continuation in
+      DispatchQueue.global().async {
+        _ = sendGroup.wait(timeout: .now() + timeout)
+        continuation.resume()
+      }
+    }
+  }
+
+  func stop() {
+    let task = withStateLock { () -> URLSessionWebSocketTask? in
+      guard !self.isStopping else { return nil }
+      self.isStopping = true
+      return self.webSocketTask
+    }
+    bufferPool.logMetrics()
+
+    let pending = withStateLock { () -> CheckedContinuation<Void, Never>? in
+      let saved = self.endOfTranscriptContinuation
+      self.endOfTranscriptContinuation = nil
+      return saved
+    }
+    pending?.resume()
+
+    guard let task else { return }
+    if task.state == .running {
+      task.cancel(with: .normalClosure, reason: nil)
+    }
+    withStateLock {
+      if self.webSocketTask === task {
+        self.webSocketTask = nil
+      }
+    }
+    logger.info("Speechmatics WebSocket connection closed")
+  }
+
+  static func startRecognitionPayload(
+    language: String? = nil,
+    model: String = "enhanced",
+    sampleRate: Int = 16000
+  ) throws -> String {
+    let languageCode = language.map(SpeechmaticsTranscriptionProvider.extractLanguageCode(from:)) ?? "en"
+    let payload: [String: Any] = [
+      "message": "StartRecognition",
+      "audio_format": [
+        "type": "raw",
+        "encoding": "pcm_s16le",
+        "sample_rate": sampleRate
+      ],
+      "transcription_config": [
+        "language": languageCode,
+        "model": model,
+        "max_delay": 0.7,
+        "enable_partials": true
+      ]
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+    guard let json = String(data: data, encoding: .utf8) else {
+      throw SpeechmaticsLiveError.encodingFailed
+    }
+    return json
+  }
+
+  static func transcriptEvent(from json: String) -> SpeechmaticsTranscriptEvent? {
+    guard let data = json.data(using: .utf8),
+          let envelope = try? JSONDecoder().decode(SpeechmaticsEnvelope.self, from: data),
+          envelope.message == "AddPartialTranscript" || envelope.message == "AddTranscript",
+          let response = try? JSONDecoder().decode(SpeechmaticsTranscriptResponse.self, from: data)
+    else {
+      return nil
+    }
+
+    let text = response.metadata.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !text.isEmpty else { return nil }
+    let isFinal = response.message == "AddTranscript"
+    let segments = isFinal ? Self.segments(from: response.results) : []
+    let confidence = isFinal ? Self.averageConfidence(from: response.results) : nil
+    return SpeechmaticsTranscriptEvent(
+      text: text,
+      isFinal: isFinal,
+      startTime: response.metadata.startTime,
+      endTime: response.metadata.endTime,
+      segments: segments,
+      confidence: confidence
+    )
+  }
+
+  private func connectWebSocket() {
+    var components = URLComponents()
+    components.scheme = "wss"
+    components.host = Self.websocketHost
+    components.path = Self.websocketPath
+    guard let url = components.url else {
+      currentOnError()?(SpeechmaticsLiveError.invalidURL)
+      return
+    }
+
+    var request = URLRequest(url: url)
+    request.setValue(apiKey, forHTTPHeaderField: "Authorization")
+
+    let task = session.webSocketTask(with: request)
+    let shouldReceive = withStateLock { () -> Bool in
+      guard !self.isStopping else { return false }
+      self.webSocketTask = task
+      task.resume()
+      return true
+    }
+    guard shouldReceive else {
+      task.cancel(with: .goingAway, reason: nil)
+      return
+    }
+
+    sendStartRecognition(on: task)
+    logger.info("Speechmatics WebSocket connecting (model: \(self.model, privacy: .public))")
+    receiveMessages()
+  }
+
+  private func sendStartRecognition(on task: URLSessionWebSocketTask) {
+    do {
+      let payload = try Self.startRecognitionPayload(language: language, model: model, sampleRate: sampleRate)
+      let sendGroup = pendingSendGroup
+      sendGroup.enter()
+      task.send(.string(payload)) { [weak self] error in
+        defer { sendGroup.leave() }
+        guard let self else { return }
+        if let error, !self.isStoppingState() {
+          self.currentOnError()?(error)
+        }
+      }
+    } catch {
+      currentOnError()?(error)
+    }
+  }
+
+  private func sendAudioFrame(_ audioData: Data, on task: URLSessionWebSocketTask) {
+    var buffer = bufferPool.checkout()
+    buffer.append(audioData)
+    withStateLock {
+      self.sentAudioFrameCount += 1
+    }
+
+    let dataToSend = buffer
+    let sendGroup = pendingSendGroup
+    sendGroup.enter()
+    task.send(.data(dataToSend)) { [weak self] error in
+      defer { sendGroup.leave() }
+      guard let self else { return }
+      var returnBuffer = buffer
+      self.bufferPool.returnBuffer(&returnBuffer)
+      if let error {
+        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        self.logger.error("Failed to send audio: \(error.localizedDescription, privacy: .public)")
+        self.currentOnError()?(error)
+      }
+    }
+  }
+
+  private func sendJSONPayload(_ payload: [String: Any], on task: URLSessionWebSocketTask) {
+    guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
+          let json = String(data: data, encoding: .utf8)
+    else { return }
+    let sendGroup = pendingSendGroup
+    sendGroup.enter()
+    task.send(.string(json)) { [weak self] error in
+      defer { sendGroup.leave() }
+      guard let self else { return }
+      if let error, !self.isStoppingState(), !self.shouldIgnoreSocketError(error) {
+        self.currentOnError()?(error)
+      }
+    }
+  }
+
+  private func flushPreStartAudio() {
+    let (task, frames) = withStateLock { () -> (URLSessionWebSocketTask?, [Data]) in
+      let pending = self.preStartAudioBuffer
+      self.preStartAudioBuffer = []
+      return (self.webSocketTask, pending)
+    }
+    guard let task, task.state == .running, !frames.isEmpty else { return }
+    logger.info("Flushing \(frames.count) pre-start audio frames to Speechmatics")
+    for frame in frames {
+      sendAudioFrame(frame, on: task)
+    }
+  }
+
+  private func receiveMessages() {
+    guard let task = currentWebSocketTask() else { return }
+    task.receive { [weak self] result in
+      guard let self else { return }
+      switch result {
+      case .success(let message):
+        self.handleMessage(message)
+        self.receiveMessages()
+      case .failure(let error):
+        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        self.logger.error("Speechmatics receive error: \(error.localizedDescription, privacy: .public)")
+        self.currentOnError()?(self.mapConnectionError(error))
+      }
+    }
+  }
+
+  private func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+    switch message {
+    case .string(let text):
+      parseResponse(text)
+    case .data(let data):
+      if let text = String(data: data, encoding: .utf8) {
+        parseResponse(text)
+      }
+    @unknown default:
+      break
+    }
+  }
+
+  private func parseResponse(_ json: String) {
+    guard let data = json.data(using: .utf8),
+          let envelope = try? JSONDecoder().decode(SpeechmaticsEnvelope.self, from: data)
+    else { return }
+
+    switch envelope.message {
+    case "RecognitionStarted":
+      withStateLock { self.recognitionStarted = true }
+      flushPreStartAudio()
+    case "AudioAdded":
+      if let message = try? JSONDecoder().decode(SpeechmaticsAudioAddedMessage.self, from: data) {
+        withStateLock { self.lastAcknowledgedSeqNo = max(self.lastAcknowledgedSeqNo, message.seqNo) }
+      }
+    case "AddPartialTranscript", "AddTranscript":
+      guard let event = Self.transcriptEvent(from: json) else { return }
+      currentOnTranscript()?(event)
+    case "EndOfTranscript":
+      let pending = withStateLock { () -> CheckedContinuation<Void, Never>? in
+        self.endOfTranscriptReceived = true
+        let saved = self.endOfTranscriptContinuation
+        self.endOfTranscriptContinuation = nil
+        return saved
+      }
+      pending?.resume()
+    case "Error":
+      let decoded = try? JSONDecoder().decode(SpeechmaticsErrorMessage.self, from: data)
+      let detail = decoded?.reason ?? decoded?.type ?? "Unknown Speechmatics error"
+      currentOnError()?(mapServerError(type: decoded?.type, detail: detail))
+    default:
+      break
+    }
+  }
+
+  private static func segments(from results: [SpeechmaticsResult]) -> [TranscriptionSegment] {
+    results.compactMap { result in
+      guard let alternative = result.alternatives.first else { return nil }
+      let content = alternative.content.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !content.isEmpty else { return nil }
+      return TranscriptionSegment(
+        startTime: result.startTime ?? 0,
+        endTime: result.endTime ?? result.startTime ?? 0,
+        text: content,
+        isFinal: true,
+        confidence: alternative.confidence
+      )
+    }
+  }
+
+  private static func averageConfidence(from results: [SpeechmaticsResult]) -> Double? {
+    let confidences = results.compactMap { $0.alternatives.first?.confidence }
+    guard !confidences.isEmpty else { return nil }
+    return confidences.reduce(0, +) / Double(confidences.count)
+  }
+
+  private func mapConnectionError(_ error: Error) -> Error {
+    let nsError = error as NSError
+    let description = nsError.localizedDescription.lowercased()
+    if nsError.code == 401 || nsError.code == 403
+      || description.contains("401") || description.contains("403")
+      || description.contains("unauthorized") || description.contains("not authorised")
+      || description.contains("forbidden") {
+      return SpeechmaticsLiveError.invalidAPIKey
+    }
+    return error
+  }
+
+  private func mapServerError(type: String?, detail: String) -> Error {
+    let errorType = type?.lowercased() ?? ""
+    if errorType.contains("not_authorised") || errorType.contains("not authorized") {
+      return SpeechmaticsLiveError.invalidAPIKey
+    }
+    return SpeechmaticsLiveError.serverError(detail)
+  }
+
+  private func shouldIgnoreSocketError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
+    if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
+      return true
+    }
+    return false
+  }
+
+  private func withStateLock<T>(_ block: () -> T) -> T {
+    stateLock.lock()
+    defer { stateLock.unlock() }
+    return block()
+  }
+
+  private func currentWebSocketTask() -> URLSessionWebSocketTask? {
+    withStateLock { self.webSocketTask }
+  }
+
+  private func isStoppingState() -> Bool {
+    withStateLock { self.isStopping }
+  }
+
+  private func currentOnTranscript() -> ((SpeechmaticsTranscriptEvent) -> Void)? {
+    withStateLock { self.onTranscript }
+  }
+
+  private func currentOnError() -> ((Error) -> Void)? {
+    withStateLock { self.onError }
+  }
+}
+// swiftlint:enable type_body_length

--- a/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
@@ -42,7 +42,7 @@ struct SpeechmaticsTranscriptionProvider: TranscriptionProvider {
     website: "https://www.speechmatics.com"
   )
 
-  private let validationURL = URL(string: "https://eu1.asr.api.speechmatics.com/v2/jobs/")!
+  private let validationURL = URL(string: "https://eu1.asr.api.speechmatics.com/v2/jobs")!
   private let session: URLSession
 
   init(session: URLSession = .shared) {
@@ -221,6 +221,12 @@ private struct SpeechmaticsPreStartAudioFlush {
   let continuation: CheckedContinuation<Bool, Never>?
 }
 
+private struct SpeechmaticsOutboundFrame {
+  let task: URLSessionWebSocketTask
+  let message: URLSessionWebSocketTask.Message
+  let completion: (Error?) -> Void
+}
+
 private struct SpeechmaticsErrorMessage: Decodable {
   let type: String?
   let reason: String?
@@ -246,6 +252,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
   private let logger = Logger(subsystem: "com.speak.app", category: "SpeechmaticsLiveTranscriber")
   private let stateLock = NSLock()
   private let pendingSendGroup = DispatchGroup()
+  private let outboundSendQueue = DispatchQueue(label: "com.speak.app.speechmatics.outbound")
 
   private var webSocketTask: URLSessionWebSocketTask?
   private var onTranscript: ((SpeechmaticsTranscriptEvent) -> Void)?
@@ -258,6 +265,8 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
   private var endOfTranscriptReceived = false
   private var endOfTranscriptContinuation: CheckedContinuation<Void, Never>?
   private var recognitionStartedContinuation: CheckedContinuation<Bool, Never>?
+  private var outboundFrames: [SpeechmaticsOutboundFrame] = []
+  private var outboundSendInFlight = false
 
   init(
     apiKey: String,
@@ -326,7 +335,10 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
   func sendEndOfStream() {
     guard let task = currentWebSocketTask(), task.state == .running else { return }
     let lastSeqNo = withStateLock {
-      max(self.lastAcknowledgedSeqNo, self.sentAudioFrameCount - 1, 0)
+      Self.endOfStreamLastSequenceNumber(
+        lastAcknowledged: self.lastAcknowledgedSeqNo,
+        sentFrameCount: self.sentAudioFrameCount
+      )
     }
     let payload: [String: Any] = [
       "message": "EndOfStream",
@@ -478,6 +490,10 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
     )
   }
 
+  static func endOfStreamLastSequenceNumber(lastAcknowledged: Int, sentFrameCount: Int) -> Int {
+    max(lastAcknowledged, sentFrameCount, 0)
+  }
+
   private func connectWebSocket() {
     var components = URLComponents()
     components.scheme = "wss"
@@ -511,10 +527,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
   private func sendStartRecognition(on task: URLSessionWebSocketTask) {
     do {
       let payload = try Self.startRecognitionPayload(language: language, model: model, sampleRate: sampleRate)
-      let sendGroup = pendingSendGroup
-      sendGroup.enter()
-      task.send(.string(payload)) { [weak self] error in
-        defer { sendGroup.leave() }
+      enqueueOutbound(.string(payload), on: task) { [weak self] error in
         guard let self else { return }
         if let error, !self.isStoppingState() {
           self.currentOnError()?(error)
@@ -533,10 +546,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
     }
 
     let dataToSend = buffer
-    let sendGroup = pendingSendGroup
-    sendGroup.enter()
-    task.send(.data(dataToSend)) { [weak self] error in
-      defer { sendGroup.leave() }
+    enqueueOutbound(.data(dataToSend), on: task) { [weak self] error in
       guard let self else { return }
       var returnBuffer = buffer
       self.bufferPool.returnBuffer(&returnBuffer)
@@ -552,13 +562,40 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
     guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
           let json = String(data: data, encoding: .utf8)
     else { return }
-    let sendGroup = pendingSendGroup
-    sendGroup.enter()
-    task.send(.string(json)) { [weak self] error in
-      defer { sendGroup.leave() }
+    enqueueOutbound(.string(json), on: task) { [weak self] error in
       guard let self else { return }
       if let error, !self.isStoppingState(), !self.shouldIgnoreSocketError(error) {
         self.currentOnError()?(error)
+      }
+    }
+  }
+
+  private func enqueueOutbound(
+    _ message: URLSessionWebSocketTask.Message,
+    on task: URLSessionWebSocketTask,
+    completion: @escaping (Error?) -> Void
+  ) {
+    pendingSendGroup.enter()
+    outboundSendQueue.async {
+      self.outboundFrames.append(
+        SpeechmaticsOutboundFrame(task: task, message: message, completion: completion)
+      )
+      self.sendNextOutboundFrameIfNeeded()
+    }
+  }
+
+  private func sendNextOutboundFrameIfNeeded() {
+    dispatchPrecondition(condition: .onQueue(outboundSendQueue))
+    guard !outboundSendInFlight, let frame = outboundFrames.first else { return }
+    outboundSendInFlight = true
+    frame.task.send(frame.message) { [weak self] error in
+      guard let self else { return }
+      self.outboundSendQueue.async {
+        let completed = self.outboundFrames.removeFirst()
+        self.outboundSendInFlight = false
+        completed.completion(error)
+        self.pendingSendGroup.leave()
+        self.sendNextOutboundFrameIfNeeded()
       }
     }
   }
@@ -625,25 +662,35 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
   }
 
   private func handleRecognitionStarted() {
-    let flush = withStateLock { () -> SpeechmaticsPreStartAudioFlush in
-      self.recognitionStarted = true
-      let frames = self.preStartAudioBuffer
-      self.preStartAudioBuffer = []
-      let continuation = self.recognitionStartedContinuation
-      self.recognitionStartedContinuation = nil
-      return SpeechmaticsPreStartAudioFlush(
-        task: self.webSocketTask,
-        frames: frames,
-        continuation: continuation
-      )
-    }
-    if let task = flush.task, task.state == .running, !flush.frames.isEmpty {
-      logger.info("Flushing \(flush.frames.count) pre-start audio frames to Speechmatics")
-      for frame in flush.frames {
-        sendAudioFrame(frame, on: task)
+    while true {
+      let flush = withStateLock { () -> SpeechmaticsPreStartAudioFlush in
+        let frames = self.preStartAudioBuffer
+        self.preStartAudioBuffer = []
+        let continuation: CheckedContinuation<Bool, Never>?
+        if frames.isEmpty {
+          self.recognitionStarted = true
+          continuation = self.recognitionStartedContinuation
+          self.recognitionStartedContinuation = nil
+        } else {
+          continuation = nil
+        }
+        return SpeechmaticsPreStartAudioFlush(
+          task: self.webSocketTask,
+          frames: frames,
+          continuation: continuation
+        )
+      }
+      guard !flush.frames.isEmpty else {
+        flush.continuation?.resume(returning: true)
+        return
+      }
+      if let task = flush.task, task.state == .running {
+        logger.info("Flushing \(flush.frames.count) pre-start audio frames to Speechmatics")
+        for frame in flush.frames {
+          sendAudioFrame(frame, on: task)
+        }
       }
     }
-    flush.continuation?.resume(returning: true)
   }
 
   private static func segments(from results: [SpeechmaticsResult]) -> [TranscriptionSegment] {

--- a/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
@@ -251,6 +251,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
   private var lastAcknowledgedSeqNo = -1
   private var endOfTranscriptReceived = false
   private var endOfTranscriptContinuation: CheckedContinuation<Void, Never>?
+  private var recognitionStartedContinuation: CheckedContinuation<Bool, Never>?
 
   init(
     apiKey: String,
@@ -280,6 +281,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
       self.lastAcknowledgedSeqNo = -1
       self.endOfTranscriptReceived = false
       self.endOfTranscriptContinuation = nil
+      self.recognitionStartedContinuation = nil
       self.onTranscript = onTranscript
       self.onError = onError
     }
@@ -313,6 +315,30 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
       "last_seq_no": lastSeqNo
     ]
     sendJSONPayload(payload, on: task)
+  }
+
+  func waitForRecognitionStarted(timeout: TimeInterval = 1.5) async -> Bool {
+    await withCheckedContinuation { continuation in
+      let shouldWait = withStateLock { () -> Bool in
+        guard !self.recognitionStarted else { return false }
+        self.recognitionStartedContinuation = continuation
+        return true
+      }
+      if !shouldWait {
+        continuation.resume(returning: true)
+        return
+      }
+      Task { [weak self] in
+        try? await Task.sleep(for: .seconds(timeout))
+        guard let self else { return }
+        let pending = self.withStateLock { () -> CheckedContinuation<Bool, Never>? in
+          let saved = self.recognitionStartedContinuation
+          self.recognitionStartedContinuation = nil
+          return saved
+        }
+        pending?.resume(returning: false)
+      }
+    }
   }
 
   func awaitEndOfTranscript(timeout: TimeInterval = 2.0) async {
@@ -363,6 +389,13 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
       return saved
     }
     pending?.resume()
+
+    let recognitionPending = withStateLock { () -> CheckedContinuation<Bool, Never>? in
+      let saved = self.recognitionStartedContinuation
+      self.recognitionStartedContinuation = nil
+      return saved
+    }
+    recognitionPending?.resume(returning: false)
 
     guard let task else { return }
     if task.state == .running {
@@ -561,8 +594,14 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
 
     switch envelope.message {
     case "RecognitionStarted":
-      withStateLock { self.recognitionStarted = true }
+      let pending = withStateLock { () -> CheckedContinuation<Bool, Never>? in
+        self.recognitionStarted = true
+        let saved = self.recognitionStartedContinuation
+        self.recognitionStartedContinuation = nil
+        return saved
+      }
       flushPreStartAudio()
+      pending?.resume(returning: true)
     case "AudioAdded":
       if let message = try? JSONDecoder().decode(SpeechmaticsAudioAddedMessage.self, from: data) {
         withStateLock { self.lastAcknowledgedSeqNo = max(self.lastAcknowledgedSeqNo, message.seqNo) }

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -3815,6 +3815,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private var assemblyAIController: AssemblyAILiveController
   private var elevenlabsController: ElevenLabsLiveController
   private var sonioxController: SonioxLiveController
+  private var speechmaticsController: SpeechmaticsLiveController
   private var cartesiaController: CartesiaLiveController
   private var gladiaController: GladiaLiveController
   private var openAIRealtimeController: OpenAIRealtimeLiveController
@@ -3872,6 +3873,12 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       secureStorage: secureStorage
     )
     sonioxController = SonioxLiveController(
+      appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    speechmaticsController = SpeechmaticsLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
@@ -3959,6 +3966,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     if model.hasPrefix("modulate/") { return modulateController }
     if model.hasPrefix("elevenlabs/") { return elevenlabsController }
     if model.hasPrefix("soniox/") { return sonioxController }
+    if model.hasPrefix("speechmatics/") { return speechmaticsController }
     if model.hasPrefix("cartesia/") { return cartesiaController }
     if model.hasPrefix("gladia/") { return gladiaController }
     // SwitchingLiveTranscriber only routes live transcription models, and
@@ -3982,6 +3990,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       assemblyAIController,
       elevenlabsController,
       sonioxController,
+      speechmaticsController,
       cartesiaController,
       gladiaController,
       openAIRealtimeController,
@@ -4038,6 +4047,12 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       secureStorage: secureStorage
     )
     sonioxController = SonioxLiveController(
+      appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    speechmaticsController = SpeechmaticsLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -3959,7 +3959,6 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     lastStopDate = nowProvider()
   }
 
-  // swiftlint:disable:next cyclomatic_complexity
   private func controller(for model: String) -> any LiveTranscriptionController {
     if let route = controllerRoutes.first(where: { model.hasPrefix($0.prefix) }) {
       return route.controller

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -3961,14 +3961,9 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
 
   // swiftlint:disable:next cyclomatic_complexity
   private func controller(for model: String) -> any LiveTranscriptionController {
-    if model.hasPrefix("assemblyai/") { return assemblyAIController }
-    if model.hasPrefix("deepgram/") { return deepgramController }
-    if model.hasPrefix("modulate/") { return modulateController }
-    if model.hasPrefix("elevenlabs/") { return elevenlabsController }
-    if model.hasPrefix("soniox/") { return sonioxController }
-    if model.hasPrefix("speechmatics/") { return speechmaticsController }
-    if model.hasPrefix("cartesia/") { return cartesiaController }
-    if model.hasPrefix("gladia/") { return gladiaController }
+    if let route = controllerRoutes.first(where: { model.hasPrefix($0.prefix) }) {
+      return route.controller
+    }
     // SwitchingLiveTranscriber only routes live transcription models, and
     // OpenAI's only live transcription transport is the Realtime WebSocket
     // API. So any openai/* live model is handled by openAIRealtimeController.
@@ -3980,6 +3975,19 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     #endif
     if ModelRouting.family(for: model).isDownloadedLocal { return unsupportedLocalLiveController }
     return nativeController
+  }
+
+  private var controllerRoutes: [(prefix: String, controller: any LiveTranscriptionController)] {
+    [
+      ("assemblyai/", assemblyAIController),
+      ("deepgram/", deepgramController),
+      ("modulate/", modulateController),
+      ("elevenlabs/", elevenlabsController),
+      ("soniox/", sonioxController),
+      ("speechmatics/", speechmaticsController),
+      ("cartesia/", cartesiaController),
+      ("gladia/", gladiaController)
+    ]
   }
 
   private func applyDelegateAndConfiguration() {

--- a/Sources/SpeakApp/TranscriptionProviderRegistry.swift
+++ b/Sources/SpeakApp/TranscriptionProviderRegistry.swift
@@ -17,6 +17,7 @@ actor TranscriptionProviderRegistry {
         providers["assemblyai"] = AssemblyAITranscriptionProvider()
         providers["elevenlabs"] = ElevenLabsTranscriptionProvider()
         providers["soniox"] = SonioxTranscriptionProvider()
+        providers["speechmatics"] = SpeechmaticsTranscriptionProvider()
         providers["groq"] = GroqTranscriptionProvider()
         providers["cartesia"] = CartesiaTranscriptionProvider()
         providers["mistral"] = MistralTranscriptionProvider()

--- a/Sources/SpeakCore/LiveModelCapabilities.swift
+++ b/Sources/SpeakCore/LiveModelCapabilities.swift
@@ -91,6 +91,10 @@ extension ModelCatalog {
         "soniox/stt-rt-v5-streaming": LiveModelCapabilities(
             supportedSpeedModes: [.instant, .livePolish]
         ),
+        "speechmatics/enhanced-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish],
+            postStopFinalizeBudget: 2.0
+        ),
         "elevenlabs/scribe-v2-streaming": LiveModelCapabilities(
             supportedSpeedModes: [.instant, .livePolish]
         ),

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -163,6 +163,11 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
                 + "faster semantic endpointing, and improved multilingual recognition across 60+ languages.",
             estimatedLatencyMs: 220, latencyTier: .fast),
         Option(
+            id: "speechmatics/enhanced-streaming",
+            displayName: "Speechmatics Enhanced (Streaming)",
+            description: "Speechmatics realtime WebSocket transcription with partial and final results.",
+            estimatedLatencyMs: 220, latencyTier: .fast),
+        Option(
             id: "elevenlabs/scribe-v2-streaming",
             displayName: "ElevenLabs Scribe v2 (Streaming)",
             description: "ElevenLabs Scribe v2 real-time WebSocket transcription. Reuses your "

--- a/Sources/SpeakCore/StreamingTranscriptionClient.swift
+++ b/Sources/SpeakCore/StreamingTranscriptionClient.swift
@@ -49,6 +49,7 @@ public enum LiveTranscriptionProviderID: String, Sendable, CaseIterable, Hashabl
     case soniox
     case elevenlabs
     case openai
+    case speechmatics
 
     /// Keychain identifier for this provider's API key, or `nil` for on-device
     /// providers that need no credential. Matches the identifiers used by both
@@ -84,6 +85,8 @@ public enum LiveTranscriptionProviderID: String, Sendable, CaseIterable, Hashabl
         switch self {
         case .apple, .deepgram, .elevenlabs, .openai, .cartesia, .soniox, .modulate, .assemblyai, .gladia:
             return true
+        case .speechmatics:
+            return false
         }
     }
 
@@ -100,6 +103,7 @@ public enum LiveTranscriptionProviderID: String, Sendable, CaseIterable, Hashabl
         case .soniox: return "Soniox"
         case .elevenlabs: return "ElevenLabs"
         case .openai: return "OpenAI"
+        case .speechmatics: return "Speechmatics"
         }
     }
 }
@@ -276,7 +280,7 @@ public enum LiveTranscriptionClientFactory {
                 language: language,
                 sampleRate: route.sampleRate
             )
-        case .apple, .openai:
+        case .apple, .openai, .speechmatics:
             return nil
         }
     }

--- a/Tests/SpeakAppTests/SpeechmaticsTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/SpeechmaticsTranscriptionProviderTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+@testable import SpeakCore
+
+final class SpeechmaticsTranscriptionProviderTests: XCTestCase {
+  func testModelCatalogLiveTranscription_includesSpeechmaticsEnhanced() {
+    let ids = ModelCatalog.liveTranscription.map(\.id)
+
+    XCTAssertTrue(ids.contains("speechmatics/enhanced-streaming"))
+  }
+
+  func testProviderRegistry_routesSpeechmaticsLiveToSpeechmaticsProvider() async {
+    let provider = await TranscriptionProviderRegistry.shared.provider(forModel: "speechmatics/enhanced-streaming")
+
+    XCTAssertEqual(provider?.metadata.id, "speechmatics")
+  }
+
+  func testLiveCapabilities_enableLivePolishAndPostStopBudget() {
+    let capabilities = ModelCatalog.liveCapabilities(for: "speechmatics/enhanced-streaming")
+
+    XCTAssertTrue(capabilities.supportedSpeedModes.contains(.instant))
+    XCTAssertTrue(capabilities.supportedSpeedModes.contains(.livePolish))
+    XCTAssertEqual(capabilities.postStopFinalizeBudget, 2.0)
+  }
+
+  func testStartRecognitionPayload_usesRawPCM16kPartialsAndLanguage() throws {
+    let payload = try SpeechmaticsLiveTranscriber.startRecognitionPayload(
+      language: "en_GB",
+      model: "enhanced",
+      sampleRate: 16000
+    )
+    let object = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+    )
+
+    XCTAssertEqual(object["message"] as? String, "StartRecognition")
+    let audioFormat = try XCTUnwrap(object["audio_format"] as? [String: Any])
+    XCTAssertEqual(audioFormat["type"] as? String, "raw")
+    XCTAssertEqual(audioFormat["encoding"] as? String, "pcm_s16le")
+    XCTAssertEqual(audioFormat["sample_rate"] as? Int, 16000)
+
+    let config = try XCTUnwrap(object["transcription_config"] as? [String: Any])
+    XCTAssertEqual(config["language"] as? String, "en")
+    XCTAssertEqual(config["model"] as? String, "enhanced")
+    XCTAssertEqual(config["enable_partials"] as? Bool, true)
+    XCTAssertEqual(config["max_delay"] as? Double, 0.7)
+  }
+
+  func testTranscriptEvent_parsesPartialMetadataTranscript() throws {
+    let json = #"""
+    {
+      "message": "AddPartialTranscript",
+      "format": "2.1",
+      "metadata": {
+        "start_time": 0.0,
+        "end_time": 0.5,
+        "transcript": "hello wor"
+      },
+      "results": []
+    }
+    """#
+
+    let event = try XCTUnwrap(SpeechmaticsLiveTranscriber.transcriptEvent(from: json))
+
+    XCTAssertEqual(event.text, "hello wor")
+    XCTAssertFalse(event.isFinal)
+    XCTAssertTrue(event.segments.isEmpty)
+    XCTAssertNil(event.confidence)
+  }
+
+  func testTranscriptEvent_parsesFinalMetadataAndSegments() throws {
+    let json = #"""
+    {
+      "message": "AddTranscript",
+      "format": "2.1",
+      "metadata": {
+        "start_time": 0.0,
+        "end_time": 1.1,
+        "transcript": "Hello, world."
+      },
+      "results": [
+        {
+          "type": "word",
+          "start_time": 0.0,
+          "end_time": 0.4,
+          "alternatives": [{"content": "Hello", "confidence": 0.9, "speaker": "S1"}]
+        },
+        {
+          "type": "punctuation",
+          "start_time": 0.4,
+          "end_time": 0.4,
+          "alternatives": [{"content": ",", "confidence": 1.0}]
+        },
+        {
+          "type": "word",
+          "start_time": 0.6,
+          "end_time": 1.1,
+          "alternatives": [{"content": "world", "confidence": 0.8}]
+        }
+      ]
+    }
+    """#
+
+    let event = try XCTUnwrap(SpeechmaticsLiveTranscriber.transcriptEvent(from: json))
+
+    XCTAssertEqual(event.text, "Hello, world.")
+    XCTAssertTrue(event.isFinal)
+    XCTAssertEqual(event.startTime, 0.0)
+    XCTAssertEqual(event.endTime, 1.1)
+    XCTAssertEqual(event.segments.map(\.text), ["Hello", ",", "world"])
+    XCTAssertEqual(event.confidence ?? 0, 0.9, accuracy: 0.0001)
+  }
+
+  func testValidateAPIKey_sendsAuthorizationHeaderToSpeechmaticsJobsEndpoint() async throws {
+    let requestObserver = SpeechmaticsRequestObserver()
+    SpeechmaticsMockURLProtocol.requestHandler = { request in
+      await requestObserver.store(request: request)
+      let response = HTTPURLResponse(
+        url: try XCTUnwrap(request.url),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+      return (response, Data(#"{"jobs":[]} "#.utf8))
+    }
+    defer { SpeechmaticsMockURLProtocol.requestHandler = nil }
+
+    let provider = SpeechmaticsTranscriptionProvider(session: makeMockSession())
+    let result = await provider.validateAPIKey("test-speechmatics-key")
+
+    if case .success = result.outcome {
+      // Expected.
+    } else {
+      XCTFail("Expected validation success")
+    }
+    let capturedRequest = await requestObserver.capturedRequest()
+    let request = try XCTUnwrap(capturedRequest)
+    XCTAssertEqual(request.url?.host, "eu1.asr.api.speechmatics.com")
+    XCTAssertEqual(request.url?.path, "/v2/jobs")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "test-speechmatics-key")
+  }
+
+  private func makeMockSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [SpeechmaticsMockURLProtocol.self]
+    return URLSession(configuration: configuration)
+  }
+}
+
+private actor SpeechmaticsRequestObserver {
+  private var request: URLRequest?
+
+  func store(request: URLRequest) {
+    self.request = request
+  }
+
+  func capturedRequest() -> URLRequest? {
+    request
+  }
+}
+
+private final class SpeechmaticsMockURLProtocol: URLProtocol {
+  nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+
+  override static func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    guard let handler = Self.requestHandler else {
+      XCTFail("SpeechmaticsMockURLProtocol.requestHandler was not set")
+      return
+    }
+
+    Task {
+      do {
+        let (response, data) = try await handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+      } catch {
+        client?.urlProtocol(self, didFailWithError: error)
+      }
+    }
+  }
+
+  override func stopLoading() {}
+}

--- a/Tests/SpeakAppTests/SpeechmaticsTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/SpeechmaticsTranscriptionProviderTests.swift
@@ -70,6 +70,20 @@ final class SpeechmaticsTranscriptionProviderTests: XCTestCase {
     XCTAssertNil(event.confidence)
   }
 
+  func testEndOfStreamSequence_usesSentFrameCountWhenAcknowledgementsLag() {
+    XCTAssertEqual(
+      SpeechmaticsLiveTranscriber.endOfStreamLastSequenceNumber(lastAcknowledged: 2, sentFrameCount: 3),
+      3
+    )
+  }
+
+  func testEndOfStreamSequence_usesHighestAcknowledgement() {
+    XCTAssertEqual(
+      SpeechmaticsLiveTranscriber.endOfStreamLastSequenceNumber(lastAcknowledged: 4, sentFrameCount: 3),
+      4
+    )
+  }
+
   func testTranscriptEvent_parsesFinalMetadataAndSegments() throws {
     let json = #"""
     {

--- a/Tests/SpeakAppTests/SpeechmaticsTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/SpeechmaticsTranscriptionProviderTests.swift
@@ -139,7 +139,7 @@ final class SpeechmaticsTranscriptionProviderTests: XCTestCase {
     let request = try XCTUnwrap(capturedRequest)
     XCTAssertEqual(request.url?.host, "eu1.asr.api.speechmatics.com")
     XCTAssertEqual(request.url?.path, "/v2/jobs")
-    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "test-speechmatics-key")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-speechmatics-key")
   }
 
   private func makeMockSession() -> URLSession {

--- a/Tests/SpeakCoreTests/LiveTranscriptionRoutingTests.swift
+++ b/Tests/SpeakCoreTests/LiveTranscriptionRoutingTests.swift
@@ -76,11 +76,13 @@ final class LiveTranscriptionRoutingTests: XCTestCase {
 
     // MARK: - iOS availability
 
-    func testIsSupportedOnIOS_allCatalogueProvidersWired() {
-        // Assert: every provider the catalogue exposes now runs on iOS.
-        for provider in LiveTranscriptionProviderID.allCases {
+    func testIsSupportedOnIOS_onlyPlatformWiredProvidersAreSelectable() {
+        // Speechmatics remains macOS-only until its shared client is moved to
+        // SpeakCore; every existing shared/native provider stays selectable.
+        for provider in LiveTranscriptionProviderID.allCases where provider != .speechmatics {
             XCTAssertTrue(provider.isSupportedOnIOS, "\(provider) should be iOS-supported")
         }
+        XCTAssertFalse(LiveTranscriptionProviderID.speechmatics.isSupportedOnIOS)
     }
 
     // MARK: - Factory


### PR DESCRIPTION
## Summary
- Adds Speechmatics Enhanced as a live transcription model using the current realtime WebSocket API.
- Streams 16 kHz PCM16 binary audio after `StartRecognition`, handles partial/final transcript messages, and sends `EndOfStream` on stop.
- Registers Speechmatics provider metadata/API-key validation and adds response/payload tests.

## Docs checked
- Current Speechmatics docs confirm `wss://eu.rt.speechmatics.com/v2/`, `Authorization` header auth, raw `pcm_s16le`, `StartRecognition`, `AddPartialTranscript`, `AddTranscript`, and `EndOfStream`.

## Follow-up scope
- Batch transcription is tracked separately in #486 to keep this live provider PR reviewable.

## Validation
- `swift test --filter SpeechmaticsTranscriptionProviderTests --disable-automatic-resolution`
- `swift build --target SpeakApp --disable-automatic-resolution`
- `swift run swiftlint lint --strict --config .swiftlint.yml Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift Sources/SpeakApp/SpeechmaticsLiveController.swift Tests/SpeakAppTests/SpeechmaticsTranscriptionProviderTests.swift`

Closes #454


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Speechmatics live-streaming transcription support, including the **enhanced-streaming** model option.
  * Enabled real-time partial transcript updates and final segment results during live transcription.
* **Bug Fixes**
  * Improved the live start/stop flow with more reliable audio buffering, end-of-stream signaling, and transcript finalization.
  * Updated live model routing to support the Speechmatics controller.
* **Tests**
  * Added unit tests covering model/provider registration, API key request authorization, payload formatting, and transcript event parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->