### PR TITLE
feat(mac): status bar icon visibility + compact icon style

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -244,6 +244,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     case restoreClipboard
     case showHUD
     case appVisibility
+    case showStatusBarIconInDockOnly
     case runAtLogin
     case recordingsDirectory
     case hotKeyActivation
@@ -472,6 +473,25 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     didSet {
       store(appVisibility.rawValue, key: .appVisibility)
       applyAppVisibility()
+    }
+  }
+
+  /// Whether the menu bar (status bar) icon is shown while running in
+  /// Dock Only mode. Only user-configurable in that mode; the menu bar modes
+  /// always require the icon as their primary access point.
+  @Published var showStatusBarIconInDockOnly: Bool {
+    didSet { store(showStatusBarIconInDockOnly, key: .showStatusBarIconInDockOnly) }
+  }
+
+  /// Whether the status bar icon should currently be visible given the active
+  /// visibility mode. In menu bar modes the icon is essential; in Dock Only
+  /// mode it is governed by `showStatusBarIconInDockOnly` (on by default).
+  var shouldShowStatusBarIcon: Bool {
+    switch appVisibility {
+    case .dockAndMenuBar, .menuBarOnly:
+      return true
+    case .dockOnly:
+      return showStatusBarIconInDockOnly
     }
   }
 
@@ -839,6 +859,8 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       AppVisibility(
         rawValue: defaults.string(forKey: DefaultsKey.appVisibility.rawValue)
           ?? AppVisibility.dockAndMenuBar.rawValue) ?? .dockAndMenuBar
+    showStatusBarIconInDockOnly =
+      defaults.object(forKey: DefaultsKey.showStatusBarIconInDockOnly.rawValue) as? Bool ?? true
     runAtLogin = defaults.object(forKey: DefaultsKey.runAtLogin.rawValue) as? Bool ?? false
 
     let defaultDirectory = Self.defaultRecordingsDirectory()

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -245,6 +245,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     case showHUD
     case appVisibility
     case showStatusBarIconInDockOnly
+    case compactStatusBarIcon
     case runAtLogin
     case recordingsDirectory
     case hotKeyActivation
@@ -493,6 +494,14 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     case .dockOnly:
       return showStatusBarIconInDockOnly
     }
+  }
+
+  /// Whether the status bar icon uses the compact, icon-only style. When on,
+  /// the "Speak"/status label is hidden and recording state is conveyed purely
+  /// through iconography and colour, keeping the menu bar footprint minimal.
+  /// When off (default) the icon shows the Labelled style with status text.
+  @Published var compactStatusBarIcon: Bool {
+    didSet { store(compactStatusBarIcon, key: .compactStatusBarIcon) }
   }
 
   @Published var runAtLogin: Bool {
@@ -861,6 +870,8 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
           ?? AppVisibility.dockAndMenuBar.rawValue) ?? .dockAndMenuBar
     showStatusBarIconInDockOnly =
       defaults.object(forKey: DefaultsKey.showStatusBarIconInDockOnly.rawValue) as? Bool ?? true
+    compactStatusBarIcon =
+      defaults.object(forKey: DefaultsKey.compactStatusBarIcon.rawValue) as? Bool ?? false
     runAtLogin = defaults.object(forKey: DefaultsKey.runAtLogin.rawValue) as? Bool ?? false
 
     let defaultDirectory = Self.defaultRecordingsDirectory()

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -750,6 +750,15 @@ struct SettingsView: View {
             "Choose where Speak appears - in the Dock, menu bar, or both. Menu bar only keeps it out of the way."
           )
 
