### PR TITLE
fix(ios): stop background recordings wiping transcription history

### DIFF
--- a/Sources/SpeakiOS/Views/iOSHistoryManager.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryManager.swift
@@ -16,6 +16,15 @@ public final class iOSHistoryManager: ObservableObject {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
+    /// Whether CloudKit sync is wired up. Disabled in unit tests so persistence
+    /// can be exercised in isolation.
+    private let syncEnabled: Bool
+
+    /// Guards against loading twice and, crucially, against saving from an
+    /// unloaded (empty) state — the root cause of background-recording history
+    /// loss (see `loadHistoryFromDiskIfNeeded`).
+    private var hasLoadedFromDisk = false
+
     /// IDs of entries that have been synced to CloudKit.
     private(set) var syncedIDs: Set<UUID> = []
     private let syncedIDsKey = "speak.sync.syncedHistoryIDs"
@@ -33,22 +42,38 @@ public final class iOSHistoryManager: ObservableObject {
         syncedIDs.contains(item.id)
     }
 
-    private init() {
+    private convenience init() {
         let documentsURL = FileManager.default.urls(
             for: .documentDirectory,
             in: .userDomainMask
         )[0]
-        self.fileURL = documentsURL.appendingPathComponent(
-            "transcription-history.json"
+        self.init(
+            fileURL: documentsURL.appendingPathComponent("transcription-history.json"),
+            syncEnabled: true
         )
+    }
+
+    /// Designated initializer. `fileURL` and `syncEnabled` are injectable so
+    /// tests can exercise persistence against a temporary file without touching
+    /// CloudKit.
+    init(fileURL: URL, syncEnabled: Bool) {
+        self.fileURL = fileURL
+        self.syncEnabled = syncEnabled
 
         encoder.dateEncodingStrategy = .iso8601
         decoder.dateDecodingStrategy = .iso8601
 
         loadSyncedIDs()
 
+        // Load history *synchronously* before this initializer returns. A
+        // headless Action Button recording touches `.shared` cold and then
+        // immediately calls `recordTranscription`; the previous async load left
+        // a window where the save ran against an empty in-memory list and wiped
+        // all prior history on disk.
+        loadHistoryFromDiskIfNeeded()
+
+        guard syncEnabled else { return }
         Task {
-            await loadHistory()
             await initializeSync()
         }
     }
@@ -64,9 +89,11 @@ public final class iOSHistoryManager: ObservableObject {
 
     /// Adds a new transcription to history.
     public func add(_ item: iOSHistoryItem) {
+        loadHistoryFromDiskIfNeeded()
         items.insert(item, at: 0)
         saveHistory()
 
+        guard syncEnabled else { return }
         Task {
             try? await HistorySyncEngine.shared.upload(
                 entry: item.toSyncable()
@@ -96,9 +123,11 @@ public final class iOSHistoryManager: ObservableObject {
 
     /// Removes an item from history.
     public func remove(_ item: iOSHistoryItem) {
+        loadHistoryFromDiskIfNeeded()
         items.removeAll { $0.id == item.id }
         saveHistory()
 
+        guard syncEnabled else { return }
         Task {
             try? await HistorySyncEngine.shared.delete(entryID: item.id)
             syncedIDs.remove(item.id)
@@ -108,10 +137,12 @@ public final class iOSHistoryManager: ObservableObject {
 
     /// Clears all history.
     public func clearAll() {
+        loadHistoryFromDiskIfNeeded()
         let allIDs = items.map(\.id)
         items.removeAll()
         saveHistory()
 
+        guard syncEnabled else { return }
         Task {
             for entryID in allIDs {
                 try? await HistorySyncEngine.shared.delete(entryID: entryID)
@@ -128,9 +159,13 @@ public final class iOSHistoryManager: ObservableObject {
 
     // MARK: - Persistence
 
-    private func loadHistory() async {
-        isLoading = true
-        defer { isLoading = false }
+    /// Loads history from disk exactly once, synchronously. Every mutation
+    /// funnels through this first so we never write from an unloaded (empty)
+    /// list and clobber the file. Called eagerly from `init` and defensively
+    /// from `add`/`remove`/`clearAll`.
+    private func loadHistoryFromDiskIfNeeded() {
+        guard !hasLoadedFromDisk else { return }
+        hasLoadedFromDisk = true
 
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             return

--- a/Sources/SpeakiOS/Views/iOSHistoryManager.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryManager.swift
@@ -95,11 +95,15 @@ public final class iOSHistoryManager: ObservableObject {
 
         guard syncEnabled else { return }
         Task {
-            try? await HistorySyncEngine.shared.upload(
-                entry: item.toSyncable()
-            )
-            syncedIDs.insert(item.id)
-            saveSyncedIDs()
+            do {
+                try await HistorySyncEngine.shared.upload(entry: item.toSyncable())
+                syncedIDs.insert(item.id)
+                saveSyncedIDs()
+            } catch {
+                // Leave the item unsynced so a later full sync retries it,
+                // rather than marking it synced after a failed upload.
+                print("[iOSHistoryManager] Failed to upload item: \(error)")
+            }
         }
     }
 
@@ -165,15 +169,21 @@ public final class iOSHistoryManager: ObservableObject {
     /// from `add`/`remove`/`clearAll`.
     private func loadHistoryFromDiskIfNeeded() {
         guard !hasLoadedFromDisk else { return }
-        hasLoadedFromDisk = true
 
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            // Nothing to load — safe to start from an empty list.
+            hasLoadedFromDisk = true
             return
         }
 
         do {
             let data = try Data(contentsOf: fileURL)
             items = try decoder.decode([iOSHistoryItem].self, from: data)
+            // Only mark loaded once we've actually read the file. A transient
+            // failure (e.g. file protection while the device is locked during a
+            // background recording) must be retried, never treated as "loaded"
+            // and then clobbered by the next save.
+            hasLoadedFromDisk = true
         } catch {
             print("[iOSHistoryManager] Failed to load history: \(error)")
         }
@@ -182,7 +192,13 @@ public final class iOSHistoryManager: ObservableObject {
     private func saveHistory() {
         do {
             let data = try encoder.encode(items)
-            try data.write(to: fileURL, options: .atomic)
+            // `completeUntilFirstUserAuthentication` keeps the file readable and
+            // writable from a background (Action Button) recording after the
+            // first unlock, so headless sessions can persist without data loss.
+            try data.write(
+                to: fileURL,
+                options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
+            )
         } catch {
             print("[iOSHistoryManager] Failed to save history: \(error)")
         }

--- a/Tests/SpeakiOSTests/HistoryManagerPersistenceTests.swift
+++ b/Tests/SpeakiOSTests/HistoryManagerPersistenceTests.swift
@@ -1,0 +1,122 @@
+#if os(iOS)
+import Foundation
+import XCTest
+
+@testable import SpeakiOSLib
+
+/// Regression coverage for the background Action Button history-loss bug: a
+/// freshly created manager (as happens when a headless intent touches `.shared`
+/// cold) must load existing history *before* the first append, so recording
+/// never wipes prior entries.
+@MainActor
+final class HistoryManagerPersistenceTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var fileURL: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        fileURL = tempDir.appendingPathComponent("transcription-history.json")
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        fileURL = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func writeHistory(_ items: [iOSHistoryItem]) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(items).write(to: fileURL, options: .atomic)
+    }
+
+    private func readHistory() throws -> [iOSHistoryItem] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([iOSHistoryItem].self, from: Data(contentsOf: fileURL))
+    }
+
+    private func makeItem(_ text: String) -> iOSHistoryItem {
+        iOSHistoryItem(
+            transcription: text,
+            model: "apple/local/SFSpeechRecognizer",
+            duration: 3,
+            wordCount: text.split(separator: " ").count
+        )
+    }
+
+    // MARK: - Tests
+
+    func testColdManagerLoadsExistingHistoryImmediately() throws {
+        // Arrange: a prior recording already on disk.
+        try writeHistory([makeItem("hello there")])
+
+        // Act: create a cold manager (as a background intent would).
+        let manager = iOSHistoryManager(fileURL: fileURL, syncEnabled: false)
+
+        // Assert: the existing entry is visible right away, no async wait.
+        XCTAssertEqual(manager.items.count, 1)
+        XCTAssertEqual(manager.items.first?.transcription, "hello there")
+    }
+
+    func testRecordingFromColdManagerPreservesExistingHistory() throws {
+        // Arrange: three prior recordings on disk.
+        let prior = (0..<3).map { makeItem("prior \($0)") }
+        try writeHistory(prior)
+
+        // Act: a cold manager records a new transcription.
+        let manager = iOSHistoryManager(fileURL: fileURL, syncEnabled: false)
+        manager.recordTranscription(
+            text: "brand new",
+            model: "apple/local/SFSpeechRecognizer",
+            duration: 2
+        )
+
+        // Assert: all four survive both in memory and on disk (newest first).
+        XCTAssertEqual(manager.items.count, 4)
+        XCTAssertEqual(manager.items.first?.transcription, "brand new")
+
+        let onDisk = try readHistory()
+        XCTAssertEqual(onDisk.count, 4)
+        XCTAssertTrue(onDisk.contains { $0.transcription == "prior 0" })
+        XCTAssertTrue(onDisk.contains { $0.transcription == "brand new" })
+    }
+
+    func testRemoveFromColdManagerDoesNotClobberOtherEntries() throws {
+        // Arrange: three prior recordings on disk.
+        let prior = (0..<3).map { makeItem("p\($0)") }
+        try writeHistory(prior)
+
+        // Act: a cold manager removes one entry.
+        let manager = iOSHistoryManager(fileURL: fileURL, syncEnabled: false)
+        manager.remove(prior[1])
+
+        // Assert: only the targeted entry is gone; the rest are retained.
+        let onDisk = try readHistory()
+        XCTAssertEqual(onDisk.count, 2)
+        XCTAssertFalse(onDisk.contains { $0.id == prior[1].id })
+    }
+
+    func testEmptyDiskRecordingPersistsSingleEntry() throws {
+        // Arrange: no file on disk yet.
+        let manager = iOSHistoryManager(fileURL: fileURL, syncEnabled: false)
+
+        // Act.
+        manager.recordTranscription(
+            text: "first ever",
+            model: "apple/local/SFSpeechRecognizer",
+            duration: 1
+        )
+
+        // Assert.
+        XCTAssertEqual(try readHistory().count, 1)
+    }
+}
+#endif


### PR DESCRIPTION
## Problem

Recording via the Action Button (headless App Intent) while the app isn't in the
foreground was **wiping most of the transcription history** — users reported "loads
of recordings" collapsing to just the last 2.

## Root cause

`iOSHistoryManager` loaded its JSON store in a detached `Task` from `init`. A
headless intent touches `iOSHistoryManager.shared` cold and immediately calls
`recordTranscription`. That runs `add → saveHistory()` **before** the async load
completes, so it inserts into an empty in-memory `items` and atomically overwrites
`transcription-history.json` with only the new entry — destroying everything else.

## Fix

- Load history **synchronously** in `init`, and defensively via
  `loadHistoryFromDiskIfNeeded()` at the top of every mutation (`add`, `remove`,
  `clearAll`), so a save can never run from an unloaded (empty) state.
- Make the store injectable (`init(fileURL:syncEnabled:)`) so persistence can be
  tested hermetically without CloudKit; `shared` keeps the Documents-dir path.

## Tests

`Tests/SpeakiOSTests/HistoryManagerPersistenceTests.swift` reproduces the bug: a
cold manager over an existing file must load prior entries before appending, and
recording/removing must not clobber other entries. Verified compiling for iOS
(`xcodebuild -scheme SpeakiOSLib -destination generic/platform=iOS`).

> Note: CI's macOS `swift test` excludes `#if os(iOS)` code, and only the SpeakCore
> scheme runs on a simulator, so these tests aren't gated by CI yet — verified via
> local iOS compile. Wiring `SpeakiOSTests` into CI is tracked separately.

Closes the history-loss part of the iOS background-recording work (bd justspeaktoit-ikp).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * History now loads from disk immediately and only once, preventing empty history from overwriting saved entries.
  * Adding, removing, or clearing items now safely preserves existing saved history, even when the app starts from a cold state.
  * Local history continues to save normally when sync is turned off, without triggering cloud sync actions.

* **Tests**
  * Added coverage for cold-start history loading, saving, removing, and empty-history persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->