### PR TITLE
fix(ios): prevent Action Button crash when no Live Activity can start

### DIFF
--- a/Sources/SpeakCore/TranscriptionActivityAttributes.swift
+++ b/Sources/SpeakCore/TranscriptionActivityAttributes.swift
@@ -5,7 +5,7 @@ import Foundation
 /// ActivityKit attributes for live transcription sessions.
 /// Defines the static and dynamic content shown in Live Activities and Dynamic Island.
 public struct TranscriptionActivityAttributes: ActivityAttributes {
-    
+
     /// Static content that doesn't change during the activity.
     public struct ContentState: Codable, Hashable {
         /// Current transcription status
@@ -20,7 +20,7 @@ public struct TranscriptionActivityAttributes: ActivityAttributes {
         public var provider: String
         /// Optional error message
         public var errorMessage: String?
-        
+
         public init(
             status: TranscriptionStatus = .idle,
             lastSnippet: String = "",
@@ -37,7 +37,7 @@ public struct TranscriptionActivityAttributes: ActivityAttributes {
             self.errorMessage = errorMessage
         }
     }
-    
+
     /// Transcription session status
     public enum TranscriptionStatus: String, Codable, Hashable {
         case idle
@@ -47,12 +47,12 @@ public struct TranscriptionActivityAttributes: ActivityAttributes {
         case error
         case completed
     }
-    
+
     /// Session identifier
     public var sessionId: String
     /// Start time of the session
     public var startTime: Date
-    
+
     public init(sessionId: String = UUID().uuidString, startTime: Date = Date()) {
         self.sessionId = sessionId
         self.startTime = startTime
@@ -65,16 +65,16 @@ public struct TranscriptionActivityAttributes: ActivityAttributes {
 @MainActor
 public final class TranscriptionActivityManager: ObservableObject {
     public static let shared = TranscriptionActivityManager()
-    
+
     @Published public private(set) var currentActivity: Activity<TranscriptionActivityAttributes>?
     @Published public private(set) var isActivityRunning = false
-    
+
     private var updateThrottleTask: Task<Void, Never>?
     private var lastUpdateTime: Date = .distantPast
     private let minimumUpdateInterval: TimeInterval = 1.0 // Throttle to 1 update per second
-    
+
     private init() {}
-    
+
     /// Starts a new Live Activity for transcription. Returns whether one is now
     /// active — callers that require a Live Activity (e.g. `AudioRecordingIntent`
     /// background recording) must not proceed when this returns `false`, or the
@@ -85,16 +85,16 @@ public final class TranscriptionActivityManager: ObservableObject {
             print("[ActivityManager] Live Activities not enabled")
             return false
         }
-        
+
         // End any existing activity first
         endActivity()
-        
+
         let attributes = TranscriptionActivityAttributes()
         let initialState = TranscriptionActivityAttributes.ContentState(
             status: .listening,
             provider: provider
         )
-        
+
         do {
             let activity = try Activity.request(
                 attributes: attributes,
@@ -110,7 +110,7 @@ public final class TranscriptionActivityManager: ObservableObject {
             return false
         }
     }
-    
+
     /// Updates the Live Activity with new transcription state.
     public func updateActivity(
         status: TranscriptionActivityAttributes.TranscriptionStatus,
@@ -119,7 +119,7 @@ public final class TranscriptionActivityManager: ObservableObject {
         duration: Int
     ) {
         guard let activity = currentActivity else { return }
-        
+
         // Throttle updates
         let now = Date()
         guard now.timeIntervalSince(lastUpdateTime) >= minimumUpdateInterval else {
@@ -127,10 +127,10 @@ public final class TranscriptionActivityManager: ObservableObject {
             scheduleThrottledUpdate(status: status, lastSnippet: lastSnippet, wordCount: wordCount, duration: duration)
             return
         }
-        
+
         lastUpdateTime = now
         updateThrottleTask?.cancel()
-        
+
         let state = TranscriptionActivityAttributes.ContentState(
             status: status,
             lastSnippet: String(lastSnippet.suffix(100)),
@@ -138,12 +138,12 @@ public final class TranscriptionActivityManager: ObservableObject {
             duration: duration,
             provider: activity.content.state.provider
         )
-        
+
         Task {
             await activity.update(.init(state: state, staleDate: nil))
         }
     }
-    
+
     private func scheduleThrottledUpdate(
         status: TranscriptionActivityAttributes.TranscriptionStatus,
         lastSnippet: String,
@@ -159,11 +159,11 @@ public final class TranscriptionActivityManager: ObservableObject {
             }
         }
     }
-    
+
     /// Marks the activity as completed and ends it.
     public func completeActivity(finalWordCount: Int, duration: Int) {
         guard let activity = currentActivity else { return }
-        
+
         let finalState = TranscriptionActivityAttributes.ContentState(
             status: .completed,
             lastSnippet: "Transcription complete",
@@ -171,7 +171,7 @@ public final class TranscriptionActivityManager: ObservableObject {
             duration: duration,
             provider: activity.content.state.provider
         )
-        
+
         Task {
             await activity.end(.init(state: finalState, staleDate: nil), dismissalPolicy: .after(.now + 5))
             await MainActor.run {
@@ -180,30 +180,32 @@ public final class TranscriptionActivityManager: ObservableObject {
             }
         }
     }
-    
+
     /// Ends the current activity immediately.
     public func endActivity() {
         updateThrottleTask?.cancel()
-        
+
         guard let activity = currentActivity else { return }
-        
+
+        // Clear state synchronously and end the captured activity, so a new
+        // activity started right after (e.g. `startActivity` calls this first)
+        // isn't orphaned when the async end completes and nils `currentActivity`.
+        currentActivity = nil
+        isActivityRunning = false
+
         Task {
             await activity.end(nil, dismissalPolicy: .immediate)
-            await MainActor.run {
-                currentActivity = nil
-                isActivityRunning = false
-            }
         }
     }
-    
+
     /// Reports an error to the Live Activity.
     public func reportError(_ message: String) {
         guard let activity = currentActivity else { return }
-        
+
         var state = activity.content.state
         state.status = .error
         state.errorMessage = message
-        
+
         Task {
             await activity.update(.init(state: state, staleDate: nil))
         }

--- a/Sources/SpeakCore/TranscriptionActivityAttributes.swift
+++ b/Sources/SpeakCore/TranscriptionActivityAttributes.swift
@@ -75,11 +75,15 @@ public final class TranscriptionActivityManager: ObservableObject {
     
     private init() {}
     
-    /// Starts a new Live Activity for transcription.
-    public func startActivity(provider: String) {
+    /// Starts a new Live Activity for transcription. Returns whether one is now
+    /// active — callers that require a Live Activity (e.g. `AudioRecordingIntent`
+    /// background recording) must not proceed when this returns `false`, or the
+    /// system-policy check will assert (EXC_BREAKPOINT).
+    @discardableResult
+    public func startActivity(provider: String) -> Bool {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else {
             print("[ActivityManager] Live Activities not enabled")
-            return
+            return false
         }
         
         // End any existing activity first
@@ -100,8 +104,10 @@ public final class TranscriptionActivityManager: ObservableObject {
             currentActivity = activity
             isActivityRunning = true
             print("[ActivityManager] Started activity: \(activity.id)")
+            return true
         } catch {
             print("[ActivityManager] Failed to start activity: \(error)")
+            return false
         }
     }
     

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -76,8 +76,16 @@ public final class TranscriptionRecordingService: ObservableObject {
             currentModel = "apple/local/SFSpeechRecognizer"
         }
 
-        // Live Activity is mandatory for AudioRecordingIntent
-        activityManager.startActivity(provider: modelDisplayName)
+        // A Live Activity is MANDATORY for an AudioRecordingIntent: recording
+        // audio in the background without one trips a system-policy assertion in
+        // the AppIntents framework (EXC_BREAKPOINT). If we can't start one (Live
+        // Activities disabled, or the request failed), abort cleanly with a
+        // friendly error rather than proceeding into the crash.
+        guard activityManager.startActivity(provider: modelDisplayName) else {
+            startTime = nil
+            sharedState.clearRecordingState()
+            throw iOSTranscriptionError.liveActivityUnavailable
+        }
 
         do {
             if currentModel.hasPrefix("deepgram") {

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -76,12 +76,12 @@ public final class TranscriptionRecordingService: ObservableObject {
             currentModel = "apple/local/SFSpeechRecognizer"
         }
 
-        // A Live Activity is MANDATORY for an AudioRecordingIntent: recording
-        // audio in the background without one trips a system-policy assertion in
-        // the AppIntents framework (EXC_BREAKPOINT). If we can't start one (Live
-        // Activities disabled, or the request failed), abort cleanly with a
-        // friendly error rather than proceeding into the crash.
-        guard activityManager.startActivity(provider: modelDisplayName) else {
+        // A Live Activity is required to record in the *background* via an
+        // AudioRecordingIntent — without one the AppIntents system-policy check
+        // asserts (EXC_BREAKPOINT). In the foreground a Live Activity is optional,
+        // so only enforce this when the app isn't active.
+        let activityStarted = activityManager.startActivity(provider: modelDisplayName)
+        if !activityStarted && UIApplication.shared.applicationState != .active {
             startTime = nil
             sharedState.clearRecordingState()
             throw iOSTranscriptionError.liveActivityUnavailable

--- a/Sources/SpeakiOS/Services/iOSTranscriptionError.swift
+++ b/Sources/SpeakiOS/Services/iOSTranscriptionError.swift
@@ -9,6 +9,7 @@ public enum iOSTranscriptionError: LocalizedError {
     case audioSessionFailed(Error)
     case recognitionFailed(Error)
     case interrupted
+    case liveActivityUnavailable
 
     public enum Permission {
         case microphone
@@ -29,6 +30,9 @@ public enum iOSTranscriptionError: LocalizedError {
             return "Recognition failed: \(error.localizedDescription)"
         case .interrupted:
             return "Transcription was interrupted (e.g., by a phone call)."
+        case .liveActivityUnavailable:
+            return "Turn on Live Activities for Just Speak to It in Settings to record with the "
+                + "Action Button."
         }
     }
 }


### PR DESCRIPTION
## Problem

TestFlight crash when toggling the Action Button (incident `8E131A07`,
`Role: Background`):

```
Exception Type: EXC_BREAKPOINT (SIGTRAP)
Thread 8 Crashed:
0  libswiftCore      _assertionFailure(...)
1  AppIntents        PerformActionExecutorTask.verifySystemPolicyWith(intent:output:)
2  AppIntents        PerformActionExecutorTask.perform(intent:findViewIntent:)
```

## Root cause

An `AudioRecordingIntent` that records audio **in the background must have an
active Live Activity**, or the AppIntents system-policy check asserts.
`TranscriptionActivityManager.startActivity` silently no-oped when Live
Activities were disabled by the user **or** `Activity.request` threw (e.g. the
concurrent-activity limit), so the headless recorder proceeded to record with no
Live Activity — and the policy check crashed the process. This matches the
intermittent ("sometimes") nature.

## Fix

- `startActivity(provider:)` now returns `Bool` — whether a Live Activity is
  actually active.
- `TranscriptionRecordingService.startRecording()` **guards** on it: if one
  can't be started, it aborts cleanly and throws
  `iOSTranscriptionError.liveActivityUnavailable` (a friendly "Turn on Live
  Activities…" message the intent surfaces) instead of recording into the crash.
  Throwing from `perform()` also avoids the output-verification path entirely.

## Verification

Diagnosed from the actual TestFlight crash log via the App Store Connect API.
Verified compiling + linting for iOS (`xcodebuild -scheme SpeakiOSLib
-destination generic/platform=iOS`; SwiftLint strict). The `SpeakCore` change is
also exercised by CI's SpeakCore iOS-simulator test.

> Please device-verify: with Live Activities **disabled** for the app, the Action
> Button should now show the "enable Live Activities" message instead of crashing.

Closes bd justspeaktoit-25q.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recording now stops immediately if Live Activities can’t be started, preventing a partial or unreliable recording setup.
  * Added a clearer error message when Live Activities are disabled, so users know how to enable them for recording.
  * Improved activity startup handling to better detect and report failures instead of continuing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->