### PR TITLE
feat(mac): add Mistral Voxtral batch transcription

### DIFF
--- a/Sources/SpeakApp/MistralTranscriptionProvider.swift
+++ b/Sources/SpeakApp/MistralTranscriptionProvider.swift
@@ -116,13 +116,6 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
         description: "Mistral Voxtral Mini batch transcription for long-form multilingual audio.",
         estimatedLatencyMs: 900,
         latencyTier: .fast
-      ),
-      ModelCatalog.Option(
-        id: "mistral/voxtral-small-latest",
-        displayName: "Voxtral Small Latest",
-        description: "Larger Mistral Voxtral batch transcription model for higher quality on difficult audio.",
-        estimatedLatencyMs: 1200,
-        latencyTier: .medium
       )
     ]
   }
@@ -297,12 +290,14 @@ private enum MistralSpeaker: Decodable {
       let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
       guard !trimmed.isEmpty else { return nil }
       let uppercased = trimmed.uppercased()
-      if uppercased.hasPrefix("SPEAKER_") || uppercased.hasPrefix("SPEAKER ") {
+      if uppercased.hasPrefix("SPEAKER_") {
         let digits = trimmed.filter(\.isNumber)
         if let index = Int(digits) {
           return "Speaker \(index + 1)"
         }
         return trimmed.replacingOccurrences(of: "_", with: " ").capitalized
+      } else if uppercased.hasPrefix("SPEAKER ") {
+        return trimmed.capitalized
       }
       return trimmed
     }

--- a/Sources/SpeakApp/MistralTranscriptionProvider.swift
+++ b/Sources/SpeakApp/MistralTranscriptionProvider.swift
@@ -1,0 +1,299 @@
+import AVFoundation
+import Foundation
+import SpeakCore
+
+struct MistralTranscriptionProvider: TranscriptionProvider {
+  let metadata = TranscriptionProviderMetadata(
+    id: "mistral",
+    displayName: "Mistral",
+    systemImage: "waveform.circle",
+    tintColor: "indigo",
+    website: "https://console.mistral.ai"
+  )
+
+  private let baseURL: URL
+  private let session: URLSession
+
+  init(
+    session: URLSession = .shared,
+    baseURL: URL = URL(string: "https://api.mistral.ai/v1")!
+  ) {
+    self.session = session
+    self.baseURL = baseURL
+  }
+
+  func transcribeFile(
+    at url: URL,
+    apiKey: String,
+    model: String,
+    language: String?
+  ) async throws -> TranscriptionResult {
+    _ = language
+    let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedKey.isEmpty else {
+      throw TranscriptionProviderError.apiKeyMissing
+    }
+
+    let endpoint = baseURL.appendingPathComponent("audio/transcriptions")
+    var request = URLRequest(url: endpoint)
+    request.httpMethod = "POST"
+
+    let boundary = "Boundary-\(UUID().uuidString)"
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
+
+    let audioData = try Data(contentsOf: url)
+    var body = Data()
+
+    let modelName = modelID(from: model)
+    body.appendFormField(named: "model", value: modelName, boundary: boundary)
+    body.appendFileField(
+      named: "file",
+      filename: url.lastPathComponent,
+      mimeType: "audio/m4a",
+      fileData: audioData,
+      boundary: boundary
+    )
+    body.appendString("--\(boundary)--\r\n")
+    request.httpBody = body
+
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw TranscriptionProviderError.invalidResponse
+    }
+
+    guard (200..<300).contains(http.statusCode) else {
+      let responseBody = String(data: data, encoding: .utf8) ?? "<no-body>"
+      throw TranscriptionProviderError.httpError(http.statusCode, responseBody)
+    }
+
+    let decoded = try JSONDecoder().decode(MistralTranscriptionResponse.self, from: data)
+    return try await buildTranscriptionResult(response: decoded, audioURL: url, model: model, payload: data)
+  }
+
+  func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
+    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return .failure(message: "API key is empty")
+    }
+
+    let url = baseURL.appendingPathComponent("models")
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+
+    do {
+      let (data, response) = try await session.data(for: request)
+      guard let http = response as? HTTPURLResponse else {
+        return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
+      }
+
+      let debug = debugSnapshot(request: request, response: http, data: data)
+      if (200..<300).contains(http.statusCode) {
+        return .success(message: "Mistral API key validated", debug: debug)
+      }
+
+      return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
+    } catch {
+      return .failure(
+        message: "Validation failed: \(error.localizedDescription)",
+        debug: debugSnapshot(request: request, error: error)
+      )
+    }
+  }
+
+  func requiresAPIKey(for model: String) -> Bool {
+    true
+  }
+
+  func supportedModels() -> [ModelCatalog.Option] {
+    [
+      ModelCatalog.Option(
+        id: "mistral/voxtral-mini-latest",
+        displayName: "Voxtral Mini Latest",
+        description: "Mistral Voxtral Mini batch transcription for long-form multilingual audio.",
+        estimatedLatencyMs: 900,
+        latencyTier: .fast
+      ),
+      ModelCatalog.Option(
+        id: "mistral/voxtral-small-latest",
+        displayName: "Voxtral Small Latest",
+        description: "Larger Mistral Voxtral batch transcription model for higher quality on difficult audio.",
+        estimatedLatencyMs: 1200,
+        latencyTier: .medium
+      )
+    ]
+  }
+
+  private func modelID(from model: String) -> String {
+    model.split(separator: "/").last.map(String.init) ?? model
+  }
+
+  private func buildTranscriptionResult(
+    response: MistralTranscriptionResponse,
+    audioURL: URL,
+    model: String,
+    payload: Data
+  ) async throws -> TranscriptionResult {
+    let duration = await resolvedDuration(for: audioURL, response: response)
+    let transcriptText = response.transcriptText
+    let mappedSegments = response.transcriptionSegments(duration: duration)
+    let segments = mappedSegments.isEmpty
+      ? [TranscriptionSegment(startTime: 0, endTime: duration, text: transcriptText)]
+      : mappedSegments
+
+    return TranscriptionResult(
+      text: transcriptText,
+      segments: segments,
+      confidence: nil,
+      duration: duration,
+      modelIdentifier: model,
+      cost: nil,
+      rawPayload: String(data: payload, encoding: .utf8),
+      debugInfo: nil
+    )
+  }
+
+  private func resolvedDuration(for audioURL: URL, response: MistralTranscriptionResponse) async -> TimeInterval {
+    if let duration = response.duration, duration > 0 {
+      return duration
+    }
+    if let lastSegmentEnd = response.lastSegmentEnd, lastSegmentEnd > 0 {
+      return lastSegmentEnd
+    }
+    let asset = AVURLAsset(url: audioURL)
+    guard let durationTime = try? await asset.load(.duration), durationTime.seconds.isFinite else {
+      return 0
+    }
+    return durationTime.seconds
+  }
+
+  private func debugSnapshot(
+    request: URLRequest,
+    response: HTTPURLResponse? = nil,
+    data: Data? = nil,
+    error: Error? = nil
+  ) -> APIKeyValidationDebugSnapshot {
+    APIKeyValidationDebugSnapshot(
+      url: request.url?.absoluteString ?? "",
+      method: request.httpMethod ?? "GET",
+      requestHeaders: request.allHTTPHeaderFields ?? [:],
+      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
+      statusCode: response?.statusCode,
+      responseHeaders: response.map { headers in
+        headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
+          guard let key = entry.key as? String else { return }
+          partialResult[key] = String(describing: entry.value)
+        }
+      } ?? [:],
+      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
+      errorDescription: error?.localizedDescription
+    )
+  }
+}
+
+private struct MistralTranscriptionResponse: Decodable {
+  struct Segment: Decodable {
+    let start: TimeInterval?
+    let end: TimeInterval?
+    let text: String?
+    let speaker: MistralSpeaker?
+  }
+
+  struct Word: Decodable {
+    let start: TimeInterval?
+    let end: TimeInterval?
+    let text: String
+  }
+
+  let text: String?
+  let transcription: String?
+  let language: String?
+  let duration: TimeInterval?
+  let segments: [Segment]?
+  let words: [Word]?
+
+  var transcriptText: String {
+    if shouldLabelSpeakers {
+      return segments?.compactMap(segmentText(for:)).joined(separator: "\n") ?? ""
+    }
+    if let text, !text.isEmpty { return text }
+    if let transcription, !transcription.isEmpty { return transcription }
+    if let segmentText = segments?.compactMap(\.text).joined(separator: " "), !segmentText.isEmpty {
+      return segmentText
+    }
+    return words?.map(\.text).joined(separator: " ") ?? ""
+  }
+
+  var lastSegmentEnd: TimeInterval? {
+    let segmentEnd = segments?.compactMap(\.end).max()
+    let wordEnd = words?.compactMap(\.end).max()
+    return [segmentEnd, wordEnd].compactMap { $0 }.max()
+  }
+
+  func transcriptionSegments(duration: TimeInterval) -> [TranscriptionSegment] {
+    if let segmentValues = segments?.compactMap({ segment -> TranscriptionSegment? in
+      guard let text = segmentText(for: segment), !text.isEmpty else { return nil }
+      let start = segment.start ?? 0
+      return TranscriptionSegment(
+        startTime: start,
+        endTime: segment.end ?? max(start, duration),
+        text: text
+      )
+    }), !segmentValues.isEmpty {
+      return segmentValues
+    }
+
+    return words?.map { word in
+      let start = word.start ?? 0
+      return TranscriptionSegment(
+        startTime: start,
+        endTime: word.end ?? start,
+        text: word.text
+      )
+    } ?? []
+  }
+
+  private var shouldLabelSpeakers: Bool {
+    segments?.contains { $0.speaker?.label != nil } == true
+  }
+
+  private func segmentText(for segment: Segment) -> String? {
+    guard let text = segment.text else { return nil }
+    guard shouldLabelSpeakers, let label = segment.speaker?.label else { return text }
+    return "\(label): \(text)"
+  }
+}
+
+private enum MistralSpeaker: Decodable {
+  case int(Int)
+  case string(String)
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let value = try? container.decode(Int.self) {
+      self = .int(value)
+      return
+    }
+    self = .string(try container.decode(String.self))
+  }
+
+  var label: String? {
+    switch self {
+    case .int(let value):
+      return "Speaker \(value + 1)"
+    case .string(let value):
+      let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else { return nil }
+      let uppercased = trimmed.uppercased()
+      if uppercased.hasPrefix("SPEAKER_") || uppercased.hasPrefix("SPEAKER ") {
+        let digits = trimmed.filter(\.isNumber)
+        if let index = Int(digits) {
+          return "Speaker \(index + 1)"
+        }
+        return trimmed.replacingOccurrences(of: "_", with: " ").capitalized
+      }
+      return trimmed
+    }
+  }
+}

