### PR TITLE
fix(ios): recover recording when audio session is rejected in background

### DIFF
--- a/Sources/SpeakCore/StreamingTranscriptionClient.swift
+++ b/Sources/SpeakCore/StreamingTranscriptionClient.swift
@@ -86,6 +86,22 @@ public enum LiveTranscriptionProviderID: String, Sendable, CaseIterable, Hashabl
             return true
         }
     }
+
+    /// Human-readable provider name, used to group models by provider in the
+    /// model picker so the UI scales cleanly as models are added.
+    public var displayName: String {
+        switch self {
+        case .apple: return "Apple"
+        case .deepgram: return "Deepgram"
+        case .cartesia: return "Cartesia"
+        case .gladia: return "Gladia"
+        case .modulate: return "Modulate"
+        case .assemblyai: return "AssemblyAI"
+        case .soniox: return "Soniox"
+        case .elevenlabs: return "ElevenLabs"
+        case .openai: return "OpenAI"
+        }
+    }
 }
 
 // MARK: - Routing

--- a/Sources/SpeakiOS/Services/AudioSessionDiagnostics.swift
+++ b/Sources/SpeakiOS/Services/AudioSessionDiagnostics.swift
@@ -139,9 +139,16 @@ public struct AudioSessionConfigurationError: LocalizedError {
 /// non-mixable session — most commonly when a recording is triggered from the
 /// background via an `AudioRecordingIntent` (Action Button / Shortcuts / Siri)
 /// while the previous audio owner is still tearing down. Apple's guidance for
-/// this specific error is to retry activation; a short bounded back-off almost
+/// this *transient* case is to retry activation; a short bounded back-off almost
 /// always succeeds on the second attempt. This is the Fallback pattern applied
 /// to a flaky boundary.
+///
+/// When the rejection is *not* transient — i.e. the session is simply not
+/// permitted to interrupt others from the background — retrying the identical
+/// activation can never succeed. `AudioSessionManager` handles that case
+/// separately by re-configuring the session as mixable (`.mixWithOthers`) and
+/// activating once more; `isCannotInterruptOthers` is the shared classifier both
+/// tiers use to recognise the error.
 public enum AudioSessionActivation {
     /// Number of activation attempts before giving up.
     public static let defaultMaxAttempts = 4

--- a/Sources/SpeakiOS/Services/AudioSessionManager.swift
+++ b/Sources/SpeakiOS/Services/AudioSessionManager.swift
@@ -39,18 +39,23 @@ public final class AudioSessionManager: ObservableObject {
 
         do {
             // Preferred: an isolated (non-mixable) measurement session for the
-            // cleanest capture.
+            // cleanest capture. Fail fast (no retry back-off): in the foreground
+            // this succeeds on the first attempt, and when it can't (a background
+            // trigger is *guaranteed* to be refused with cannotInterruptOthers)
+            // there is no point burning the retry budget before falling back to a
+            // mixable session below.
             try configureCategory(on: session, mixWithOthers: false)
-            try await activate(session)
+            try await activate(session, maxAttempts: 1)
         } catch let error as AudioSessionConfigurationError
             where error.operation == .setActive
             && AudioSessionActivation.isCannotInterruptOthers(error.underlying) {
             // A `cannotInterruptOthers` rejection is how the system refuses a
             // *non-mixable* session that tries to go active from the background
-            // (Action Button / Shortcuts / Siri). Retrying the identical
-            // activation cannot clear it, so re-configure as a *mixable* session
-            // and try once more — mixable sessions are allowed to activate from
-            // the background because they don't interrupt other audio.
+            // (Action Button / Shortcuts / Siri). Re-configure as a *mixable*
+            // session and try again — mixable sessions are allowed to activate
+            // from the background because they don't interrupt other audio. Keep
+            // the retry back-off here to ride out a transient owner still tearing
+            // its own session down.
             try configureCategory(on: session, mixWithOthers: true)
             try await activate(session)
         }
@@ -83,10 +88,15 @@ public final class AudioSessionManager: ObservableObject {
     }
 
     /// Activates the session, retrying transient `cannotInterruptOthers` failures
-    /// with a short back-off before surfacing a diagnostic error.
-    private func activate(_ session: AVAudioSession) async throws {
+    /// with a short back-off before surfacing a diagnostic error. `maxAttempts`
+    /// caps the retries: pass `1` to fail fast when a fallback path will handle
+    /// the failure.
+    private func activate(
+        _ session: AVAudioSession,
+        maxAttempts: Int = AudioSessionActivation.defaultMaxAttempts
+    ) async throws {
         do {
-            try await AudioSessionActivation.activate {
+            try await AudioSessionActivation.activate(maxAttempts: maxAttempts) {
                 try session.setActive(true, options: .notifyOthersOnDeactivation)
             }
         } catch {

--- a/Sources/SpeakiOS/Services/AudioSessionManager.swift
+++ b/Sources/SpeakiOS/Services/AudioSessionManager.swift
@@ -38,36 +38,60 @@ public final class AudioSessionManager: ObservableObject {
         let session = AVAudioSession.sharedInstance()
 
         do {
-            // Category: playAndRecord allows simultaneous input/output
-            // Mode: measurement for high-quality audio capture
-            // Options: allowBluetooth for headsets, defaultToSpeaker for better UX
-            try session.setCategory(
-                .playAndRecord,
-                mode: .measurement,
-                options: [.allowBluetooth, .defaultToSpeaker, .allowBluetoothA2DP]
-            )
+            // Preferred: an isolated (non-mixable) measurement session for the
+            // cleanest capture.
+            try configureCategory(on: session, mixWithOthers: false)
+            try await activate(session)
+        } catch let error as AudioSessionConfigurationError
+            where error.operation == .setActive
+            && AudioSessionActivation.isCannotInterruptOthers(error.underlying) {
+            // A `cannotInterruptOthers` rejection is how the system refuses a
+            // *non-mixable* session that tries to go active from the background
+            // (Action Button / Shortcuts / Siri). Retrying the identical
+            // activation cannot clear it, so re-configure as a *mixable* session
+            // and try once more — mixable sessions are allowed to activate from
+            // the background because they don't interrupt other audio.
+            try configureCategory(on: session, mixWithOthers: true)
+            try await activate(session)
+        }
+
+        lastError = nil
+        isConfigured = true
+        updateCurrentRoute()
+
+        let inputRoute = Self.routeDescription(ports: session.currentRoute.inputs)
+        print("[AudioSessionManager] Configured for recording: \(inputRoute)")
+    }
+
+    /// Recording options common to both the isolated and mixable configurations.
+    /// `allowBluetooth` enables headsets, `defaultToSpeaker` improves UX, and the
+    /// A2DP variant keeps high-quality Bluetooth output available.
+    private static let baseRecordingOptions: AVAudioSession.CategoryOptions =
+        [.allowBluetooth, .defaultToSpeaker, .allowBluetoothA2DP]
+
+    /// Applies the `playAndRecord`/`measurement` category, optionally adding
+    /// `mixWithOthers` so the session can activate from the background without
+    /// interrupting other audio.
+    private func configureCategory(on session: AVAudioSession, mixWithOthers: Bool) throws {
+        var options = Self.baseRecordingOptions
+        if mixWithOthers { options.insert(.mixWithOthers) }
+        do {
+            try session.setCategory(.playAndRecord, mode: .measurement, options: options)
         } catch {
             throw configurationFailure(.setCategory, error, session)
         }
+    }
 
+    /// Activates the session, retrying transient `cannotInterruptOthers` failures
+    /// with a short back-off before surfacing a diagnostic error.
+    private func activate(_ session: AVAudioSession) async throws {
         do {
-            // Activation intermittently fails with `cannotInterruptOthers` when a
-            // recording is triggered from the background (Action Button /
-            // Shortcuts / Siri) while another app is still releasing its audio
-            // session. Retry with a short back-off before surfacing the
-            // diagnostic error — the second attempt almost always succeeds.
             try await AudioSessionActivation.activate {
                 try session.setActive(true, options: .notifyOthersOnDeactivation)
             }
         } catch {
             throw configurationFailure(.setActive, error, session)
         }
-
-        isConfigured = true
-        updateCurrentRoute()
-
-        let inputRoute = Self.routeDescription(ports: session.currentRoute.inputs)
-        print("[AudioSessionManager] Configured for recording: \(inputRoute)")
     }
 
     /// Builds a diagnostic error for a failed configuration step, snapshotting

--- a/Sources/SpeakiOS/Views/OpenClawVisibility.swift
+++ b/Sources/SpeakiOS/Views/OpenClawVisibility.swift
@@ -1,0 +1,23 @@
+#if os(iOS)
+import SwiftUI
+
+/// Environment flag controlling whether OpenClaw surfaces (the tab bar item and
+/// its Settings section) are visible.
+///
+/// The library defaults it to `false` so App Store builds hide OpenClaw
+/// everywhere, even if the host app forgets to configure it. The app target
+/// injects the real value from its build-time `SHOW_OPENCLAW_TAB` compile
+/// condition, keeping every OpenClaw surface in lockstep without the library
+/// having to depend on the app.
+private struct OpenClawEnabledKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+public extension EnvironmentValues {
+    /// Whether OpenClaw surfaces should be shown. Injected by the app target.
+    var openClawEnabled: Bool {
+        get { self[OpenClawEnabledKey.self] }
+        set { self[OpenClawEnabledKey.self] = newValue }
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -427,10 +427,39 @@ private struct LiveModelRow: View {
     }
 }
 
+/// A provider-titled group of live-transcription models, so the picker can list
+/// a growing catalogue in tidy per-provider sections instead of one long list.
+private struct LiveModelGroup: Identifiable {
+    let id: String
+    let title: String
+    let options: [ModelCatalog.Option]
+
+    /// Buckets catalogue options by provider, preserving first-appearance order
+    /// so the sections stay stable as models are added. Options whose id doesn't
+    /// resolve to a known provider are still shown (grouped by their id prefix)
+    /// rather than silently dropped.
+    static func grouped(_ options: [ModelCatalog.Option]) -> [LiveModelGroup] {
+        var order: [String] = []
+        var titles: [String: String] = [:]
+        var buckets: [String: [ModelCatalog.Option]] = [:]
+        for option in options {
+            let route = LiveTranscriptionRouting.route(for: option.id)
+            let key = route?.provider.rawValue ?? String(option.id.prefix { $0 != "/" })
+            if buckets[key] == nil {
+                order.append(key)
+                titles[key] = route?.provider.displayName ?? key.capitalized
+            }
+            buckets[key, default: []].append(option)
+        }
+        return order.map { LiveModelGroup(id: $0, title: titles[$0] ?? $0, options: buckets[$0] ?? []) }
+    }
+}
+
 // swiftlint:disable:next type_body_length
 public struct SettingsView: View {
     @StateObject private var settings = AppSettings.shared
     @Environment(\.openURL) private var openURL
+    @Environment(\.openClawEnabled) private var openClawEnabled
     @State private var showingAPIKeys = false
     @State private var missingTranscriptionAPIKeyAlert: IOSMissingTranscriptionAPIKeyAlert?
 
@@ -440,8 +469,12 @@ public struct SettingsView: View {
         Form {
             Section("Transcription") {
                 Picker("Live Model", selection: selectedModelBinding) {
-                    ForEach(ModelCatalog.liveTranscription) { option in
-                        LiveModelRow(option: option).tag(option.id)
+                    ForEach(LiveModelGroup.grouped(ModelCatalog.liveTranscription)) { group in
+                        Section(group.title) {
+                            ForEach(group.options) { option in
+                                LiveModelRow(option: option).tag(option.id)
+                            }
+                        }
                     }
                 }
                 .pickerStyle(.navigationLink)
@@ -630,17 +663,19 @@ public struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section("OpenClaw") {
-                NavigationLink {
-                    OpenClawSettingsView()
-                } label: {
-                    Label("Configure OpenClaw", systemImage: "bolt.horizontal.icloud")
-                }
+            if openClawEnabled {
+                Section("OpenClaw") {
+                    NavigationLink {
+                        OpenClawSettingsView()
+                    } label: {
+                        Label("Configure OpenClaw", systemImage: "bolt.horizontal.icloud")
+                    }
 
-                if OpenClawSettings.shared.isConfigured {
-                    Label("Connected", systemImage: "checkmark.circle")
-                        .font(.caption)
-                        .foregroundStyle(.green)
+                    if OpenClawSettings.shared.isConfigured {
+                        Label("Connected", systemImage: "checkmark.circle")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                    }
                 }
             }
 

--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -57,6 +57,7 @@ struct SpeakiOSApp: App {
             MainTabView()
                 .tint(.brandAccent)
                 .environmentObject(deepLinkRouter)
+                .environment(\.openClawEnabled, FeatureFlags.openClawTabEnabled)
                 .onOpenURL { url in
                     deepLinkRouter.handle(url)
                 }


### PR DESCRIPTION
## Why

Reported on a shipped iOS build:
1. **Action Button / Shortcuts "Toggle Recording" still fails** with `Audio session setActive failed [cannotInterruptOthers, '!int', code 560557684]` — even after the #492 retry.
2. **OpenClaw still shows in Settings** (and the tab) despite the hide flag.
3. **Not all models appear** and the model picker needs to handle the expanded catalogue.

(2) and (3) were partly because no iOS build had shipped since #492 — but there were still real bugs on `main`, fixed here.

## What

**Audio — background activation recovery (the core fix).**
`configureForRecording()` used a non-mixable `playAndRecord`/`measurement` session. iOS refuses to activate a non-mixable session **from the background** (Action Button / Shortcuts / Siri) with `cannotInterruptOthers`, even when nothing else is playing — so retrying the *identical* activation could never succeed. On that specific error we now reconfigure the session as **mixable (`.mixWithOthers`)** and reactivate; mixable sessions are allowed to go active from the background without interrupting other audio. The transient-retry path is preserved for the genuinely flaky case.

**OpenClaw — gate the Settings section too.**
The tab bar was gated, but the Settings "OpenClaw" section was always shown because `FeatureFlags` lives in the **app target** and `SpeakiOSLib` can't see it. Added an `openClawEnabled` SwiftUI **Environment** flag (default `false`) that the app injects from its `SHOW_OPENCLAW_TAB` build condition. The Settings section is now gated on it, so the flag covers **both** the tab bar and Settings. Default-false means App Store builds hide it even if injection is missed.

**Model picker — per-provider sections.**
The picker already iterates the full shared `ModelCatalog.liveTranscription`; grouped it into per-provider `Section`s (via new `LiveTranscriptionProviderID.displayName`) so the growing catalogue stays legible. The existing selection binding and the missing-API-key alert are unchanged.

## Shipping

Merging with the `fix(ios):` subject lets `auto-release.yml` cut the release and auto-trigger the iOS TestFlight build (this is why #492 never reached iOS — its squash subject wasn't a conventional releasing type). OpenClaw ships hidden (`tuist generate` runs without `SHOW_OPENCLAW_TAB`).

## Verification

- iOS-SDK type-check of `SpeakiOSLib` (`swiftc -target arm64-apple-ios*-simulator`): **0 errors** (macOS `swift build` strips `#if os(iOS)`, so this is the check that actually compiles the changed files).
- macOS `swift build`: clean. `swift test`: **546 pass, 0 failures**.
- SwiftLint `--strict` (baseline): **0 violations**.
- On-device audio activation from the Action Button is verifiable only on hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live transcription models are now grouped by provider in the model picker for easier browsing.
  * The OpenClaw settings section now appears only when enabled by the app.

* **Bug Fixes**
  * Improved audio session setup so recording can recover more reliably when activation is temporarily blocked.
  * Updated provider labels to show clearer, human-friendly names in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->