### PR TITLE
fix(mac): handle no microphone on Mac Mini or devices without audio input

### DIFF
--- a/Sources/SpeakApp/CaptureHealthSnapshot.swift
+++ b/Sources/SpeakApp/CaptureHealthSnapshot.swift
@@ -12,12 +12,15 @@ struct CaptureHealthSnapshot: Equatable {
     }
 
     var microphonePermission: MicrophonePermission
+    /// `true` when CoreAudio reports zero input devices with usable channels — e.g. a Mac Mini with no mic attached.
+    var noInputDevicesAvailable: Bool
     var inputDeviceName: String
     var providerLabel: String
     var latencyTier: LatencyTier
 
     static let empty = CaptureHealthSnapshot(
         microphonePermission: .notDetermined,
+        noInputDevicesAvailable: false,
         inputDeviceName: "Unknown",
         providerLabel: "Unknown",
         latencyTier: .medium

--- a/Sources/SpeakApp/HUDView.swift
+++ b/Sources/SpeakApp/HUDView.swift
@@ -190,8 +190,12 @@ struct HUDOverlay: View {
   @ViewBuilder
   private var captureHealthRow: some View {
     let health = manager.captureHealth
-    let micColor: Color = health.microphonePermission == .denied ? phaseColor : .secondary
+    let micWarning = health.noInputDevicesAvailable || health.microphonePermission == .denied
+    let micColor: Color = micWarning ? phaseColor : .secondary
     let microphonePermissionLabel = {
+      if health.noInputDevicesAvailable {
+        return "No device"
+      }
       switch health.microphonePermission {
       case .granted:
         return "Granted"
@@ -201,19 +205,21 @@ struct HUDOverlay: View {
         return "Unknown"
       }
     }()
+    let micIcon = micWarning ? "mic.slash.fill" : "mic.fill"
+    let deviceLabel = health.noInputDevicesAvailable ? "No microphone connected" : health.inputDeviceName
     HStack(spacing: 8) {
-      Image(systemName: health.microphonePermission == .denied ? "mic.slash.fill" : "mic.fill")
+      Image(systemName: micIcon)
         .font(.system(size: 10, weight: .semibold))
         .foregroundStyle(micColor)
-        .accessibilityLabel("Microphone permission: \(microphonePermissionLabel)")
+        .accessibilityLabel("Microphone: \(microphonePermissionLabel)")
 
-      Text(health.inputDeviceName)
+      Text(deviceLabel)
         .font(.caption2)
-        .foregroundStyle(.secondary)
+        .foregroundStyle(health.noInputDevicesAvailable ? micColor : .secondary)
         .lineLimit(1)
         .truncationMode(.tail)
-        .help(health.inputDeviceName)
-        .accessibilityLabel("Input device: \(health.inputDeviceName)")
+        .help(deviceLabel)
+        .accessibilityLabel("Input device: \(deviceLabel)")
 
       Text(health.providerLabel)
         .font(.caption2)

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -368,6 +368,7 @@ final class MainManager: ObservableObject {
 
     return CaptureHealthSnapshot(
       microphonePermission: micPermission,
+      noInputDevicesAvailable: audioInputDeviceManager.devices.isEmpty,
       inputDeviceName: deviceName,
       providerLabel: providerLabel,
       latencyTier: latencyTier
@@ -583,6 +584,12 @@ final class MainManager: ObservableObject {
   private func startSession(trigger: SessionTriggerSource) async {
     guard activeSession == nil else { return }
     if await presentMissingLiveAPIKeyAlertIfNeeded() { return }
+
+    if audioInputDeviceManager.devices.isEmpty {
+      state = .failed("No microphone connected. Plug in a USB or Bluetooth microphone and try again.")
+      lastErrorMessage = "No microphone connected. Plug in a USB or Bluetooth microphone and try again."
+      return
+    }
 
     // Failsafe: if live transcription is still running but we have no activeSession,
     // cancel it so the app can always recover without requiring a restart.

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -586,8 +586,13 @@ final class MainManager: ObservableObject {
     if await presentMissingLiveAPIKeyAlertIfNeeded() { return }
 
     if audioInputDeviceManager.devices.isEmpty {
-      state = .failed("No microphone connected. Plug in a USB or Bluetooth microphone and try again.")
-      lastErrorMessage = "No microphone connected. Plug in a USB or Bluetooth microphone and try again."
+      let message = "No microphone connected. Plug in a USB or Bluetooth microphone and try again."
+      state = .failed(message)
+      lastErrorMessage = message
+      hudManager.finishFailure(
+        headline: "No microphone connected",
+        message: "Plug in a USB or Bluetooth microphone and try again."
+      )
       return
     }
 

--- a/Tests/SpeakAppTests/CaptureHealthSnapshotTests.swift
+++ b/Tests/SpeakAppTests/CaptureHealthSnapshotTests.swift
@@ -10,6 +10,7 @@ final class CaptureHealthSnapshotTests: XCTestCase {
   func testSnapshot_defaultEmpty_hasExpectedValues() {
     let snapshot = CaptureHealthSnapshot.empty
     XCTAssertEqual(snapshot.microphonePermission, .notDetermined)
+    XCTAssertFalse(snapshot.noInputDevicesAvailable)
     XCTAssertEqual(snapshot.inputDeviceName, "Unknown")
     XCTAssertEqual(snapshot.providerLabel, "Unknown")
     XCTAssertEqual(snapshot.latencyTier, .medium)
@@ -18,12 +19,14 @@ final class CaptureHealthSnapshotTests: XCTestCase {
   func testSnapshot_equality_sameValues() {
     let snapshotA = CaptureHealthSnapshot(
       microphonePermission: .granted,
+      noInputDevicesAvailable: false,
       inputDeviceName: "MacBook Mic",
       providerLabel: "AssemblyAI Universal",
       latencyTier: .fast
     )
     let snapshotB = CaptureHealthSnapshot(
       microphonePermission: .granted,
+      noInputDevicesAvailable: false,
       inputDeviceName: "MacBook Mic",
       providerLabel: "AssemblyAI Universal",
       latencyTier: .fast
@@ -34,12 +37,14 @@ final class CaptureHealthSnapshotTests: XCTestCase {
   func testSnapshot_equality_differentPermission() {
     let granted = CaptureHealthSnapshot(
       microphonePermission: .granted,
+      noInputDevicesAvailable: false,
       inputDeviceName: "MacBook Mic",
       providerLabel: "Apple Speech",
       latencyTier: .instant
     )
     let denied = CaptureHealthSnapshot(
       microphonePermission: .denied,
+      noInputDevicesAvailable: false,
       inputDeviceName: "MacBook Mic",
       providerLabel: "Apple Speech",
       latencyTier: .instant
@@ -51,6 +56,26 @@ final class CaptureHealthSnapshotTests: XCTestCase {
     XCTAssertTrue(CaptureHealthSnapshot.MicrophonePermission.granted.isGranted)
     XCTAssertFalse(CaptureHealthSnapshot.MicrophonePermission.denied.isGranted)
     XCTAssertFalse(CaptureHealthSnapshot.MicrophonePermission.notDetermined.isGranted)
+  }
+
+  func testSnapshot_noInputDevicesAvailable_isDistinctFromPermissionDenied() {
+    let noDevices = CaptureHealthSnapshot(
+      microphonePermission: .notDetermined,
+      noInputDevicesAvailable: true,
+      inputDeviceName: "System Default",
+      providerLabel: "Apple Speech",
+      latencyTier: .instant
+    )
+    let permDenied = CaptureHealthSnapshot(
+      microphonePermission: .denied,
+      noInputDevicesAvailable: false,
+      inputDeviceName: "Built-in Mic",
+      providerLabel: "Apple Speech",
+      latencyTier: .instant
+    )
+    XCTAssertTrue(noDevices.noInputDevicesAvailable)
+    XCTAssertFalse(permDenied.noInputDevicesAvailable)
+    XCTAssertNotEqual(noDevices, permDenied)
   }
 
   // MARK: - HUDManager captureHealth property
@@ -66,6 +91,7 @@ final class CaptureHealthSnapshotTests: XCTestCase {
     let manager = HUDManager(appSettings: AppSettings())
     let snapshot = CaptureHealthSnapshot(
       microphonePermission: .granted,
+      noInputDevicesAvailable: false,
       inputDeviceName: "USB Microphone",
       providerLabel: "Deepgram Nova-3",
       latencyTier: .fast
@@ -79,12 +105,14 @@ final class CaptureHealthSnapshotTests: XCTestCase {
     let manager = HUDManager(appSettings: AppSettings())
     let first = CaptureHealthSnapshot(
       microphonePermission: .denied,
+      noInputDevicesAvailable: false,
       inputDeviceName: "Built-in Mic",
       providerLabel: "Apple Speech",
       latencyTier: .instant
     )
     let second = CaptureHealthSnapshot(
       microphonePermission: .granted,
+      noInputDevicesAvailable: false,
       inputDeviceName: "USB Microphone",
       providerLabel: "AssemblyAI Universal",
       latencyTier: .fast

--- a/Tests/SpeakAppTests/CaptureHealthSnapshotTests.swift
+++ b/Tests/SpeakAppTests/CaptureHealthSnapshotTests.swift
@@ -62,7 +62,7 @@ final class CaptureHealthSnapshotTests: XCTestCase {
     let noDevices = CaptureHealthSnapshot(
       microphonePermission: .notDetermined,
       noInputDevicesAvailable: true,
-      inputDeviceName: "System Default",
+      inputDeviceName: "Built-in Mic",
       providerLabel: "Apple Speech",
       latencyTier: .instant
     )
@@ -76,6 +76,19 @@ final class CaptureHealthSnapshotTests: XCTestCase {
     XCTAssertTrue(noDevices.noInputDevicesAvailable)
     XCTAssertFalse(permDenied.noInputDevicesAvailable)
     XCTAssertNotEqual(noDevices, permDenied)
+  }
+
+  func testSnapshot_noInputDevicesAvailable_isOnlyDifferingField() {
+    let base = CaptureHealthSnapshot(
+      microphonePermission: .granted,
+      noInputDevicesAvailable: false,
+      inputDeviceName: "Built-in Mic",
+      providerLabel: "Apple Speech",
+      latencyTier: .instant
+    )
+    var noDevices = base
+    noDevices.noInputDevicesAvailable = true
+    XCTAssertNotEqual(base, noDevices)
   }
 
   // MARK: - HUDManager captureHealth property


### PR DESCRIPTION
## Problem

On a Mac Mini (or any Mac with no built-in mic and nothing plugged in), starting a recording failed with a confusing error. With zero audio input devices, macOS won't prompt for microphone permission, so the flow fell through to a generic permission / "selected microphone is unavailable" message that didn't explain the real cause.

## Fix

- Add `noInputDevicesAvailable` to `CaptureHealthSnapshot`, set from `AudioInputDeviceManager.devices.isEmpty`.
- Guard early in `MainManager.startSession()` with a clear, actionable message — *"No microphone connected. Plug in a USB or Bluetooth microphone and try again."* — instead of proceeding into audio setup.
- HUD capture-health row now shows `mic.slash.fill` and a **No microphone connected** label in the warning colour when no input devices are present, distinct from permission-denied.

The device list is CoreAudio-observed, so plugging in a USB/Bluetooth mic updates state and recording works without a restart.

## Tests

- New unit test asserting `noInputDevicesAvailable` is distinct from permission-denied.
- Updated existing `CaptureHealthSnapshot` tests for the new field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now detects when no microphone/input device is connected and shows a clearer “No device” status.
  * Microphone indicators and accessibility labels now better reflect the actual input device state.

* **Bug Fixes**
  * Starting a session now stops immediately if no input device is available, preventing failed transcription/recording attempts.
  * Microphone warnings now distinguish between missing devices and denied permissions for more accurate feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->