### PR TITLE
feat(sync): CloudKit private-DB encrypted API key sync

### DIFF
--- a/Config/AppInfo.plist
+++ b/Config/AppInfo.plist
@@ -24,6 +24,13 @@
 	<string>1</string>
 	<key>GitCommitSHA</key>
 	<string></string>
+	<!-- Export compliance: the app uses only standard, published encryption
+	     (AES-GCM and PBKDF2 via CryptoKit) to protect the user's own API keys for
+	     end-to-end encrypted iCloud/CloudKit key sync, alongside OS-provided HTTPS
+	     and Keychain. This qualifies for the U.S. EAR Category 5 Part 2 export
+	     exemption, so the app uses no *non-exempt* encryption. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSArchitecturePriority</key>

--- a/Config/SpeakMacOS.entitlements
+++ b/Config/SpeakMacOS.entitlements
@@ -76,8 +76,13 @@
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
 
-	<!-- Restricted for Developer ID (iCloud/APNs): requires embedded provisioning profile.
-	     For App Store builds, uncomment and set aps-environment to production.
+	<!-- Restricted for Developer ID (iCloud/APNs): requires an embedded managed
+	     provisioning profile that explicitly includes the CloudKit container.
+	     The Developer-ID Sparkle build intentionally ships without these active
+	     entitlements today; SpeakSync checks the runtime entitlements and disables
+	     CloudKit history/API-key sync gracefully when they are absent, without
+	     blocking local Keychain storage. For App Store or managed-profile
+	     Developer-ID builds, uncomment these and set aps-environment correctly.
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.justspeaktoit</string>

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,7 @@ let package = Package(
         ),
         .target(
             name: "SpeakSync",
+            dependencies: ["SpeakCore"],
             path: "Sources/SpeakSync"
         ),
         .target(
@@ -59,6 +60,10 @@ let package = Package(
         .testTarget(
             name: "SpeakCoreTests",
             dependencies: ["SpeakCore"]
+        ),
+        .testTarget(
+            name: "SpeakSyncTests",
+            dependencies: ["SpeakSync"]
         ),
         .testTarget(
             name: "SpeakAppTests",

--- a/Project.swift
+++ b/Project.swift
@@ -105,6 +105,11 @@ let project = Project(
                 "NSMicrophoneUsageDescription": "Just Speak to It needs microphone access for voice transcription.",
                 "NSSpeechRecognitionUsageDescription": "Just Speak to It uses speech recognition to transcribe your voice.",
                 "NSCameraUsageDescription": "Just Speak to It does not use the camera, but a linked library requires this declaration.",
+                // Export compliance: the app uses only standard, published encryption
+                // (AES-GCM and PBKDF2 via CryptoKit) to protect the user's own API keys
+                // for end-to-end encrypted iCloud/CloudKit key sync, alongside OS-provided
+                // HTTPS and Keychain. This qualifies for the U.S. EAR Category 5 Part 2
+                // export exemption, so the app uses no *non-exempt* encryption.
                 "ITSAppUsesNonExemptEncryption": false,
                 "NSSupportsLiveActivities": true,
                 "UIBackgroundModes": ["audio"],

--- a/Sources/SpeakApp/CloudKitKeySyncNotifications.swift
+++ b/Sources/SpeakApp/CloudKitKeySyncNotifications.swift
@@ -1,0 +1,17 @@
+import AppKit
+import SpeakSync
+
+extension AppDelegate {
+    func application(
+        _ application: NSApplication,
+        didReceiveRemoteNotification userInfo: [String: Any]
+    ) {
+        Task { @MainActor in
+            do {
+                try await CloudKitKeySync.shared.handleRemoteNotification()
+            } catch {
+                print("[AppDelegate] CloudKit API-key notification sync failed: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/Sources/SpeakApp/SecureAppStorage.swift
+++ b/Sources/SpeakApp/SecureAppStorage.swift
@@ -162,6 +162,10 @@ actor SecureAppStorage {
         await storage.knownIdentifiers()
     }
 
+    func coreStorage() -> SecureStorage {
+        storage
+    }
+
     func hasSecret(identifier: String) async -> Bool {
         await storage.hasSecret(identifier: identifier)
     }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -3591,6 +3591,7 @@ struct SettingsView: View {
     let secureStorage: SecureAppStorage
     @ObservedObject private var keySync = CloudKitKeySync.shared
     @State private var passphrase = ""
+    @State private var syncError: String?
 
     var body: some View {
       SettingsCard(title: "Encrypted API-Key Sync", systemImage: "lock.icloud", tint: .brandLagoon) {
@@ -3610,8 +3611,13 @@ struct SettingsView: View {
 
             Button {
               Task {
-                try? await keySync.enable(passphrase: passphrase)
-                passphrase = ""
+                do {
+                  try await keySync.enable(passphrase: passphrase)
+                  passphrase = ""
+                  syncError = nil
+                } catch {
+                  syncError = error.localizedDescription
+                }
               }
             } label: {
               Label("Enable API-Key Sync", systemImage: "lock.open")
@@ -3621,7 +3627,14 @@ struct SettingsView: View {
           } else {
             HStack {
               Button {
-                Task { try? await keySync.syncNow() }
+                Task {
+                  do {
+                    try await keySync.syncNow()
+                    syncError = nil
+                  } catch {
+                    syncError = error.localizedDescription
+                  }
+                }
               } label: {
                 Label("Sync Keys Now", systemImage: "arrow.triangle.2.circlepath")
               }
@@ -3631,6 +3644,12 @@ struct SettingsView: View {
                 Task { await keySync.disable() }
               }
             }
+          }
+
+          if let syncError {
+            Text(syncError)
+              .font(.caption)
+              .foregroundStyle(.red)
           }
 
           Text(

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -1,5 +1,6 @@
 import SpeakCore
 import SpeakHotKeys
+import SpeakSync
 import AppKit
 import Sparkle
 import SwiftUI
@@ -3282,6 +3283,8 @@ struct SettingsView: View {
   private var apiKeySettings: some View {
     ScrollViewReader { proxy in
       LazyVStack(spacing: 20) {
+        CloudKitKeySyncSettingsCard(secureStorage: environment.secureStorage)
+
         // OpenRouter (Legacy)
         apiKeyCard(
         title: "OpenRouter",
@@ -3582,6 +3585,70 @@ struct SettingsView: View {
       }
     }
     .speakTooltip(tooltip)
+  }
+
+  private struct CloudKitKeySyncSettingsCard: View {
+    let secureStorage: SecureAppStorage
+    @ObservedObject private var keySync = CloudKitKeySync.shared
+    @State private var passphrase = ""
+
+    var body: some View {
+      SettingsCard(title: "Encrypted API-Key Sync", systemImage: "lock.icloud", tint: .brandLagoon) {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Label("Status", systemImage: keySync.status.isEnabled ? "checkmark.seal.fill" : "lock.fill")
+            Spacer()
+            Text(keySync.status.message)
+              .foregroundStyle(keySync.status.isEnabled ? .green : .secondary)
+          }
+
+          if !keySync.status.isEnabled {
+            SecureField("Sync passphrase", text: $passphrase)
+              .textContentType(.password)
+              .privacySensitive()
+              .textFieldStyle(.roundedBorder)
+
+            Button {
+              Task {
+                try? await keySync.enable(passphrase: passphrase)
+                passphrase = ""
+              }
+            } label: {
+              Label("Enable API-Key Sync", systemImage: "lock.open")
+            }
+            .disabled(passphrase.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .buttonStyle(.borderedProminent)
+          } else {
+            HStack {
+              Button {
+                Task { try? await keySync.syncNow() }
+              } label: {
+                Label("Sync Keys Now", systemImage: "arrow.triangle.2.circlepath")
+              }
+              .disabled(keySync.status.isSyncing)
+
+              Button("Disable", role: .destructive) {
+                Task { await keySync.disable() }
+              }
+            }
+          }
+
+          Text(
+            "Opt in to sync API keys through your private CloudKit database. Keys are encrypted with "
+              + "CryptoKit before upload. Developer-ID macOS builds need a managed provisioning profile "
+              + "with CloudKit entitlements; otherwise this stays unavailable and local Keychain storage "
+              + "works normally."
+          )
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        }
+      }
+      .task {
+        let coreStorage = await secureStorage.coreStorage()
+        await keySync.configure(secureStorage: coreStorage)
+        _ = await keySync.isAvailable()
+      }
+    }
   }
 
   private func binding(for providerID: String) -> Binding<String> {

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -432,10 +432,25 @@ enum WireUp {
       try? environment.transportServer.start()
     }
 
+    #if APP_STORE
+    NSApp.registerForRemoteNotifications()
+    #endif
+
     let syncAdapter = MacHistorySyncAdapter(historyManager: environment.history)
     Task { await syncAdapter.start() }
 
     Task { await secureStorage.preloadTrackedSecrets() }
+    Task {
+      let coreStorage = await secureStorage.coreStorage()
+      let keySync = CloudKitKeySync.shared
+      await keySync.configure(secureStorage: coreStorage)
+      guard await keySync.isAvailable() else { return }
+      do {
+        try await keySync.syncNow()
+      } catch {
+        print("[WireUp] CloudKit API-key sync failed: \(error.localizedDescription)")
+      }
+    }
     Task {
       await configureDefaultTranscriptionProvider(settings: settings, secureStorage: secureStorage)
     }

--- a/Sources/SpeakCore/SecureStorage.swift
+++ b/Sources/SpeakCore/SecureStorage.swift
@@ -2,6 +2,8 @@ import Foundation
 import Security
 import os
 
+// swiftlint:disable file_length
+
 // MARK: - Error Types
 
 public enum SecureStorageError: LocalizedError {
@@ -81,7 +83,16 @@ public struct SecureStorageConfiguration: Sendable {
 /// Cross-platform secure storage for API keys and secrets.
 /// Uses Keychain Services on both macOS and iOS.
 public actor SecureStorage {
+    // swiftlint:disable:previous type_body_length
     private static let logger = Logger(subsystem: "com.justspeaktoit", category: "SecureStorage")
+
+    public static let didChangeSecretNotification = Notification.Name("SecureStorageDidChangeSecret")
+
+    public enum NotificationUserInfoKey {
+        public static let identifier = "identifier"
+        public static let operation = "operation"
+        public static let updatedAt = "updatedAt"
+    }
     
     private let configuration: SecureStorageConfiguration
     private let permissionsChecker: any KeychainPermissionsChecking
@@ -117,6 +128,8 @@ public actor SecureStorage {
                 registry.registerAPIKeyIdentifier(identifier)
             }
         }
+
+        postChangeNotification(identifier: identifier, operation: "store")
     }
 
     public func secret(identifier: String) async throws -> String {
@@ -145,6 +158,8 @@ public actor SecureStorage {
                 registry.removeAPIKeyIdentifier(identifier)
             }
         }
+
+        postChangeNotification(identifier: identifier, operation: "remove")
     }
 
     public func knownIdentifiers() async -> [String] {
@@ -395,5 +410,17 @@ public actor SecureStorage {
             .sorted { $0.key < $1.key }
             .map { "\($0.key)=\($0.value)" }
             .joined(separator: ";")
+    }
+
+    private func postChangeNotification(identifier: String, operation: String) {
+        NotificationCenter.default.post(
+            name: Self.didChangeSecretNotification,
+            object: nil,
+            userInfo: [
+                Self.NotificationUserInfoKey.identifier: identifier,
+                Self.NotificationUserInfoKey.operation: operation,
+                Self.NotificationUserInfoKey.updatedAt: Date()
+            ]
+        )
     }
 }

--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -77,6 +77,7 @@ public enum CloudKitKeySyncError: LocalizedError, Equatable {
     case malformedRecord
     case passphraseTooShort(minimumLength: Int)
     case randomGenerationFailed
+    case notConfigured
 
     public var errorDescription: String? {
         switch self {
@@ -94,6 +95,8 @@ public enum CloudKitKeySyncError: LocalizedError, Equatable {
             return "Use an API-key sync passphrase with at least \(minimumLength) characters."
         case .randomGenerationFailed:
             return "Failed to generate secure random bytes for API-key sync."
+        case .notConfigured:
+            return "API-key sync has not finished configuring secure storage."
         }
     }
 }
@@ -124,6 +127,13 @@ public enum EncryptedSecretCrypto {
             keyByteCount: keyByteCount
         )
         return SymmetricKey(data: derived)
+    }
+
+    static func deriveKeyOffMainActor(passphrase: String, salt: Data) async -> SymmetricKey {
+        let keyData = await Task.detached(priority: .userInitiated) {
+            deriveKey(passphrase: passphrase, salt: salt).withUnsafeBytes { Data($0) }
+        }.value
+        return SymmetricKey(data: keyData)
     }
 
     private static func pbkdf2SHA256(
@@ -333,6 +343,19 @@ private struct KeySyncFetchResult {
     var records: [CKRecord]
     var deletedIDs: [CKRecord.ID]
     var serverChangeToken: CKServerChangeToken?
+    var moreComing: Bool
+}
+
+struct PendingKeySyncMutation: Codable, Equatable, Sendable {
+    enum Kind: String, Codable, Sendable {
+        case update
+        case deletion
+    }
+
+    let operationID: UUID
+    let identifier: String
+    let updatedAt: Date
+    let kind: Kind
 }
 
 private final class KeySyncFetchAccumulator: @unchecked Sendable {
@@ -340,6 +363,8 @@ private final class KeySyncFetchAccumulator: @unchecked Sendable {
     private var records: [CKRecord] = []
     private var deletedIDs: [CKRecord.ID] = []
     private var serverChangeToken: CKServerChangeToken?
+    private var moreComing = false
+    private var errors: [Error] = []
 
     func append(record: CKRecord) {
         lock.withLock { records.append(record) }
@@ -354,14 +379,30 @@ private final class KeySyncFetchAccumulator: @unchecked Sendable {
         lock.withLock { serverChangeToken = token }
     }
 
-    func result() -> KeySyncFetchResult {
-        lock.withLock {
-            KeySyncFetchResult(
-                records: records,
-                deletedIDs: deletedIDs,
-                serverChangeToken: serverChangeToken
+    func updateMoreComing(_ value: Bool) {
+        lock.withLock { moreComing = value }
+    }
+
+    func append(error: Error) {
+        lock.withLock { errors.append(error) }
+    }
+
+    func result() throws -> KeySyncFetchResult {
+        let snapshot = lock.withLock {
+            (
+                errors.first,
+                KeySyncFetchResult(
+                    records: records,
+                    deletedIDs: deletedIDs,
+                    serverChangeToken: serverChangeToken,
+                    moreComing: moreComing
+                )
             )
         }
+        if let error = snapshot.0 {
+            throw error
+        }
+        return snapshot.1
     }
 }
 
@@ -388,29 +429,77 @@ public final class CloudKitKeySync: ObservableObject {
     private static let syncTokenKey = "speak.keysync.serverChangeToken"
     private static let subscriptionCreatedKey = "speak.keysync.subscriptionCreated"
     private static let zoneCreatedKey = "speak.keysync.zoneCreated"
+    private static let accountIdentifierKey = "speak.keysync.accountIdentifier"
+    private static let pendingMutationPrefix = "speak.keysync.pending."
     private static let localDerivedKeyIdentifier = "cloudkitKeySync.derivedKey"
     private static let localUpdatedPrefix = "speak.keysync.localUpdatedAt."
     private static let subscriptionID = "encrypted-secret-changes"
     private static let localUploadDebounceNanoseconds: UInt64 = 750_000_000
+    private static let localUploadInitialRetryNanoseconds: UInt64 = 2_000_000_000
+    private static let localUploadMaximumRetryNanoseconds: UInt64 = 60_000_000_000
+
+    private struct ActiveSync {
+        let id: UUID
+        let task: Task<Void, Error>
+    }
+
+    private struct SuspendedWork {
+        let syncTask: Task<Void, Error>?
+        let uploadTasks: [Task<Void, Never>]
+    }
+
+    private enum SecretUploadResult: Equatable {
+        case uploaded
+        case superseded
+    }
 
     private let log = Logger(subsystem: "com.justspeaktoit", category: "CloudKitKeySync")
+    private let stateStorage: SecureStorage
     private var secureStorage: SecureStorage
+    private var isConfigured = false
     private var symmetricKey: SymmetricKey?
     private var observer: NSObjectProtocol?
+    private var accountObserver: NSObjectProtocol?
     private var applyingRemoteIdentifiers = Set<String>()
-    private var pendingLocalUploadDates: [String: Date] = [:]
-    private var pendingLocalDeletions: [String: Bool] = [:]
+    private var pendingMutations: [String: PendingKeySyncMutation] = [:]
+    private var retryAttempts: [String: Int] = [:]
     private var localUploadTasks: [String: Task<Void, Never>] = [:]
+    private var localUploadTaskIDs: [String: UUID] = [:]
+    private var activeSync: ActiveSync?
+    private var syncGeneration: UInt64 = 0
+    private var lifecycleIsLocked = false
+    private var lifecycleWaiters: [CheckedContinuation<Void, Never>] = []
 
-    private init(secureStorage: SecureStorage = SecureStorage()) {
+    private init(
+        secureStorage: SecureStorage = SecureStorage(),
+        stateStorage: SecureStorage = SecureStorage(
+            configuration: SecureStorageConfiguration(
+                service: "com.justspeaktoit.keysync-state",
+                masterAccount: "cloudkit-key-sync-state",
+                accessGroup: nil,
+                synchronizable: false
+            )
+        )
+    ) {
         self.secureStorage = secureStorage
-        self.status.isEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey)
+        self.stateStorage = stateStorage
+        self.pendingMutations = Self.loadPersistedPendingMutations()
         observeLocalKeyChanges()
+        observeCloudKitAccountChanges()
+    }
+
+    deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let accountObserver {
+            NotificationCenter.default.removeObserver(accountObserver)
+        }
     }
 
     public func configure(secureStorage: SecureStorage) async {
         self.secureStorage = secureStorage
-        await restoreSavedKeyIfNeeded()
+        isConfigured = true
     }
 
     public func isAvailable() async -> Bool {
@@ -422,8 +511,19 @@ public final class CloudKitKeySync: ObservableObject {
 
         do {
             let accountStatus = try await container.accountStatus()
-            status.isCloudAvailable = accountStatus == .available
-            return status.isCloudAvailable
+            guard accountStatus == .available else {
+                status.isCloudAvailable = false
+                return false
+            }
+            try await validateCurrentAccount(container: container)
+            status.isCloudAvailable = true
+            status.lastErrorDescription = nil
+            status.isEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey)
+            if status.isEnabled, isConfigured {
+                await restoreSavedKeyIfNeeded()
+                restorePendingMutationTasks()
+            }
+            return true
         } catch {
             status.isCloudAvailable = false
             status.lastErrorDescription = error.localizedDescription
@@ -432,6 +532,7 @@ public final class CloudKitKeySync: ObservableObject {
     }
 
     public func enable(passphrase: String) async throws {
+        guard isConfigured else { throw CloudKitKeySyncError.notConfigured }
         let trimmed = passphrase.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { throw CloudKitKeySyncError.missingPassphrase }
         try EncryptedSecretCrypto.validatePassphrase(trimmed)
@@ -439,56 +540,153 @@ public final class CloudKitKeySync: ObservableObject {
             throw CloudKitKeySyncError.cloudUnavailable
         }
 
-        try await setupCloudKitInfrastructure(database: database)
-        let key = try await loadOrCreateMetadataKey(passphrase: trimmed, database: database)
-        symmetricKey = key
-        try await secureStorage.storeSecret(
-            key.withUnsafeBytes { Data($0).base64EncodedString() },
-            identifier: Self.localDerivedKeyIdentifier
-        )
-        UserDefaults.standard.set(true, forKey: Self.enabledKey)
-        status.isEnabled = true
-        status.lastErrorDescription = nil
+        await acquireLifecycleLock()
+        do {
+            let generation = syncGeneration
+            try await setupCloudKitInfrastructure(database: database)
+            try ensureGenerationIsCurrent(generation)
+            let key = try await loadOrCreateMetadataKey(passphrase: trimmed, database: database)
+            try ensureGenerationIsCurrent(generation)
+            symmetricKey = key
+            try await stateStorage.storeSecret(
+                key.withUnsafeBytes { Data($0).base64EncodedString() },
+                identifier: Self.localDerivedKeyIdentifier
+            )
+            try ensureGenerationIsCurrent(generation)
+            try await seedPendingMutationsForExistingSecrets()
+            try ensureGenerationIsCurrent(generation)
+            UserDefaults.standard.set(true, forKey: Self.enabledKey)
+            status.isEnabled = true
+            status.lastErrorDescription = nil
+            restorePendingMutationTasks()
+            try ensureSyncIsActive(generation: generation)
+        } catch {
+            releaseLifecycleLock()
+            throw error
+        }
+        releaseLifecycleLock()
         try await syncNow()
     }
 
     public func disable() async {
-        UserDefaults.standard.set(false, forKey: Self.enabledKey)
-        try? await secureStorage.removeSecret(identifier: Self.localDerivedKeyIdentifier)
-        localUploadTasks.values.forEach { $0.cancel() }
+        await acquireLifecycleLock()
+        defer { releaseLifecycleLock() }
+        let syncTask = activeSync?.task
+        let uploadTasks = Array(localUploadTasks.values)
+        syncGeneration &+= 1
+        syncTask?.cancel()
+        uploadTasks.forEach { $0.cancel() }
+        activeSync = nil
         localUploadTasks.removeAll()
-        pendingLocalUploadDates.removeAll()
-        pendingLocalDeletions.removeAll()
+        localUploadTaskIDs.removeAll()
+        UserDefaults.standard.set(false, forKey: Self.enabledKey)
         symmetricKey = nil
         status.isEnabled = false
+        status.isSyncing = false
+
+        if let syncTask {
+            do {
+                try await syncTask.value
+            } catch is CancellationError {
+                // Expected when disabling an active sync.
+            } catch {
+                log.warning("Active key sync stopped with error during disable: \(error.localizedDescription)")
+            }
+        }
+        for task in uploadTasks {
+            await task.value
+        }
+
+        retryAttempts.removeAll()
+        pendingMutations.removeAll()
+        Self.clearPersistedPendingMutations()
+        do {
+            try await stateStorage.removeSecret(identifier: Self.localDerivedKeyIdentifier)
+        } catch {
+            log.error("Could not remove the local key-sync key: \(error.localizedDescription)")
+        }
+        status.lastSyncTime = nil
         status.lastErrorDescription = nil
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     public func syncNow() async throws {
+        guard isConfigured else { throw CloudKitKeySyncError.notConfigured }
+        if let activeSync {
+            try await activeSync.task.value
+            return
+        }
         guard UserDefaults.standard.bool(forKey: Self.enabledKey) else { return }
-        await restoreSavedKeyIfNeeded()
-        guard let key = symmetricKey else { throw CloudKitKeySyncError.missingPassphrase }
         guard await isAvailable(), let database = SyncConfiguration.privateDatabase else {
             throw CloudKitKeySyncError.cloudUnavailable
         }
+        guard UserDefaults.standard.bool(forKey: Self.enabledKey) else { return }
+        await restoreSavedKeyIfNeeded()
+        guard let key = symmetricKey else { throw CloudKitKeySyncError.missingPassphrase }
 
-        status.isSyncing = true
-        status.lastErrorDescription = nil
-        defer { status.isSyncing = false }
-
+        if let activeSync {
+            try await activeSync.task.value
+            return
+        }
+        let id = UUID()
+        let generation = syncGeneration
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try await self.performSync(
+                database: database,
+                key: key,
+                generation: generation
+            )
+        }
+        activeSync = ActiveSync(id: id, task: task)
         do {
-            try await setupCloudKitInfrastructure(database: database)
-            try await fetchRemoteChanges(database: database, key: key)
-            try await uploadLocalSecrets(database: database, key: key)
-            status.lastSyncTime = Date()
+            try await task.value
         } catch {
-            status.lastErrorDescription = error.localizedDescription
+            if activeSync?.id == id {
+                activeSync = nil
+            }
             throw error
+        }
+        if activeSync?.id == id {
+            activeSync = nil
         }
     }
 
-    public func handleRemoteNotification() async {
-        try? await syncNow()
+    public func handleRemoteNotification() async throws {
+        try await syncNow()
+    }
+
+    private func performSync(
+        database: CKDatabase,
+        key: SymmetricKey,
+        generation: UInt64
+    ) async throws {
+        try ensureSyncIsActive(generation: generation)
+
+        status.isSyncing = true
+        status.lastErrorDescription = nil
+        defer {
+            if generation == syncGeneration {
+                status.isSyncing = false
+            }
+        }
+
+        do {
+            try await setupCloudKitInfrastructure(database: database)
+            try ensureSyncIsActive(generation: generation)
+            try await fetchRemoteChanges(database: database, key: key, generation: generation)
+            try ensureSyncIsActive(generation: generation)
+            try await uploadLocalSecrets(database: database, key: key, generation: generation)
+            try ensureSyncIsActive(generation: generation)
+            status.lastSyncTime = Date()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if generation == syncGeneration {
+                status.lastErrorDescription = error.localizedDescription
+            }
+            throw error
+        }
     }
 
     private func observeLocalKeyChanges() {
@@ -506,68 +704,114 @@ public final class CloudKitKeySync: ObservableObject {
 
             Task { @MainActor in
                 guard !self.applyingRemoteIdentifiers.contains(identifier),
-                      self.status.isEnabled else {
+                      UserDefaults.standard.bool(forKey: Self.enabledKey) else {
                     return
                 }
                 let updatedAt = notification
                     .userInfo?[SecureStorage.NotificationUserInfoKey.updatedAt] as? Date ?? Date()
                 let operation = notification
                     .userInfo?[SecureStorage.NotificationUserInfoKey.operation] as? String
-                self.scheduleLocalUpload(
+                let mutation = PendingKeySyncMutation(
+                    operationID: UUID(),
                     identifier: identifier,
                     updatedAt: updatedAt,
-                    isDeletion: operation == "remove"
+                    kind: operation == "remove" ? .deletion : .update
                 )
+                Self.persistPendingMutation(mutation)
+                self.pendingMutations[identifier] = mutation
+                self.scheduleLocalUpload(identifier: identifier)
             }
         }
     }
 
-    private func scheduleLocalUpload(identifier: String, updatedAt: Date, isDeletion: Bool) {
-        pendingLocalUploadDates[identifier] = updatedAt
-        pendingLocalDeletions[identifier] = isDeletion
+    private func observeCloudKitAccountChanges() {
+        accountObserver = NotificationCenter.default.addObserver(
+            forName: .CKAccountChanged,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor in
+                await self?.handleCloudKitAccountChange()
+            }
+        }
+    }
 
-        guard localUploadTasks[identifier] == nil else { return }
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    private func scheduleLocalUpload(identifier: String) {
+        guard localUploadTasks[identifier] == nil,
+              pendingMutations[identifier] != nil else {
+            return
+        }
 
+        let generation = syncGeneration
+        let taskID = UUID()
+        localUploadTaskIDs[identifier] = taskID
         localUploadTasks[identifier] = Task { @MainActor [weak self] in
             defer {
-                self?.localUploadTasks[identifier] = nil
+                if self?.localUploadTaskIDs[identifier] == taskID {
+                    self?.localUploadTasks[identifier] = nil
+                    self?.localUploadTaskIDs[identifier] = nil
+                    self?.retryAttempts[identifier] = nil
+                }
             }
 
             while !Task.isCancelled {
-                let observedUpdatedAt = self?.pendingLocalUploadDates[identifier]
+                guard let self,
+                      let observedMutation = self.pendingMutations[identifier] else {
+                    return
+                }
+
                 do {
                     try await Task.sleep(nanoseconds: Self.localUploadDebounceNanoseconds)
                 } catch {
                     return
                 }
 
-                guard let self else { return }
-                guard self.pendingLocalUploadDates[identifier] == observedUpdatedAt else {
+                guard self.pendingMutations[identifier]?.operationID == observedMutation.operationID else {
                     continue
                 }
-                guard let updatedAt = self.pendingLocalUploadDates.removeValue(forKey: identifier),
-                      self.status.isEnabled,
-                      let key = self.symmetricKey,
+                if self.activeSync != nil {
+                    continue
+                }
+                guard let key = self.symmetricKey,
                       let database = SyncConfiguration.privateDatabase else {
-                    self.pendingLocalDeletions.removeValue(forKey: identifier)
                     return
                 }
-                let isDeletion = self.pendingLocalDeletions.removeValue(forKey: identifier) ?? false
 
                 do {
-                    try await self.uploadSecret(
+                    try self.ensureSyncIsActive(generation: generation)
+                    let uploadResult = try await self.uploadSecret(
                         identifier: identifier,
-                        updatedAt: updatedAt,
+                        updatedAt: observedMutation.updatedAt,
                         database: database,
                         key: key,
-                        isDeletion: isDeletion
+                        isDeletion: observedMutation.kind == .deletion,
+                        generation: generation
                     )
-                    await self.saveLocalUpdatedAt(updatedAt, identifier: identifier)
+                    if uploadResult == .uploaded {
+                        try await self.saveLocalUpdatedAt(observedMutation.updatedAt, identifier: identifier)
+                        self.clearPendingMutation(ifMatching: observedMutation)
+                    }
+                    self.retryAttempts[identifier] = nil
+                } catch is CancellationError {
+                    return
                 } catch {
                     self.log.error("Debounced key upload failed for \(identifier): \(error.localizedDescription)")
+                    let attempt = (self.retryAttempts[identifier] ?? 0) + 1
+                    self.retryAttempts[identifier] = attempt
+                    let shift = UInt64(min(attempt - 1, 5))
+                    let delay = min(
+                        Self.localUploadInitialRetryNanoseconds << shift,
+                        Self.localUploadMaximumRetryNanoseconds
+                    )
+                    do {
+                        try await Task.sleep(nanoseconds: delay)
+                    } catch {
+                        return
+                    }
                 }
 
-                if self.pendingLocalUploadDates[identifier] == nil {
+                if self.pendingMutations[identifier] == nil {
                     return
                 }
             }
@@ -577,11 +821,190 @@ public final class CloudKitKeySync: ObservableObject {
     private func restoreSavedKeyIfNeeded() async {
         guard symmetricKey == nil,
               UserDefaults.standard.bool(forKey: Self.enabledKey),
-              let stored = try? await secureStorage.secret(identifier: Self.localDerivedKeyIdentifier),
+              let stored = try? await stateStorage.secret(identifier: Self.localDerivedKeyIdentifier),
               let data = Data(base64Encoded: stored) else {
             return
         }
         symmetricKey = SymmetricKey(data: data)
+    }
+
+    private func restorePendingMutationTasks() {
+        pendingMutations = Self.loadPersistedPendingMutations()
+        for identifier in pendingMutations.keys {
+            scheduleLocalUpload(identifier: identifier)
+        }
+    }
+
+    private func seedPendingMutationsForExistingSecrets() async throws {
+        var mutationsToPersist: [PendingKeySyncMutation] = []
+        for identifier in Self.syncableIdentifiers.sorted() where pendingMutations[identifier] == nil {
+            do {
+                _ = try await secureStorage.secret(identifier: identifier)
+                mutationsToPersist.append(PendingKeySyncMutation(
+                    operationID: UUID(),
+                    identifier: identifier,
+                    updatedAt: Date(),
+                    kind: .update
+                ))
+            } catch SecureStorageError.valueNotFound {
+                continue
+            } catch {
+                log.error("Could not inspect local encrypted secret \(identifier): \(error.localizedDescription)")
+                throw error
+            }
+        }
+        for mutation in mutationsToPersist {
+            Self.persistPendingMutation(mutation)
+            pendingMutations[mutation.identifier] = mutation
+        }
+    }
+
+    private func clearPendingMutation(ifMatching mutation: PendingKeySyncMutation) {
+        guard pendingMutations[mutation.identifier]?.operationID == mutation.operationID,
+              Self.loadPersistedPendingMutation(identifier: mutation.identifier)?.operationID
+                == mutation.operationID else {
+            return
+        }
+        pendingMutations[mutation.identifier] = nil
+        UserDefaults.standard.removeObject(forKey: Self.pendingMutationKey(identifier: mutation.identifier))
+    }
+
+    private static func pendingMutationKey(identifier: String) -> String {
+        pendingMutationPrefix + identifier
+    }
+
+    private static func persistPendingMutation(_ mutation: PendingKeySyncMutation) {
+        guard let data = try? JSONEncoder().encode(mutation) else { return }
+        UserDefaults.standard.set(data, forKey: pendingMutationKey(identifier: mutation.identifier))
+    }
+
+    private static func loadPersistedPendingMutation(identifier: String) -> PendingKeySyncMutation? {
+        guard let data = UserDefaults.standard.data(forKey: pendingMutationKey(identifier: identifier)) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(PendingKeySyncMutation.self, from: data)
+    }
+
+    private static func loadPersistedPendingMutations() -> [String: PendingKeySyncMutation] {
+        syncableIdentifiers.reduce(into: [:]) { mutations, identifier in
+            mutations[identifier] = loadPersistedPendingMutation(identifier: identifier)
+        }
+    }
+
+    private static func clearPersistedPendingMutations() {
+        for identifier in syncableIdentifiers {
+            UserDefaults.standard.removeObject(forKey: pendingMutationKey(identifier: identifier))
+        }
+    }
+
+    private func validateCurrentAccount(container: CKContainer) async throws {
+        let recordName = try await container.userRecordID().recordName
+        let fingerprint = SHA256.hash(data: Data(recordName.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        try await resetAccountBoundState(ifNeededFor: fingerprint)
+    }
+
+    private func handleCloudKitAccountChange() async {
+        let suspendedWork = suspendActiveWork()
+        await acquireLifecycleLock()
+        symmetricKey = nil
+        status.isEnabled = false
+        status.isCloudAvailable = false
+        await waitForSuspendedWork(suspendedWork)
+        releaseLifecycleLock()
+        _ = await isAvailable()
+    }
+
+    private func resetAccountBoundState(ifNeededFor fingerprint: String) async throws {
+        await acquireLifecycleLock()
+        defer { releaseLifecycleLock() }
+        guard UserDefaults.standard.string(forKey: Self.accountIdentifierKey) != fingerprint else {
+            return
+        }
+        let suspendedWork = suspendActiveWork()
+        await waitForSuspendedWork(suspendedWork)
+        pendingMutations.removeAll()
+        retryAttempts.removeAll()
+        Self.clearPersistedPendingMutations()
+        UserDefaults.standard.removeObject(forKey: Self.enabledKey)
+        UserDefaults.standard.removeObject(forKey: Self.syncTokenKey)
+        UserDefaults.standard.removeObject(forKey: Self.zoneCreatedKey)
+        UserDefaults.standard.removeObject(forKey: Self.subscriptionCreatedKey)
+        try await stateStorage.removeSecret(identifier: Self.localDerivedKeyIdentifier)
+        for identifier in Self.syncableIdentifiers {
+            try await stateStorage.removeSecret(identifier: Self.localUpdatedPrefix + identifier)
+        }
+        symmetricKey = nil
+        status.isEnabled = false
+        status.isSyncing = false
+        status.lastSyncTime = nil
+        status.lastErrorDescription = nil
+        UserDefaults.standard.set(fingerprint, forKey: Self.accountIdentifierKey)
+    }
+
+    private func suspendActiveWork() -> SuspendedWork {
+        let suspendedWork = SuspendedWork(
+            syncTask: activeSync?.task,
+            uploadTasks: Array(localUploadTasks.values)
+        )
+        syncGeneration &+= 1
+        suspendedWork.syncTask?.cancel()
+        suspendedWork.uploadTasks.forEach { $0.cancel() }
+        activeSync = nil
+        localUploadTasks.removeAll()
+        localUploadTaskIDs.removeAll()
+        retryAttempts.removeAll()
+        status.isSyncing = false
+        return suspendedWork
+    }
+
+    private func waitForSuspendedWork(_ suspendedWork: SuspendedWork) async {
+        if let syncTask = suspendedWork.syncTask {
+            do {
+                try await syncTask.value
+            } catch is CancellationError {
+                // Expected after invalidating the previous account generation.
+            } catch {
+                log.warning("Suspended key sync ended with error: \(error.localizedDescription)")
+            }
+        }
+        for task in suspendedWork.uploadTasks {
+            await task.value
+        }
+    }
+
+    private func acquireLifecycleLock() async {
+        guard lifecycleIsLocked else {
+            lifecycleIsLocked = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            lifecycleWaiters.append(continuation)
+        }
+    }
+
+    private func releaseLifecycleLock() {
+        guard !lifecycleWaiters.isEmpty else {
+            lifecycleIsLocked = false
+            return
+        }
+        lifecycleWaiters.removeFirst().resume()
+    }
+
+    private func ensureSyncIsActive(generation: UInt64) throws {
+        try ensureGenerationIsCurrent(generation)
+        guard UserDefaults.standard.bool(forKey: Self.enabledKey),
+              status.isEnabled else {
+            throw CancellationError()
+        }
+    }
+
+    private func ensureGenerationIsCurrent(_ generation: UInt64) throws {
+        try Task.checkCancellation()
+        guard generation == syncGeneration else {
+            throw CancellationError()
+        }
     }
 
     private func setupCloudKitInfrastructure(database: CKDatabase) async throws {
@@ -613,7 +1036,10 @@ public final class CloudKitKeySync: ObservableObject {
             guard let metadata = KeySyncMetadataRecordMapper.metadata(from: record) else {
                 throw CloudKitKeySyncError.malformedRecord
             }
-            let key = EncryptedSecretCrypto.deriveKey(passphrase: passphrase, salt: metadata.salt)
+            let key = await EncryptedSecretCrypto.deriveKeyOffMainActor(
+                passphrase: passphrase,
+                salt: metadata.salt
+            )
             guard EncryptedSecretCrypto.verifyToken(
                 nonce: metadata.verifierNonce,
                 ciphertext: metadata.verifierCiphertext,
@@ -626,7 +1052,7 @@ public final class CloudKitKeySync: ObservableObject {
         }
 
         let salt = try randomData(byteCount: 32)
-        let key = EncryptedSecretCrypto.deriveKey(passphrase: passphrase, salt: salt)
+        let key = await EncryptedSecretCrypto.deriveKeyOffMainActor(passphrase: passphrase, salt: salt)
         let token = try EncryptedSecretCrypto.makeVerificationToken(key: key)
         let metadata = KeySyncMetadata(
             salt: salt,
@@ -638,41 +1064,96 @@ public final class CloudKitKeySync: ObservableObject {
         return key
     }
 
-    private func fetchRemoteChanges(database: CKDatabase, key: SymmetricKey) async throws {
-        let result = try await executeFetchOperation(database: database, changeToken: loadChangeToken())
+    private func fetchRemoteChanges(
+        database: CKDatabase,
+        key: SymmetricKey,
+        generation: UInt64
+    ) async throws {
+        do {
+            try await fetchAndApplyRemoteChanges(
+                database: database,
+                key: key,
+                changeToken: loadChangeToken(),
+                generation: generation
+            )
+        } catch {
+            guard Self.isChangeTokenExpired(error) else { throw error }
+            clearChangeToken()
+            try ensureSyncIsActive(generation: generation)
+            try await fetchAndApplyRemoteChanges(
+                database: database,
+                key: key,
+                changeToken: nil,
+                generation: generation
+            )
+        }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func fetchAndApplyRemoteChanges(
+        database: CKDatabase,
+        key: SymmetricKey,
+        changeToken: CKServerChangeToken?,
+        generation: UInt64
+    ) async throws {
+        let result = try await executeFetchOperation(database: database, changeToken: changeToken)
+        try ensureSyncIsActive(generation: generation)
+        var firstError: Error?
 
         for record in result.records {
+            try ensureSyncIsActive(generation: generation)
+            guard record.recordType == EncryptedSecretRecordMapper.recordType else { continue }
             guard let secret = EncryptedSecretRecordMapper.secret(from: record) else {
-                log.warning("Skipping malformed encrypted secret record: \(record.recordID.recordName)")
+                let error = CloudKitKeySyncError.malformedRecord
+                firstError = firstError ?? error
+                log.error("Malformed encrypted secret record: \(record.recordID.recordName)")
                 continue
             }
 
             do {
-                try await applyRemoteSecret(secret, key: key)
+                try await applyRemoteSecret(secret, key: key, generation: generation)
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
-                log.error("Skipping encrypted secret \(secret.identifier): \(error.localizedDescription)")
+                firstError = firstError ?? error
+                log.error("Could not apply encrypted secret \(secret.identifier): \(error.localizedDescription)")
             }
         }
 
         for recordID in result.deletedIDs {
+            try ensureSyncIsActive(generation: generation)
             guard let identifier = identifierFromRecordName(recordID.recordName) else { continue }
 
             do {
-                try await applyRemoteDeletion(identifier: identifier, updatedAt: Date())
+                try await applyRemoteDeletion(identifier: identifier, updatedAt: Date(), generation: generation)
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
-                log.error("Skipping encrypted secret deletion \(identifier): \(error.localizedDescription)")
+                firstError = firstError ?? error
+                log.error("Could not apply encrypted secret deletion \(identifier): \(error.localizedDescription)")
             }
         }
 
+        if let firstError {
+            throw firstError
+        }
+        try ensureSyncIsActive(generation: generation)
         if let token = result.serverChangeToken {
             saveChangeToken(token)
         }
     }
 
-    private func applyRemoteSecret(_ secret: EncryptedSecret, key: SymmetricKey) async throws {
+    private func applyRemoteSecret(
+        _ secret: EncryptedSecret,
+        key: SymmetricKey,
+        generation: UInt64
+    ) async throws {
         guard Self.syncableIdentifiers.contains(secret.identifier) else { return }
-        let localUpdatedAt = await loadLocalUpdatedAt(identifier: secret.identifier)
-        guard localUpdatedAt == nil || secret.updatedAt >= (localUpdatedAt ?? .distantPast) else { return }
+        let pendingMutation = pendingMutations[secret.identifier]
+            ?? Self.loadPersistedPendingMutation(identifier: secret.identifier)
+        let localUpdatedAt = try await effectiveLocalUpdatedAt(identifier: secret.identifier)
+        guard localUpdatedAt == nil || secret.updatedAt > (localUpdatedAt ?? .distantPast) else { return }
+        try ensureSyncIsActive(generation: generation)
 
         applyingRemoteIdentifiers.insert(secret.identifier)
         defer { applyingRemoteIdentifiers.remove(secret.identifier) }
@@ -683,71 +1164,113 @@ public final class CloudKitKeySync: ObservableObject {
             let value = try EncryptedSecretCrypto.decryptSecret(secret, key: key)
             try await secureStorage.storeSecret(value, identifier: secret.identifier)
         }
-        await saveLocalUpdatedAt(secret.updatedAt, identifier: secret.identifier)
-    }
-
-    private func applyRemoteDeletion(identifier: String, updatedAt: Date) async throws {
-        guard Self.syncableIdentifiers.contains(identifier) else { return }
-        applyingRemoteIdentifiers.insert(identifier)
-        defer { applyingRemoteIdentifiers.remove(identifier) }
-        try await secureStorage.removeSecret(identifier: identifier)
-        await saveLocalUpdatedAt(updatedAt, identifier: identifier)
-    }
-
-    private func uploadLocalSecrets(database: CKDatabase, key: SymmetricKey) async throws {
-        let identifiers = (await secureStorage.knownIdentifiers())
-            .filter { Self.syncableIdentifiers.contains($0) }
-            .prefix(SyncConfiguration.batchSize)
-        for identifier in identifiers {
-            let updatedAt = await loadLocalUpdatedAt(identifier: identifier) ?? Date()
-            do {
-                try await uploadSecret(
-                    identifier: identifier,
-                    updatedAt: updatedAt,
-                    database: database,
-                    key: key,
-                    isDeletion: false
-                )
-                await saveLocalUpdatedAt(updatedAt, identifier: identifier)
-            } catch {
-                log.error("Skipping local encrypted secret upload \(identifier): \(error.localizedDescription)")
-            }
+        try ensureSyncIsActive(generation: generation)
+        try await saveLocalUpdatedAt(secret.updatedAt, identifier: secret.identifier)
+        if let pendingMutation {
+            clearPendingMutation(ifMatching: pendingMutation)
         }
     }
 
+    private func applyRemoteDeletion(identifier: String, updatedAt: Date, generation: UInt64) async throws {
+        guard Self.syncableIdentifiers.contains(identifier) else { return }
+        guard pendingMutations[identifier] == nil,
+              Self.loadPersistedPendingMutation(identifier: identifier) == nil else {
+            return
+        }
+        try ensureSyncIsActive(generation: generation)
+        applyingRemoteIdentifiers.insert(identifier)
+        defer { applyingRemoteIdentifiers.remove(identifier) }
+        try await secureStorage.removeSecret(identifier: identifier)
+        try ensureSyncIsActive(generation: generation)
+        try await saveLocalUpdatedAt(updatedAt, identifier: identifier)
+    }
+
+    private func uploadLocalSecrets(
+        database: CKDatabase,
+        key: SymmetricKey,
+        generation: UInt64
+    ) async throws {
+        var firstError: Error?
+        let mutations = Self.syncableIdentifiers
+            .compactMap { identifier in
+                pendingMutations[identifier]
+                    ?? Self.loadPersistedPendingMutation(identifier: identifier)
+            }
+            .sorted { $0.identifier < $1.identifier }
+            .prefix(SyncConfiguration.batchSize)
+
+        for mutation in mutations {
+            try ensureSyncIsActive(generation: generation)
+            do {
+                let uploadResult = try await uploadSecret(
+                    identifier: mutation.identifier,
+                    updatedAt: mutation.updatedAt,
+                    database: database,
+                    key: key,
+                    isDeletion: mutation.kind == .deletion,
+                    generation: generation
+                )
+                if uploadResult == .uploaded {
+                    try await saveLocalUpdatedAt(mutation.updatedAt, identifier: mutation.identifier)
+                    clearPendingMutation(ifMatching: mutation)
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                firstError = firstError ?? error
+                log.error(
+                    "Could not upload local encrypted secret \(mutation.identifier): \(error.localizedDescription)"
+                )
+            }
+        }
+
+        if let firstError {
+            throw firstError
+        }
+    }
+
+    // swiftlint:disable:next function_parameter_count
     private func uploadSecret(
         identifier: String,
         updatedAt: Date,
         database: CKDatabase,
         key: SymmetricKey,
-        isDeletion: Bool
-    ) async throws {
+        isDeletion: Bool,
+        generation: UInt64
+    ) async throws -> SecretUploadResult {
         let value: String
         if isDeletion {
             value = ""
         } else {
-            do {
-                value = try await secureStorage.secret(identifier: identifier)
-            } catch SecureStorageError.valueNotFound {
-                log.warning("Skipping missing local encrypted secret \(identifier)")
-                return
-            }
+            value = try await secureStorage.secret(identifier: identifier)
         }
-        let isDeleted = isDeletion
+        try ensureSyncIsActive(generation: generation)
         let secret = try EncryptedSecretCrypto.encryptSecret(
             identifier: identifier,
             value: value,
             updatedAt: updatedAt,
             key: key,
-            isDeleted: isDeleted
+            isDeleted: isDeletion
         )
         let recordID = CKRecord.ID(
             recordName: EncryptedSecretRecordMapper.recordName(for: identifier),
             zoneID: SyncConfiguration.zoneID
         )
         let existing = try await fetchRecord(id: recordID, database: database)
+        try ensureSyncIsActive(generation: generation)
+        if let existing {
+            guard let remoteSecret = EncryptedSecretRecordMapper.secret(from: existing) else {
+                throw CloudKitKeySyncError.malformedRecord
+            }
+            if remoteSecret.updatedAt > updatedAt {
+                try await applyRemoteSecret(remoteSecret, key: key, generation: generation)
+                return .superseded
+            }
+        }
         let record = EncryptedSecretRecordMapper.record(from: secret, existingRecord: existing)
         _ = try await database.save(record)
+        try ensureSyncIsActive(generation: generation)
+        return .uploaded
     }
 
     private func executeFetchOperation(
@@ -760,12 +1283,18 @@ public final class CloudKitKeySync: ObservableObject {
             recordZoneIDs: [SyncConfiguration.zoneID],
             configurationsByRecordZoneID: [SyncConfiguration.zoneID: config]
         )
+        operation.fetchAllChanges = true
 
         let accumulator = KeySyncFetchAccumulator()
 
         operation.recordWasChangedBlock = { _, result in
-            if case .success(let record) = result {
+            switch result {
+            case .success(let record) where record.recordType == EncryptedSecretRecordMapper.recordType:
                 accumulator.append(record: record)
+            case .success:
+                break
+            case .failure(let error):
+                accumulator.append(error: error)
             }
         }
         operation.recordWithIDWasDeletedBlock = { recordID, _ in
@@ -775,8 +1304,12 @@ public final class CloudKitKeySync: ObservableObject {
             accumulator.updateToken(token)
         }
         operation.recordZoneFetchResultBlock = { _, result in
-            if case .success(let (token, _, _)) = result {
+            switch result {
+            case .success(let (token, _, moreComing)):
                 accumulator.updateToken(token)
+                accumulator.updateMoreComing(moreComing)
+            case .failure(let error):
+                accumulator.append(error: error)
             }
         }
 
@@ -792,7 +1325,7 @@ public final class CloudKitKeySync: ObservableObject {
             database.add(operation)
         }
 
-        return accumulator.result()
+        return try accumulator.result()
     }
 
     private func fetchRecord(id: CKRecord.ID, database: CKDatabase) async throws -> CKRecord? {
@@ -814,19 +1347,46 @@ public final class CloudKitKeySync: ObservableObject {
         }
     }
 
-    private func saveLocalUpdatedAt(_ date: Date, identifier: String) async {
-        try? await secureStorage.storeSecret(
+    private func clearChangeToken() {
+        UserDefaults.standard.removeObject(forKey: Self.syncTokenKey)
+    }
+
+    private static func isChangeTokenExpired(_ error: Error) -> Bool {
+        guard let cloudError = error as? CKError else { return false }
+        if cloudError.code == .changeTokenExpired {
+            return true
+        }
+        return cloudError.partialErrorsByItemID?.values.contains {
+            isChangeTokenExpired($0)
+        } == true
+    }
+
+    private func saveLocalUpdatedAt(_ date: Date, identifier: String) async throws {
+        try await stateStorage.storeSecret(
             String(date.timeIntervalSince1970),
             identifier: Self.localUpdatedPrefix + identifier
         )
     }
 
-    private func loadLocalUpdatedAt(identifier: String) async -> Date? {
-        guard let value = try? await secureStorage.secret(identifier: Self.localUpdatedPrefix + identifier),
-              let timestamp = TimeInterval(value) else {
+    private func loadLocalUpdatedAt(identifier: String) async throws -> Date? {
+        let value: String
+        do {
+            value = try await stateStorage.secret(identifier: Self.localUpdatedPrefix + identifier)
+        } catch SecureStorageError.valueNotFound {
             return nil
         }
+        guard let timestamp = TimeInterval(value) else {
+            throw CloudKitKeySyncError.malformedRecord
+        }
         return Date(timeIntervalSince1970: timestamp)
+    }
+
+    private func effectiveLocalUpdatedAt(identifier: String) async throws -> Date? {
+        let committed = try await loadLocalUpdatedAt(identifier: identifier)
+        let pending = pendingMutations[identifier]
+            ?? Self.loadPersistedPendingMutation(identifier: identifier)
+        guard let pending else { return committed }
+        return max(committed ?? .distantPast, pending.updatedAt)
     }
 
     private func randomData(byteCount: Int) throws -> Data {

--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -313,12 +313,15 @@ public final class CloudKitKeySync: ObservableObject {
     private static let localDerivedKeyIdentifier = "cloudkitKeySync.derivedKey"
     private static let localUpdatedPrefix = "speak.keysync.localUpdatedAt."
     private static let subscriptionID = "encrypted-secret-changes"
+    private static let localUploadDebounceNanoseconds: UInt64 = 750_000_000
 
     private let log = Logger(subsystem: "com.justspeaktoit", category: "CloudKitKeySync")
     private var secureStorage: SecureStorage
     private var symmetricKey: SymmetricKey?
     private var observer: NSObjectProtocol?
     private var applyingRemoteIdentifiers = Set<String>()
+    private var pendingLocalUploadDates: [String: Date] = [:]
+    private var localUploadTasks: [String: Task<Void, Never>] = [:]
 
     private init(secureStorage: SecureStorage = SecureStorage()) {
         self.secureStorage = secureStorage
@@ -372,6 +375,9 @@ public final class CloudKitKeySync: ObservableObject {
     public func disable() async {
         UserDefaults.standard.set(false, forKey: Self.enabledKey)
         try? await secureStorage.removeSecret(identifier: Self.localDerivedKeyIdentifier)
+        localUploadTasks.values.forEach { $0.cancel() }
+        localUploadTasks.removeAll()
+        pendingLocalUploadDates.removeAll()
         symmetricKey = nil
         status.isEnabled = false
         status.lastErrorDescription = nil
@@ -419,15 +425,61 @@ public final class CloudKitKeySync: ObservableObject {
 
             Task { @MainActor in
                 guard !self.applyingRemoteIdentifiers.contains(identifier),
+                      self.status.isEnabled else {
+                    return
+                }
+                let updatedAt = notification
+                    .userInfo?[SecureStorage.NotificationUserInfoKey.updatedAt] as? Date ?? Date()
+                self.scheduleLocalUpload(identifier: identifier, updatedAt: updatedAt)
+            }
+        }
+    }
+
+    private func scheduleLocalUpload(identifier: String, updatedAt: Date) {
+        pendingLocalUploadDates[identifier] = updatedAt
+
+        guard localUploadTasks[identifier] == nil else { return }
+
+        localUploadTasks[identifier] = Task { @MainActor [weak self] in
+            defer {
+                self?.localUploadTasks[identifier] = nil
+            }
+
+            while !Task.isCancelled {
+                let observedUpdatedAt = self?.pendingLocalUploadDates[identifier]
+                do {
+                    try await Task.sleep(nanoseconds: Self.localUploadDebounceNanoseconds)
+                } catch {
+                    return
+                }
+
+                guard let self else { return }
+                guard self.pendingLocalUploadDates[identifier] == observedUpdatedAt else {
+                    continue
+                }
+                guard let updatedAt = self.pendingLocalUploadDates.removeValue(forKey: identifier),
                       self.status.isEnabled,
                       let key = self.symmetricKey,
                       let database = SyncConfiguration.privateDatabase else {
                     return
                 }
-                let updatedAt = notification
-                    .userInfo?[SecureStorage.NotificationUserInfoKey.updatedAt] as? Date ?? Date()
+
                 await self.saveLocalUpdatedAt(updatedAt, identifier: identifier)
-                try? await self.uploadSecret(identifier: identifier, updatedAt: updatedAt, database: database, key: key)
+
+                do {
+                    try await self.uploadSecret(
+                        identifier: identifier,
+                        updatedAt: updatedAt,
+                        database: database,
+                        key: key
+                    )
+                } catch {
+                    self.log.error("Debounced key upload failed for \(identifier): \(error.localizedDescription)")
+                }
+
+                if self.pendingLocalUploadDates[identifier] == nil {
+                    return
+                }
             }
         }
     }
@@ -500,13 +552,26 @@ public final class CloudKitKeySync: ObservableObject {
         let result = try await executeFetchOperation(database: database, changeToken: loadChangeToken())
 
         for record in result.records {
-            guard let secret = EncryptedSecretRecordMapper.secret(from: record) else { continue }
-            try await applyRemoteSecret(secret, key: key)
+            guard let secret = EncryptedSecretRecordMapper.secret(from: record) else {
+                log.warning("Skipping malformed encrypted secret record: \(record.recordID.recordName)")
+                continue
+            }
+
+            do {
+                try await applyRemoteSecret(secret, key: key)
+            } catch {
+                log.error("Skipping encrypted secret \(secret.identifier): \(error.localizedDescription)")
+            }
         }
 
         for recordID in result.deletedIDs {
             guard let identifier = identifierFromRecordName(recordID.recordName) else { continue }
-            try await applyRemoteDeletion(identifier: identifier, updatedAt: Date())
+
+            do {
+                try await applyRemoteDeletion(identifier: identifier, updatedAt: Date())
+            } catch {
+                log.error("Skipping encrypted secret deletion \(identifier): \(error.localizedDescription)")
+            }
         }
 
         if let token = result.serverChangeToken {

--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -136,7 +136,7 @@ public enum EncryptedSecretCrypto {
         return SymmetricKey(data: keyData)
     }
 
-    private static func pbkdf2SHA256(
+    static func pbkdf2SHA256(
         password: Data,
         salt: Data,
         iterations: Int,

--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -1,0 +1,673 @@
+import CloudKit
+import Combine
+import CryptoKit
+import Foundation
+import os.log
+import Security
+
+import SpeakCore
+
+// swiftlint:disable file_length
+
+public struct EncryptedSecret: Equatable, Sendable {
+    public let identifier: String
+    public let ciphertext: Data
+    public let nonce: Data
+    public let tag: Data
+    public let updatedAt: Date
+    public let isDeleted: Bool
+
+    public init(
+        identifier: String,
+        ciphertext: Data,
+        nonce: Data,
+        tag: Data,
+        updatedAt: Date,
+        isDeleted: Bool = false
+    ) {
+        self.identifier = identifier
+        self.ciphertext = ciphertext
+        self.nonce = nonce
+        self.tag = tag
+        self.updatedAt = updatedAt
+        self.isDeleted = isDeleted
+    }
+}
+
+public struct CloudKitKeySyncStatus: Equatable, Sendable {
+    public var isEnabled: Bool
+    public var isCloudAvailable: Bool
+    public var isSyncing: Bool
+    public var lastSyncTime: Date?
+    public var lastErrorDescription: String?
+
+    public init(
+        isEnabled: Bool = false,
+        isCloudAvailable: Bool = false,
+        isSyncing: Bool = false,
+        lastSyncTime: Date? = nil,
+        lastErrorDescription: String? = nil
+    ) {
+        self.isEnabled = isEnabled
+        self.isCloudAvailable = isCloudAvailable
+        self.isSyncing = isSyncing
+        self.lastSyncTime = lastSyncTime
+        self.lastErrorDescription = lastErrorDescription
+    }
+
+    public var message: String {
+        if let lastErrorDescription { return lastErrorDescription }
+        if !isCloudAvailable { return "CloudKit unavailable" }
+        if !isEnabled { return "Off" }
+        if isSyncing { return "Syncing…" }
+        if let lastSyncTime {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .abbreviated
+            return "Synced \(formatter.localizedString(for: lastSyncTime, relativeTo: Date()))"
+        }
+        return "Ready"
+    }
+}
+
+public enum CloudKitKeySyncError: LocalizedError, Equatable {
+    case cloudUnavailable
+    case missingPassphrase
+    case incorrectPassphrase
+    case encryptionFailed
+    case malformedRecord
+
+    public var errorDescription: String? {
+        switch self {
+        case .cloudUnavailable:
+            return "CloudKit is unavailable for this build, device, or iCloud account."
+        case .missingPassphrase:
+            return "Enter the API-key sync passphrase to join this device."
+        case .incorrectPassphrase:
+            return "The API-key sync passphrase is incorrect."
+        case .encryptionFailed:
+            return "Failed to encrypt or decrypt the API key."
+        case .malformedRecord:
+            return "CloudKit returned an invalid encrypted key record."
+        }
+    }
+}
+
+public enum EncryptedSecretCrypto {
+    private static let info = Data("justspeaktoit.api-key-sync.v1".utf8)
+    private static let verifierPlaintext = Data("justspeaktoit.api-key-sync.verifier.v1".utf8)
+
+    /// Derives the local encryption key from a user-owned passphrase and a CloudKit-stored salt.
+    /// The passphrase is never sent to CloudKit. CloudKit stores only the random salt and an
+    /// AES-GCM verification token, so iCloud private-database access alone cannot read API keys.
+    /// A device joins sync by entering the passphrase once; the derived key is then kept only in
+    /// that device's Keychain via SecureStorage, not in CloudKit.
+    public static func deriveKey(passphrase: String, salt: Data) -> SymmetricKey {
+        let inputKeyMaterial = SymmetricKey(data: Data(passphrase.utf8))
+        return HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: inputKeyMaterial,
+            salt: salt,
+            info: info,
+            outputByteCount: 32
+        )
+    }
+
+    public static func encryptSecret(
+        identifier: String,
+        value: String,
+        updatedAt: Date,
+        key: SymmetricKey,
+        isDeleted: Bool = false
+    ) throws -> EncryptedSecret {
+        let sealedBox = try AES.GCM.seal(Data(value.utf8), using: key)
+        return EncryptedSecret(
+            identifier: identifier,
+            ciphertext: sealedBox.ciphertext,
+            nonce: Data(sealedBox.nonce),
+            tag: sealedBox.tag,
+            updatedAt: updatedAt,
+            isDeleted: isDeleted
+        )
+    }
+
+    public static func decryptSecret(_ secret: EncryptedSecret, key: SymmetricKey) throws -> String {
+        let nonce = try AES.GCM.Nonce(data: secret.nonce)
+        let sealedBox = try AES.GCM.SealedBox(
+            nonce: nonce,
+            ciphertext: secret.ciphertext,
+            tag: secret.tag
+        )
+        let plaintext = try AES.GCM.open(sealedBox, using: key)
+        guard let value = String(data: plaintext, encoding: .utf8) else {
+            throw CloudKitKeySyncError.encryptionFailed
+        }
+        return value
+    }
+
+    struct VerificationToken {
+        let nonce: Data
+        let ciphertext: Data
+        let tag: Data
+    }
+
+    static func makeVerificationToken(key: SymmetricKey) throws -> VerificationToken {
+        let sealedBox = try AES.GCM.seal(verifierPlaintext, using: key)
+        return VerificationToken(
+            nonce: Data(sealedBox.nonce),
+            ciphertext: sealedBox.ciphertext,
+            tag: sealedBox.tag
+        )
+    }
+
+    static func verifyToken(nonce: Data, ciphertext: Data, tag: Data, key: SymmetricKey) -> Bool {
+        do {
+            let box = try AES.GCM.SealedBox(
+                nonce: AES.GCM.Nonce(data: nonce),
+                ciphertext: ciphertext,
+                tag: tag
+            )
+            let plaintext = try AES.GCM.open(box, using: key)
+            return plaintext == verifierPlaintext
+        } catch {
+            return false
+        }
+    }
+}
+
+public enum EncryptedSecretRecordMapper {
+    public static let recordType = "EncryptedSecret"
+
+    private enum FieldKey {
+        static let identifier = "identifier"
+        static let ciphertext = "ciphertext"
+        static let nonce = "nonce"
+        static let tag = "tag"
+        static let updatedAt = "updatedAt"
+        static let isDeleted = "isDeleted"
+    }
+
+    public static func recordName(for identifier: String) -> String {
+        let encoded = Data(identifier.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "secret-\(encoded)"
+    }
+
+    public static func record(from secret: EncryptedSecret, existingRecord: CKRecord? = nil) -> CKRecord {
+        let recordID = CKRecord.ID(
+            recordName: recordName(for: secret.identifier),
+            zoneID: SyncConfiguration.zoneID
+        )
+        let record = existingRecord ?? CKRecord(recordType: recordType, recordID: recordID)
+        record[FieldKey.identifier] = secret.identifier
+        record[FieldKey.ciphertext] = secret.ciphertext
+        record[FieldKey.nonce] = secret.nonce
+        record[FieldKey.tag] = secret.tag
+        record[FieldKey.updatedAt] = secret.updatedAt
+        record[FieldKey.isDeleted] = secret.isDeleted ? 1 : 0
+        return record
+    }
+
+    public static func secret(from record: CKRecord) -> EncryptedSecret? {
+        guard record.recordType == recordType,
+              let identifier = record[FieldKey.identifier] as? String,
+              let ciphertext = record[FieldKey.ciphertext] as? Data,
+              let nonce = record[FieldKey.nonce] as? Data,
+              let tag = record[FieldKey.tag] as? Data,
+              let updatedAt = record[FieldKey.updatedAt] as? Date else {
+            return nil
+        }
+        let deletedValue = record[FieldKey.isDeleted]
+        let isDeleted = (deletedValue as? Int) == 1 || (deletedValue as? Bool) == true
+        return EncryptedSecret(
+            identifier: identifier,
+            ciphertext: ciphertext,
+            nonce: nonce,
+            tag: tag,
+            updatedAt: updatedAt,
+            isDeleted: isDeleted
+        )
+    }
+}
+
+private struct KeySyncMetadata {
+    let salt: Data
+    let verifierNonce: Data
+    let verifierCiphertext: Data
+    let verifierTag: Data
+}
+
+private enum KeySyncMetadataRecordMapper {
+    static let recordType = "EncryptedSecretMetadata"
+    static let recordName = "api-key-sync-metadata"
+
+    private enum FieldKey {
+        static let salt = "salt"
+        static let verifierNonce = "verifierNonce"
+        static let verifierCiphertext = "verifierCiphertext"
+        static let verifierTag = "verifierTag"
+        static let updatedAt = "updatedAt"
+    }
+
+    static var recordID: CKRecord.ID {
+        CKRecord.ID(recordName: recordName, zoneID: SyncConfiguration.zoneID)
+    }
+
+    static func record(from metadata: KeySyncMetadata, existingRecord: CKRecord? = nil) -> CKRecord {
+        let record = existingRecord ?? CKRecord(recordType: recordType, recordID: recordID)
+        record[FieldKey.salt] = metadata.salt
+        record[FieldKey.verifierNonce] = metadata.verifierNonce
+        record[FieldKey.verifierCiphertext] = metadata.verifierCiphertext
+        record[FieldKey.verifierTag] = metadata.verifierTag
+        record[FieldKey.updatedAt] = Date()
+        return record
+    }
+
+    static func metadata(from record: CKRecord) -> KeySyncMetadata? {
+        guard record.recordType == recordType,
+              let salt = record[FieldKey.salt] as? Data,
+              let nonce = record[FieldKey.verifierNonce] as? Data,
+              let ciphertext = record[FieldKey.verifierCiphertext] as? Data,
+              let tag = record[FieldKey.verifierTag] as? Data else {
+            return nil
+        }
+        return KeySyncMetadata(
+            salt: salt,
+            verifierNonce: nonce,
+            verifierCiphertext: ciphertext,
+            verifierTag: tag
+        )
+    }
+}
+
+private struct KeySyncFetchResult {
+    var records: [CKRecord]
+    var deletedIDs: [CKRecord.ID]
+    var serverChangeToken: CKServerChangeToken?
+}
+
+@MainActor
+// swiftlint:disable:next type_body_length
+public final class CloudKitKeySync: ObservableObject {
+    public static let shared = CloudKitKeySync()
+
+    public nonisolated static let syncableIdentifiers: Set<String> = [
+        "deepgram.apiKey",
+        "openai.apiKey",
+        "openrouter.apiKey",
+        "elevenlabs.apiKey",
+        "cartesia.apiKey",
+        "assemblyai.apiKey",
+        "gladia.apiKey",
+        "modulate.apiKey",
+        "soniox.apiKey"
+    ]
+
+    @Published public private(set) var status = CloudKitKeySyncStatus()
+
+    private static let enabledKey = "speak.keysync.enabled"
+    private static let syncTokenKey = "speak.keysync.serverChangeToken"
+    private static let subscriptionCreatedKey = "speak.keysync.subscriptionCreated"
+    private static let zoneCreatedKey = "speak.keysync.zoneCreated"
+    private static let localDerivedKeyIdentifier = "cloudkitKeySync.derivedKey"
+    private static let localUpdatedPrefix = "speak.keysync.localUpdatedAt."
+    private static let subscriptionID = "encrypted-secret-changes"
+
+    private let log = Logger(subsystem: "com.justspeaktoit", category: "CloudKitKeySync")
+    private var secureStorage: SecureStorage
+    private var symmetricKey: SymmetricKey?
+    private var observer: NSObjectProtocol?
+    private var applyingRemoteIdentifiers = Set<String>()
+
+    private init(secureStorage: SecureStorage = SecureStorage()) {
+        self.secureStorage = secureStorage
+        self.status.isEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey)
+        observeLocalKeyChanges()
+    }
+
+    public func configure(secureStorage: SecureStorage) async {
+        self.secureStorage = secureStorage
+        await restoreSavedKeyIfNeeded()
+    }
+
+    public func isAvailable() async -> Bool {
+        guard SyncConfiguration.hasCloudKitEntitlement,
+              let container = SyncConfiguration.container else {
+            status.isCloudAvailable = false
+            return false
+        }
+
+        do {
+            let accountStatus = try await container.accountStatus()
+            status.isCloudAvailable = accountStatus == .available
+            return status.isCloudAvailable
+        } catch {
+            status.isCloudAvailable = false
+            status.lastErrorDescription = error.localizedDescription
+            return false
+        }
+    }
+
+    public func enable(passphrase: String) async throws {
+        let trimmed = passphrase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw CloudKitKeySyncError.missingPassphrase }
+        guard await isAvailable(), let database = SyncConfiguration.privateDatabase else {
+            throw CloudKitKeySyncError.cloudUnavailable
+        }
+
+        try await setupCloudKitInfrastructure(database: database)
+        let key = try await loadOrCreateMetadataKey(passphrase: trimmed, database: database)
+        symmetricKey = key
+        try await secureStorage.storeSecret(
+            key.withUnsafeBytes { Data($0).base64EncodedString() },
+            identifier: Self.localDerivedKeyIdentifier
+        )
+        UserDefaults.standard.set(true, forKey: Self.enabledKey)
+        status.isEnabled = true
+        status.lastErrorDescription = nil
+        try await syncNow()
+    }
+
+    public func disable() async {
+        UserDefaults.standard.set(false, forKey: Self.enabledKey)
+        try? await secureStorage.removeSecret(identifier: Self.localDerivedKeyIdentifier)
+        symmetricKey = nil
+        status.isEnabled = false
+        status.lastErrorDescription = nil
+    }
+
+    public func syncNow() async throws {
+        guard UserDefaults.standard.bool(forKey: Self.enabledKey) else { return }
+        await restoreSavedKeyIfNeeded()
+        guard let key = symmetricKey else { throw CloudKitKeySyncError.missingPassphrase }
+        guard await isAvailable(), let database = SyncConfiguration.privateDatabase else {
+            throw CloudKitKeySyncError.cloudUnavailable
+        }
+
+        status.isSyncing = true
+        status.lastErrorDescription = nil
+        defer { status.isSyncing = false }
+
+        do {
+            try await setupCloudKitInfrastructure(database: database)
+            try await fetchRemoteChanges(database: database, key: key)
+            try await uploadLocalSecrets(database: database, key: key)
+            status.lastSyncTime = Date()
+        } catch {
+            status.lastErrorDescription = error.localizedDescription
+            throw error
+        }
+    }
+
+    public func handleRemoteNotification() async {
+        try? await syncNow()
+    }
+
+    private func observeLocalKeyChanges() {
+        observer = NotificationCenter.default.addObserver(
+            forName: SecureStorage.didChangeSecretNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            guard let self,
+                  let identifier = notification
+                    .userInfo?[SecureStorage.NotificationUserInfoKey.identifier] as? String,
+                  Self.syncableIdentifiers.contains(identifier) else {
+                return
+            }
+
+            Task { @MainActor in
+                guard !self.applyingRemoteIdentifiers.contains(identifier),
+                      self.status.isEnabled,
+                      let key = self.symmetricKey,
+                      let database = SyncConfiguration.privateDatabase else {
+                    return
+                }
+                let updatedAt = notification
+                    .userInfo?[SecureStorage.NotificationUserInfoKey.updatedAt] as? Date ?? Date()
+                await self.saveLocalUpdatedAt(updatedAt, identifier: identifier)
+                try? await self.uploadSecret(identifier: identifier, updatedAt: updatedAt, database: database, key: key)
+            }
+        }
+    }
+
+    private func restoreSavedKeyIfNeeded() async {
+        guard symmetricKey == nil,
+              UserDefaults.standard.bool(forKey: Self.enabledKey),
+              let stored = try? await secureStorage.secret(identifier: Self.localDerivedKeyIdentifier),
+              let data = Data(base64Encoded: stored) else {
+            return
+        }
+        symmetricKey = SymmetricKey(data: data)
+    }
+
+    private func setupCloudKitInfrastructure(database: CKDatabase) async throws {
+        if !UserDefaults.standard.bool(forKey: Self.zoneCreatedKey) {
+            do {
+                _ = try await database.save(SyncConfiguration.recordZone)
+                UserDefaults.standard.set(true, forKey: Self.zoneCreatedKey)
+            } catch let error as CKError where error.code == .serverRecordChanged {
+                UserDefaults.standard.set(true, forKey: Self.zoneCreatedKey)
+            }
+        }
+
+        if !UserDefaults.standard.bool(forKey: Self.subscriptionCreatedKey) {
+            let subscription = CKDatabaseSubscription(subscriptionID: Self.subscriptionID)
+            let info = CKSubscription.NotificationInfo()
+            info.shouldSendContentAvailable = true
+            subscription.notificationInfo = info
+            do {
+                _ = try await database.save(subscription)
+                UserDefaults.standard.set(true, forKey: Self.subscriptionCreatedKey)
+            } catch let error as CKError where error.code == .serverRejectedRequest {
+                log.warning("Key sync subscription unavailable: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func loadOrCreateMetadataKey(passphrase: String, database: CKDatabase) async throws -> SymmetricKey {
+        if let record = try await fetchRecord(id: KeySyncMetadataRecordMapper.recordID, database: database) {
+            guard let metadata = KeySyncMetadataRecordMapper.metadata(from: record) else {
+                throw CloudKitKeySyncError.malformedRecord
+            }
+            let key = EncryptedSecretCrypto.deriveKey(passphrase: passphrase, salt: metadata.salt)
+            guard EncryptedSecretCrypto.verifyToken(
+                nonce: metadata.verifierNonce,
+                ciphertext: metadata.verifierCiphertext,
+                tag: metadata.verifierTag,
+                key: key
+            ) else {
+                throw CloudKitKeySyncError.incorrectPassphrase
+            }
+            return key
+        }
+
+        let salt = randomData(byteCount: 32)
+        let key = EncryptedSecretCrypto.deriveKey(passphrase: passphrase, salt: salt)
+        let token = try EncryptedSecretCrypto.makeVerificationToken(key: key)
+        let metadata = KeySyncMetadata(
+            salt: salt,
+            verifierNonce: token.nonce,
+            verifierCiphertext: token.ciphertext,
+            verifierTag: token.tag
+        )
+        _ = try await database.save(KeySyncMetadataRecordMapper.record(from: metadata))
+        return key
+    }
+
+    private func fetchRemoteChanges(database: CKDatabase, key: SymmetricKey) async throws {
+        let result = try await executeFetchOperation(database: database, changeToken: loadChangeToken())
+
+        for record in result.records {
+            guard let secret = EncryptedSecretRecordMapper.secret(from: record) else { continue }
+            try await applyRemoteSecret(secret, key: key)
+        }
+
+        for recordID in result.deletedIDs {
+            guard let identifier = identifierFromRecordName(recordID.recordName) else { continue }
+            try await applyRemoteDeletion(identifier: identifier, updatedAt: Date())
+        }
+
+        if let token = result.serverChangeToken {
+            saveChangeToken(token)
+        }
+    }
+
+    private func applyRemoteSecret(_ secret: EncryptedSecret, key: SymmetricKey) async throws {
+        guard Self.syncableIdentifiers.contains(secret.identifier) else { return }
+        let localUpdatedAt = await loadLocalUpdatedAt(identifier: secret.identifier)
+        guard localUpdatedAt == nil || secret.updatedAt >= (localUpdatedAt ?? .distantPast) else { return }
+
+        applyingRemoteIdentifiers.insert(secret.identifier)
+        defer { applyingRemoteIdentifiers.remove(secret.identifier) }
+
+        if secret.isDeleted {
+            try await secureStorage.removeSecret(identifier: secret.identifier)
+        } else {
+            let value = try EncryptedSecretCrypto.decryptSecret(secret, key: key)
+            try await secureStorage.storeSecret(value, identifier: secret.identifier)
+        }
+        await saveLocalUpdatedAt(secret.updatedAt, identifier: secret.identifier)
+    }
+
+    private func applyRemoteDeletion(identifier: String, updatedAt: Date) async throws {
+        guard Self.syncableIdentifiers.contains(identifier) else { return }
+        applyingRemoteIdentifiers.insert(identifier)
+        defer { applyingRemoteIdentifiers.remove(identifier) }
+        try await secureStorage.removeSecret(identifier: identifier)
+        await saveLocalUpdatedAt(updatedAt, identifier: identifier)
+    }
+
+    private func uploadLocalSecrets(database: CKDatabase, key: SymmetricKey) async throws {
+        let identifiers = (await secureStorage.knownIdentifiers())
+            .filter { Self.syncableIdentifiers.contains($0) }
+            .prefix(SyncConfiguration.batchSize)
+        for identifier in identifiers {
+            let updatedAt = await loadLocalUpdatedAt(identifier: identifier) ?? Date()
+            try await uploadSecret(identifier: identifier, updatedAt: updatedAt, database: database, key: key)
+            await saveLocalUpdatedAt(updatedAt, identifier: identifier)
+        }
+    }
+
+    private func uploadSecret(
+        identifier: String,
+        updatedAt: Date,
+        database: CKDatabase,
+        key: SymmetricKey
+    ) async throws {
+        let value = (try? await secureStorage.secret(identifier: identifier)) ?? ""
+        let isDeleted = value.isEmpty
+        let secret = try EncryptedSecretCrypto.encryptSecret(
+            identifier: identifier,
+            value: value,
+            updatedAt: updatedAt,
+            key: key,
+            isDeleted: isDeleted
+        )
+        let recordID = CKRecord.ID(
+            recordName: EncryptedSecretRecordMapper.recordName(for: identifier),
+            zoneID: SyncConfiguration.zoneID
+        )
+        let existing = try await fetchRecord(id: recordID, database: database)
+        let record = EncryptedSecretRecordMapper.record(from: secret, existingRecord: existing)
+        _ = try await database.save(record)
+    }
+
+    private func executeFetchOperation(
+        database: CKDatabase,
+        changeToken: CKServerChangeToken?
+    ) async throws -> KeySyncFetchResult {
+        let config = CKFetchRecordZoneChangesOperation.ZoneConfiguration()
+        config.previousServerChangeToken = changeToken
+        let operation = CKFetchRecordZoneChangesOperation(
+            recordZoneIDs: [SyncConfiguration.zoneID],
+            configurationsByRecordZoneID: [SyncConfiguration.zoneID: config]
+        )
+
+        var records: [CKRecord] = []
+        var deletedIDs: [CKRecord.ID] = []
+        var newToken: CKServerChangeToken?
+
+        operation.recordWasChangedBlock = { _, result in
+            if case .success(let record) = result {
+                records.append(record)
+            }
+        }
+        operation.recordWithIDWasDeletedBlock = { recordID, _ in
+            deletedIDs.append(recordID)
+        }
+        operation.recordZoneChangeTokensUpdatedBlock = { _, token, _ in
+            newToken = token
+        }
+        operation.recordZoneFetchResultBlock = { _, result in
+            if case .success(let (token, _, _)) = result {
+                newToken = token
+            }
+        }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            operation.fetchRecordZoneChangesResultBlock = { result in
+                switch result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+            database.add(operation)
+        }
+
+        return KeySyncFetchResult(records: records, deletedIDs: deletedIDs, serverChangeToken: newToken)
+    }
+
+    private func fetchRecord(id: CKRecord.ID, database: CKDatabase) async throws -> CKRecord? {
+        do {
+            return try await database.record(for: id)
+        } catch let error as CKError where error.code == .unknownItem {
+            return nil
+        }
+    }
+
+    private func loadChangeToken() -> CKServerChangeToken? {
+        guard let data = UserDefaults.standard.data(forKey: Self.syncTokenKey) else { return nil }
+        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: CKServerChangeToken.self, from: data)
+    }
+
+    private func saveChangeToken(_ token: CKServerChangeToken) {
+        if let data = try? NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true) {
+            UserDefaults.standard.set(data, forKey: Self.syncTokenKey)
+        }
+    }
+
+    private func saveLocalUpdatedAt(_ date: Date, identifier: String) async {
+        try? await secureStorage.storeSecret(
+            String(date.timeIntervalSince1970),
+            identifier: Self.localUpdatedPrefix + identifier
+        )
+    }
+
+    private func loadLocalUpdatedAt(identifier: String) async -> Date? {
+        guard let value = try? await secureStorage.secret(identifier: Self.localUpdatedPrefix + identifier),
+              let timestamp = TimeInterval(value) else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: timestamp)
+    }
+
+    private func randomData(byteCount: Int) -> Data {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes)
+    }
+
+    private func identifierFromRecordName(_ recordName: String) -> String? {
+        guard recordName.hasPrefix("secret-") else { return nil }
+        var encoded = String(recordName.dropFirst("secret-".count))
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while encoded.count % 4 != 0 { encoded.append("=") }
+        guard let data = Data(base64Encoded: encoded) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -75,6 +75,8 @@ public enum CloudKitKeySyncError: LocalizedError, Equatable {
     case incorrectPassphrase
     case encryptionFailed
     case malformedRecord
+    case passphraseTooShort(minimumLength: Int)
+    case randomGenerationFailed
 
     public var errorDescription: String? {
         switch self {
@@ -88,6 +90,10 @@ public enum CloudKitKeySyncError: LocalizedError, Equatable {
             return "Failed to encrypt or decrypt the API key."
         case .malformedRecord:
             return "CloudKit returned an invalid encrypted key record."
+        case .passphraseTooShort(let minimumLength):
+            return "Use an API-key sync passphrase with at least \(minimumLength) characters."
+        case .randomGenerationFailed:
+            return "Failed to generate secure random bytes for API-key sync."
         }
     }
 }
@@ -95,20 +101,62 @@ public enum CloudKitKeySyncError: LocalizedError, Equatable {
 public enum EncryptedSecretCrypto {
     private static let info = Data("justspeaktoit.api-key-sync.v1".utf8)
     private static let verifierPlaintext = Data("justspeaktoit.api-key-sync.verifier.v1".utf8)
+    private static let keyByteCount = 32
+    private static let pbkdf2Iterations = 210_000
+    public static let minimumPassphraseLength = 12
 
     /// Derives the local encryption key from a user-owned passphrase and a CloudKit-stored salt.
     /// The passphrase is never sent to CloudKit. CloudKit stores only the random salt and an
     /// AES-GCM verification token, so iCloud private-database access alone cannot read API keys.
     /// A device joins sync by entering the passphrase once; the derived key is then kept only in
     /// that device's Keychain via SecureStorage, not in CloudKit.
+    public static func validatePassphrase(_ passphrase: String) throws {
+        guard passphrase.count >= minimumPassphraseLength else {
+            throw CloudKitKeySyncError.passphraseTooShort(minimumLength: minimumPassphraseLength)
+        }
+    }
+
     public static func deriveKey(passphrase: String, salt: Data) -> SymmetricKey {
-        let inputKeyMaterial = SymmetricKey(data: Data(passphrase.utf8))
-        return HKDF<SHA256>.deriveKey(
-            inputKeyMaterial: inputKeyMaterial,
-            salt: salt,
-            info: info,
-            outputByteCount: 32
+        let derived = pbkdf2SHA256(
+            password: Data(passphrase.utf8),
+            salt: salt + info,
+            iterations: pbkdf2Iterations,
+            keyByteCount: keyByteCount
         )
+        return SymmetricKey(data: derived)
+    }
+
+    private static func pbkdf2SHA256(
+        password: Data,
+        salt: Data,
+        iterations: Int,
+        keyByteCount: Int
+    ) -> Data {
+        let hmacKey = SymmetricKey(data: password)
+        let blockCount = Int(ceil(Double(keyByteCount) / Double(SHA256.byteCount)))
+        var derived = Data()
+
+        for blockIndex in 1...blockCount {
+            var blockSalt = salt
+            var bigEndianIndex = UInt32(blockIndex).bigEndian
+            withUnsafeBytes(of: &bigEndianIndex) { blockSalt.append(contentsOf: $0) }
+
+            var iterationOutput = Data(HMAC<SHA256>.authenticationCode(for: blockSalt, using: hmacKey))
+            var block = iterationOutput
+
+            if iterations > 1 {
+                for _ in 2...iterations {
+                    iterationOutput = Data(HMAC<SHA256>.authenticationCode(for: iterationOutput, using: hmacKey))
+                    for index in block.indices {
+                        block[index] ^= iterationOutput[index]
+                    }
+                }
+            }
+
+            derived.append(block)
+        }
+
+        return Data(derived.prefix(keyByteCount))
     }
 
     public static func encryptSecret(
@@ -287,6 +335,36 @@ private struct KeySyncFetchResult {
     var serverChangeToken: CKServerChangeToken?
 }
 
+private final class KeySyncFetchAccumulator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var records: [CKRecord] = []
+    private var deletedIDs: [CKRecord.ID] = []
+    private var serverChangeToken: CKServerChangeToken?
+
+    func append(record: CKRecord) {
+        lock.withLock { records.append(record) }
+    }
+
+    func appendDeletedID(_ recordID: CKRecord.ID) {
+        lock.withLock { deletedIDs.append(recordID) }
+    }
+
+    func updateToken(_ token: CKServerChangeToken?) {
+        guard let token else { return }
+        lock.withLock { serverChangeToken = token }
+    }
+
+    func result() -> KeySyncFetchResult {
+        lock.withLock {
+            KeySyncFetchResult(
+                records: records,
+                deletedIDs: deletedIDs,
+                serverChangeToken: serverChangeToken
+            )
+        }
+    }
+}
+
 @MainActor
 // swiftlint:disable:next type_body_length
 public final class CloudKitKeySync: ObservableObject {
@@ -321,6 +399,7 @@ public final class CloudKitKeySync: ObservableObject {
     private var observer: NSObjectProtocol?
     private var applyingRemoteIdentifiers = Set<String>()
     private var pendingLocalUploadDates: [String: Date] = [:]
+    private var pendingLocalDeletions: [String: Bool] = [:]
     private var localUploadTasks: [String: Task<Void, Never>] = [:]
 
     private init(secureStorage: SecureStorage = SecureStorage()) {
@@ -355,6 +434,7 @@ public final class CloudKitKeySync: ObservableObject {
     public func enable(passphrase: String) async throws {
         let trimmed = passphrase.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { throw CloudKitKeySyncError.missingPassphrase }
+        try EncryptedSecretCrypto.validatePassphrase(trimmed)
         guard await isAvailable(), let database = SyncConfiguration.privateDatabase else {
             throw CloudKitKeySyncError.cloudUnavailable
         }
@@ -378,6 +458,7 @@ public final class CloudKitKeySync: ObservableObject {
         localUploadTasks.values.forEach { $0.cancel() }
         localUploadTasks.removeAll()
         pendingLocalUploadDates.removeAll()
+        pendingLocalDeletions.removeAll()
         symmetricKey = nil
         status.isEnabled = false
         status.lastErrorDescription = nil
@@ -430,13 +511,20 @@ public final class CloudKitKeySync: ObservableObject {
                 }
                 let updatedAt = notification
                     .userInfo?[SecureStorage.NotificationUserInfoKey.updatedAt] as? Date ?? Date()
-                self.scheduleLocalUpload(identifier: identifier, updatedAt: updatedAt)
+                let operation = notification
+                    .userInfo?[SecureStorage.NotificationUserInfoKey.operation] as? String
+                self.scheduleLocalUpload(
+                    identifier: identifier,
+                    updatedAt: updatedAt,
+                    isDeletion: operation == "remove"
+                )
             }
         }
     }
 
-    private func scheduleLocalUpload(identifier: String, updatedAt: Date) {
+    private func scheduleLocalUpload(identifier: String, updatedAt: Date, isDeletion: Bool) {
         pendingLocalUploadDates[identifier] = updatedAt
+        pendingLocalDeletions[identifier] = isDeletion
 
         guard localUploadTasks[identifier] == nil else { return }
 
@@ -461,18 +549,20 @@ public final class CloudKitKeySync: ObservableObject {
                       self.status.isEnabled,
                       let key = self.symmetricKey,
                       let database = SyncConfiguration.privateDatabase else {
+                    self.pendingLocalDeletions.removeValue(forKey: identifier)
                     return
                 }
-
-                await self.saveLocalUpdatedAt(updatedAt, identifier: identifier)
+                let isDeletion = self.pendingLocalDeletions.removeValue(forKey: identifier) ?? false
 
                 do {
                     try await self.uploadSecret(
                         identifier: identifier,
                         updatedAt: updatedAt,
                         database: database,
-                        key: key
+                        key: key,
+                        isDeletion: isDeletion
                     )
+                    await self.saveLocalUpdatedAt(updatedAt, identifier: identifier)
                 } catch {
                     self.log.error("Debounced key upload failed for \(identifier): \(error.localizedDescription)")
                 }
@@ -535,7 +625,7 @@ public final class CloudKitKeySync: ObservableObject {
             return key
         }
 
-        let salt = randomData(byteCount: 32)
+        let salt = try randomData(byteCount: 32)
         let key = EncryptedSecretCrypto.deriveKey(passphrase: passphrase, salt: salt)
         let token = try EncryptedSecretCrypto.makeVerificationToken(key: key)
         let metadata = KeySyncMetadata(
@@ -610,8 +700,18 @@ public final class CloudKitKeySync: ObservableObject {
             .prefix(SyncConfiguration.batchSize)
         for identifier in identifiers {
             let updatedAt = await loadLocalUpdatedAt(identifier: identifier) ?? Date()
-            try await uploadSecret(identifier: identifier, updatedAt: updatedAt, database: database, key: key)
-            await saveLocalUpdatedAt(updatedAt, identifier: identifier)
+            do {
+                try await uploadSecret(
+                    identifier: identifier,
+                    updatedAt: updatedAt,
+                    database: database,
+                    key: key,
+                    isDeletion: false
+                )
+                await saveLocalUpdatedAt(updatedAt, identifier: identifier)
+            } catch {
+                log.error("Skipping local encrypted secret upload \(identifier): \(error.localizedDescription)")
+            }
         }
     }
 
@@ -619,10 +719,21 @@ public final class CloudKitKeySync: ObservableObject {
         identifier: String,
         updatedAt: Date,
         database: CKDatabase,
-        key: SymmetricKey
+        key: SymmetricKey,
+        isDeletion: Bool
     ) async throws {
-        let value = (try? await secureStorage.secret(identifier: identifier)) ?? ""
-        let isDeleted = value.isEmpty
+        let value: String
+        if isDeletion {
+            value = ""
+        } else {
+            do {
+                value = try await secureStorage.secret(identifier: identifier)
+            } catch SecureStorageError.valueNotFound {
+                log.warning("Skipping missing local encrypted secret \(identifier)")
+                return
+            }
+        }
+        let isDeleted = isDeletion
         let secret = try EncryptedSecretCrypto.encryptSecret(
             identifier: identifier,
             value: value,
@@ -650,24 +761,22 @@ public final class CloudKitKeySync: ObservableObject {
             configurationsByRecordZoneID: [SyncConfiguration.zoneID: config]
         )
 
-        var records: [CKRecord] = []
-        var deletedIDs: [CKRecord.ID] = []
-        var newToken: CKServerChangeToken?
+        let accumulator = KeySyncFetchAccumulator()
 
         operation.recordWasChangedBlock = { _, result in
             if case .success(let record) = result {
-                records.append(record)
+                accumulator.append(record: record)
             }
         }
         operation.recordWithIDWasDeletedBlock = { recordID, _ in
-            deletedIDs.append(recordID)
+            accumulator.appendDeletedID(recordID)
         }
         operation.recordZoneChangeTokensUpdatedBlock = { _, token, _ in
-            newToken = token
+            accumulator.updateToken(token)
         }
         operation.recordZoneFetchResultBlock = { _, result in
             if case .success(let (token, _, _)) = result {
-                newToken = token
+                accumulator.updateToken(token)
             }
         }
 
@@ -683,7 +792,7 @@ public final class CloudKitKeySync: ObservableObject {
             database.add(operation)
         }
 
-        return KeySyncFetchResult(records: records, deletedIDs: deletedIDs, serverChangeToken: newToken)
+        return accumulator.result()
     }
 
     private func fetchRecord(id: CKRecord.ID, database: CKDatabase) async throws -> CKRecord? {
@@ -720,9 +829,12 @@ public final class CloudKitKeySync: ObservableObject {
         return Date(timeIntervalSince1970: timestamp)
     }
 
-    private func randomData(byteCount: Int) -> Data {
+    private func randomData(byteCount: Int) throws -> Data {
         var bytes = [UInt8](repeating: 0, count: byteCount)
-        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw CloudKitKeySyncError.randomGenerationFailed
+        }
         return Data(bytes)
     }
 

--- a/Sources/SpeakSync/SyncConfiguration.swift
+++ b/Sources/SpeakSync/SyncConfiguration.swift
@@ -40,8 +40,7 @@ public enum SyncConfiguration {
 
     /// Whether this app build has CloudKit entitlements.
     /// Developer ID Sparkle builds may omit CloudKit entitlements.
-    /// iOS builds currently ship without iCloud entitlements until
-    /// the provisioning profile is configured with the correct container.
+    /// iOS builds declare CloudKit entitlements in SpeakiOS.entitlements.
     static var hasCloudKitEntitlement: Bool {
 #if os(macOS)
         guard let task = SecTaskCreateFromSelf(nil) else {
@@ -63,7 +62,7 @@ public enum SyncConfiguration {
         let hasContainerIdentifier = containers?.contains(containerIdentifier) == true
         return hasCloudKitService && hasContainerIdentifier
 #else
-        return false
+        return true
 #endif
     }
 

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -149,13 +149,13 @@ public final class AppSettings: ObservableObject {
 
     private static let logger = Logger(subsystem: "com.justspeaktoit.ios", category: "AppSettings")
     private var keyChangeObserver: NSObjectProtocol?
-    private var isApplyingSyncedKeys = false
+    private var syncedKeyReloadDepth = 0
 
     /// Persists (or clears when empty) an API key on the canonical secure store.
     /// Keychain failures are logged rather than silently dropped so a key that
     /// appears saved but didn't persist is diagnosable from logs.
     private func persistSecret(_ value: String, identifier: String) {
-        guard !isApplyingSyncedKeys else { return }
+        guard syncedKeyReloadDepth == 0 else { return }
         Task {
             do {
                 if value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -342,8 +342,8 @@ public final class AppSettings: ObservableObject {
     public var hasGladiaKey: Bool { !gladiaAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
 
     public func reloadSyncedAPIKeys() async {
-        isApplyingSyncedKeys = true
-        defer { isApplyingSyncedKeys = false }
+        syncedKeyReloadDepth += 1
+        defer { syncedKeyReloadDepth -= 1 }
         deepgramAPIKey = await Self.syncedAPIKeyValue(
             identifier: Self.deepgramKeyID,
             currentValue: deepgramAPIKey

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -138,7 +138,7 @@ public final class AppSettings: ObservableObject {
     /// runtime probe confirms the entitlement is present.
     private static let sharedAccessGroup = "8X4ZN58TYH.com.justspeaktoit.shared"
 
-    private static let credentialStorage = SecureStorage(
+    static let credentialStorage = SecureStorage(
         configuration: .iCloudSyncedIfAvailable(
             service: "com.justspeaktoit.credentials",
             masterAccount: "speak-app-secrets",
@@ -147,11 +147,14 @@ public final class AppSettings: ObservableObject {
     )
 
     private static let logger = Logger(subsystem: "com.justspeaktoit.ios", category: "AppSettings")
+    private var keyChangeObserver: NSObjectProtocol?
+    private var isApplyingSyncedKeys = false
 
     /// Persists (or clears when empty) an API key on the canonical secure store.
     /// Keychain failures are logged rather than silently dropped so a key that
     /// appears saved but didn't persist is diagnosable from logs.
     private func persistSecret(_ value: String, identifier: String) {
+        guard !isApplyingSyncedKeys else { return }
         Task {
             do {
                 if value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -290,17 +293,15 @@ public final class AppSettings: ObservableObject {
         Task { @MainActor [weak self] in
             guard let self else { return }
             await Self.migrateLegacyKeysIfNeeded()
-            self.deepgramAPIKey = (try? await Self.credentialStorage.secret(identifier: Self.deepgramKeyID)) ?? ""
-            self.openRouterAPIKey = (try? await Self.credentialStorage.secret(identifier: Self.openRouterKeyID)) ?? ""
-            self.openAIAPIKey = (try? await Self.credentialStorage.secret(identifier: Self.openAIKeyID)) ?? ""
-            self.elevenLabsAPIKey = (try? await Self.credentialStorage.secret(identifier: Self.elevenLabsKeyID)) ?? ""
-            self.cartesiaAPIKey = (try? await Self.credentialStorage.secret(identifier: Self.cartesiaKeyID)) ?? ""
-            self.sonioxAPIKey = (try? await Self.credentialStorage.secret(identifier: Self.sonioxKeyID)) ?? ""
-            self.modulateAPIKey = (try? await Self.credentialStorage.secret(identifier: Self.modulateKeyID)) ?? ""
-            self.assemblyAIAPIKey =
-                (try? await Self.credentialStorage.secret(identifier: Self.assemblyAIKeyID)) ?? ""
-            self.gladiaAPIKey = (try? await Self.credentialStorage.secret(identifier: Self.gladiaKeyID)) ?? ""
+            await self.reloadSyncedAPIKeys()
+            self.observeSecureStorageChanges()
             self.configureDefaultProviderIfNeeded()
+        }
+    }
+
+    deinit {
+        if let keyChangeObserver {
+            NotificationCenter.default.removeObserver(keyChangeObserver)
         }
     }
 
@@ -339,6 +340,48 @@ public final class AppSettings: ObservableObject {
     public var hasModulateKey: Bool { !modulateAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     public var hasAssemblyAIKey: Bool { !assemblyAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     public var hasGladiaKey: Bool { !gladiaAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    public func reloadSyncedAPIKeys() async {
+        let values = await Self.syncedAPIKeyValues()
+        isApplyingSyncedKeys = true
+        defer { isApplyingSyncedKeys = false }
+        deepgramAPIKey = values[Self.deepgramKeyID] ?? deepgramAPIKey
+        openRouterAPIKey = values[Self.openRouterKeyID] ?? openRouterAPIKey
+        openAIAPIKey = values[Self.openAIKeyID] ?? openAIAPIKey
+        elevenLabsAPIKey = values[Self.elevenLabsKeyID] ?? elevenLabsAPIKey
+        cartesiaAPIKey = values[Self.cartesiaKeyID] ?? cartesiaAPIKey
+        sonioxAPIKey = values[Self.sonioxKeyID] ?? sonioxAPIKey
+        modulateAPIKey = values[Self.modulateKeyID] ?? modulateAPIKey
+        assemblyAIAPIKey = values[Self.assemblyAIKeyID] ?? assemblyAIAPIKey
+        gladiaAPIKey = values[Self.gladiaKeyID] ?? gladiaAPIKey
+    }
+
+    private static func syncedAPIKeyValues() async -> [String: String] {
+        var values: [String: String] = [:]
+        for identifier in CloudKitKeySync.syncableIdentifiers {
+            if let value = try? await credentialStorage.secret(identifier: identifier) {
+                values[identifier] = value
+            }
+        }
+        return values
+    }
+
+    private func observeSecureStorageChanges() {
+        guard keyChangeObserver == nil else { return }
+        keyChangeObserver = NotificationCenter.default.addObserver(
+            forName: SecureStorage.didChangeSecretNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let identifier = notification.userInfo?[SecureStorage.NotificationUserInfoKey.identifier] as? String,
+                  CloudKitKeySync.syncableIdentifiers.contains(identifier) else {
+                return
+            }
+            Task { @MainActor [weak self] in
+                await self?.reloadSyncedAPIKeys()
+            }
+        }
+    }
 
     /// Returns the stored API key for a resolved live-transcription route, used
     /// by the generic shared-client recording path.
@@ -591,6 +634,8 @@ public struct SettingsView: View {
             Section("Sync") {
                 // CloudKit History Sync
                 CloudKitSyncSettingsSection()
+
+                CloudKitKeySyncSettingsSection(settings: settings)
 
                 // Sync status
                 let syncStatus = SyncStatus.current()
@@ -1524,6 +1569,66 @@ struct CloudKitSyncSettingsSection: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+        }
+    }
+}
+
+
+struct CloudKitKeySyncSettingsSection: View {
+    @ObservedObject private var keySync = CloudKitKeySync.shared
+    @ObservedObject var settings: AppSettings
+    @State private var passphrase = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label("Encrypted API-Key Sync", systemImage: "lock.icloud")
+                Spacer()
+                Text(keySync.status.message)
+                    .foregroundStyle(keySync.status.isEnabled ? .green : .secondary)
+            }
+            .accessibilityElement(children: .combine)
+
+            if !keySync.status.isEnabled {
+                SecureField("Sync passphrase", text: $passphrase)
+                    .textContentType(.password)
+                    .autocorrectionDisabled()
+
+                Button {
+                    Task {
+                        try? await keySync.enable(passphrase: passphrase)
+                        await settings.reloadSyncedAPIKeys()
+                        passphrase = ""
+                    }
+                } label: {
+                    Label("Enable API-Key Sync", systemImage: "lock.open")
+                }
+                .disabled(passphrase.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            } else {
+                HStack {
+                    Button {
+                        Task {
+                            try? await keySync.syncNow()
+                            await settings.reloadSyncedAPIKeys()
+                        }
+                    } label: {
+                        Label("Sync Keys Now", systemImage: "arrow.triangle.2.circlepath")
+                    }
+                    .disabled(keySync.status.isSyncing)
+
+                    Button("Disable", role: .destructive) {
+                        Task { await keySync.disable() }
+                    }
+                }
+            }
+
+            Text("Keys are encrypted on this device before they are written to your private CloudKit database.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .task {
+            await keySync.configure(secureStorage: AppSettings.credentialStorage)
+            _ = await keySync.isAvailable()
         }
     }
 }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -139,7 +139,7 @@ public final class AppSettings: ObservableObject {
     /// runtime probe confirms the entitlement is present.
     private static let sharedAccessGroup = "8X4ZN58TYH.com.justspeaktoit.shared"
 
-    static let credentialStorage = SecureStorage(
+    private static let credentialStorage = SecureStorage(
         configuration: .iCloudSyncedIfAvailable(
             service: "com.justspeaktoit.credentials",
             masterAccount: "speak-app-secrets",
@@ -380,6 +380,22 @@ public final class AppSettings: ObservableObject {
             identifier: Self.gladiaKeyID,
             currentValue: gladiaAPIKey
         )
+    }
+
+    @discardableResult
+    public func syncCloudKitKeys() async -> Bool {
+        let keySync = CloudKitKeySync.shared
+        await keySync.configure(secureStorage: Self.credentialStorage)
+        guard await keySync.isAvailable() else { return false }
+
+        do {
+            try await keySync.syncNow()
+            await reloadSyncedAPIKeys()
+            return true
+        } catch {
+            Self.logger.error("CloudKit API-key sync failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
     }
 
     private static func syncedAPIKeyValue(identifier: String, currentValue: String) async -> String {
@@ -1737,8 +1753,7 @@ struct CloudKitKeySyncSettingsSection: View {
                 .foregroundStyle(.secondary)
         }
         .task {
-            await keySync.configure(secureStorage: AppSettings.credentialStorage)
-            _ = await keySync.isAvailable()
+            _ = await AppSettings.shared.syncCloudKitKeys()
         }
     }
 }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -694,7 +694,7 @@ public struct SettingsView: View {
                 // CloudKit History Sync
                 CloudKitSyncSettingsSection()
 
-                CloudKitKeySyncSettingsSection(settings: settings)
+                CloudKitKeySyncSettingsSection()
 
                 // Sync status
                 let syncStatus = SyncStatus.current()
@@ -1636,7 +1636,6 @@ struct CloudKitSyncSettingsSection: View {
 
 struct CloudKitKeySyncSettingsSection: View {
     @ObservedObject private var keySync = CloudKitKeySync.shared
-    @ObservedObject var settings: AppSettings
     @State private var passphrase = ""
     @State private var syncError: String?
 
@@ -1660,7 +1659,7 @@ struct CloudKitKeySyncSettingsSection: View {
                     Task {
                         do {
                             try await keySync.enable(passphrase: passphrase)
-                            await settings.reloadSyncedAPIKeys()
+                            await AppSettings.shared.reloadSyncedAPIKeys()
                             passphrase = ""
                             syncError = nil
                         } catch {
@@ -1677,7 +1676,7 @@ struct CloudKitKeySyncSettingsSection: View {
                         Task {
                             do {
                                 try await keySync.syncNow()
-                                await settings.reloadSyncedAPIKeys()
+                                await AppSettings.shared.reloadSyncedAPIKeys()
                                 syncError = nil
                             } catch {
                                 syncError = error.localizedDescription

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -67,6 +67,7 @@ public enum HardwareTriggerDestination: String, CaseIterable, Identifiable, Send
 /// Simple UserDefaults-based settings for iOS app.
 @MainActor
 public final class AppSettings: ObservableObject {
+    // swiftlint:disable:previous type_body_length
     public static let shared = AppSettings()
 
     @Published public var selectedModel: String {
@@ -228,7 +229,6 @@ public final class AppSettings: ObservableObject {
         PostProcessingModelInfo(id: "anthropic/claude-sonnet-4", name: "Claude Sonnet", description: "Best structure preservation"),
     ]
 
-    // swiftlint:disable:next function_body_length
     private init() {
         let selectedRaw = UserDefaults.standard.string(forKey: "selectedModel") ?? "apple/local/SFSpeechRecognizer"
         // Normalise to canonical catalogue ids. Keep any id already in the
@@ -1572,7 +1572,6 @@ struct CloudKitSyncSettingsSection: View {
         }
     }
 }
-
 
 struct CloudKitKeySyncSettingsSection: View {
     @ObservedObject private var keySync = CloudKitKeySync.shared

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -342,28 +342,54 @@ public final class AppSettings: ObservableObject {
     public var hasGladiaKey: Bool { !gladiaAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
 
     public func reloadSyncedAPIKeys() async {
-        let values = await Self.syncedAPIKeyValues()
         isApplyingSyncedKeys = true
         defer { isApplyingSyncedKeys = false }
-        deepgramAPIKey = values[Self.deepgramKeyID] ?? deepgramAPIKey
-        openRouterAPIKey = values[Self.openRouterKeyID] ?? openRouterAPIKey
-        openAIAPIKey = values[Self.openAIKeyID] ?? openAIAPIKey
-        elevenLabsAPIKey = values[Self.elevenLabsKeyID] ?? elevenLabsAPIKey
-        cartesiaAPIKey = values[Self.cartesiaKeyID] ?? cartesiaAPIKey
-        sonioxAPIKey = values[Self.sonioxKeyID] ?? sonioxAPIKey
-        modulateAPIKey = values[Self.modulateKeyID] ?? modulateAPIKey
-        assemblyAIAPIKey = values[Self.assemblyAIKeyID] ?? assemblyAIAPIKey
-        gladiaAPIKey = values[Self.gladiaKeyID] ?? gladiaAPIKey
+        deepgramAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.deepgramKeyID,
+            currentValue: deepgramAPIKey
+        )
+        openRouterAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.openRouterKeyID,
+            currentValue: openRouterAPIKey
+        )
+        openAIAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.openAIKeyID,
+            currentValue: openAIAPIKey
+        )
+        elevenLabsAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.elevenLabsKeyID,
+            currentValue: elevenLabsAPIKey
+        )
+        cartesiaAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.cartesiaKeyID,
+            currentValue: cartesiaAPIKey
+        )
+        sonioxAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.sonioxKeyID,
+            currentValue: sonioxAPIKey
+        )
+        modulateAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.modulateKeyID,
+            currentValue: modulateAPIKey
+        )
+        assemblyAIAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.assemblyAIKeyID,
+            currentValue: assemblyAIAPIKey
+        )
+        gladiaAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.gladiaKeyID,
+            currentValue: gladiaAPIKey
+        )
     }
 
-    private static func syncedAPIKeyValues() async -> [String: String] {
-        var values: [String: String] = [:]
-        for identifier in CloudKitKeySync.syncableIdentifiers {
-            if let value = try? await credentialStorage.secret(identifier: identifier) {
-                values[identifier] = value
-            }
+    private static func syncedAPIKeyValue(identifier: String, currentValue: String) async -> String {
+        do {
+            return try await credentialStorage.secret(identifier: identifier)
+        } catch SecureStorageError.valueNotFound {
+            return ""
+        } catch {
+            return currentValue
         }
-        return values
     }
 
     private func observeSecureStorageChanges() {
@@ -1577,6 +1603,7 @@ struct CloudKitKeySyncSettingsSection: View {
     @ObservedObject private var keySync = CloudKitKeySync.shared
     @ObservedObject var settings: AppSettings
     @State private var passphrase = ""
+    @State private var syncError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -1592,12 +1619,18 @@ struct CloudKitKeySyncSettingsSection: View {
                 SecureField("Sync passphrase", text: $passphrase)
                     .textContentType(.password)
                     .autocorrectionDisabled()
+                    .privacySensitive()
 
                 Button {
                     Task {
-                        try? await keySync.enable(passphrase: passphrase)
-                        await settings.reloadSyncedAPIKeys()
-                        passphrase = ""
+                        do {
+                            try await keySync.enable(passphrase: passphrase)
+                            await settings.reloadSyncedAPIKeys()
+                            passphrase = ""
+                            syncError = nil
+                        } catch {
+                            syncError = error.localizedDescription
+                        }
                     }
                 } label: {
                     Label("Enable API-Key Sync", systemImage: "lock.open")
@@ -1607,8 +1640,13 @@ struct CloudKitKeySyncSettingsSection: View {
                 HStack {
                     Button {
                         Task {
-                            try? await keySync.syncNow()
-                            await settings.reloadSyncedAPIKeys()
+                            do {
+                                try await keySync.syncNow()
+                                await settings.reloadSyncedAPIKeys()
+                                syncError = nil
+                            } catch {
+                                syncError = error.localizedDescription
+                            }
                         }
                     } label: {
                         Label("Sync Keys Now", systemImage: "arrow.triangle.2.circlepath")
@@ -1619,6 +1657,12 @@ struct CloudKitKeySyncSettingsSection: View {
                         Task { await keySync.disable() }
                     }
                 }
+            }
+
+            if let syncError {
+                Text(syncError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
             }
 
             Text("Keys are encrypted on this device before they are written to your private CloudKit database.")

--- a/SpeakiOS.entitlements
+++ b/SpeakiOS.entitlements
@@ -19,5 +19,15 @@
          "development" only for local Xcode-signed development builds. -->
     <key>aps-environment</key>
     <string>production</string>
+
+    <!-- CloudKit private database: history sync and encrypted API-key sync -->
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array>
+        <string>iCloud.com.justspeaktoit.ios</string>
+    </array>
+    <key>com.apple.developer.icloud-services</key>
+    <array>
+        <string>CloudKit</string>
+    </array>
 </dict>
 </plist>

--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -8,10 +8,25 @@ final class SpeakiOSAppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
+        application.registerForRemoteNotifications()
+        Task { @MainActor in
+            _ = await AppSettings.shared.syncCloudKitKeys()
+        }
         if let shortcutItem = launchOptions?[.shortcutItem] as? UIApplicationShortcutItem {
             return !handleQuickAction(shortcutItem, application: application)
         }
         return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        Task { @MainActor in
+            let synced = await AppSettings.shared.syncCloudKitKeys()
+            completionHandler(synced ? .newData : .noData)
+        }
     }
 
     func application(

--- a/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
+++ b/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
@@ -85,4 +85,18 @@ final class CloudKitKeySyncTests: XCTestCase {
 
         XCTAssertEqual(decoded, mutation)
     }
+
+    func testPBKDF2SHA256_MatchesIndependentKnownAnswerVector() {
+        let derived = EncryptedSecretCrypto.pbkdf2SHA256(
+            password: Data("password".utf8),
+            salt: Data("salt".utf8),
+            iterations: 4_096,
+            keyByteCount: 32
+        )
+
+        XCTAssertEqual(
+            derived.map { String(format: "%02x", $0) }.joined(),
+            "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a"
+        )
+    }
 }

--- a/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
+++ b/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
@@ -1,0 +1,57 @@
+import CloudKit
+import CryptoKit
+import XCTest
+@testable import SpeakSync
+
+final class CloudKitKeySyncTests: XCTestCase {
+    func testEncryptDecryptRoundTripWithCorrectPassphrase() throws {
+        let salt = Data("stable-test-salt".utf8)
+        let key = EncryptedSecretCrypto.deriveKey(passphrase: "correct horse battery staple", salt: salt)
+        let updatedAt = Date(timeIntervalSince1970: 1_720_000_000)
+
+        let encrypted = try EncryptedSecretCrypto.encryptSecret(
+            identifier: "openai.apiKey",
+            value: "secret-value",
+            updatedAt: updatedAt,
+            key: key
+        )
+
+        let decrypted = try EncryptedSecretCrypto.decryptSecret(encrypted, key: key)
+        XCTAssertEqual(decrypted, "secret-value")
+        XCTAssertEqual(encrypted.identifier, "openai.apiKey")
+        XCTAssertEqual(encrypted.updatedAt, updatedAt)
+    }
+
+    func testDecryptFailsWithIncorrectPassphrase() throws {
+        let salt = Data("stable-test-salt".utf8)
+        let correctKey = EncryptedSecretCrypto.deriveKey(passphrase: "correct", salt: salt)
+        let wrongKey = EncryptedSecretCrypto.deriveKey(passphrase: "incorrect", salt: salt)
+        let encrypted = try EncryptedSecretCrypto.encryptSecret(
+            identifier: "deepgram.apiKey",
+            value: "secret-value",
+            updatedAt: Date(),
+            key: correctKey
+        )
+
+        XCTAssertThrowsError(try EncryptedSecretCrypto.decryptSecret(encrypted, key: wrongKey))
+    }
+
+    func testEncryptedSecretRecordRoundTrip() {
+        let updatedAt = Date(timeIntervalSince1970: 1_720_000_001)
+        let secret = EncryptedSecret(
+            identifier: "assemblyai.apiKey",
+            ciphertext: Data([1, 2, 3]),
+            nonce: Data([4, 5, 6]),
+            tag: Data([7, 8, 9]),
+            updatedAt: updatedAt,
+            isDeleted: true
+        )
+
+        let record = EncryptedSecretRecordMapper.record(from: secret)
+        let mapped = EncryptedSecretRecordMapper.secret(from: record)
+
+        XCTAssertEqual(record.recordType, EncryptedSecretRecordMapper.recordType)
+        XCTAssertEqual(record.recordID.recordName, EncryptedSecretRecordMapper.recordName(for: secret.identifier))
+        XCTAssertEqual(mapped, secret)
+    }
+}

--- a/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
+++ b/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
@@ -54,4 +54,35 @@ final class CloudKitKeySyncTests: XCTestCase {
         XCTAssertEqual(record.recordID.recordName, EncryptedSecretRecordMapper.recordName(for: secret.identifier))
         XCTAssertEqual(mapped, secret)
     }
+
+    func testDeriveKeyOffMainActor_MatchesSynchronousDerivation() async {
+        let salt = Data("stable-test-salt".utf8)
+        let expected = EncryptedSecretCrypto.deriveKey(
+            passphrase: "correct horse battery staple",
+            salt: salt
+        )
+        let actual = await EncryptedSecretCrypto.deriveKeyOffMainActor(
+            passphrase: "correct horse battery staple",
+            salt: salt
+        )
+
+        XCTAssertEqual(
+            expected.withUnsafeBytes { Data($0) },
+            actual.withUnsafeBytes { Data($0) }
+        )
+    }
+
+    func testPendingMutation_CodableRoundTripsDeletion() throws {
+        let mutation = PendingKeySyncMutation(
+            operationID: UUID(uuidString: "E30F13E5-8DAB-4D46-8BD1-5566B3D72893")!,
+            identifier: "openai.apiKey",
+            updatedAt: Date(timeIntervalSince1970: 1_720_000_002),
+            kind: .deletion
+        )
+
+        let encoded = try JSONEncoder().encode(mutation)
+        let decoded = try JSONDecoder().decode(PendingKeySyncMutation.self, from: encoded)
+
+        XCTAssertEqual(decoded, mutation)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds opt-in, client-side encrypted API-key sync through each platform's CloudKit private database.
- Encrypts every supported secret with AES-GCM using a key derived from a user passphrase via PBKDF2-HMAC-SHA256 (210,000 iterations) and a random CloudKit-stored salt.
- Stores the derived key only in a separate device-local Keychain item; CloudKit receives only ciphertext, nonces, tags, timestamps, tombstones, salt, and an encrypted verification token.
- Starts sync at app launch, observes local SecureStorage changes, handles CloudKit pushes, and exposes enable/disable/manual-sync controls on macOS and iOS.

## Reliability and data integrity
- Journals local updates and deletions durably before upload, coalesces rapid edits, and retries failures with bounded exponential backoff.
- Uploads only journaled mutations and compares the latest server timestamp before saving, preventing a stale device from overwriting a newer remote secret.
- Applies remote changes before committing the server change token; failed decryptions or Keychain writes are retried instead of silently skipped.
- Recovers from expired CloudKit change tokens with one tokenless full-zone retry.
- Scopes derived keys, tokens, infrastructure flags, timestamps, and journals to the current iCloud account; account changes cancel in-flight work and require re-enabling with the passphrase.
- Serialises enable/disable/account-reset transitions and generation-guards network work so cancelled syncs cannot mutate state after teardown.
- Keeps internal key-sync metadata in a separate Keychain service so it cannot pollute the app's tracked API-key registry.

## Entitlements and graceful degradation
- iOS declares the existing `iCloud.com.justspeaktoit.ios` CloudKit container and registers for remote notifications.
- Mac App Store builds use the managed `iCloud.com.justspeaktoit` container and register for CloudKit pushes.
- Developer ID macOS builds remain safe without CloudKit entitlements: availability checks leave encrypted key sync off while local Keychain storage continues normally.

## Verification
- Full Swift test suite: 568 passed, 11 skipped, 0 failures.
- SwiftLint plugin with the repository baseline: 0 violations.
- Full generated Tuist iOS app build for a generic iOS Simulator destination: passed.
- SwiftPM macOS App Store compilation variant (`APP_STORE`): passed.
- Focused encryption, wrong-passphrase, record mapping, detached derivation, and durable mutation coding tests: passed.

## On-device checklist
- Enable with the same passphrase on two devices using the same platform CloudKit container.
- Add, update, and delete each supported API key; verify propagation after debounce and after relaunch.
- Enter a wrong passphrase on the second device and confirm the key set is not changed.
- Disable during sync and switch iCloud accounts; verify no old-account key or pending mutation is applied.
- Confirm Developer ID macOS reports CloudKit unavailable without affecting local API keys.
