### PR TITLE
feat(mac): add Gladia live transcription

### DIFF
--- a/Sources/SpeakApp/GladiaLiveController.swift
+++ b/Sources/SpeakApp/GladiaLiveController.swift
@@ -4,6 +4,7 @@ import Foundation
 import os.log
 import SpeakCore
 
+@MainActor
 // swiftlint:disable:next type_body_length
 final class GladiaLiveController: NSObject, LiveTranscriptionController {
   weak var delegate: LiveTranscriptionSessionDelegate?
@@ -160,9 +161,7 @@ final class GladiaLiveController: NSObject, LiveTranscriptionController {
     }
 
     let result = buildFinalResult()
-    await MainActor.run {
-      delegate?.liveTranscriber(self, didFinishWith: result)
-    }
+    delegate?.liveTranscriber(self, didFinishWith: result)
 
     await endActiveInputSession()
     transcriber = nil
@@ -290,6 +289,7 @@ final class GladiaLiveController: NSObject, LiveTranscriptionController {
       return copy
     }
 
+    // swiftlint:disable:next function_body_length
     private func processAndSendAudio(
       _ buffer: AVAudioPCMBuffer,
       from inputFormat: AVAudioFormat,
@@ -328,7 +328,13 @@ final class GladiaLiveController: NSObject, LiveTranscriptionController {
 
       converter.reset()
       var error: NSError?
+      var didProvideInput = false
       let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+        guard !didProvideInput else {
+          outStatus.pointee = .noDataNow
+          return nil
+        }
+        didProvideInput = true
         outStatus.pointee = .haveData
         return buffer
       }

--- a/Sources/SpeakApp/GladiaLiveController.swift
+++ b/Sources/SpeakApp/GladiaLiveController.swift
@@ -1,0 +1,448 @@
+// swiftlint:disable file_length
+import AVFoundation
+import Foundation
+import os.log
+import SpeakCore
+
+// swiftlint:disable:next type_body_length
+final class GladiaLiveController: NSObject, LiveTranscriptionController {
+  weak var delegate: LiveTranscriptionSessionDelegate?
+  private(set) var isRunning: Bool = false
+
+  private let appSettings: AppSettings
+  private let permissionsManager: PermissionsManager
+  private let audioDeviceManager: AudioInputDeviceManager
+  private let secureStorage: SecureAppStorage
+  private var transcriber: GladiaLiveTranscriber?
+  private var currentLanguage: String?
+  private var currentModel: String?
+  private var activeInputSession: AudioInputDeviceManager.SessionContext?
+  private var audioEngine = AVAudioEngine()
+  private let logger = Logger(subsystem: "com.speak.app", category: "GladiaLiveController")
+  private let audioProcessor = GladiaAudioProcessor()
+  private var hasFinished: Bool = false
+  private var stopContinuation: CheckedContinuation<Void, Never>?
+
+  private let targetSampleRate: Double = 16_000
+  private var targetFormat: AVAudioFormat?
+  private var streamingStartTime: Date?
+  private var finalSegments: [TranscriptionSegment] = []
+  private var currentInterim: String = ""
+  private var fullTranscript: String = ""
+
+  init(
+    appSettings: AppSettings,
+    permissionsManager: PermissionsManager,
+    audioDeviceManager: AudioInputDeviceManager,
+    secureStorage: SecureAppStorage
+  ) {
+    self.appSettings = appSettings
+    self.permissionsManager = permissionsManager
+    self.audioDeviceManager = audioDeviceManager
+    self.secureStorage = secureStorage
+  }
+
+  func configure(language: String?, model: String) {
+    currentLanguage = language
+    currentModel = model
+    logger.info("Configured Gladia with model: \(model, privacy: .public)")
+  }
+
+  // swiftlint:disable:next function_body_length
+  func start() async throws {
+    guard await ensurePermissions() else {
+      throw TranscriptionManagerError.permissionsMissing
+    }
+
+    let apiKey = try await gladiaAPIKey()
+    activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    audioEngine = AVAudioEngine()
+    resetStartState()
+
+    do {
+      let inputNode = audioEngine.inputNode
+      inputNode.removeTap(onBus: 0)
+      let inputFormat = inputNode.outputFormat(forBus: 0)
+      guard audioInputFormatIsUsable(inputFormat) else {
+        throw TranscriptionManagerError.noUsableAudioInput
+      }
+
+      guard let outputFormat = AVAudioFormat(
+        commonFormat: .pcmFormatInt16,
+        sampleRate: targetSampleRate,
+        channels: 1,
+        interleaved: true
+      ) else {
+        throw GladiaLiveError.connectionFailed
+      }
+      targetFormat = outputFormat
+
+      let provider = GladiaTranscriptionProvider()
+      let newTranscriber = provider.createLiveTranscriber(
+        apiKey: apiKey,
+        model: currentModel ?? appSettings.liveTranscriptionModel,
+        language: currentLanguage,
+        sampleRate: 16_000
+      )
+      transcriber = newTranscriber
+
+      newTranscriber.start(
+        onTranscript: { [weak self] event in
+          Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.handleTranscript(event)
+          }
+        },
+        onError: { [weak self] error in
+          Task { @MainActor [weak self] in
+            guard let self else { return }
+            if !self.isRunning { return }
+            self.delegate?.liveTranscriber(self, didFail: error)
+          }
+        }
+      )
+
+      audioProcessor.setRunning(true)
+      let processor = audioProcessor
+      let log = logger
+      inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { buffer, _ in
+        processor.handleAudioTap(
+          buffer,
+          inputFormat: inputFormat,
+          outputFormat: outputFormat,
+          transcriber: newTranscriber,
+          logger: log
+        )
+      }
+
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
+      isRunning = true
+      streamingStartTime = Date()
+    } catch {
+      await cleanupAfterFailedStart()
+      throw error
+    }
+  }
+
+  func stop() async {
+    guard isRunning else { return }
+    guard !hasFinished else { return }
+    hasFinished = true
+
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    isRunning = false
+
+    if let transcriber {
+      audioProcessor.flushPendingAudio(to: transcriber)
+      await transcriber.waitForPendingSends()
+      audioProcessor.setRunning(false)
+      await applyLiveStopGrace(appSettings.liveStopGracePeriod)
+      transcriber.sendStopRecording()
+      await transcriber.waitForPendingSends()
+
+      let budget = appSettings.liveModelCapabilities.postStopFinalizeBudget
+      if budget > 0 {
+        await withCheckedContinuation { continuation in
+          stopContinuation = continuation
+          Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(budget))
+            guard let self, let cont = self.stopContinuation else { return }
+            self.stopContinuation = nil
+            cont.resume()
+          }
+        }
+      }
+
+      transcriber.stop()
+    } else {
+      audioProcessor.setRunning(false)
+    }
+
+    let result = buildFinalResult()
+    await MainActor.run {
+      delegate?.liveTranscriber(self, didFinishWith: result)
+    }
+
+    await endActiveInputSession()
+    transcriber = nil
+  }
+
+  private func handleTranscript(_ event: GladiaTranscriptEvent) {
+    if event.isFinal {
+      let segment = TranscriptionSegment(
+        startTime: 0,
+        endTime: 0,
+        text: event.text,
+        isFinal: true,
+        confidence: event.confidence
+      )
+      finalSegments.append(segment)
+      fullTranscript = finalSegments.map(\.text).joined(separator: " ")
+      currentInterim = ""
+      delegate?.liveTranscriber(self, didUpdateWith: LiveTranscriptionUpdate(
+        text: fullTranscript,
+        isFinal: true,
+        confidence: event.confidence
+      ))
+      delegate?.liveTranscriber(self, didUpdatePartial: fullTranscript)
+      delegate?.liveTranscriber(self, didDetectUtteranceBoundary: event.text)
+
+      if hasFinished, let continuation = stopContinuation {
+        stopContinuation = nil
+        continuation.resume()
+      }
+    } else {
+      currentInterim = event.text
+      let displayText = fullTranscript.isEmpty
+        ? currentInterim
+        : fullTranscript + " " + currentInterim
+      delegate?.liveTranscriber(self, didUpdateWith: LiveTranscriptionUpdate(
+        text: displayText,
+        isFinal: false,
+        confidence: event.confidence
+      ))
+      delegate?.liveTranscriber(self, didUpdatePartial: displayText)
+    }
+  }
+
+  private final class GladiaAudioProcessor: @unchecked Sendable {
+    private static let minimumChunkBytes = GladiaLiveTranscriber.minimumChunkBytes
+    private static let preferredChunkBytes = GladiaLiveTranscriber.preferredChunkBytes
+
+    private let queue = DispatchQueue(label: "com.speak.app.gladia.audioProcessing")
+    private var isRunning: Bool = false
+    private var cachedConverter: AVAudioConverter?
+    private var cachedInputFormat: AVAudioFormat?
+    private var reusableOutputBuffer: AVAudioPCMBuffer?
+    private var pendingPCMData = Data()
+
+    func setRunning(_ running: Bool) {
+      queue.sync {
+        isRunning = running
+        if !running {
+          cachedConverter = nil
+          cachedInputFormat = nil
+          reusableOutputBuffer = nil
+          pendingPCMData.removeAll(keepingCapacity: false)
+        }
+      }
+    }
+
+    func flushPendingAudio(to transcriber: GladiaLiveTranscriber) {
+      queue.sync {
+        guard !pendingPCMData.isEmpty else { return }
+
+        var offset = 0
+        while pendingPCMData.count - offset >= Self.preferredChunkBytes {
+          let chunk = pendingPCMData.subdata(in: offset..<(offset + Self.preferredChunkBytes))
+          transcriber.sendAudio(chunk)
+          offset += Self.preferredChunkBytes
+        }
+        if offset > 0 {
+          pendingPCMData = Data(pendingPCMData.dropFirst(offset))
+        }
+
+        guard !pendingPCMData.isEmpty else { return }
+        if pendingPCMData.count < Self.minimumChunkBytes {
+          pendingPCMData.append(
+            contentsOf: repeatElement(0, count: Self.minimumChunkBytes - pendingPCMData.count))
+        }
+        transcriber.sendAudio(pendingPCMData)
+        pendingPCMData.removeAll(keepingCapacity: false)
+      }
+    }
+
+    func handleAudioTap(
+      _ buffer: AVAudioPCMBuffer,
+      inputFormat: AVAudioFormat,
+      outputFormat: AVAudioFormat,
+      transcriber: GladiaLiveTranscriber,
+      logger: Logger
+    ) {
+      guard let copied = copyPCMBuffer(buffer) else { return }
+      queue.async { [weak self] in
+        guard let self, self.isRunning else { return }
+        self.processAndSendAudio(
+          copied,
+          from: inputFormat,
+          to: outputFormat,
+          transcriber: transcriber,
+          logger: logger
+        )
+      }
+    }
+
+    private func copyPCMBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+      let frameLength = buffer.frameLength
+      guard let copy = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: frameLength) else {
+        return nil
+      }
+      copy.frameLength = frameLength
+      let src = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: buffer.audioBufferList))
+      let dst = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: copy.audioBufferList))
+      for idx in 0..<min(src.count, dst.count) {
+        let srcBuffer = src[idx]
+        guard let srcData = srcBuffer.mData, let dstData = dst[idx].mData else { continue }
+        dstData.copyMemory(from: srcData, byteCount: Int(srcBuffer.mDataByteSize))
+        dst[idx].mDataByteSize = srcBuffer.mDataByteSize
+      }
+      return copy
+    }
+
+    private func processAndSendAudio(
+      _ buffer: AVAudioPCMBuffer,
+      from inputFormat: AVAudioFormat,
+      to outputFormat: AVAudioFormat,
+      transcriber: GladiaLiveTranscriber,
+      logger: Logger
+    ) {
+      let converter: AVAudioConverter
+      if let cached = cachedConverter, cachedInputFormat == inputFormat {
+        converter = cached
+      } else {
+        guard let newConverter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+          logger.error("Failed to create Gladia audio converter")
+          return
+        }
+        cachedConverter = newConverter
+        cachedInputFormat = inputFormat
+        converter = newConverter
+      }
+
+      let ratio = outputFormat.sampleRate / inputFormat.sampleRate
+      let outputFrameCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
+
+      let outputBuffer: AVAudioPCMBuffer
+      if let reusable = reusableOutputBuffer, reusable.frameCapacity >= outputFrameCapacity {
+        reusable.frameLength = 0
+        outputBuffer = reusable
+      } else {
+        guard let newBuffer = AVAudioPCMBuffer(
+          pcmFormat: outputFormat,
+          frameCapacity: outputFrameCapacity
+        ) else { return }
+        reusableOutputBuffer = newBuffer
+        outputBuffer = newBuffer
+      }
+
+      converter.reset()
+      var error: NSError?
+      let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+        outStatus.pointee = .haveData
+        return buffer
+      }
+
+      guard status != .error, error == nil else {
+        logger.error("Gladia audio conversion failed: \(error?.localizedDescription ?? "unknown", privacy: .public)")
+        return
+      }
+
+      guard let int16Data = outputBuffer.int16ChannelData else { return }
+      let frameLength = Int(outputBuffer.frameLength)
+      let data = Data(bytes: int16Data[0], count: frameLength * 2)
+      pendingPCMData.append(data)
+
+      var offset = 0
+      while pendingPCMData.count - offset >= Self.preferredChunkBytes {
+        let chunk = pendingPCMData.subdata(in: offset..<(offset + Self.preferredChunkBytes))
+        transcriber.sendAudio(chunk)
+        offset += Self.preferredChunkBytes
+      }
+      if offset > 0 {
+        pendingPCMData = Data(pendingPCMData.dropFirst(offset))
+      }
+    }
+  }
+}
+
+private extension GladiaLiveController {
+  func ensurePermissions() async -> Bool {
+    let microphone = await permissionsManager.ensureGranted(.microphone)
+    let speech = await permissionsManager.ensureGranted(.speechRecognition)
+    return microphone.isGranted && speech.isGranted
+  }
+
+  func gladiaAPIKey() async throws -> String {
+    do {
+      let apiKey = try await secureStorage.secret(identifier: "gladia.apiKey")
+      guard !apiKey.isEmpty else {
+        throw GladiaLiveError.missingAPIKey
+      }
+      return apiKey
+    } catch let error as SecureAppStorageError {
+      if case .valueNotFound = error {
+        throw GladiaLiveError.missingAPIKey
+      }
+      throw error
+    }
+  }
+
+  func resetStartState() {
+    transcriber = nil
+    targetFormat = nil
+    finalSegments = []
+    currentInterim = ""
+    fullTranscript = ""
+    streamingStartTime = nil
+    stopContinuation = nil
+    hasFinished = false
+    isRunning = false
+  }
+
+  func cleanupAfterFailedStart() async {
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    isRunning = false
+    audioProcessor.setRunning(false)
+    transcriber?.stop()
+    transcriber = nil
+    targetFormat = nil
+    finalSegments = []
+    currentInterim = ""
+    fullTranscript = ""
+    streamingStartTime = nil
+    stopContinuation = nil
+    await endActiveInputSession()
+  }
+
+  func buildFinalResult() -> TranscriptionResult {
+    var text = finalSegments.map(\.text).joined(separator: " ")
+    let trimmedInterim = currentInterim.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmedInterim.isEmpty {
+      if !text.isEmpty { text += " " }
+      text += trimmedInterim
+    }
+
+    let streamingDuration: TimeInterval
+    if let startTime = streamingStartTime {
+      streamingDuration = Date().timeIntervalSince(startTime)
+    } else {
+      streamingDuration = 0
+    }
+
+    return TranscriptionResult(
+      text: text,
+      segments: finalSegments,
+      confidence: finalSegments.compactMap(\.confidence).average,
+      duration: streamingDuration,
+      modelIdentifier: currentModel ?? "gladia/solaria-1-streaming",
+      cost: nil,
+      rawPayload: nil,
+      debugInfo: nil
+    )
+  }
+
+  func endActiveInputSession() async {
+    guard let session = activeInputSession else { return }
+    activeInputSession = nil
+    await audioDeviceManager.endUsingPreferredInput(session: session)
+  }
+}
+
+private extension Array where Element == Double {
+  var average: Double? {
+    guard !isEmpty else { return nil }
+    return reduce(0, +) / Double(count)
+  }
+}