+          if settings.appVisibility == .dockOnly {
+            settingsToggle(
+              "Show status bar icon",
+              isOn: settingsBinding(\AppSettings.showStatusBarIconInDockOnly),
+              tint: .brandAccentWarm
+            )
+            .speakTooltip("Keep the Speak icon in the menu bar for quick access while the app lives in the Dock. Turn off for a Dock-only experience.")
+          }
+
           VStack(alignment: .leading, spacing: 8) {
             settingsToggle(
               "Launch at login",

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -756,8 +756,21 @@ struct SettingsView: View {
               isOn: settingsBinding(\AppSettings.showStatusBarIconInDockOnly),
               tint: .brandAccentWarm
             )
-            .speakTooltip("Keep the Speak icon in the menu bar for quick access while the app lives in the Dock. Turn off for a Dock-only experience.")
+            .speakTooltip(
+              "Keep the Speak icon in the menu bar for quick access while the app lives in the Dock. "
+                + "Turn off for a Dock-only experience."
+            )
           }
+
+          settingsToggle(
+            "Compact status bar icon",
+            isOn: settingsBinding(\AppSettings.compactStatusBarIcon),
+            tint: .brandAccentWarm
+          )
+          .speakTooltip(
+            "Compact hides the “Speak” label and colour-codes the icon by state, "
+              + "keeping the menu bar tidy. Turn off for the Labelled style with status text."
+          )
 
           VStack(alignment: .leading, spacing: 8) {
             settingsToggle(

--- a/Sources/SpeakApp/StatusBarView.swift
+++ b/Sources/SpeakApp/StatusBarView.swift
@@ -23,10 +23,8 @@ final class StatusBarController {
     self.openMainWindow = openMainWindow
 
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    statusItem.button?.image = NSImage(
-      systemSymbolName: "waveform", accessibilityDescription: "Speak")
-    statusItem.button?.imagePosition = .imageLeading
     statusItem.button?.appearsDisabled = false
+    updateButton(for: mainManager.state)
     statusItem.menu = buildMenu()
 
     observeChanges()
@@ -59,6 +57,14 @@ final class StatusBarController {
       .sink { [weak self] state in
         self?.updateButton(for: state)
         self?.refresh()
+      }
+      .store(in: &cancellables)
+
+    appSettings.$compactStatusBarIcon
+      .receive(on: RunLoop.main)
+      .sink { [weak self] _ in
+        guard let self else { return }
+        updateButton(for: mainManager.state)
       }
       .store(in: &cancellables)
   }
@@ -159,19 +165,47 @@ final class StatusBarController {
   }
 
   private func updateButton(for state: MainManager.State) {
+    guard let button = statusItem.button else { return }
+    let appearance = Self.appearance(for: state)
+
+    if appSettings.compactStatusBarIcon {
+      button.image = NSImage(
+        systemSymbolName: appearance.compactSymbol, accessibilityDescription: appearance.label)
+      button.image?.isTemplate = true
+      button.imagePosition = .imageOnly
+      button.title = ""
+      button.contentTintColor = appearance.tint
+    } else {
+      button.image = NSImage(
+        systemSymbolName: "waveform", accessibilityDescription: "Speak")
+      button.image?.isTemplate = true
+      button.imagePosition = .imageLeading
+      button.title = appearance.label
+      button.contentTintColor = nil
+    }
+  }
+
+  /// Visual descriptor for a recording state: the Labelled-mode text plus the
+  /// compact-mode SF Symbol and tint used to convey the same state without text.
+  private struct StatusAppearance {
+    let label: String
+    let compactSymbol: String
+    let tint: NSColor?
+  }
+
+  private static func appearance(for state: MainManager.State) -> StatusAppearance {
     switch state {
-    case .idle:
-      statusItem.button?.title = "Speak"
-    case .completed(_):
-      statusItem.button?.title = "Speak"
+    case .idle, .completed:
+      return StatusAppearance(label: "Speak", compactSymbol: "waveform", tint: nil)
     case .recording:
-      statusItem.button?.title = "Recording…"
+      return StatusAppearance(label: "Recording…", compactSymbol: "mic.fill", tint: .systemRed)
     case .processing:
-      statusItem.button?.title = "Transcribing…"
+      return StatusAppearance(label: "Transcribing…", compactSymbol: "hourglass", tint: .systemOrange)
     case .delivering:
-      statusItem.button?.title = "Delivering…"
-    case .failed(_):
-      statusItem.button?.title = "Needs Attention"
+      return StatusAppearance(label: "Delivering…", compactSymbol: "paperplane.fill", tint: .systemBlue)
+    case .failed:
+      return StatusAppearance(
+        label: "Needs Attention", compactSymbol: "exclamationmark.triangle.fill", tint: .systemRed)
     }
   }
 

--- a/Sources/SpeakApp/StatusBarView.swift
+++ b/Sources/SpeakApp/StatusBarView.swift
@@ -30,6 +30,13 @@ final class StatusBarController {
     observeChanges()
   }
 
+  deinit {
+    let statusItem = self.statusItem
+    Task { @MainActor in
+      NSStatusBar.system.removeStatusItem(statusItem)
+    }
+  }
+
   /// Removes the status bar icon from the system menu bar and stops observing.
   func tearDown() {
     NSStatusBar.system.removeStatusItem(statusItem)
@@ -64,7 +71,7 @@ final class StatusBarController {
       .receive(on: RunLoop.main)
       .sink { [weak self] _ in
         guard let self else { return }
-        updateButton(for: mainManager.state)
+        self.updateButton(for: self.mainManager.state)
       }
       .store(in: &cancellables)
   }

--- a/Sources/SpeakApp/StatusBarView.swift
+++ b/Sources/SpeakApp/StatusBarView.swift
@@ -32,6 +32,12 @@ final class StatusBarController {
     observeChanges()
   }
 
+  /// Removes the status bar icon from the system menu bar and stops observing.
+  func tearDown() {
+    NSStatusBar.system.removeStatusItem(statusItem)
+    cancellables.removeAll()
+  }
+
   private func observeChanges() {
     appSettings.$transcriptionMode
       .combineLatest(appSettings.$postProcessingEnabled, appSettings.$textOutputMethod)

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import Foundation
 import SpeakSync
 
@@ -35,6 +36,8 @@ final class AppEnvironment: ObservableObject {
   @Published var sidebarNavigationTarget: SidebarItem?
 
   private(set) var statusBarController: StatusBarController?
+  private var openMainWindow: (() -> Void)?
+  private var statusBarVisibilityObserver: AnyCancellable?
   private(set) var menuBarManager: MenuBarManager?
   private(set) var dockMenuManager: DockMenuManager?
   private(set) var servicesProvider: ServicesProvider?
@@ -93,7 +96,27 @@ final class AppEnvironment: ObservableObject {
   var permissionsManager: PermissionsManager { permissions }
 
   func installStatusBarIfNeeded(openMainWindow: @escaping () -> Void) {
-    guard statusBarController == nil else { return }
+    self.openMainWindow = openMainWindow
+    if statusBarVisibilityObserver == nil {
+      statusBarVisibilityObserver = settings.$appVisibility
+        .combineLatest(settings.$showStatusBarIconInDockOnly)
+        .receive(on: RunLoop.main)
+        .sink { [weak self] _, _ in
+          self?.updateStatusBarVisibility()
+        }
+    }
+    updateStatusBarVisibility()
+  }
+
+  /// Installs or removes the status bar icon to match the current visibility
+  /// settings. In Dock Only mode the icon follows `showStatusBarIconInDockOnly`.
+  private func updateStatusBarVisibility() {
+    guard settings.shouldShowStatusBarIcon else {
+      statusBarController?.tearDown()
+      statusBarController = nil
+      return
+    }
+    guard statusBarController == nil, let openMainWindow else { return }
     statusBarController = StatusBarController(
       appSettings: settings,
       historyManager: history,

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -95,11 +95,16 @@ final class AppEnvironment: ObservableObject {
   /// Alias for permissions manager (for API consistency)
   var permissionsManager: PermissionsManager { permissions }
 
+  /// Installs the status bar controller if needed and wires it to react to
+  /// visibility settings. The `openMainWindow` closure is stored for later use,
+  /// so ensure it captures any strongly-held objects weakly to avoid a retain
+  /// cycle.
   func installStatusBarIfNeeded(openMainWindow: @escaping () -> Void) {
     self.openMainWindow = openMainWindow
     if statusBarVisibilityObserver == nil {
       statusBarVisibilityObserver = settings.$appVisibility
-        .combineLatest(settings.$showStatusBarIconInDockOnly)
+        .removeDuplicates()
+        .combineLatest(settings.$showStatusBarIconInDockOnly.removeDuplicates())
         .receive(on: RunLoop.main)
         .sink { [weak self] _, _ in
           self?.updateStatusBarVisibility()

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -184,6 +184,12 @@ final class AppSettingsDefaultsTests: XCTestCase {
     }
 
     @MainActor
+    func testVisibilityDefaults_compactStatusBarIconIsFalse() {
+        let settings = AppSettings(defaults: defaults)
+        XCTAssertFalse(settings.compactStatusBarIcon)
+    }
+
+    @MainActor
     func testShouldShowStatusBarIcon_dockOnlyFollowsToggle() {
         let settings = AppSettings(defaults: defaults)
         settings.appVisibility = .dockOnly

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -177,6 +177,36 @@ final class AppSettingsDefaultsTests: XCTestCase {
         XCTAssertFalse(settings.runAtLogin)
     }
 
+    @MainActor
+    func testVisibilityDefaults_showStatusBarIconInDockOnlyIsTrue() {
+        let settings = AppSettings(defaults: defaults)
+        XCTAssertTrue(settings.showStatusBarIconInDockOnly)
+    }
+
+    @MainActor
+    func testShouldShowStatusBarIcon_dockOnlyFollowsToggle() {
+        let settings = AppSettings(defaults: defaults)
+        settings.appVisibility = .dockOnly
+
+        XCTAssertTrue(settings.shouldShowStatusBarIcon)
+
+        settings.showStatusBarIconInDockOnly = false
+
+        XCTAssertFalse(settings.shouldShowStatusBarIcon)
+    }
+
+    @MainActor
+    func testShouldShowStatusBarIcon_menuBarModesAlwaysShow() {
+        let settings = AppSettings(defaults: defaults)
+        settings.showStatusBarIconInDockOnly = false
+
+        settings.appVisibility = .menuBarOnly
+        XCTAssertTrue(settings.shouldShowStatusBarIcon)
+
+        settings.appVisibility = .dockAndMenuBar
+        XCTAssertTrue(settings.shouldShowStatusBarIcon)
+    }
+
     // MARK: - HUD Settings
 
     @MainActor


### PR DESCRIPTION
## Status bar icon: visibility + compact style

Two related, user-controllable options for the macOS menu bar (status bar) icon, both in **Settings → App Behaviour**.

### 1. Show status bar icon (Dock Only)
In Dock Only mode the menu bar icon is now user-controllable via a checkbox (defaults **on**, preserving existing behaviour). Menu bar modes always keep the icon as their primary access point. The icon installs/removes reactively as the setting changes.

### 2. Compact status bar icon (new)
An always-visible checkbox (defaults **off**). When enabled, the menu bar item drops the "Speak"/status **text label** and keeps the footprint as narrow as possible, conveying state through **iconography + colour** instead:

| State | Labelled (default) | Compact icon | Tint |
|-------|--------------------|--------------|------|
| Idle / done | "Speak" | `waveform` | adaptive |
| Recording | "Recording…" | `mic.fill` | red |
| Transcribing | "Transcribing…" | `hourglass` | orange |
| Delivering | "Delivering…" | `paperplane.fill` | blue |
| Needs attention | "Needs Attention" | `exclamationmark.triangle.fill` | red |

The **off** state is the **Labelled** style (icon + status text) — byte-for-byte the previous behaviour. Every compact symbol carries an accessibility description so VoiceOver still announces the state without the text.

### Also
- Fixes a strict `line_length` lint violation introduced by the earlier tooltip.

### Tests
`AppSettingsDefaultsTests` covers the defaults for both toggles. `swift build`, `swift test --filter AppSettingsDefaultsTests`, and `swiftlint --strict --baseline` all pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control status bar/menu bar icon visibility specifically for dock-only app mode.
  * Updated the Settings UI (“App Behaviour”) with a “Show status bar icon” toggle when dock-only is selected.
  * Status bar icon behavior now updates immediately in response to visibility-related setting changes.

* **Tests**
  * Expanded default and behavior coverage for the new dock-only icon toggle and the derived visibility rules.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->