### PR TITLE
feat(ios): history actions — copy raw/polished, reprocess, delete, errors

### DIFF
--- a/Sources/SpeakiOS/Views/HistoryItemRow.swift
+++ b/Sources/SpeakiOS/Views/HistoryItemRow.swift
@@ -7,7 +7,16 @@ import SpeakSync
 struct HistoryItemRow: View {
     let item: iOSHistoryItem
     let isSynced: Bool
+    var isReprocessing: Bool = false
+    var onCopyRaw: () -> Void = {}
+    var onCopyPolished: () -> Void = {}
+    var onReprocess: () -> Void = {}
+    var onDelete: () -> Void = {}
     @State private var isExpanded = false
+
+    private var displayedText: String {
+        item.bestText
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -24,6 +33,11 @@ struct HistoryItemRow: View {
                 Spacer()
 
                 HStack(spacing: 8) {
+                    if isReprocessing {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+
                     Image(
                         systemName: isSynced ? "icloud.fill" : "icloud.slash"
                     )
@@ -45,10 +59,17 @@ struct HistoryItemRow: View {
                 }
             }
 
-            Text(item.transcription)
+            Text(displayedText)
                 .font(.body)
                 .lineLimit(isExpanded ? nil : 3)
                 .animation(.easeInOut(duration: 0.2), value: isExpanded)
+
+            if let error = item.errorMessage {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .lineLimit(isExpanded ? nil : 2)
+            }
 
             HStack {
                 Text(modelDisplayName)
@@ -59,6 +80,17 @@ struct HistoryItemRow: View {
                         Color.secondary.opacity(0.15),
                         in: Capsule()
                     )
+
+                if item.hasPolishedText {
+                    Label("Polished", systemImage: "wand.and.stars")
+                        .font(.caption2)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            Color.purple.opacity(0.15),
+                            in: Capsule()
+                        )
+                }
 
                 if item.originPlatform != "ios" {
                     Text(platformDisplayName)
@@ -73,7 +105,7 @@ struct HistoryItemRow: View {
 
                 Spacer()
 
-                if item.transcription.count > 150 {
+                if displayedText.count > 150 {
                     Button {
                         isExpanded.toggle()
                     } label: {
@@ -86,8 +118,38 @@ struct HistoryItemRow: View {
         .padding(.vertical, 4)
         .contentShape(Rectangle())
         .onTapGesture {
-            if item.transcription.count > 150 {
+            if displayedText.count > 150 {
                 isExpanded.toggle()
+            }
+        }
+        .contextMenu {
+            Button {
+                onCopyRaw()
+            } label: {
+                Label("Copy Transcript", systemImage: "doc.on.doc")
+            }
+
+            if item.hasPolishedText {
+                Button {
+                    onCopyPolished()
+                } label: {
+                    Label("Copy Polished", systemImage: "doc.on.doc.fill")
+                }
+            }
+
+            Button {
+                onReprocess()
+            } label: {
+                Label("Reprocess", systemImage: "wand.and.stars")
+            }
+            .disabled(isReprocessing)
+
+            Divider()
+
+            Button(role: .destructive) {
+                onDelete()
+            } label: {
+                Label("Delete", systemImage: "trash")
             }
         }
     }

--- a/Sources/SpeakiOS/Views/HistoryView.swift
+++ b/Sources/SpeakiOS/Views/HistoryView.swift
@@ -123,7 +123,14 @@ public struct HistoryView: View {
                 ForEach(historyManager.items) { item in
                     HistoryItemRow(
                         item: item,
-                        isSynced: historyManager.isSynced(item)
+                        isSynced: historyManager.isSynced(item),
+                        isReprocessing: historyManager.isReprocessing(item),
+                        onCopyRaw: { UIPasteboard.general.string = item.transcription },
+                        onCopyPolished: {
+                            UIPasteboard.general.string = item.postProcessedTranscription ?? item.transcription
+                        },
+                        onReprocess: { Task { await historyManager.reprocess(item) } },
+                        onDelete: { historyManager.remove(item) }
                     )
                     .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                         Button(role: .destructive) {
@@ -134,7 +141,7 @@ public struct HistoryView: View {
                     }
                     .swipeActions(edge: .leading, allowsFullSwipe: true) {
                         Button {
-                            UIPasteboard.general.string = item.transcription
+                            UIPasteboard.general.string = item.bestText
                         } label: {
                             Label("Copy", systemImage: "doc.on.doc")
                         }

--- a/Sources/SpeakiOS/Views/PostProcessingView.swift
+++ b/Sources/SpeakiOS/Views/PostProcessingView.swift
@@ -2,6 +2,8 @@
 import SwiftUI
 import SpeakCore
 
+// swiftlint:disable file_length
+
 // MARK: - Post-Processing Manager
 
 /// Manages post-processing of transcriptions via OpenRouter API.
@@ -70,6 +72,32 @@ public final class iOSPostProcessingManager: ObservableObject {
         streamTask?.cancel()
         streamTask = nil
         isProcessing = false
+    }
+
+    /// Runs post-processing once and returns the full polished result. Unlike
+    /// `process`, this does not mutate the shared published UI state, so it's
+    /// safe to call for background work such as reprocessing a history entry.
+    /// Reuses the same OpenRouter streaming path as the interactive editor.
+    public func polish(
+        text: String,
+        model: String,
+        prompt: String,
+        apiKey: String
+    ) async throws -> String {
+        guard !text.isEmpty else { return text }
+        guard !apiKey.isEmpty else { throw PostProcessingError.apiKeyMissing }
+
+        let effectivePrompt = prompt.isEmpty ? AppSettings.defaultPostProcessingPrompt : prompt
+        var result = ""
+        for try await chunk in sendChatStreaming(
+            systemPrompt: effectivePrompt,
+            userMessage: text,
+            model: model,
+            apiKey: apiKey
+        ) {
+            result += chunk
+        }
+        return result
     }
     
     // MARK: - OpenRouter API

--- a/Sources/SpeakiOS/Views/PostProcessingView.swift
+++ b/Sources/SpeakiOS/Views/PostProcessingView.swift
@@ -95,6 +95,7 @@ public final class iOSPostProcessingManager: ObservableObject {
             model: model,
             apiKey: apiKey
         ) {
+            try Task.checkCancellation()
             result += chunk
         }
         return result

--- a/Sources/SpeakiOS/Views/iOSHistoryManager.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryManager.swift
@@ -12,6 +12,9 @@ public final class iOSHistoryManager: ObservableObject {
     @Published public private(set) var items: [iOSHistoryItem] = []
     @Published public private(set) var isLoading = false
 
+    /// IDs currently being reprocessed (drives per-row progress in the UI).
+    @Published public private(set) var reprocessingIDs: Set<UUID> = []
+
     private let fileURL: URL
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
@@ -159,6 +162,62 @@ public final class iOSHistoryManager: ObservableObject {
     /// Trigger a manual sync.
     public func triggerSync() async {
         await HistorySyncEngine.shared.sync()
+    }
+
+    // MARK: - Reprocess
+
+    /// Re-runs post-processing on an entry with the current model/prompt and
+    /// stores the polished result alongside the raw transcript (mirrors the Mac
+    /// "Reprocess with current model" action). Surfaces failures on the entry.
+    public func reprocess(_ item: iOSHistoryItem) async {
+        let settings = AppSettings.shared
+        guard settings.hasOpenRouterKey else {
+            setError("Add an OpenRouter API key in Settings to reprocess.", for: item.id)
+            return
+        }
+        guard !reprocessingIDs.contains(item.id) else { return }
+
+        reprocessingIDs.insert(item.id)
+        defer { reprocessingIDs.remove(item.id) }
+
+        do {
+            let polished = try await iOSPostProcessingManager.shared.polish(
+                text: item.transcription,
+                model: settings.postProcessingModel,
+                prompt: settings.postProcessingPrompt,
+                apiKey: settings.openRouterAPIKey
+            )
+            setPostProcessed(polished, for: item.id)
+        } catch {
+            setError(error.localizedDescription, for: item.id)
+        }
+    }
+
+    /// Stores a polished transcript on an entry and re-syncs it.
+    public func setPostProcessed(_ processed: String, for id: UUID) {
+        loadHistoryFromDiskIfNeeded()
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        items[index] = items[index].withPostProcessed(processed)
+        saveHistory()
+
+        guard syncEnabled else { return }
+        let entry = items[index].toSyncable()
+        Task {
+            try? await HistorySyncEngine.shared.upload(entry: entry)
+        }
+    }
+
+    /// Records an error against an entry (surfaced in the history UI).
+    public func setError(_ message: String, for id: UUID) {
+        loadHistoryFromDiskIfNeeded()
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        items[index] = items[index].withError(message)
+        saveHistory()
+    }
+
+    /// Whether an entry is currently being reprocessed.
+    public func isReprocessing(_ item: iOSHistoryItem) -> Bool {
+        reprocessingIDs.contains(item.id)
     }
 
     // MARK: - Persistence

--- a/Sources/SpeakiOS/Views/iOSHistoryManager.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryManager.swift
@@ -188,6 +188,9 @@ public final class iOSHistoryManager: ObservableObject {
                 apiKey: settings.openRouterAPIKey
             )
             setPostProcessed(polished, for: item.id)
+        } catch is CancellationError {
+            // Reprocess was cancelled (e.g. the user navigated away) — leave the
+            // entry untouched rather than persisting a confusing error.
         } catch {
             setError(error.localizedDescription, for: item.id)
         }
@@ -202,8 +205,18 @@ public final class iOSHistoryManager: ObservableObject {
 
         guard syncEnabled else { return }
         let entry = items[index].toSyncable()
+        // Mark the entry unsynced until the updated version uploads, so a failed
+        // upload is retried by the next full sync instead of silently desyncing.
+        syncedIDs.remove(id)
+        saveSyncedIDs()
         Task {
-            try? await HistorySyncEngine.shared.upload(entry: entry)
+            do {
+                try await HistorySyncEngine.shared.upload(entry: entry)
+                syncedIDs.insert(id)
+                saveSyncedIDs()
+            } catch {
+                print("[iOSHistoryManager] Failed to upload reprocessed item: \(error)")
+            }
         }
     }
 

--- a/Sources/SpeakiOS/Views/iOSHistoryModels.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryModels.swift
@@ -9,27 +9,76 @@ public struct iOSHistoryItem: Identifiable, Codable {
     public let id: UUID
     public let createdAt: Date
     public let transcription: String
+    /// Polished (post-processed) text, when the entry has been reprocessed.
+    public let postProcessedTranscription: String?
     public let model: String
     public let duration: TimeInterval
     public let wordCount: Int
     public let originPlatform: String
+    /// Most recent error captured for this entry (e.g. a failed reprocess),
+    /// surfaced in the history UI. Local-only — not synced.
+    public let errorMessage: String?
 
     public init(
         id: UUID = UUID(),
         createdAt: Date = Date(),
         transcription: String,
+        postProcessedTranscription: String? = nil,
         model: String,
         duration: TimeInterval,
         wordCount: Int,
-        originPlatform: String = "ios"
+        originPlatform: String = "ios",
+        errorMessage: String? = nil
     ) {
         self.id = id
         self.createdAt = createdAt
         self.transcription = transcription
+        self.postProcessedTranscription = postProcessedTranscription
         self.model = model
         self.duration = duration
         self.wordCount = wordCount
         self.originPlatform = originPlatform
+        self.errorMessage = errorMessage
+    }
+
+    /// The best available transcript for copy/display: polished if present, else raw.
+    public var bestText: String {
+        postProcessedTranscription ?? transcription
+    }
+
+    /// Whether a polished version exists.
+    public var hasPolishedText: Bool {
+        !(postProcessedTranscription ?? "").isEmpty
+    }
+
+    /// Returns a copy with the polished transcript set and any prior error cleared.
+    public func withPostProcessed(_ text: String) -> iOSHistoryItem {
+        iOSHistoryItem(
+            id: id,
+            createdAt: createdAt,
+            transcription: transcription,
+            postProcessedTranscription: text,
+            model: model,
+            duration: duration,
+            wordCount: wordCount,
+            originPlatform: originPlatform,
+            errorMessage: nil
+        )
+    }
+
+    /// Returns a copy carrying an error message (e.g. a failed reprocess).
+    public func withError(_ message: String?) -> iOSHistoryItem {
+        iOSHistoryItem(
+            id: id,
+            createdAt: createdAt,
+            transcription: transcription,
+            postProcessedTranscription: postProcessedTranscription,
+            model: model,
+            duration: duration,
+            wordCount: wordCount,
+            originPlatform: originPlatform,
+            errorMessage: message
+        )
     }
 
     /// Convert to a syncable entry for CloudKit.
@@ -38,7 +87,7 @@ public struct iOSHistoryItem: Identifiable, Codable {
             id: id,
             createdAt: createdAt,
             rawTranscription: transcription,
-            postProcessedText: nil,
+            postProcessedText: postProcessedTranscription,
             model: model,
             duration: duration,
             wordCount: wordCount,
@@ -49,13 +98,11 @@ public struct iOSHistoryItem: Identifiable, Codable {
 
     /// Create from a synced remote entry.
     static func fromSyncable(_ entry: SyncableHistoryEntry) -> iOSHistoryItem {
-        let text = entry.postProcessedText
-            ?? entry.rawTranscription
-            ?? ""
-        return iOSHistoryItem(
+        iOSHistoryItem(
             id: entry.id,
             createdAt: entry.createdAt,
-            transcription: text,
+            transcription: entry.rawTranscription ?? entry.postProcessedText ?? "",
+            postProcessedTranscription: entry.postProcessedText,
             model: entry.model,
             duration: entry.duration,
             wordCount: entry.wordCount,

--- a/Tests/SpeakiOSTests/HistoryItemModelTests.swift
+++ b/Tests/SpeakiOSTests/HistoryItemModelTests.swift
@@ -1,0 +1,65 @@
+#if os(iOS)
+import Foundation
+import XCTest
+
+@testable import SpeakiOSLib
+
+/// Covers the enriched history model: raw/polished text, error state, sync
+/// round-trip, and — critically — backward-compatible decoding of history JSON
+/// written before these fields existed.
+final class HistoryItemModelTests: XCTestCase {
+
+    func testBestTextPrefersPolishedButPreservesRaw() {
+        let raw = iOSHistoryItem(transcription: "raw", model: "m", duration: 1, wordCount: 1)
+        XCTAssertEqual(raw.bestText, "raw")
+        XCTAssertFalse(raw.hasPolishedText)
+
+        let polished = raw.withPostProcessed("polished")
+        XCTAssertEqual(polished.bestText, "polished")
+        XCTAssertTrue(polished.hasPolishedText)
+        XCTAssertEqual(polished.transcription, "raw", "raw transcript must be preserved")
+    }
+
+    func testReprocessingClearsPriorError() {
+        let errored = iOSHistoryItem(transcription: "t", model: "m", duration: 1, wordCount: 1)
+            .withError("boom")
+        XCTAssertEqual(errored.errorMessage, "boom")
+        XCTAssertNil(errored.withPostProcessed("done").errorMessage)
+    }
+
+    func testSyncRoundTripPreservesRawAndPolished() {
+        let item = iOSHistoryItem(
+            transcription: "raw",
+            postProcessedTranscription: "polished",
+            model: "m",
+            duration: 2,
+            wordCount: 1
+        )
+        let restored = iOSHistoryItem.fromSyncable(item.toSyncable())
+        XCTAssertEqual(restored.transcription, "raw")
+        XCTAssertEqual(restored.postProcessedTranscription, "polished")
+    }
+
+    func testDecodesLegacyJSONWithoutNewFields() throws {
+        let json = """
+        {
+          "id": "\(UUID().uuidString)",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "transcription": "hello",
+          "model": "apple/local/SFSpeechRecognizer",
+          "duration": 1,
+          "wordCount": 1,
+          "originPlatform": "ios"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let item = try decoder.decode(iOSHistoryItem.self, from: Data(json.utf8))
+
+        XCTAssertEqual(item.transcription, "hello")
+        XCTAssertNil(item.postProcessedTranscription)
+        XCTAssertNil(item.errorMessage)
+        XCTAssertEqual(item.bestText, "hello")
+    }
+}
+#endif


### PR DESCRIPTION
## What

Adds Mac-style history actions to the iOS history list:

- **Copy transcript** and **Copy polished** (when a polished version exists).
- **Reprocess** with the current post-processing model — runs the polish and
  **persists the polished result alongside the raw transcript** (a "Polished" chip
  marks it), with a per-row spinner while it runs.
- **Delete** an entry.
- **Surface errors** — a failed reprocess is recorded on the entry and shown with
  an orange badge (similar to the Mac history view).

## How

- `iOSHistoryItem` gains `postProcessedTranscription` and `errorMessage`
  (backward-compatible optional decoding of existing history JSON), plus
  `bestText` / `withPostProcessed` / `withError` helpers, and syncs the polished
  text via `SyncableHistoryEntry.postProcessedText`.
- `iOSHistoryManager` gains `reprocess`, `setPostProcessed`, `setError` and a
  published `reprocessingIDs` set. Reprocess **reuses** the existing OpenRouter
  path via a new non-mutating `iOSPostProcessingManager.polish(...)`.
- `HistoryItemRow` gets a context menu + polished/error UI.

Verified compiling + linting for iOS (`xcodebuild -scheme SpeakiOSLib -destination
generic/platform=iOS`; SwiftLint strict). Tests: `HistoryItemModelTests` covers
best-text/error/sync round-trip and **legacy JSON decoding**.

> Based on #499 (history data-loss fix). Will retarget to `main` once #499 merges.
> First slice of the "port Mac history concepts to iOS" epic (bd justspeaktoit-zfj).

bd justspeaktoit-skw