--- a/Sources/SpeakApp/GladiaTranscriptionProvider.swift
+++ b/Sources/SpeakApp/GladiaTranscriptionProvider.swift
@@ -1,0 +1,608 @@
+// swiftlint:disable file_length
+import Foundation
+import os.log
+import SpeakCore
+
+enum GladiaLiveError: LocalizedError {
+  case missingAPIKey
+  case invalidURLComponents
+  case invalidAPIKey
+  case invalidInitResponse
+  case connectionFailed
+  case batchNotSupported
+  case serverError(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .missingAPIKey:
+      return "Gladia API key is missing. Please add it in Settings → Gladia."
+    case .invalidURLComponents:
+      return "Failed to construct Gladia request URL."
+    case .invalidAPIKey:
+      return "Gladia API key is invalid. Check your key in Settings → Gladia."
+    case .invalidInitResponse:
+      return "Gladia returned an invalid live-session response."
+    case .connectionFailed:
+      return "Failed to establish live transcription with Gladia."
+    case .batchNotSupported:
+      return "Gladia Solaria-1 is currently only available for live streaming in Speak."
+    case .serverError(let message):
+      return "Gladia transcription failed: \(message)"
+    }
+  }
+}
+
+struct GladiaTranscriptionProvider: TranscriptionProvider {
+  let metadata = TranscriptionProviderMetadata(
+    id: "gladia",
+    displayName: "Gladia",
+    systemImage: "waveform.badge.sparkles",
+    tintColor: "teal",
+    website: "https://www.gladia.io"
+  )
+
+  private let session: URLSession
+  private let baseURL: URL
+
+  init(session: URLSession = .shared, baseURL: URL = GladiaLiveTranscriber.defaultBaseURL) {
+    self.session = session
+    self.baseURL = baseURL
+  }
+
+  func transcribeFile(
+    at url: URL,
+    apiKey: String,
+    model: String,
+    language: String?
+  ) async throws -> TranscriptionResult {
+    _ = (url, apiKey, model, language)
+    throw GladiaLiveError.batchNotSupported
+  }
+
+  func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
+    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return .failure(message: "Empty API key")
+    }
+
+    var request = URLRequest(url: baseURL.appendingPathComponent("v2/live"))
+    request.httpMethod = "GET"
+    request.setValue(trimmed, forHTTPHeaderField: "x-gladia-key")
+
+    do {
+      let (data, response) = try await session.data(for: request)
+      guard let http = response as? HTTPURLResponse else {
+        return .failure(message: "Non-HTTP response")
+      }
+      let debug = debugSnapshot(request: request, response: http, data: data)
+      switch http.statusCode {
+      case 200..<300:
+        return .success(message: "Gladia API key validated", debug: debug)
+      case 401, 403:
+        return .failure(message: "Gladia rejected the key (HTTP \(http.statusCode))", debug: debug)
+      default:
+        return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
+      }
+    } catch {
+      return .failure(message: "Validation failed: \(error.localizedDescription)")
+    }
+  }
+
+  func requiresAPIKey(for model: String) -> Bool {
+    true
+  }
+
+  func supportedModels() -> [ModelCatalog.Option] {
+    [
+      ModelCatalog.Option(
+        id: "gladia/solaria-1-streaming",
+        displayName: "Solaria-1 Streaming",
+        description: "Gladia Solaria-1 real-time multilingual STT with automatic language detection."
+      )
+    ]
+  }
+
+  func createLiveTranscriber(
+    apiKey: String,
+    model: String = "gladia/solaria-1-streaming",
+    language: String? = nil,
+    sampleRate: Int = 16_000
+  ) -> GladiaLiveTranscriber {
+    GladiaLiveTranscriber(
+      apiKey: apiKey,
+      model: model,
+      language: language,
+      sampleRate: sampleRate,
+      session: session,
+      baseURL: baseURL
+    )
+  }
+
+  private func debugSnapshot(
+    request: URLRequest,
+    response: HTTPURLResponse,
+    data: Data
+  ) -> APIKeyValidationDebugSnapshot {
+    APIKeyValidationDebugSnapshot(
+      url: request.url?.absoluteString ?? "",
+      method: request.httpMethod ?? "GET",
+      requestHeaders: request.allHTTPHeaderFields ?? [:],
+      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
+      statusCode: response.statusCode,
+      responseHeaders: response.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
+        guard let key = entry.key as? String else { return }
+        partialResult[key] = String(describing: entry.value)
+      },
+      responseBody: String(data: data, encoding: .utf8),
+      errorDescription: nil
+    )
+  }
+}
+
+struct GladiaTranscriptEvent: Equatable, Sendable {
+  let text: String
+  let isFinal: Bool
+  let confidence: Double?
+}
+
+// swiftlint:disable:next type_body_length
+final class GladiaLiveTranscriber: @unchecked Sendable {
+  static let defaultBaseURL = URL(string: "https://api.gladia.io")!
+  static let preferredChunkBytes = 3_200
+  static let minimumChunkBytes = 1_600
+
+  private let apiKey: String
+  private let model: String
+  private let language: String?
+  private let sampleRate: Int
+  private let session: URLSession
+  private let baseURL: URL
+  private let logger = Logger(subsystem: "com.speak.app", category: "GladiaLiveTranscriber")
+  private let stateLock = NSLock()
+  private let pendingSendGroup = DispatchGroup()
+
+  private var webSocketTask: URLSessionWebSocketTask?
+  private var initTask: Task<Void, Never>?
+  private var pendingAudio = Data()
+  private var onTranscript: ((GladiaTranscriptEvent) -> Void)?
+  private var onError: ((Error) -> Void)?
+  private var isStopping = false
+
+  init(
+    apiKey: String,
+    model: String = "gladia/solaria-1-streaming",
+    language: String? = nil,
+    sampleRate: Int = 16_000,
+    session: URLSession = .shared,
+    baseURL: URL = GladiaLiveTranscriber.defaultBaseURL
+  ) {
+    self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    self.model = model
+    self.language = language
+    self.sampleRate = sampleRate
+    self.session = session
+    self.baseURL = baseURL
+  }
+
+  func start(
+    onTranscript: @escaping (GladiaTranscriptEvent) -> Void,
+    onError: @escaping (Error) -> Void
+  ) {
+    withStateLock {
+      isStopping = false
+      pendingAudio.removeAll(keepingCapacity: true)
+      self.onTranscript = onTranscript
+      self.onError = onError
+    }
+
+    initTask = Task { [weak self] in
+      await self?.initiateAndConnect()
+    }
+  }
+
+  func sendAudio(_ audioData: Data) {
+    guard let task = currentWebSocketTask(), task.state == .running else {
+      bufferPendingAudio(audioData)
+      return
+    }
+    flushPendingAudio(to: task)
+    send(audioData, to: task)
+  }
+
+  func sendStopRecording() {
+    guard let task = currentWebSocketTask(), task.state == .running else { return }
+    let message = Self.stopRecordingMessage()
+    let sendGroup = pendingSendGroup
+    sendGroup.enter()
+    task.send(.string(message)) { [weak self] error in
+      defer { sendGroup.leave() }
+      guard let self else { return }
+      if let error, !self.isStoppingState(), !self.shouldIgnoreSocketError(error) {
+        self.currentOnError()?(error)
+      }
+    }
+  }
+
+  func waitForPendingSends(timeout: TimeInterval = 1.5) async {
+    let sendGroup = pendingSendGroup
+    await withCheckedContinuation { continuation in
+      let lock = NSLock()
+      var didResume = false
+      let resumeOnce = {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !didResume else { return }
+        didResume = true
+        continuation.resume()
+      }
+      sendGroup.notify(queue: .global()) {
+        resumeOnce()
+      }
+      DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+        resumeOnce()
+      }
+    }
+  }
+
+  func stop() {
+    let task = withStateLock { () -> URLSessionWebSocketTask? in
+      guard !isStopping else { return nil }
+      isStopping = true
+      initTask?.cancel()
+      initTask = nil
+      return webSocketTask
+    }
+    guard let task else { return }
+    if task.state == .running {
+      task.cancel(with: .normalClosure, reason: nil)
+    }
+    withStateLock {
+      if webSocketTask === task { webSocketTask = nil }
+    }
+  }
+
+  nonisolated static func stopRecordingMessage() -> String {
+    #"{"type":"stop_recording"}"#
+  }
+
+  nonisolated static func liveModelName(from model: String) -> String {
+    let name = model.split(separator: "/").last.map(String.init) ?? model
+    let cleaned = name.replacingOccurrences(of: "-streaming", with: "")
+    return cleaned.isEmpty ? "solaria-1" : cleaned
+  }
+
+  nonisolated static func makeInitRequest(
+    apiKey: String,
+    model: String,
+    language: String?,
+    sampleRate: Int,
+    baseURL: URL = defaultBaseURL
+  ) throws -> URLRequest {
+    let payload = GladiaLiveInitRequest(
+      model: liveModelName(from: model),
+      sampleRate: sampleRate,
+      languageConfig: GladiaLanguageConfig.automaticCodeSwitching,
+      messagesConfig: GladiaMessagesConfig.transcriptsOnly
+    )
+    var request = URLRequest(url: baseURL.appendingPathComponent("v2/live"))
+    request.httpMethod = "POST"
+    request.setValue(apiKey.trimmingCharacters(in: .whitespacesAndNewlines), forHTTPHeaderField: "x-gladia-key")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONEncoder().encode(payload)
+    _ = language
+    return request
+  }
+
+  nonisolated static func transcriptEvent(from json: String) -> GladiaTranscriptEvent? {
+    guard let data = json.data(using: .utf8) else { return nil }
+    guard let envelope = try? JSONDecoder().decode(GladiaLiveMessage.self, from: data) else { return nil }
+    guard envelope.type == "transcript" else { return nil }
+    guard let transcript = envelope.data, let utterance = transcript.utterance else { return nil }
+    let text = utterance.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !text.isEmpty else { return nil }
+    return GladiaTranscriptEvent(
+      text: text,
+      isFinal: transcript.isFinal,
+      confidence: utterance.confidence
+    )
+  }
+
+  private func initiateAndConnect() async {
+    do {
+      let response = try await initiateLiveSession()
+      guard let url = URL(string: response.url) else {
+        throw GladiaLiveError.invalidInitResponse
+      }
+      connectWebSocket(url: url)
+    } catch {
+      guard !isStoppingState() else { return }
+      currentOnError()?(mapConnectionError(error))
+    }
+  }
+
+  private func initiateLiveSession() async throws -> GladiaLiveInitResponse {
+    let request = try Self.makeInitRequest(
+      apiKey: apiKey,
+      model: model,
+      language: language,
+      sampleRate: sampleRate,
+      baseURL: baseURL
+    )
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw GladiaLiveError.invalidInitResponse
+    }
+    guard http.statusCode == 201 else {
+      let body = String(data: data, encoding: .utf8) ?? "<no-body>"
+      throw TranscriptionProviderError.httpError(http.statusCode, body)
+    }
+    return try JSONDecoder().decode(GladiaLiveInitResponse.self, from: data)
+  }
+
+  private func connectWebSocket(url: URL) {
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 30
+    let task = session.webSocketTask(with: request)
+    let shouldReceive = withStateLock { () -> Bool in
+      guard !isStopping else { return false }
+      webSocketTask = task
+      task.resume()
+      return true
+    }
+    guard shouldReceive else {
+      task.cancel(with: .goingAway, reason: nil)
+      return
+    }
+    logger.info("Gladia WebSocket connecting")
+    flushPendingAudio(to: task)
+    receiveMessages()
+  }
+
+  private func send(_ audioData: Data, to task: URLSessionWebSocketTask) {
+    let sendGroup = pendingSendGroup
+    sendGroup.enter()
+    task.send(.data(audioData)) { [weak self] error in
+      defer { sendGroup.leave() }
+      guard let self else { return }
+      if let error {
+        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        self.currentOnError()?(self.mapConnectionError(error))
+      }
+    }
+  }
+
+  private func receiveMessages() {
+    guard let task = currentWebSocketTask() else { return }
+    task.receive { [weak self] result in
+      guard let self else { return }
+      switch result {
+      case .success(let message):
+        self.handleMessage(message)
+        self.receiveMessages()
+      case .failure(let error):
+        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        self.currentOnError()?(self.mapConnectionError(error))
+      }
+    }
+  }
+
+  private func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+    switch message {
+    case .string(let text):
+      parseResponse(text)
+    case .data(let data):
+      if let text = String(data: data, encoding: .utf8) {
+        parseResponse(text)
+      }
+    @unknown default:
+      break
+    }
+  }
+
+  private func parseResponse(_ json: String) {
+    if let event = Self.transcriptEvent(from: json) {
+      currentOnTranscript()?(event)
+      return
+    }
+
+    guard let data = json.data(using: .utf8),
+      let envelope = try? JSONDecoder().decode(GladiaLiveMessage.self, from: data),
+      let error = envelope.error else {
+      return
+    }
+    let detail = error.message ?? error.exception ?? "Unknown server error"
+    currentOnError()?(GladiaLiveError.serverError(detail))
+  }
+
+  private func mapConnectionError(_ error: Error) -> Error {
+    if case TranscriptionProviderError.httpError(let code, _) = error,
+      code == 401 || code == 403 {
+      return GladiaLiveError.invalidAPIKey
+    }
+    let nsError = error as NSError
+    let description = nsError.localizedDescription.lowercased()
+    if nsError.code == 401 || nsError.code == 403
+      || description.contains("401") || description.contains("403")
+      || description.contains("unauthorized") || description.contains("forbidden") {
+      return GladiaLiveError.invalidAPIKey
+    }
+    return error
+  }
+
+  private func shouldIgnoreSocketError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
+    if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
+      return true
+    }
+    return false
+  }
+
+  private func withStateLock<T>(_ block: () -> T) -> T {
+    stateLock.lock()
+    defer { stateLock.unlock() }
+    return block()
+  }
+
+  private func currentWebSocketTask() -> URLSessionWebSocketTask? {
+    withStateLock { webSocketTask }
+  }
+
+  private func isStoppingState() -> Bool {
+    withStateLock { isStopping }
+  }
+
+  private func currentOnTranscript() -> ((GladiaTranscriptEvent) -> Void)? {
+    withStateLock { onTranscript }
+  }
+
+  private func currentOnError() -> ((Error) -> Void)? {
+    withStateLock { onError }
+  }
+
+  private func bufferPendingAudio(_ audioData: Data) {
+    withStateLock {
+      pendingAudio.append(audioData)
+      let maxBufferedBytes = Self.preferredChunkBytes * 50
+      if pendingAudio.count > maxBufferedBytes {
+        pendingAudio = Data(pendingAudio.suffix(maxBufferedBytes))
+      }
+    }
+  }
+
+  private func flushPendingAudio(to task: URLSessionWebSocketTask) {
+    let buffered = withStateLock { () -> Data in
+      let snapshot = pendingAudio
+      pendingAudio.removeAll(keepingCapacity: true)
+      return snapshot
+    }
+    guard !buffered.isEmpty else { return }
+    send(buffered, to: task)
+  }
+}
+
+private struct GladiaLiveInitRequest: Encodable {
+  let model: String
+  let encoding = "wav/pcm"
+  let bitDepth = 16
+  let sampleRate: Int
+  let channels = 1
+  let languageConfig: GladiaLanguageConfig
+  let messagesConfig: GladiaMessagesConfig
+
+  private enum CodingKeys: String, CodingKey {
+    case model
+    case encoding
+    case bitDepth = "bit_depth"
+    case sampleRate = "sample_rate"
+    case channels
+    case languageConfig = "language_config"
+    case messagesConfig = "messages_config"
+  }
+}
+
+private struct GladiaLanguageConfig: Encodable {
+  static let automaticCodeSwitching = GladiaLanguageConfig(languages: [], codeSwitching: true)
+
+  let languages: [String]
+  let codeSwitching: Bool
+
+  private enum CodingKeys: String, CodingKey {
+    case languages
+    case codeSwitching = "code_switching"
+  }
+}
+
+private struct GladiaMessagesConfig: Encodable {
+  static let transcriptsOnly = GladiaMessagesConfig(
+    receivePartialTranscripts: true,
+    receiveFinalTranscripts: true,
+    receiveSpeechEvents: false,
+    receivePreProcessingEvents: false,
+    receiveRealtimeProcessingEvents: false,
+    receivePostProcessingEvents: false,
+    receiveAcknowledgments: false,
+    receiveErrors: true,
+    receiveLifecycleEvents: true
+  )
+
+  let receivePartialTranscripts: Bool
+  let receiveFinalTranscripts: Bool
+  let receiveSpeechEvents: Bool
+  let receivePreProcessingEvents: Bool
+  let receiveRealtimeProcessingEvents: Bool
+  let receivePostProcessingEvents: Bool
+  let receiveAcknowledgments: Bool
+  let receiveErrors: Bool
+  let receiveLifecycleEvents: Bool
+
+  private enum CodingKeys: String, CodingKey {
+    case receivePartialTranscripts = "receive_partial_transcripts"
+    case receiveFinalTranscripts = "receive_final_transcripts"
+    case receiveSpeechEvents = "receive_speech_events"
+    case receivePreProcessingEvents = "receive_pre_processing_events"
+    case receiveRealtimeProcessingEvents = "receive_realtime_processing_events"
+    case receivePostProcessingEvents = "receive_post_processing_events"
+    case receiveAcknowledgments = "receive_acknowledgments"
+    case receiveErrors = "receive_errors"
+    case receiveLifecycleEvents = "receive_lifecycle_events"
+  }
+}
+
+private struct GladiaLiveInitResponse: Decodable {
+  let id: String
+  let createdAt: String
+  let url: String
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case createdAt = "created_at"
+    case url
+  }
+}
+
+private struct GladiaLiveMessage: Decodable {
+  let type: String?
+  let data: GladiaTranscriptData?
+  let error: GladiaServerError?
+}
+
+private struct GladiaTranscriptData: Decodable {
+  let id: String?
+  let isFinal: Bool
+  let utterance: GladiaUtterance?
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case isFinal = "is_final"
+    case utterance
+  }
+}
+
+private struct GladiaUtterance: Decodable {
+  let text: String?
+  let confidence: Double?
+}
+
+private struct GladiaServerError: Decodable {
+  let statusCode: String?
+  let exception: String?
+  let message: String?
+
+  private enum CodingKeys: String, CodingKey {
+    case statusCode = "status_code"
+    case exception
+    case message
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    if let intCode = try? container.decode(Int.self, forKey: .statusCode) {
+      statusCode = String(intCode)
+    } else {
+      statusCode = try? container.decode(String.self, forKey: .statusCode)
+    }
+    exception = try? container.decode(String.self, forKey: .exception)
+    message = try? container.decode(String.self, forKey: .message)
+  }
+}