--- a/Sources/SpeakApp/MistralTranscriptionProvider.swift
+++ b/Sources/SpeakApp/MistralTranscriptionProvider.swift
@@ -28,7 +28,6 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
     model: String,
     language: String?
   ) async throws -> TranscriptionResult {
-    _ = language
     let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmedKey.isEmpty else {
       throw TranscriptionProviderError.apiKeyMissing
@@ -47,6 +46,9 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
 
     let modelName = modelID(from: model)
     body.appendFormField(named: "model", value: modelName, boundary: boundary)
+    if let languageCode = languageCode(from: language) {
+      body.appendFormField(named: "language", value: languageCode, boundary: boundary)
+    }
     body.appendFileField(
       named: "file",
       filename: url.lastPathComponent,
@@ -127,6 +129,15 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
 
   private func modelID(from model: String) -> String {
     model.split(separator: "/").last.map(String.init) ?? model
+  }
+
+  private func languageCode(from language: String?) -> String? {
+    guard let language else { return nil }
+    let normalized = language
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: "_", with: "-")
+    guard let code = normalized.split(separator: "-").first, !code.isEmpty else { return nil }
+    return String(code).lowercased()
   }
 
   private func buildTranscriptionResult(

--- a/Sources/SpeakApp/TranscriptionProviderRegistry.swift
+++ b/Sources/SpeakApp/TranscriptionProviderRegistry.swift
@@ -19,6 +19,7 @@ actor TranscriptionProviderRegistry {
         providers["soniox"] = SonioxTranscriptionProvider()
         providers["groq"] = GroqTranscriptionProvider()
         providers["cartesia"] = CartesiaTranscriptionProvider()
+        providers["mistral"] = MistralTranscriptionProvider()
     }
 
     func allProviders() -> [TranscriptionProviderMetadata] {

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -214,11 +214,6 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             description: "Mistral Voxtral Mini batch transcription for long-form multilingual audio.",
             estimatedLatencyMs: 900, latencyTier: .fast),
         Option(
-            id: "mistral/voxtral-small-latest",
-            displayName: "Voxtral Small Latest (Mistral)",
-            description: "Larger Mistral Voxtral batch transcription model for higher quality on difficult audio.",
-            estimatedLatencyMs: 1200, latencyTier: .medium),
-        Option(
             id: "soniox/stt-async-v5",
             displayName: "Soniox Async v5",
             description: "Soniox v5 asynchronous batch STT with speaker diarization and language identification.",

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -209,6 +209,16 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             description: "Groq-hosted Whisper Large v3 Turbo. Fast, low-cost OpenAI-compatible batch transcription.",
             estimatedLatencyMs: 500, latencyTier: .fast),
         Option(
+            id: "mistral/voxtral-mini-latest",
+            displayName: "Voxtral Mini Latest (Mistral)",
+            description: "Mistral Voxtral Mini batch transcription for long-form multilingual audio.",
+            estimatedLatencyMs: 900, latencyTier: .fast),
+        Option(
+            id: "mistral/voxtral-small-latest",
+            displayName: "Voxtral Small Latest (Mistral)",
+            description: "Larger Mistral Voxtral batch transcription model for higher quality on difficult audio.",
+            estimatedLatencyMs: 1200, latencyTier: .medium),
+        Option(
             id: "soniox/stt-async-v5",
             displayName: "Soniox Async v5",
             description: "Soniox v5 asynchronous batch STT with speaker diarization and language identification.",

--- a/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
@@ -1,0 +1,259 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+@testable import SpeakCore
+
+final class MistralTranscriptionProviderTests: XCTestCase {
+  func testModelCatalogBatchTranscription_includesVoxtralModels() {
+    let ids = ModelCatalog.batchTranscription.map(\.id)
+
+    XCTAssertTrue(ids.contains("mistral/voxtral-mini-latest"))
+    XCTAssertTrue(ids.contains("mistral/voxtral-small-latest"))
+  }
+
+  func testSupportedModels_returnsVoxtralModels() {
+    let ids = MistralTranscriptionProvider().supportedModels().map(\.id)
+
+    XCTAssertEqual(ids, [
+      "mistral/voxtral-mini-latest",
+      "mistral/voxtral-small-latest"
+    ])
+  }
+
+  func testProviderRegistry_routesVoxtralModelsToMistralProvider() async {
+    for model in [
+      "mistral/voxtral-mini-latest",
+      "mistral/voxtral-small-latest"
+    ] {
+      let provider = await TranscriptionProviderRegistry.shared.provider(forModel: model)
+
+      XCTAssertEqual(provider?.metadata.id, "mistral", "\(model) should route to Mistral provider")
+      XCTAssertEqual(provider?.metadata.apiKeyIdentifier, "mistral.apiKey")
+    }
+  }
+
+  func testAllProviders_includesMistralMetadataForAPIKeySettings() async {
+    let providers = await TranscriptionProviderRegistry.shared.allProviders()
+
+    let mistral = providers.first { $0.id == "mistral" }
+    XCTAssertEqual(mistral?.displayName, "Mistral")
+    XCTAssertEqual(mistral?.apiKeyLabel, "Mistral API Key")
+  }
+
+  func testTranscribeFile_usesMistralMultipartEndpoint() async throws {
+    let requestObserver = MistralRequestObserver()
+    MistralMockURLProtocol.requestHandler = { request in
+      await requestObserver.store(request: request)
+      return try Self.makeResponse(for: request, body: #"{"text":"hello world","duration":1.25}"#)
+    }
+    defer { MistralMockURLProtocol.requestHandler = nil }
+
+    let result = try await makeProvider().transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-mistral-key",
+      model: "mistral/voxtral-mini-latest",
+      language: "en_GB"
+    )
+
+    let capturedRequest = await requestObserver.capturedRequest()
+    let capturedBody = await requestObserver.capturedBodyString()
+    let request = try XCTUnwrap(capturedRequest)
+    let body = try XCTUnwrap(capturedBody)
+
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.url?.absoluteString, "https://api.mistral.ai/v1/audio/transcriptions")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-mistral-key")
+    let contentType = request.value(forHTTPHeaderField: "Content-Type")
+    XCTAssertTrue(contentType?.hasPrefix("multipart/form-data; boundary=") == true)
+    XCTAssertTrue(body.contains(#"name="model""#))
+    XCTAssertTrue(body.contains("\r\nvoxtral-mini-latest\r\n"))
+    XCTAssertFalse(body.contains("\r\nmistral/voxtral-mini-latest\r\n"))
+    XCTAssertTrue(body.contains(#"name="file"; filename=""#))
+    XCTAssertFalse(body.contains("response_format"))
+    XCTAssertEqual(result.text, "hello world")
+    XCTAssertEqual(result.duration, 1.25)
+    XCTAssertEqual(result.modelIdentifier, "mistral/voxtral-mini-latest")
+  }
+
+  func testTranscribeFile_mapsSegments() async throws {
+    let responseBody = """
+    {
+      "text": "Hello there. Hi back.",
+      "duration": 2.0,
+      "segments": [
+        {"start": 0.0, "end": 1.0, "text": "Hello there."},
+        {"start": 1.1, "end": 2.0, "text": "Hi back."}
+      ]
+    }
+    """
+    MistralMockURLProtocol.requestHandler = { request in
+      try Self.makeResponse(for: request, body: responseBody)
+    }
+    defer { MistralMockURLProtocol.requestHandler = nil }
+
+    let result = try await makeProvider().transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-mistral-key",
+      model: "mistral/voxtral-small-latest",
+      language: nil
+    )
+
+    XCTAssertEqual(result.text, "Hello there. Hi back.")
+    XCTAssertEqual(result.duration, 2.0)
+    XCTAssertEqual(result.segments.map(\.text), ["Hello there.", "Hi back."])
+    XCTAssertEqual(result.segments.map(\.startTime), [0.0, 1.1])
+    XCTAssertEqual(result.segments.map(\.endTime), [1.0, 2.0])
+  }
+
+  func testTranscribeFile_labelsSpeakerSegmentsWhenPresent() async throws {
+    let responseBody = """
+    {
+      "duration": 2.0,
+      "segments": [
+        {"start": 0.0, "end": 1.0, "text": "Hello there.", "speaker": 0},
+        {"start": 1.1, "end": 2.0, "text": "Hi back.", "speaker": 1}
+      ]
+    }
+    """
+    MistralMockURLProtocol.requestHandler = { request in
+      try Self.makeResponse(for: request, body: responseBody)
+    }
+    defer { MistralMockURLProtocol.requestHandler = nil }
+
+    let result = try await makeProvider().transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-mistral-key",
+      model: "mistral/voxtral-small-latest",
+      language: nil
+    )
+
+    XCTAssertEqual(result.text, "Speaker 1: Hello there.\nSpeaker 2: Hi back.")
+    XCTAssertEqual(result.segments.map(\.text), ["Speaker 1: Hello there.", "Speaker 2: Hi back."])
+  }
+
+  func testValidateAPIKey_usesMistralModelsEndpoint() async throws {
+    let requestObserver = MistralRequestObserver()
+    MistralMockURLProtocol.requestHandler = { request in
+      await requestObserver.store(request: request)
+      return try Self.makeResponse(for: request, body: #"{"data":[]}"#)
+    }
+    defer { MistralMockURLProtocol.requestHandler = nil }
+
+    let result = await makeProvider().validateAPIKey("test-mistral-key")
+    let capturedRequest = await requestObserver.capturedRequest()
+    let request = try XCTUnwrap(capturedRequest)
+
+    XCTAssertEqual(request.url?.absoluteString, "https://api.mistral.ai/v1/models")
+    XCTAssertEqual(request.httpMethod, "GET")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-mistral-key")
+    XCTAssertEqual(result.outcome, .success(message: "Mistral API key validated"))
+    XCTAssertNotEqual(result.debug?.requestHeaders["Authorization"], "Bearer test-mistral-key")
+  }
+
+  func testValidateAPIKey_returnsFailureForEmptyKey() async {
+    let result = await MistralTranscriptionProvider().validateAPIKey("  ")
+
+    XCTAssertEqual(result.outcome, .failure(message: "API key is empty"))
+  }
+
+  private func makeProvider() -> MistralTranscriptionProvider {
+    MistralTranscriptionProvider(session: makeMockSession())
+  }
+
+  private func makeMockSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MistralMockURLProtocol.self]
+    return URLSession(configuration: configuration)
+  }
+
+  private func makeAudioFile() throws -> URL {
+    let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+    let directory = root.appendingPathComponent(".build/test-audio", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let url = directory.appendingPathComponent("mistral-transcription-\(UUID().uuidString).m4a")
+    try Data("fake-audio".utf8).write(to: url)
+    addTeardownBlock {
+      try? FileManager.default.removeItem(at: url)
+    }
+    return url
+  }
+
+  private static func makeResponse(for request: URLRequest, body: String) throws -> (HTTPURLResponse, Data) {
+    let response = HTTPURLResponse(
+      url: try XCTUnwrap(request.url),
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: ["Content-Type": "application/json"]
+    )!
+    return (response, Data(body.utf8))
+  }
+}
+
+private actor MistralRequestObserver {
+  private var request: URLRequest?
+  private var body: Data?
+
+  func store(request: URLRequest) {
+    self.request = request
+    body = request.httpBody ?? readBody(from: request.httpBodyStream)
+  }
+
+  func capturedRequest() -> URLRequest? {
+    request
+  }
+
+  func capturedBodyString() -> String? {
+    body.flatMap { String(data: $0, encoding: .utf8) }
+  }
+
+  private func readBody(from stream: InputStream?) -> Data? {
+    guard let stream else { return nil }
+    stream.open()
+    defer { stream.close() }
+
+    var data = Data()
+    let bufferSize = 4096
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+
+    while stream.hasBytesAvailable {
+      let readCount = stream.read(buffer, maxLength: bufferSize)
+      if readCount <= 0 { break }
+      data.append(buffer, count: readCount)
+    }
+    return data.isEmpty ? nil : data
+  }
+}
+
+private final class MistralMockURLProtocol: URLProtocol {
+  nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+
+  override static func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    guard let handler = Self.requestHandler else {
+      XCTFail("MistralMockURLProtocol.requestHandler was not set")
+      return
+    }
+
+    Task {
+      do {
+        let (response, data) = try await handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+      } catch {
+        client?.urlProtocol(self, didFailWithError: error)
+      }
+    }
+  }
+
+  override func stopLoading() {}
+}

--- a/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
@@ -69,6 +69,8 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     XCTAssertTrue(body.contains(#"name="model""#))
     XCTAssertTrue(body.contains("\r\nvoxtral-mini-latest\r\n"))
     XCTAssertFalse(body.contains("\r\nmistral/voxtral-mini-latest\r\n"))
+    XCTAssertTrue(body.contains(#"name="language""#))
+    XCTAssertTrue(body.contains("\r\nen\r\n"))
     XCTAssertTrue(body.contains(#"name="file"; filename=""#))
     XCTAssertFalse(body.contains("response_format"))
     XCTAssertEqual(result.text, "hello world")

--- a/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
@@ -9,22 +9,19 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     let ids = ModelCatalog.batchTranscription.map(\.id)
 
     XCTAssertTrue(ids.contains("mistral/voxtral-mini-latest"))
-    XCTAssertTrue(ids.contains("mistral/voxtral-small-latest"))
   }
 
   func testSupportedModels_returnsVoxtralModels() {
     let ids = MistralTranscriptionProvider().supportedModels().map(\.id)
 
     XCTAssertEqual(ids, [
-      "mistral/voxtral-mini-latest",
-      "mistral/voxtral-small-latest"
+      "mistral/voxtral-mini-latest"
     ])
   }
 
   func testProviderRegistry_routesVoxtralModelsToMistralProvider() async {
     for model in [
-      "mistral/voxtral-mini-latest",
-      "mistral/voxtral-small-latest"
+      "mistral/voxtral-mini-latest"
     ] {
       let provider = await TranscriptionProviderRegistry.shared.provider(forModel: model)
 
@@ -97,7 +94,7 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     let result = try await makeProvider().transcribeFile(
       at: try makeAudioFile(),
       apiKey: "test-mistral-key",
-      model: "mistral/voxtral-small-latest",
+      model: "mistral/voxtral-mini-latest",
       language: nil
     )
 
@@ -126,12 +123,36 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     let result = try await makeProvider().transcribeFile(
       at: try makeAudioFile(),
       apiKey: "test-mistral-key",
-      model: "mistral/voxtral-small-latest",
+      model: "mistral/voxtral-mini-latest",
       language: nil
     )
 
     XCTAssertEqual(result.text, "Speaker 1: Hello there.\nSpeaker 2: Hi back.")
     XCTAssertEqual(result.segments.map(\.text), ["Speaker 1: Hello there.", "Speaker 2: Hi back."])
+  }
+
+  func testTranscribeFile_preservesOneIndexedSpeakerLabels() async throws {
+    let responseBody = """
+    {
+      "duration": 1.0,
+      "segments": [
+        {"start": 0.0, "end": 1.0, "text": "Hello there.", "speaker": "Speaker 1"}
+      ]
+    }
+    """
+    MistralMockURLProtocol.requestHandler = { request in
+      try Self.makeResponse(for: request, body: responseBody)
+    }
+    defer { MistralMockURLProtocol.requestHandler = nil }
+
+    let result = try await makeProvider().transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-mistral-key",
+      model: "mistral/voxtral-mini-latest",
+      language: nil
+    )
+
+    XCTAssertEqual(result.text, "Speaker 1: Hello there.")
   }
 
   func testValidateAPIKey_usesMistralModelsEndpoint() async throws {


### PR DESCRIPTION
## Summary
- Add a Mistral batch transcription provider for Voxtral Mini and Small.
- Register Mistral in the provider registry and generic API-key settings metadata.
- Add Voxtral batch models to `ModelCatalog` with request/registry/catalog tests.

## Follow-up scope
- Voxtral cloud live streaming is tracked in #484.
- Local/on-device Voxtral realtime support is tracked in #485.

Closes #456

## Validation
- `swift test --filter MistralTranscriptionProviderTests --disable-automatic-resolution`
- `swift test --filter 'ModelCatalogTests/testAllOptions_haveUniqueIDsWithinCategories|ModelCatalogTests/testAllOptions_containsAllCategories' --disable-automatic-resolution`
- `swiftlint lint --strict --config .swiftlint.yml Sources/SpeakApp/MistralTranscriptionProvider.swift Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift Sources/SpeakApp/TranscriptionProviderRegistry.swift Sources/SpeakCore/ModelCatalog.swift`
- `swift build --target SpeakApp --disable-automatic-resolution`

## Notes
- Mistral key validation uses `GET /v1/models`; no real Mistral key was available for live API validation.
