### PR TITLE
fix(mac): fix onboarding permissions, default to Deepgram streaming, add Soniox

### DIFF
--- a/Sources/SpeakApp/GladiaLiveController.swift
+++ b/Sources/SpeakApp/GladiaLiveController.swift
@@ -364,9 +364,10 @@ final class GladiaLiveController: NSObject, LiveTranscriptionController {
 
 private extension GladiaLiveController {
   func ensurePermissions() async -> Bool {
+    // Remote streaming providers only need microphone access; speech recognition
+    // permission is exclusive to the on-device Apple transcriber.
     let microphone = await permissionsManager.ensureGranted(.microphone)
-    let speech = await permissionsManager.ensureGranted(.speechRecognition)
-    return microphone.isGranted && speech.isGranted
+    return microphone.isGranted
   }
 
   func gladiaAPIKey() async throws -> String {

--- a/Sources/SpeakApp/GladiaLiveController.swift
+++ b/Sources/SpeakApp/GladiaLiveController.swift
@@ -52,7 +52,7 @@ final class GladiaLiveController: NSObject, LiveTranscriptionController {
   // swiftlint:disable:next function_body_length
   func start() async throws {
     guard await ensurePermissions() else {
-      throw TranscriptionManagerError.permissionsMissing
+      throw TranscriptionManagerError.microphonePermissionMissing
     }
 
     let apiKey = try await gladiaAPIKey()

--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -515,10 +515,6 @@ struct PermissionsStepView: View {
     @ObservedObject var state: OnboardingState
     @State private var showAccessibilityHelper = false
     @State private var accessibilityAttempted = false
-    // Accessibility and Input Monitoring are granted in System Settings and the
-    // OS never notifies us, so poll while this step is on screen to reflect the
-    // grants live instead of forcing an app restart.
-    private let permissionPollTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     
     var body: some View {
         VStack(spacing: 20) {
@@ -609,8 +605,15 @@ struct PermissionsStepView: View {
                 .foregroundColor(.accentColor)
             }
         }
-        .onReceive(permissionPollTimer) { _ in
-            state.refreshPermissions()
+        .task {
+            // Accessibility and Input Monitoring are granted in System Settings
+            // and the OS never notifies us, so poll while this step is on screen
+            // to reflect the grants live instead of forcing an app restart. The
+            // loop is automatically cancelled when the view disappears.
+            while !Task.isCancelled {
+                state.refreshPermissions()
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
         }
     }
 }

--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import AppKit
 import AVFoundation
 import SpeakHotKeys
@@ -7,6 +8,7 @@ import SwiftUI
 
 enum OnboardingProvider: String, CaseIterable, Identifiable {
     case deepgram
+    case soniox
     case openai
     case openrouter
     case revai
@@ -16,6 +18,7 @@ enum OnboardingProvider: String, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .deepgram: return "Deepgram"
+        case .soniox: return "Soniox"
         case .openai: return "OpenAI Whisper"
         case .openrouter: return "OpenRouter"
         case .revai: return "Rev.ai"
@@ -25,6 +28,7 @@ enum OnboardingProvider: String, CaseIterable, Identifiable {
     var signupURL: URL {
         switch self {
         case .deepgram: return URL(string: "https://console.deepgram.com/signup")!
+        case .soniox: return URL(string: "https://console.soniox.com")!
         case .openai: return URL(string: "https://platform.openai.com/signup")!
         case .openrouter: return URL(string: "https://openrouter.ai/keys")!
         case .revai: return URL(string: "https://www.rev.ai/auth/signup")!
@@ -34,6 +38,7 @@ enum OnboardingProvider: String, CaseIterable, Identifiable {
     var apiKeyInstructions: String {
         switch self {
         case .deepgram: return "Go to Settings → API Keys → Create Key"
+        case .soniox: return "Go to Dashboard → API Keys → New API Key"
         case .openai: return "Go to API Keys → Create new secret key"
         case .openrouter: return "Go to Keys → Create Key"
         case .revai: return "Go to Access Token → Generate Token"
@@ -43,6 +48,7 @@ enum OnboardingProvider: String, CaseIterable, Identifiable {
     var freeCredits: String? {
         switch self {
         case .deepgram: return "Free tier includes $200 credit"
+        case .soniox: return "Free tier includes $200 credit, real-time streaming STT"
         case .openai: return nil
         case .openrouter: return "Pay-as-you-go with many model options"
         case .revai: return "Free tier includes 5 hours"
@@ -50,6 +56,29 @@ enum OnboardingProvider: String, CaseIterable, Identifiable {
     }
     
     var keychainIdentifier: String { "\(rawValue).apiKey" }
+
+    /// The live streaming transcription model this provider maps to, if any.
+    /// Selecting such a provider during onboarding switches the app to remote
+    /// streaming so the freshly-added key is used immediately.
+    var defaultLiveTranscriptionModel: String? {
+        switch self {
+        case .deepgram: return "deepgram/nova-3-streaming"
+        case .soniox: return "soniox/stt-rt-v5-streaming"
+        case .openai, .openrouter, .revai: return nil
+        }
+    }
+
+    /// Short label used in the segmented onboarding picker where horizontal
+    /// space is tight; `displayName` is used everywhere else.
+    var pickerLabel: String {
+        switch self {
+        case .deepgram: return "Deepgram"
+        case .soniox: return "Soniox"
+        case .openai: return "OpenAI"
+        case .openrouter: return "OpenRouter"
+        case .revai: return "Rev.ai"
+        }
+    }
 }
 
 // MARK: - Onboarding State
@@ -97,6 +126,9 @@ final class OnboardingState: ObservableObject {
     func refreshPermissions() {
         permissionsGranted = []
         for perm in [PermissionType.microphone, .accessibility, .inputMonitoring] {
+            // Force a fresh computation; cached statuses go stale when the user
+            // toggles a permission in System Settings (the OS never notifies us).
+            permissionsManager.refresh(perm)
             if permissionsManager.status(for: perm).isGranted {
                 permissionsGranted.insert(perm)
             }
@@ -108,6 +140,7 @@ final class OnboardingState: ObservableObject {
         permissionsGranted.contains(.accessibility)
     }
     
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     func validateAPIKey() async -> Bool {
         guard !apiKey.isEmpty else {
             validationError = "Please enter an API key"
@@ -135,6 +168,25 @@ final class OnboardingState: ObservableObject {
                     }
                 }
                 
+            case .soniox:
+                let url = URL(string: "https://api.soniox.com/v1/auth/temporary-api-key")!
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.httpBody = Data("{\"usage_type\":\"transcribe_websocket\",\"expires_in_seconds\":60}".utf8)
+                let (_, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse {
+                    if (200...299).contains(httpResponse.statusCode) {
+                        isValidating = false
+                        return true
+                    } else if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+                        validationError = "Invalid API key"
+                    } else {
+                        validationError = "Unexpected response (\(httpResponse.statusCode))"
+                    }
+                }
+
             case .openai:
                 let url = URL(string: "https://api.openai.com/v1/models")!
                 var request = URLRequest(url: url)
@@ -195,6 +247,21 @@ final class OnboardingState: ObservableObject {
         try await secureStorage.storeSecret(apiKey, identifier: selectedProvider.keychainIdentifier)
         // Register the key identifier so it shows up in settings
         settings.registerAPIKeyIdentifier(selectedProvider.keychainIdentifier)
+
+        // If the chosen provider offers live streaming, make it the active
+        // transcription engine straight away so the key the user just added is
+        // actually used. Deepgram (and other streaming providers) default to
+        // no post-processing for the fastest, cleanest live experience.
+        //
+        // Only switch when the user is still on the untouched default (Apple
+        // on-device speech) so re-running onboarding never clobbers a returning
+        // user's deliberately configured model / batch / post-processing setup.
+        if let liveModel = selectedProvider.defaultLiveTranscriptionModel,
+           settings.liveTranscriptionModel == "apple/local/SFSpeechRecognizer" {
+            settings.transcriptionMode = .liveNative
+            settings.liveTranscriptionModel = liveModel
+            settings.postProcessingEnabled = false
+        }
     }
 }
 
@@ -448,6 +515,10 @@ struct PermissionsStepView: View {
     @ObservedObject var state: OnboardingState
     @State private var showAccessibilityHelper = false
     @State private var accessibilityAttempted = false
+    // Accessibility and Input Monitoring are granted in System Settings and the
+    // OS never notifies us, so poll while this step is on screen to reflect the
+    // grants live instead of forcing an app restart.
+    private let permissionPollTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     
     var body: some View {
         VStack(spacing: 20) {
@@ -537,6 +608,9 @@ struct PermissionsStepView: View {
                 .buttonStyle(.plain)
                 .foregroundColor(.accentColor)
             }
+        }
+        .onReceive(permissionPollTimer) { _ in
+            state.refreshPermissions()
         }
     }
 }
@@ -681,7 +755,7 @@ struct APIKeyStepView: View {
                     
                     Picker("Provider", selection: $state.selectedProvider) {
                         ForEach(OnboardingProvider.allCases) { provider in
-                            Text(provider.displayName).tag(provider)
+                            Text(provider.pickerLabel).tag(provider)
                         }
                     }
                     .pickerStyle(.segmented)

--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -69,7 +69,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
   // swiftlint:disable:next function_body_length
   func start() async throws {
     guard await ensurePermissions() else {
-      throw TranscriptionManagerError.permissionsMissing
+      throw TranscriptionManagerError.microphonePermissionMissing
     }
 
     let apiKey = try await openAIAPIKey()

--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -330,9 +330,10 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
   }
 
   private func ensurePermissions() async -> Bool {
+    // Remote streaming providers only need microphone access; speech recognition
+    // permission is exclusive to the on-device Apple transcriber.
     let microphone = await permissionsManager.request(.microphone)
-    let speech = await permissionsManager.request(.speechRecognition)
-    return microphone.isGranted && speech.isGranted
+    return microphone.isGranted
   }
 
   private func trimmedKeytermsPrompt() -> String? {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -1359,9 +1359,10 @@ final class DeepgramLiveController: NSObject, LiveTranscriptionController {
 
 private extension DeepgramLiveController {
   func ensurePermissions() async -> Bool {
+    // Remote streaming providers only need microphone access; speech recognition
+    // permission is exclusive to the on-device Apple transcriber.
     let microphone = await permissionsManager.ensureGranted(.microphone)
-    let speech = await permissionsManager.ensureGranted(.speechRecognition)
-    return microphone.isGranted && speech.isGranted
+    return microphone.isGranted
   }
 
   func deepgramAPIKey() async throws -> String {
@@ -2015,9 +2016,10 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
   }
 
   private func ensurePermissions() async -> Bool {
+    // Remote streaming providers only need microphone access; speech recognition
+    // permission is exclusive to the on-device Apple transcriber.
     let microphone = await permissionsManager.ensureGranted(.microphone)
-    let speech = await permissionsManager.ensureGranted(.speechRecognition)
-    return microphone.isGranted && speech.isGranted
+    return microphone.isGranted
   }
 
   private func assemblyAIAPIKey() async throws -> String {
@@ -2363,9 +2365,10 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
   }
 
   private func ensurePermissions() async -> Bool {
+    // Remote streaming providers only need microphone access; speech recognition
+    // permission is exclusive to the on-device Apple transcriber.
     let microphone = await permissionsManager.ensureGranted(.microphone)
-    let speech = await permissionsManager.ensureGranted(.speechRecognition)
-    return microphone.isGranted && speech.isGranted
+    return microphone.isGranted
   }
 
   private func modulateAPIKey() async throws -> String {
@@ -2865,9 +2868,10 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
 
 private extension ElevenLabsLiveController {
   func ensurePermissions() async -> Bool {
+    // Remote streaming providers only need microphone access; speech recognition
+    // permission is exclusive to the on-device Apple transcriber.
     let microphone = await permissionsManager.ensureGranted(.microphone)
-    let speech = await permissionsManager.ensureGranted(.speechRecognition)
-    return microphone.isGranted && speech.isGranted
+    return microphone.isGranted
   }
 
   func elevenLabsAPIKey() async throws -> String {
@@ -3309,9 +3313,10 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
 
 private extension SonioxLiveController {
   func ensurePermissions() async -> Bool {
+    // Remote streaming providers only need microphone access; speech recognition
+    // permission is exclusive to the on-device Apple transcriber.
     let microphone = await permissionsManager.ensureGranted(.microphone)
-    let speech = await permissionsManager.ensureGranted(.speechRecognition)
-    return microphone.isGranted && speech.isGranted
+    return microphone.isGranted
   }
 
   func sonioxAPIKey() async throws -> String {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -22,6 +22,7 @@ enum TranscriptionManagerError: LocalizedError, Equatable {
   case liveSessionNotRunning
   case recognizerUnavailable
   case permissionsMissing
+  case microphonePermissionMissing
   case localLiveStreamingUnsupported
   case invalidLocalStreamingSource(String)
   case noUsableAudioInput
@@ -36,6 +37,8 @@ enum TranscriptionManagerError: LocalizedError, Equatable {
       return "The speech recogniser could not be configured for the selected locale."
     case .permissionsMissing:
       return "Required microphone or speech recognition permissions are missing."
+    case .microphonePermissionMissing:
+      return "Microphone permission is missing. Grant microphone access in System Settings and try again."
     case .localLiveStreamingUnsupported:
       return "Downloaded local models are offline-only in this prerelease. Use Local Batch after recording."
     case .invalidLocalStreamingSource(let sourceID):
@@ -742,7 +745,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
       throw TranscriptionManagerError.liveSessionAlreadyRunning
     }
     guard await permissionsManager.ensureGranted(.microphone).isGranted else {
-      throw TranscriptionManagerError.permissionsMissing
+      throw TranscriptionManagerError.microphonePermissionMissing
     }
 
     let modelID = currentModel ?? appSettings.localStreamingModelSource
@@ -1137,7 +1140,7 @@ final class DeepgramLiveController: NSObject, LiveTranscriptionController {
 
     guard await ensurePermissions() else {
       print("[DeepgramLiveController] ERROR: Permissions missing")
-      throw TranscriptionManagerError.permissionsMissing
+      throw TranscriptionManagerError.microphonePermissionMissing
     }
 
     let apiKey = try await deepgramAPIKey()
@@ -1598,7 +1601,7 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
   // swiftlint:disable:next function_body_length
   func start() async throws {
     guard await ensurePermissions() else {
-      throw TranscriptionManagerError.permissionsMissing
+      throw TranscriptionManagerError.microphonePermissionMissing
     }
 
     let apiKey = try await assemblyAIAPIKey()
@@ -2092,7 +2095,7 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
 
   func start() async throws {
     guard await ensurePermissions() else {
-      throw TranscriptionManagerError.permissionsMissing
+      throw TranscriptionManagerError.microphonePermissionMissing
     }
 
     let apiKey = try await modulateAPIKey()
@@ -2598,7 +2601,7 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
   // swiftlint:disable:next function_body_length
   func start() async throws {
     guard await ensurePermissions() else {
-      throw TranscriptionManagerError.permissionsMissing
+      throw TranscriptionManagerError.microphonePermissionMissing
     }
 
     let apiKey = try await elevenLabsAPIKey()
@@ -3001,7 +3004,7 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
   // swiftlint:disable:next function_body_length
   func start() async throws {
     guard await ensurePermissions() else {
-      throw TranscriptionManagerError.permissionsMissing
+      throw TranscriptionManagerError.microphonePermissionMissing
     }
 
     let apiKey = try await sonioxAPIKey()
@@ -3433,7 +3436,7 @@ final class CartesiaLiveController: NSObject, LiveTranscriptionController {
   // swiftlint:disable:next function_body_length
   func start() async throws {
     guard await ensurePermissions() else {
-      throw TranscriptionManagerError.permissionsMissing
+      throw TranscriptionManagerError.microphonePermissionMissing
     }
 
     let apiKey = try await cartesiaAPIKey()


### PR DESCRIPTION
## Summary
Fixes the first-run onboarding issues reported by a user (permissions not turning green, outdated model list, and a hang/crash on first recording).

## Changes
### 1. First-record hang/crash on remote streaming providers
Every **remote** streaming live-transcription controller required both microphone **and** Speech Recognition permission. Speech Recognition is only relevant to the on-device Apple transcriber. On a fresh install this triggered an unexpected Speech Recognition prompt on first record, and if not granted the session silently failed/hung — even though a valid Deepgram key was configured.

Fixed `ensurePermissions()` to require **microphone only** for: Deepgram, AssemblyAI, Modulate, ElevenLabs, Soniox, Gladia, and OpenAI Realtime. `NativeOSXLiveTranscriber` (Apple on-device) still requires Speech Recognition. (Cartesia already did the right thing.)

### 2. Default to Deepgram streaming (no post-processing) when a key is added
Previously onboarding stored the key but left the model on the default `apple/local/SFSpeechRecognizer`, so a Deepgram key was never used. `saveAPIKey()` now activates the chosen streaming provider (Deepgram → `deepgram/nova-3-streaming`, Soniox → `soniox/stt-rt-v5-streaming`), switches to remote streaming, and disables post-processing. This only applies when still on the untouched default model, so returning users' configurations are never clobbered.

### 3. Add Soniox to the onboarding provider list
Added Soniox (real-time streaming STT) as an onboarding provider, including API-key validation against Soniox's temporary-key endpoint.

### 4. Onboarding permissions update live
`refreshPermissions()` now forces a fresh status computation (the cached value went stale when permissions were toggled in System Settings), and the permissions step polls once per second — so Accessibility/Input Monitoring grants turn green without restarting the app.

## Testing
- `swift build` (SpeakApp) ✅
- `swift build --target SpeakiOSLib` ✅
- `swift test` — 521 tests pass, 0 failures ✅
- SwiftLint (`--strict --baseline`) — 0 violations ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new onboarding provider option, including updated setup guidance and quick labels in the provider picker.
  * The permissions screen now refreshes automatically, so changes made in system settings appear without restarting the app.

* **Bug Fixes**
  * Remote transcription can now start with microphone access alone, avoiding unnecessary permission blocks.
  * After adding an API key, supported providers can now switch into live transcription mode automatically when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->