--- a/Sources/SpeakApp/GladiaTranscriptionProvider.swift
+++ b/Sources/SpeakApp/GladiaTranscriptionProvider.swift
@@ -74,13 +74,15 @@ struct GladiaTranscriptionProvider: TranscriptionProvider {
       guard let http = response as? HTTPURLResponse else {
         return .failure(message: "Non-HTTP response")
       }
-      let debug = debugSnapshot(request: request, response: http, data: data)
       switch http.statusCode {
       case 200..<300:
+        let debug = debugSnapshot(request: request, response: http, data: nil)
         return .success(message: "Gladia API key validated", debug: debug)
       case 401, 403:
+        let debug = debugSnapshot(request: request, response: http, data: data)
         return .failure(message: "Gladia rejected the key (HTTP \(http.statusCode))", debug: debug)
       default:
+        let debug = debugSnapshot(request: request, response: http, data: data)
         return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
       }
     } catch {
@@ -121,7 +123,7 @@ struct GladiaTranscriptionProvider: TranscriptionProvider {
   private func debugSnapshot(
     request: URLRequest,
     response: HTTPURLResponse,
-    data: Data
+    data: Data?
   ) -> APIKeyValidationDebugSnapshot {
     APIKeyValidationDebugSnapshot(
       url: request.url?.absoluteString ?? "",
@@ -133,7 +135,7 @@ struct GladiaTranscriptionProvider: TranscriptionProvider {
         guard let key = entry.key as? String else { return }
         partialResult[key] = String(describing: entry.value)
       },
-      responseBody: String(data: data, encoding: .utf8),
+      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
       errorDescription: nil
     )
   }

--- a/Sources/SpeakApp/GladiaTranscriptionProvider.swift
+++ b/Sources/SpeakApp/GladiaTranscriptionProvider.swift
@@ -190,15 +190,23 @@ final class GladiaLiveTranscriber: @unchecked Sendable {
     onTranscript: @escaping (GladiaTranscriptEvent) -> Void,
     onError: @escaping (Error) -> Void
   ) {
-    withStateLock {
+    let oldInitTask = withStateLock { () -> Task<Void, Never>? in
       isStopping = false
       pendingAudio.removeAll(keepingCapacity: true)
       self.onTranscript = onTranscript
       self.onError = onError
+      let old = initTask
+      initTask = nil
+      return old
     }
+    oldInitTask?.cancel()
 
-    initTask = Task { [weak self] in
-      await self?.initiateAndConnect()
+    let task = Task { [weak self] in
+      guard let self else { return }
+      await self.initiateAndConnect()
+    }
+    withStateLock {
+      self.initTask = task
     }
   }
 
@@ -283,7 +291,7 @@ final class GladiaLiveTranscriber: @unchecked Sendable {
     let payload = GladiaLiveInitRequest(
       model: liveModelName(from: model),
       sampleRate: sampleRate,
-      languageConfig: GladiaLanguageConfig.automaticCodeSwitching,
+      languageConfig: GladiaLanguageConfig.from(language: language),
       messagesConfig: GladiaMessagesConfig.transcriptsOnly
     )
     var request = URLRequest(url: baseURL.appendingPathComponent("v2/live"))
@@ -291,7 +299,6 @@ final class GladiaLiveTranscriber: @unchecked Sendable {
     request.setValue(apiKey.trimmingCharacters(in: .whitespacesAndNewlines), forHTTPHeaderField: "x-gladia-key")
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.httpBody = try JSONEncoder().encode(payload)
-    _ = language
     return request
   }
 
@@ -505,6 +512,17 @@ private struct GladiaLiveInitRequest: Encodable {
 
 private struct GladiaLanguageConfig: Encodable {
   static let automaticCodeSwitching = GladiaLanguageConfig(languages: [], codeSwitching: true)
+
+  static func from(language: String?) -> GladiaLanguageConfig {
+    guard let language else { return automaticCodeSwitching }
+    let normalized = language
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: "_", with: "-")
+    guard let code = normalized.split(separator: "-").first, !code.isEmpty else {
+      return automaticCodeSwitching
+    }
+    return GladiaLanguageConfig(languages: [String(code).lowercased()], codeSwitching: false)
+  }
 
   let languages: [String]
   let codeSwitching: Bool

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -3796,6 +3796,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private var elevenlabsController: ElevenLabsLiveController
   private var sonioxController: SonioxLiveController
   private var cartesiaController: CartesiaLiveController
+  private var gladiaController: GladiaLiveController
   private var openAIRealtimeController: OpenAIRealtimeLiveController
   private var sherpaOnnxController: SherpaOnnxLiveController
   private var unsupportedLocalLiveController: UnsupportedLocalLiveTranscriber
@@ -3855,6 +3856,12 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       secureStorage: secureStorage
     )
     cartesiaController = CartesiaLiveController(
+      appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    gladiaController = GladiaLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
@@ -3928,6 +3935,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     if model.hasPrefix("elevenlabs/") { return elevenlabsController }
     if model.hasPrefix("soniox/") { return sonioxController }
     if model.hasPrefix("cartesia/") { return cartesiaController }
+    if model.hasPrefix("gladia/") { return gladiaController }
     // SwitchingLiveTranscriber only routes live transcription models, and
     // OpenAI's only live transcription transport is the Realtime WebSocket
     // API. So any openai/* live model is handled by openAIRealtimeController.
@@ -3946,6 +3954,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       elevenlabsController,
       sonioxController,
       cartesiaController,
+      gladiaController,
       openAIRealtimeController,
       sherpaOnnxController,
       unsupportedLocalLiveController
@@ -4004,6 +4013,12 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       secureStorage: secureStorage
     )
     cartesiaController = CartesiaLiveController(
+      appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    gladiaController = GladiaLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,

--- a/Sources/SpeakApp/TranscriptionProviderRegistry.swift
+++ b/Sources/SpeakApp/TranscriptionProviderRegistry.swift
@@ -20,6 +20,7 @@ actor TranscriptionProviderRegistry {
         providers["groq"] = GroqTranscriptionProvider()
         providers["cartesia"] = CartesiaTranscriptionProvider()
         providers["mistral"] = MistralTranscriptionProvider()
+        providers["gladia"] = GladiaTranscriptionProvider()
     }
 
     func allProviders() -> [TranscriptionProviderMetadata] {

--- a/Sources/SpeakCore/LiveModelCapabilities.swift
+++ b/Sources/SpeakCore/LiveModelCapabilities.swift
@@ -81,6 +81,10 @@ extension ModelCatalog {
         "cartesia/ink-2-streaming": LiveModelCapabilities(
             supportedSpeedModes: [.instant, .livePolish]
         ),
+        "gladia/solaria-1-streaming": LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish],
+            postStopFinalizeBudget: 1.5
+        ),
         "modulate/velma-2-stt-streaming": LiveModelCapabilities(
             supportedSpeedModes: [.instant, .livePolish]
         ),

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -144,6 +144,11 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             description: "English real-time STT with built-in turn detection and structured-data accuracy.",
             estimatedLatencyMs: 180, latencyTier: .fast),
         Option(
+            id: "gladia/solaria-1-streaming",
+            displayName: "Gladia Solaria-1 (Streaming)",
+            description: "Real-time multilingual STT with automatic language detection and partial transcripts.",
+            estimatedLatencyMs: 220, latencyTier: .fast),
+        Option(
             id: "modulate/velma-2-stt-streaming", displayName: "Modulate Velma-2 (Streaming)",
             description: "Real-time multilingual WebSocket transcription with diarization and signal detection.",
             estimatedLatencyMs: 220, latencyTier: .fast),

--- a/Sources/SpeakCore/SensitiveHeaderRedactor.swift
+++ b/Sources/SpeakCore/SensitiveHeaderRedactor.swift
@@ -14,9 +14,10 @@ public enum SensitiveHeaderRedactor {
         "openai-api-key",
         "deepgram-api-key",
         "anthropic-api-key",
-        "xi-api-key"
+        "xi-api-key",
+        "x-gladia-key"
     ]
-    
+
     /// Redacts sensitive headers in a dictionary by masking values
     /// - Parameter headers: Dictionary of HTTP headers
     /// - Returns: Dictionary with sensitive values redacted
@@ -32,7 +33,7 @@ public enum SensitiveHeaderRedactor {
         }
         return result
     }
-    
+
     /// Determines if a header key is sensitive
     /// - Parameter key: Header name
     /// - Returns: True if the header is known to contain sensitive data
@@ -40,47 +41,45 @@ public enum SensitiveHeaderRedactor {
         let normalized = key.lowercased()
         return sensitiveHeaderKeys.contains(normalized)
     }
-    
+
     /// Checks if a value appears to be sensitive (e.g., API key, token)
     /// - Parameter value: Header value to check
     /// - Returns: True if the value matches common sensitive patterns
     private static func isSensitiveValue(_ value: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespaces)
-        
+
         // Common API key patterns
         let patterns = [
             "^sk-[A-Za-z0-9]{20,}$",           // OpenAI style: sk-...
             "^Bearer .+$",                       // Bearer tokens
             "^[A-Za-z0-9]{32,}$",               // Long alphanumeric strings (likely keys)
-            "^[A-Za-z0-9_-]{40,}$",             // JWT-style tokens
+            "^[A-Za-z0-9_-]{40,}$"              // JWT-style tokens
         ]
-        
-        for pattern in patterns {
-            if trimmed.range(of: pattern, options: .regularExpression) != nil {
-                return true
-            }
+
+        for pattern in patterns where trimmed.range(of: pattern, options: .regularExpression) != nil {
+            return true
         }
-        
+
         return false
     }
-    
+
     /// Redacts a sensitive value by showing only first 3 and last 4 characters
     /// - Parameter value: The sensitive value to redact
     /// - Returns: Redacted string in format "abc...xyz1" or "[REDACTED]" if too short
     public static func redactValue(_ value: String) -> String {
         let trimmed = value.trimmingCharacters(in: .whitespaces)
-        
+
         // Handle Bearer tokens specially
         if trimmed.hasPrefix("Bearer ") {
             let token = String(trimmed.dropFirst(7))
             return "Bearer \(redactValue(token))"
         }
-        
+
         // For very short values, just fully redact
         guard trimmed.count >= 10 else {
             return "[REDACTED]"
         }
-        
+
         // Show first 3 and last 4 characters with ellipsis in between
         let prefix = String(trimmed.prefix(3))
         let suffix = String(trimmed.suffix(4))

--- a/Tests/SpeakAppTests/GladiaTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/GladiaTranscriptionProviderTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+@testable import SpeakCore
+
+final class GladiaTranscriptionProviderTests: XCTestCase {
+  func testModelCatalogLiveTranscription_includesGladiaSolariaStreaming() throws {
+    let option = try XCTUnwrap(ModelCatalog.liveTranscription.first { $0.id == "gladia/solaria-1-streaming" })
+
+    XCTAssertEqual(option.displayName, "Gladia Solaria-1 (Streaming)")
+    XCTAssertEqual(option.latencyTier, .fast)
+  }
+
+  func testGladiaCapabilities_supportLivePolishAndPostStopFinalisation() {
+    let capabilities = ModelCatalog.liveCapabilities(for: "gladia/solaria-1-streaming")
+
+    XCTAssertTrue(capabilities.supportedSpeedModes.contains(.instant))
+    XCTAssertTrue(capabilities.supportedSpeedModes.contains(.livePolish))
+    XCTAssertGreaterThan(capabilities.postStopFinalizeBudget, 0)
+  }
+
+  func testProviderRegistry_routesGladiaModelToGladiaProvider() async {
+    let provider = await TranscriptionProviderRegistry.shared.provider(forModel: "gladia/solaria-1-streaming")
+
+    XCTAssertEqual(provider?.metadata.id, "gladia")
+    XCTAssertEqual(provider?.metadata.apiKeyIdentifier, "gladia.apiKey")
+  }
+
+  func testProviderSupportedModels_returnsLiveSolariaModel() {
+    let provider = GladiaTranscriptionProvider()
+    let ids = provider.supportedModels().map(\.id)
+
+    XCTAssertEqual(ids, ["gladia/solaria-1-streaming"])
+  }
+
+  func testInitRequest_usesDocumentedEndpointHeadersAndPCM16Config() throws {
+    let request = try GladiaLiveTranscriber.makeInitRequest(
+      apiKey: "test-gladia-key",
+      model: "gladia/solaria-1-streaming",
+      language: "en_GB",
+      sampleRate: 16_000
+    )
+    let body = try XCTUnwrap(request.httpBody)
+    let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+    let payload = try XCTUnwrap(json)
+    let languageConfig = try XCTUnwrap(payload["language_config"] as? [String: Any])
+    let messagesConfig = try XCTUnwrap(payload["messages_config"] as? [String: Any])
+
+    XCTAssertEqual(request.url?.absoluteString, "https://api.gladia.io/v2/live")
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "x-gladia-key"), "test-gladia-key")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    XCTAssertEqual(payload["model"] as? String, "solaria-1")
+    XCTAssertEqual(payload["encoding"] as? String, "wav/pcm")
+    XCTAssertEqual(payload["bit_depth"] as? Int, 16)
+    XCTAssertEqual(payload["sample_rate"] as? Int, 16_000)
+    XCTAssertEqual(payload["channels"] as? Int, 1)
+    XCTAssertEqual(languageConfig["languages"] as? [String], [])
+    XCTAssertEqual(languageConfig["code_switching"] as? Bool, true)
+    XCTAssertEqual(messagesConfig["receive_partial_transcripts"] as? Bool, true)
+    XCTAssertEqual(messagesConfig["receive_final_transcripts"] as? Bool, true)
+  }
+
+  func testStopRecordingMessage_usesDocumentedShape() {
+    XCTAssertEqual(GladiaLiveTranscriber.stopRecordingMessage(), #"{"type":"stop_recording"}"#)
+  }
+
+  func testTranscriptEvent_parsesPartialTranscript() {
+    let json = """
+    {
+      "session_id": "550e8400-e29b-41d4-a716-446655440000",
+      "created_at": "2025-09-19T12:34:10Z",
+      "type": "transcript",
+      "data": {
+        "id": "00-00000011",
+        "is_final": false,
+        "utterance": {
+          "text": "Hello wor",
+          "confidence": 0.91,
+          "language": "en"
+        }
+      }
+    }
+    """
+
+    let event = GladiaLiveTranscriber.transcriptEvent(from: json)
+
+    XCTAssertEqual(event?.text, "Hello wor")
+    XCTAssertEqual(event?.isFinal, false)
+    XCTAssertEqual(event?.confidence, 0.91)
+  }
+
+  func testTranscriptEvent_parsesFinalTranscript() {
+    let json = """
+    {
+      "type": "transcript",
+      "data": {
+        "id": "00-00000011",
+        "is_final": true,
+        "utterance": {"text": "Hello world.", "confidence": 0.98}
+      }
+    }
+    """
+
+    let event = GladiaLiveTranscriber.transcriptEvent(from: json)
+
+    XCTAssertEqual(event?.text, "Hello world.")
+    XCTAssertEqual(event?.isFinal, true)
+    XCTAssertEqual(event?.confidence, 0.98)
+  }
+
+  func testTranscriptEvent_ignoresNonTranscriptAndEmptyText() {
+    XCTAssertNil(GladiaLiveTranscriber.transcriptEvent(from: #"{"type":"speech_start","data":{}}"#))
+    XCTAssertNil(GladiaLiveTranscriber.transcriptEvent(
+      from: #"{"type":"transcript","data":{"is_final":true,"utterance":{"text":""}}}"#
+    ))
+  }
+
+  func testValidateAPIKey_sendsXGladiaKeyAndRedactsDebugHeaders() async throws {
+    let observer = GladiaRequestObserver()
+    GladiaMockURLProtocol.requestHandler = { request in
+      await observer.store(request: request)
+      let response = HTTPURLResponse(
+        url: try XCTUnwrap(request.url),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+      return (response, Data(#"{"items":[]}"#.utf8))
+    }
+    defer { GladiaMockURLProtocol.requestHandler = nil }
+
+    let provider = GladiaTranscriptionProvider(session: makeMockSession())
+    let result = await provider.validateAPIKey("gladia-test-key")
+
+    let capturedRequest = await observer.capturedRequest()
+    let captured = try XCTUnwrap(capturedRequest)
+    XCTAssertEqual(captured.url?.path, "/v2/live")
+    XCTAssertEqual(captured.httpMethod, "GET")
+    XCTAssertEqual(captured.value(forHTTPHeaderField: "x-gladia-key"), "gladia-test-key")
+    if case .success = result.outcome {
+      // pass
+    } else {
+      XCTFail("Expected validation success")
+    }
+    XCTAssertEqual(result.debug?.requestHeaders["x-gladia-key"], "gla...-key")
+  }
+
+  func testValidateAPIKey_returnsFailureOnUnauthorized() async {
+    GladiaMockURLProtocol.requestHandler = { request in
+      let response = HTTPURLResponse(
+        url: try XCTUnwrap(request.url),
+        statusCode: 401,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+      return (response, Data(#"{"message":"invalid key"}"#.utf8))
+    }
+    defer { GladiaMockURLProtocol.requestHandler = nil }
+
+    let provider = GladiaTranscriptionProvider(session: makeMockSession())
+    let result = await provider.validateAPIKey("bad-key")
+
+    if case .failure(let message) = result.outcome {
+      XCTAssertTrue(message.contains("401"))
+    } else {
+      XCTFail("Expected validation failure")
+    }
+  }
+
+  private func makeMockSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [GladiaMockURLProtocol.self]
+    return URLSession(configuration: configuration)
+  }
+}
+
+private actor GladiaRequestObserver {
+  private var request: URLRequest?
+
+  func store(request: URLRequest) {
+    self.request = request
+  }
+
+  func capturedRequest() -> URLRequest? {
+    request
+  }
+}
+
+private final class GladiaMockURLProtocol: URLProtocol {
+#if compiler(>=5.10)
+  nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+#else
+  static var requestHandler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+#endif
+
+  override static func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    guard let handler = Self.requestHandler else {
+      XCTFail("GladiaMockURLProtocol.requestHandler was not set")
+      return
+    }
+
+    Task {
+      do {
+        let (response, data) = try await handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+      } catch {
+        client?.urlProtocol(self, didFailWithError: error)
+      }
+    }
+  }
+
+  override func stopLoading() {}
+}

--- a/Tests/SpeakAppTests/GladiaTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/GladiaTranscriptionProviderTests.swift
@@ -56,8 +56,8 @@ final class GladiaTranscriptionProviderTests: XCTestCase {
     XCTAssertEqual(payload["bit_depth"] as? Int, 16)
     XCTAssertEqual(payload["sample_rate"] as? Int, 16_000)
     XCTAssertEqual(payload["channels"] as? Int, 1)
-    XCTAssertEqual(languageConfig["languages"] as? [String], [])
-    XCTAssertEqual(languageConfig["code_switching"] as? Bool, true)
+    XCTAssertEqual(languageConfig["languages"] as? [String], ["en"])
+    XCTAssertEqual(languageConfig["code_switching"] as? Bool, false)
     XCTAssertEqual(messagesConfig["receive_partial_transcripts"] as? Bool, true)
     XCTAssertEqual(messagesConfig["receive_final_transcripts"] as? Bool, true)
   }

--- a/Tests/SpeakAppTests/GladiaTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/GladiaTranscriptionProviderTests.swift
@@ -127,7 +127,8 @@ final class GladiaTranscriptionProviderTests: XCTestCase {
         httpVersion: nil,
         headerFields: ["Content-Type": "application/json"]
       )!
-      return (response, Data(#"{"items":[]}"#.utf8))
+      let body = #"{"items":[{"status":"done","result":{"transcription":"private prior transcript"}}]}"#
+      return (response, Data(body.utf8))
     }
     defer { GladiaMockURLProtocol.requestHandler = nil }
 
@@ -145,6 +146,7 @@ final class GladiaTranscriptionProviderTests: XCTestCase {
       XCTFail("Expected validation success")
     }
     XCTAssertEqual(result.debug?.requestHeaders["x-gladia-key"], "gla...-key")
+    XCTAssertNil(result.debug?.responseBody)
   }
 
   func testValidateAPIKey_returnsFailureOnUnauthorized() async {
@@ -167,6 +169,7 @@ final class GladiaTranscriptionProviderTests: XCTestCase {
     } else {
       XCTFail("Expected validation failure")
     }
+    XCTAssertEqual(result.debug?.responseBody, #"{"message":"invalid key"}"#)
   }
 
   private func makeMockSession() -> URLSession {


### PR DESCRIPTION
## Summary
- Adds Gladia Solaria-1 as a remote streaming transcription provider.
- Wires the live model catalogue, provider registry, API key metadata/settings path, SecureAppStorage lookup, and missing-key flow via provider metadata.
- Implements Gladia live session init, raw PCM16 16 kHz binary WebSocket streaming, transcript partial/final parsing, and `stop_recording` shutdown.

## Docs checked
Current Gladia docs confirm the integration shape:
- `POST /v2/live` initiates a live WebSocket session and returns a temporary WebSocket `url`.
- Live WebSocket supports binary audio frames matching `encoding`, `bit_depth`, `sample_rate`, and `channels`.
- Stop message shape is `{ "type": "stop_recording" }`.
- Transcript messages are `type: transcript` with `data.is_final` and `data.utterance.text`.

## Follow-up scope
- Batch transcription is tracked separately in #487 to keep this live provider PR reviewable.

## Validation
- `swift test --filter GladiaTranscriptionProviderTests --disable-automatic-resolution`
- `swift build --target SpeakApp --disable-automatic-resolution`
- `swiftlint lint --strict --config .swiftlint.yml Sources/SpeakApp/GladiaTranscriptionProvider.swift Sources/SpeakApp/GladiaLiveController.swift Tests/SpeakAppTests/GladiaTranscriptionProviderTests.swift Sources/SpeakCore/SensitiveHeaderRedactor.swift`

Closes #455
