### PR TITLE
feat(mac): dual App Store + Developer ID builds, with iOS iCloud sync

### DIFF
--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -73,12 +73,14 @@ jobs:
 
       - name: Generate Xcode Project
         env:
-          APP_STORE: "1"
+          TUIST_APP_STORE: "1"
         run: |
-          # APP_STORE=1 makes Project.swift define the APP_STORE compilation
+          # TUIST_APP_STORE=1 makes Project.swift define the APP_STORE compilation
           # condition (compiling out Sparkle self-update and the downloaded
           # local-model runtimes) and select the sandboxed entitlements file
           # Config/SpeakMacOS.AppStore.entitlements. Mac App Store REQUIRES the sandbox.
+          # The var MUST be TUIST_-prefixed: Tuist only forwards TUIST_* env vars into
+          # manifest evaluation, so a plain APP_STORE=1 would be silently ignored.
           tuist generate --no-open
 
       - name: Update Version

--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -72,11 +72,14 @@ jobs:
           echo -n "$MAC_APP_STORE_PROFILE" | base64 --decode -o ~/Library/MobileDevice/Provisioning\ Profiles/mac-app-store.provisionprofile
 
       - name: Generate Xcode Project
+        env:
+          APP_STORE: "1"
         run: |
+          # APP_STORE=1 makes Project.swift define the APP_STORE compilation
+          # condition (compiling out Sparkle self-update and the downloaded
+          # local-model runtimes) and select the sandboxed entitlements file
+          # Config/SpeakMacOS.AppStore.entitlements. Mac App Store REQUIRES the sandbox.
           tuist generate --no-open
-
-      # NOTE: Before using this workflow, re-enable sandbox in Config/SpeakMacOS.entitlements
-      # by uncommenting the App Store entitlements section. Mac App Store REQUIRES sandbox.
 
       - name: Update Version
         run: |

--- a/Config/SpeakMacOS.AppStore.entitlements
+++ b/Config/SpeakMacOS.AppStore.entitlements
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  macOS Entitlements for Mac App Store distribution (sandboxed).
+
+  Selected automatically when the project is generated with APP_STORE=1
+  (see Project.swift). The App Store REQUIRES the sandbox, and forbids
+  `com.apple.security.cs.disable-library-validation`, so that entitlement is
+  deliberately absent here (it lives only in the Developer ID file).
+
+  Unlike Developer ID builds, App Store builds ship with a managed provisioning
+  profile, so iCloud (KV store + CloudKit) and keychain-sharing entitlements are
+  available here — this is what lets settings/history sync work on the App Store
+  build. SyncConfiguration/SettingsSync detect these at runtime and fall back
+  gracefully when absent.
+
+  NOTE: Sandboxed apps cannot auto-prompt for Accessibility / Input Monitoring;
+  users must add the app manually in System Settings. The in-app permission
+  helpers guide them through this (see PermissionsManager + onboarding).
+-->
+<plist version="1.0">
+<dict>
+	<!-- Sandbox (REQUIRED for App Store) -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+
+	<!-- Microphone access -->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+
+	<!-- Outbound network for transcription/post-processing providers -->
+	<key>com.apple.security.network.client</key>
+	<true/>
+
+	<!-- User-selected files (import/export audio + transcripts) -->
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+
+	<!-- AppleScript/Automation - send events to other apps for text insertion -->
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+
+	<!-- Shared keychain (App Store managed profile supports this) -->
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.justspeaktoit.shared</string>
+	</array>
+
+	<!-- iCloud Key-Value Storage - settings sync -->
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)com.justspeaktoit</string>
+
+	<!-- iCloud CloudKit - transcription history sync -->
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.justspeaktoit</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+
+	<!-- CloudKit silent push for sync -->
+	<key>aps-environment</key>
+	<string>production</string>
+</dict>
+</plist>

--- a/Config/SpeakMacOS.AppStore.entitlements
+++ b/Config/SpeakMacOS.AppStore.entitlements
@@ -3,7 +3,7 @@
 <!--
   macOS Entitlements for Mac App Store distribution (sandboxed).
 
-  Selected automatically when the project is generated with APP_STORE=1
+  Selected automatically when the project is generated with TUIST_APP_STORE=1
   (see Project.swift). The App Store REQUIRES the sandbox, and forbids
   `com.apple.security.cs.disable-library-validation`, so that entitlement is
   deliberately absent here (it lives only in the Developer ID file).

--- a/Config/SpeakiOS.entitlements
+++ b/Config/SpeakiOS.entitlements
@@ -7,13 +7,20 @@
     <key>keychain-access-groups</key>
     <array>
         <!-- Default app keychain group -->
-    <string>$(AppIdentifierPrefix)com.justspeaktoit.shared</string>
+        <string>$(AppIdentifierPrefix)com.justspeaktoit.shared</string>
     </array>
-    
-    <!-- iCloud: Disabled - requires Apple Developer subscription -->
-    <!-- Uncomment if you have a subscription and want iCloud settings sync -->
-    <!-- <key>com.apple.developer.ubiquity-kvstore-identifier</key> -->
-    <!-- <string>$(TeamIdentifierPrefix)com.speak.ios</string> -->
+
+    <!-- iCloud: Enables settings (KVS) and transcription history (CloudKit) sync -->
+    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
+    <string>$(TeamIdentifierPrefix)com.justspeaktoit.ios</string>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array>
+        <string>iCloud.com.justspeaktoit.ios</string>
+    </array>
+    <key>com.apple.developer.icloud-services</key>
+    <array>
+        <string>CloudKit</string>
+    </array>
     
     <!-- App Groups: Enables shared container for widget extension -->
     <key>com.apple.security.application-groups</key>
@@ -21,7 +28,10 @@
         <string>group.com.justspeaktoit.ios</string>
     </array>
     
-    <!-- Background Modes: Required for audio recording -->
-    <!-- Note: Also add to Info.plist UIBackgroundModes array -->
+    <!-- Push Notifications: Required for CloudKit silent push sync.
+         App Store / TestFlight builds must use "production"; switch back to
+         "development" only for local Xcode-signed development builds. -->
+    <key>aps-environment</key>
+    <string>production</string>
 </dict>
 </plist>

--- a/Project.swift
+++ b/Project.swift
@@ -27,6 +27,27 @@ var iosAppSettings: [String: SettingValue] = [
 if ProcessInfo.processInfo.environment["SHOW_OPENCLAW_TAB"] != nil {
     iosAppSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) SHOW_OPENCLAW_TAB"
 }
+
+// Distribution channel selection for macOS. The app compiles from one codebase into
+// two flavours: Developer ID / direct download (default) and Mac App Store. Generate
+// with `APP_STORE=1 tuist generate` to produce a sandboxed App Store build: it defines
+// the `APP_STORE` Swift active compilation condition (gates Sparkle self-update and the
+// downloaded local-model runtimes — see Sources/SpeakCore/DistributionChannel.swift) and
+// selects the sandboxed entitlements file.
+let isAppStoreBuild = ProcessInfo.processInfo.environment["APP_STORE"] != nil
+let macEntitlementsPath = isAppStoreBuild
+    ? "Config/SpeakMacOS.AppStore.entitlements"
+    : "Config/SpeakMacOS.entitlements"
+var macAppSettings: [String: SettingValue] = [
+    "DEVELOPMENT_TEAM": "8X4ZN58TYH",
+    "CODE_SIGN_STYLE": "Automatic",
+    "CODE_SIGN_IDENTITY": "Apple Development",
+    "PRODUCT_BUNDLE_IDENTIFIER": "com.justspeaktoit.mac"
+]
+if isAppStoreBuild {
+    macAppSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) APP_STORE"
+}
+
 var iosWidgetSettings: [String: SettingValue] = [
     "CURRENT_PROJECT_VERSION": "1",
     "MARKETING_VERSION": "\(version)"
@@ -75,7 +96,7 @@ let project = Project(
                 .glob(pattern: "Resources/AppIcon.icns"),
                 .glob(pattern: "Resources/Sounds/**")
             ],
-            entitlements: .file(path: "Config/SpeakMacOS.entitlements"),
+            entitlements: .file(path: .relativeToRoot(macEntitlementsPath)),
             dependencies: [
                 .package(product: "SpeakCore"),
                 .package(product: "SpeakSync"),
@@ -84,12 +105,7 @@ let project = Project(
                 .package(product: "Sparkle"),
                 .package(product: "Sentry")
             ],
-            settings: .settings(base: [
-                "DEVELOPMENT_TEAM": "8X4ZN58TYH",
-                "CODE_SIGN_STYLE": "Automatic",
-                "CODE_SIGN_IDENTITY": "Apple Development",
-                "PRODUCT_BUNDLE_IDENTIFIER": "com.justspeaktoit.mac"
-            ])
+            settings: .settings(base: macAppSettings)
         ),
         .target(
             name: "SpeakiOS",

--- a/Project.swift
+++ b/Project.swift
@@ -30,11 +30,17 @@ if ProcessInfo.processInfo.environment["SHOW_OPENCLAW_TAB"] != nil {
 
 // Distribution channel selection for macOS. The app compiles from one codebase into
 // two flavours: Developer ID / direct download (default) and Mac App Store. Generate
-// with `APP_STORE=1 tuist generate` to produce a sandboxed App Store build: it defines
-// the `APP_STORE` Swift active compilation condition (gates Sparkle self-update and the
-// downloaded local-model runtimes — see Sources/SpeakCore/DistributionChannel.swift) and
-// selects the sandboxed entitlements file.
-let isAppStoreBuild = ProcessInfo.processInfo.environment["APP_STORE"] != nil
+// with `TUIST_APP_STORE=1 tuist generate` to produce a sandboxed App Store build: it
+// defines the `APP_STORE` Swift active compilation condition (gates Sparkle self-update
+// and the downloaded local-model runtimes — see Sources/SpeakCore/DistributionChannel.swift)
+// and selects the sandboxed entitlements file.
+//
+// NOTE: the env var MUST be `TUIST_`-prefixed. Tuist only forwards environment variables
+// whose names start with `TUIST_` into the manifest evaluation process, so a plain
+// `APP_STORE=1` is silently ignored here and the manifest would fall back to the direct
+// (non-sandboxed) entitlements. The Swift compilation condition itself stays `APP_STORE`
+// (that is what the `#if !APP_STORE` source guards check).
+let isAppStoreBuild = ProcessInfo.processInfo.environment["TUIST_APP_STORE"] != nil
 let macEntitlementsPath = isAppStoreBuild
     ? "Config/SpeakMacOS.AppStore.entitlements"
     : "Config/SpeakMacOS.entitlements"

--- a/Project.swift
+++ b/Project.swift
@@ -40,7 +40,10 @@ if ProcessInfo.processInfo.environment["SHOW_OPENCLAW_TAB"] != nil {
 // `APP_STORE=1` is silently ignored here and the manifest would fall back to the direct
 // (non-sandboxed) entitlements. The Swift compilation condition itself stays `APP_STORE`
 // (that is what the `#if !APP_STORE` source guards check).
-let isAppStoreBuild = ProcessInfo.processInfo.environment["TUIST_APP_STORE"] != nil
+// Parse an explicit truthy value so `TUIST_APP_STORE=0` (or an empty value) predictably
+// selects the direct build instead of silently enabling the App Store variant.
+let appStoreFlag = (ProcessInfo.processInfo.environment["TUIST_APP_STORE"] ?? "").lowercased()
+let isAppStoreBuild = ["1", "true", "yes"].contains(appStoreFlag)
 let macEntitlementsPath = isAppStoreBuild
     ? "Config/SpeakMacOS.AppStore.entitlements"
     : "Config/SpeakMacOS.entitlements"

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -354,7 +354,15 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   @Published var localTranscriptionMode: LocalTranscriptionMode {
-    didSet { store(localTranscriptionMode.rawValue, key: .localTranscriptionMode) }
+    didSet {
+      #if APP_STORE
+      if !DistributionChannel.current.supportsLocalModelRuntime, localTranscriptionMode == .streaming {
+        localTranscriptionMode = .batch
+        return
+      }
+      #endif
+      store(localTranscriptionMode.rawValue, key: .localTranscriptionMode)
+    }
   }
 
   @Published var localStreamingModelSource: String {
@@ -803,15 +811,26 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       Self.normalizedLocalTranscriptionModel(
         defaults.string(forKey: DefaultsKey.localTranscriptionModel.rawValue)
       )
-    localTranscriptionMode =
-      LocalTranscriptionMode(
-        rawValue: defaults.string(forKey: DefaultsKey.localTranscriptionMode.rawValue)
-          ?? LocalTranscriptionMode.batch.rawValue
-      ) ?? .batch
+    let loadedLocalTranscriptionMode = LocalTranscriptionMode(
+      rawValue: defaults.string(forKey: DefaultsKey.localTranscriptionMode.rawValue)
+        ?? LocalTranscriptionMode.batch.rawValue
+    ) ?? .batch
+    #if APP_STORE
+    localTranscriptionMode = DistributionChannel.current.supportsLocalModelRuntime
+      ? loadedLocalTranscriptionMode
+      : .batch
+    #else
+    localTranscriptionMode = loadedLocalTranscriptionMode
+    #endif
     let storedLocalStreamingSource = defaults.string(forKey: DefaultsKey.localStreamingModelSource.rawValue)
+    #if APP_STORE
+    let defaultLocalStreamingSource = ""
+    let supportedLocalStreamingIDs: Set<String> = []
+    #else
     let defaultLocalStreamingSource = LocalModelManager.recommendedStreamingModelSources.first?.id ?? ""
     let supportedLocalStreamingIDs = Set(LocalModelManager.recommendedStreamingModelSources.map(\.id))
       .union(LocalModelManager.shared.streamingModelSources.map(\.id))
+    #endif
     localStreamingModelSource =
       supportedLocalStreamingIDs.contains(storedLocalStreamingSource ?? "")
       ? storedLocalStreamingSource ?? defaultLocalStreamingSource

--- a/Sources/SpeakApp/LocalModelManager.swift
+++ b/Sources/SpeakApp/LocalModelManager.swift
@@ -23,10 +23,14 @@ enum LocalModelError: LocalizedError {
     case .invalidHuggingFaceRepo(let repo):
       return "\(repo) is not a valid Hugging Face repo ID. Use owner/repo, for example argmaxinc/whisperkit-coreml."
     case .invalidHuggingFaceModel:
+      #if APP_STORE
+      return "Enter a supported local batch model name. Local Batch expects a WhisperKit variant."
+      #else
       return """
       Enter a supported local model name. Local Batch expects a WhisperKit variant; \
       Local Streaming expects a sherpa-onnx streaming ASR source.
       """
+      #endif
     }
   }
 }
@@ -45,6 +49,7 @@ final class LocalModelManager: ObservableObject {
 
   @Published private(set) var installStates: [String: InstallState] = [:]
   @Published private(set) var importedModels: [LocalTranscriptionModel] = []
+  #if !APP_STORE
   @Published private(set) var streamingModelSources: [LocalStreamingModelSource] = []
 
   static let recommendedStreamingModelSources: [LocalStreamingModelSource] = [
@@ -93,6 +98,7 @@ final class LocalModelManager: ObservableObject {
       approximateSizeMB: 44
     )
   ]
+  #endif
 
   private var activePipelines: [String: WhisperKit] = [:]
   private var loadingPipelines: [String: Task<WhisperKit, Error>] = [:]
@@ -100,7 +106,9 @@ final class LocalModelManager: ObservableObject {
   private let logger = Logger(subsystem: "com.github.speakapp", category: "LocalModelManager")
   private let markerDirectory: URL
   private let importedModelsURL: URL
+  #if !APP_STORE
   private let streamingModelSourcesURL: URL
+  #endif
   private var storageError: Error?
 
   private init(fileManager: FileManager = .default) {
@@ -111,7 +119,9 @@ final class LocalModelManager: ObservableObject {
       .appendingPathComponent("SpeakApp", isDirectory: true)
       .appendingPathComponent("LocalModels", isDirectory: true)
     importedModelsURL = markerDirectory.appendingPathComponent("imported-hugging-face-models.json")
+    #if !APP_STORE
     streamingModelSourcesURL = markerDirectory.appendingPathComponent("streaming-model-sources.json")
+    #endif
     do {
       try fileManager.createDirectory(at: markerDirectory, withIntermediateDirectories: true)
     } catch {
@@ -119,7 +129,9 @@ final class LocalModelManager: ObservableObject {
       logger.error("Failed to prepare local model storage: \(error.localizedDescription, privacy: .public)")
     }
     loadImportedModels()
+    #if !APP_STORE
     loadStreamingModelSources()
+    #endif
     refreshInstallStates()
   }
 
@@ -197,6 +209,7 @@ final class LocalModelManager: ObservableObject {
     return model
   }
 
+  #if !APP_STORE
   @discardableResult
   func addStreamingModelSource(repoID: String, modelName: String) throws -> LocalStreamingModelSource {
     let repoID = repoID.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -232,6 +245,7 @@ final class LocalModelManager: ObservableObject {
       logger.error("Failed to save local streaming model sources: \(error.localizedDescription, privacy: .public)")
     }
   }
+  #endif
 
   func install(_ model: LocalTranscriptionModel) async {
     installStates[model.id] = .installing
@@ -353,6 +367,7 @@ final class LocalModelManager: ObservableObject {
     }
   }
 
+  #if !APP_STORE
   private func loadStreamingModelSources() {
     guard fileManager.fileExists(atPath: streamingModelSourcesURL.path) else { return }
     do {
@@ -369,6 +384,7 @@ final class LocalModelManager: ObservableObject {
       logger.error("Failed to load local streaming model sources: \(error.localizedDescription, privacy: .public)")
     }
   }
+  #endif
 
   private func saveImportedModels() throws {
     let records = importedModels.map(ImportedModelRecord.init(model:))
@@ -376,10 +392,12 @@ final class LocalModelManager: ObservableObject {
     try data.write(to: importedModelsURL, options: .atomic)
   }
 
+  #if !APP_STORE
   private func saveStreamingModelSources() throws {
     let data = try JSONEncoder().encode(streamingModelSources)
     try data.write(to: streamingModelSourcesURL, options: .atomic)
   }
+  #endif
 
   nonisolated static func huggingFaceModelID(repoID: String, modelName: String) -> String {
     "local/whisperkit/huggingface/\(slug(repoID))/\(slug(modelName))"
@@ -423,6 +441,7 @@ final class LocalModelManager: ObservableObject {
     )
   }
 
+  #if !APP_STORE
   nonisolated static func normalizedStreamingModelSource(_ source: LocalStreamingModelSource) -> LocalStreamingModelSource { // swiftlint:disable:this line_length
     LocalStreamingModelSource(
       repoID: source.repoID,
@@ -433,6 +452,7 @@ final class LocalModelManager: ObservableObject {
       archiveURL: source.archiveURL
     )
   }
+  #endif
 
   nonisolated static func slug(_ value: String) -> String {
     value
@@ -452,6 +472,7 @@ final class LocalModelManager: ObservableObject {
     }.reversed()
   }
 
+  #if !APP_STORE
   nonisolated static func streamingRuntimeHint(for repoID: String, modelName: String) -> String {
     let searchText = "\(repoID) \(modelName)".lowercased()
     if searchText.contains("sherpa") || searchText.contains("zipformer") || searchText.contains("onnx") {
@@ -491,6 +512,7 @@ final class LocalModelManager: ObservableObject {
     }
     return text.contains("sherpa") && (text.contains("zipformer") || text.contains("nemotron"))
   }
+  #endif
 
   nonisolated static func resolveHuggingFaceModel(repoID: String, modelName: String) -> ResolvedHuggingFaceModel {
     let repo = repoID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -605,6 +627,7 @@ struct ResolvedHuggingFaceModel: Equatable, Sendable {
   let approximateSizeMB: Int
 }
 
+#if !APP_STORE
 struct LocalStreamingModelSource: Codable, Equatable, Identifiable, Sendable {
   let id: String
   let repoID: String
@@ -635,6 +658,7 @@ struct LocalStreamingModelSource: Codable, Equatable, Identifiable, Sendable {
     "\(modelName) from \(repoID)"
   }
 }
+#endif
 
 private struct ImportedModelRecord: Codable {
   let id: String

--- a/Sources/SpeakApp/LocalPostProcessingModelManager.swift
+++ b/Sources/SpeakApp/LocalPostProcessingModelManager.swift
@@ -3,6 +3,7 @@ import OSLog
 import SpeakCore
 
 // swiftlint:disable file_length
+#if !APP_STORE
 enum LocalPostProcessingModelError: LocalizedError {
   case pythonUnavailable
   case runtimeUnavailable(String)
@@ -31,6 +32,7 @@ enum LocalPostProcessingModelError: LocalizedError {
     }
   }
 }
+#endif
 
 @MainActor
 // swiftlint:disable:next type_body_length
@@ -51,6 +53,7 @@ final class LocalPostProcessingModelManager: ObservableObject {
 
   nonisolated static let builtInRulesModelID = "local/post-processing/rules"
 
+  #if !APP_STORE
   static let recommendedModels: [LocalPostProcessingModel] = [
     LocalPostProcessingModel(
       id: "local/post-processing/qwen3-1.7b-q4",
@@ -81,9 +84,11 @@ final class LocalPostProcessingModelManager: ObservableObject {
   @Published private(set) var runtimeState: InstallState = .notInstalled
   @Published private(set) var modelStates: [String: InstallState] = [:]
   @Published private(set) var importedModels: [LocalPostProcessingModel] = []
+  #endif
 
   private let fileManager: FileManager
   private let logger = Logger(subsystem: "com.github.speakapp", category: "LocalPostProcessing")
+  #if !APP_STORE
   private let baseDirectory: URL
   private let modelsDirectory: URL
   private let runtimeDirectory: URL
@@ -91,9 +96,11 @@ final class LocalPostProcessingModelManager: ObservableObject {
   private let virtualEnvironmentURL: URL
   private let importedModelsURL: URL
   private var pythonExecutableCache: URL?
+  #endif
 
   private init(fileManager: FileManager = .default) {
     self.fileManager = fileManager
+    #if !APP_STORE
     let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
       ?? fileManager.homeDirectoryForCurrentUser
     baseDirectory = base
@@ -114,10 +121,15 @@ final class LocalPostProcessingModelManager: ObservableObject {
     }
     loadImportedModels()
     refresh()
+    #endif
   }
 
   var availableModels: [LocalPostProcessingModel] {
+    #if APP_STORE
+    []
+    #else
     Self.recommendedModels + importedModels
+    #endif
   }
 
   var availableModelOptions: [ModelCatalog.Option] {
@@ -125,6 +137,7 @@ final class LocalPostProcessingModelManager: ObservableObject {
   }
 
   func refresh() {
+    #if !APP_STORE
     Task { await refreshRuntimeState() }
     for model in availableModels {
       if modelStates[model.id] == .installing {
@@ -132,10 +145,15 @@ final class LocalPostProcessingModelManager: ObservableObject {
       }
       modelStates[model.id] = modelFileExists(for: model) ? .installed : .notInstalled
     }
+    #endif
   }
 
   func installState(for modelID: String) -> InstallState {
+    #if APP_STORE
+    .notInstalled
+    #else
     modelStates[modelID] ?? .notInstalled
+    #endif
   }
 
   func isInstalled(_ modelID: String) -> Bool {
@@ -146,6 +164,7 @@ final class LocalPostProcessingModelManager: ObservableObject {
     availableModels.first { $0.id == modelID }
   }
 
+  #if !APP_STORE
   @discardableResult
   func addHuggingFaceModel(
     repoID: String,
@@ -393,6 +412,7 @@ final class LocalPostProcessingModelManager: ObservableObject {
     if let existing = try? Data(contentsOf: sidecarURL), existing == data { return }
     try data.write(to: sidecarURL, options: .atomic)
   }
+  #endif
 
   nonisolated static func isDownloadedLocalModelID(_ id: String) -> Bool {
     id.lowercased().hasPrefix("local/post-processing/")
@@ -482,6 +502,7 @@ final class LocalPostProcessingModelManager: ObservableObject {
     return "\(base) from \(repoID)"
   }
 
+  #if !APP_STORE
   // swiftlint:disable:next function_body_length
   private nonisolated static func runProcess(
     executableURL: URL,
@@ -628,6 +649,7 @@ def main():
 if __name__ == "__main__":
     main()
 """#
+  #endif
 }
 
 struct LocalPostProcessingModel: Codable, Equatable, Identifiable, Sendable {

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -37,8 +37,12 @@ final class MainManager: ObservableObject {
   }
 
   private var isStreamingTranscriptionMode: Bool {
+    #if APP_STORE
+    appSettings.transcriptionMode == .liveNative
+    #else
     appSettings.transcriptionMode == .liveNative
       || (appSettings.transcriptionMode == .localModel && appSettings.localTranscriptionMode == .streaming)
+    #endif
   }
 
   private var cachedRetryData: RetryData?
@@ -359,9 +363,13 @@ final class MainManager: ObservableObject {
     case .batchRemote:
       activeModel = appSettings.batchTranscriptionModel
     case .localModel:
+      #if APP_STORE
+      activeModel = appSettings.localTranscriptionModel
+      #else
       activeModel = appSettings.localTranscriptionMode == .streaming
         ? appSettings.localStreamingModelSource
         : appSettings.localTranscriptionModel
+      #endif
     }
     let providerLabel = captureHealthProviderLabel(for: activeModel)
     let latencyTier = ModelCatalog.allOptions.first(where: { $0.id == activeModel })?.latencyTier ?? .medium
@@ -382,9 +390,13 @@ final class MainManager: ObservableObject {
     case .batchRemote:
       return appSettings.batchTranscriptionModel
     case .localModel:
+      #if APP_STORE
+      return appSettings.localTranscriptionModel
+      #else
       return appSettings.localTranscriptionMode == .streaming
         ? appSettings.localStreamingModelSource
         : appSettings.localTranscriptionModel
+      #endif
     }
   }
 
@@ -431,11 +443,13 @@ final class MainManager: ObservableObject {
     guard appSettings.transcriptionMode == .localModel else {
       return ModelCatalog.friendlyName(for: modelID)
     }
+    #if !APP_STORE
     if appSettings.localTranscriptionMode == .streaming {
       let source = LocalModelManager.shared.streamingModelSources.first { $0.id == modelID }
         ?? LocalModelManager.recommendedStreamingModelSources.first { $0.id == modelID }
       return source?.modelName ?? "Local Streaming"
     }
+    #endif
     guard let localModel = LocalModelManager.shared.model(for: modelID) else {
       return ModelCatalog.friendlyName(for: modelID)
     }
@@ -726,6 +740,8 @@ final class MainManager: ObservableObject {
         }
         // Log network exchange for live transcription
         let durationStr = String(format: "%.1f", result.duration)
+        var didRecordLiveExchange = false
+        #if !APP_STORE
         if result.modelIdentifier.hasPrefix("local/streaming/") {
           let localURL = URL(string: "local://sherpa-onnx")!
             .appendingPathComponent(result.modelIdentifier)
@@ -743,7 +759,10 @@ final class MainManager: ObservableObject {
               responseBodyPreview: "Transcript: \(String(result.text.prefix(500)))"
             )
           )
-        } else if result.modelIdentifier.contains("deepgram") {
+          didRecordLiveExchange = true
+        }
+        #endif
+        if !didRecordLiveExchange, result.modelIdentifier.contains("deepgram") {
           session.networkExchanges.append(
             HistoryNetworkExchange(
               url: URL(string: "wss://api.deepgram.com/v1/listen")!,
@@ -758,7 +777,7 @@ final class MainManager: ObservableObject {
               responseBodyPreview: result.rawPayload ?? "Transcript: \(String(result.text.prefix(500)))"
             )
           )
-        } else if result.modelIdentifier.contains("apple") {
+        } else if !didRecordLiveExchange, result.modelIdentifier.contains("apple") {
           session.networkExchanges.append(
             HistoryNetworkExchange(
               url: URL(string: "local://SFSpeechRecognizer")!,

--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -643,7 +643,7 @@ struct AccessibilityManualHelper: View {
             HStack(spacing: 12) {
                 Button("Open Accessibility Settings") {
                     // Open directly to Accessibility pane
-                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+                    NSWorkspace.shared.open(PermissionType.accessibility.settingsURL)
                     currentStep = 1
                 }
                 .buttonStyle(.borderedProminent)

--- a/Sources/SpeakApp/PermissionsManager.swift
+++ b/Sources/SpeakApp/PermissionsManager.swift
@@ -74,7 +74,7 @@ enum PermissionType: CaseIterable, Identifiable {
         "Open \(displayName) settings.",
         "Click the + button at the bottom of the app list, or unlock first if macOS asks.",
         "Navigate to Applications → JustSpeakToIt.",
-        "Click Open, then enable the toggle.",
+        "Click Open, then enable the toggle."
       ]
     case .microphone, .speechRecognition:
       return nil

--- a/Sources/SpeakApp/PermissionsManager.swift
+++ b/Sources/SpeakApp/PermissionsManager.swift
@@ -53,6 +53,33 @@ enum PermissionType: CaseIterable, Identifiable {
       return "Permit hotkey monitoring so Speak notices only the shortcuts you assign—nothing more."
     }
   }
+
+  var settingsURL: URL {
+    switch self {
+    case .microphone:
+      return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!
+    case .speechRecognition:
+      return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition")!
+    case .accessibility:
+      return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
+    case .inputMonitoring:
+      return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")!
+    }
+  }
+
+  var manualSetupSteps: [String]? {
+    switch self {
+    case .accessibility, .inputMonitoring:
+      return [
+        "Open \(displayName) settings.",
+        "Click the + button at the bottom of the app list, or unlock first if macOS asks.",
+        "Navigate to Applications → JustSpeakToIt.",
+        "Click Open, then enable the toggle.",
+      ]
+    case .microphone, .speechRecognition:
+      return nil
+    }
+  }
 }
 
 enum PermissionStatus: Equatable {

--- a/Sources/SpeakApp/PostProcessingManager.swift
+++ b/Sources/SpeakApp/PostProcessingManager.swift
@@ -105,6 +105,18 @@ final class PostProcessingManager: ObservableObject {
     }
 
     if Self.isDownloadedLocalPostProcessingModel(model) {
+      #if APP_STORE
+      let cleaned = Self.processLocally(rawText)
+      return .success(
+        .init(
+          original: rawText,
+          processed: cleaned,
+          response: nil,
+          systemPrompt: "Local offline transcript cleanup",
+          promptPayload: nil
+        )
+      )
+      #else
       do {
         let cleaned = try await LocalPostProcessingModelManager.shared.process(
           modelID: model,
@@ -131,6 +143,7 @@ final class PostProcessingManager: ObservableObject {
         log.error("Local post-processing failed: \(error.localizedDescription, privacy: .public)")
         return .failure(error)
       }
+      #endif
     }
 
     let userMessage = """

--- a/Sources/SpeakApp/Services/UpdaterManager.swift
+++ b/Sources/SpeakApp/Services/UpdaterManager.swift
@@ -1,12 +1,17 @@
+import Combine
 import Foundation
+import SpeakCore
+#if !APP_STORE
 import Sparkle
+#endif
 
-/// Manages automatic updates using Sparkle framework
+/// Manages app update capabilities for the current distribution channel.
 @MainActor
 final class UpdaterManager: NSObject, ObservableObject {
     /// Shared instance for app-wide access
     static let shared = UpdaterManager()
 
+#if !APP_STORE
     /// The Sparkle updater controller
     private lazy var updaterController: SPUStandardUpdaterController = {
         SPUStandardUpdaterController(
@@ -53,8 +58,42 @@ final class UpdaterManager: NSObject, ObservableObject {
     var updater: SPUUpdater {
         updaterController.updater
     }
+#else
+    /// App Store builds receive updates through the Mac App Store.
+    @Published var automaticallyChecksForUpdates = false
+
+    /// Manual update checks are unavailable in App Store builds.
+    @Published private(set) var canCheckForUpdates = false
+
+    @Published private(set) var latestVersion: String?
+
+    private var currentVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
+    }
+
+    private override init() {
+        super.init()
+        latestVersion = currentVersion
+    }
+
+    /// App Store builds use the Mac App Store update flow.
+    func checkForUpdates() {}
+#endif
+
+    var supportsSelfUpdate: Bool {
+        DistributionChannel.current.supportsSelfUpdate
+    }
+
+    var allowsCrossChannelMessaging: Bool {
+        DistributionChannel.current.allowsCrossChannelMessaging
+    }
+
+    var updateStatusMessage: String {
+        supportsSelfUpdate ? "Latest unknown" : "Updates are delivered through the App Store."
+    }
 }
 
+#if !APP_STORE
 extension UpdaterManager: SPUUpdaterDelegate {
     nonisolated func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
         Task { @MainActor in
@@ -68,3 +107,4 @@ extension UpdaterManager: SPUUpdaterDelegate {
         }
     }
 }
+#endif

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -1,7 +1,6 @@
 import SpeakCore
 import SpeakHotKeys
 import AppKit
-import Sparkle
 import SwiftUI
 
 // swiftlint:disable file_length type_body_length
@@ -779,10 +778,16 @@ struct SettingsView: View {
               tint: .brandAccentWarm
             )
             .speakTooltip("Have Speak start alongside macOS so recording is always one shortcut away.")
-            Toggle("Automatically check for updates", isOn: $updaterManager.automaticallyChecksForUpdates)
-              .toggleStyle(.switch)
-              .tint(.brandAccentWarm)
-              .speakTooltip("Periodically check for new versions and notify you when updates are available.")
+            if updaterManager.supportsSelfUpdate {
+              Toggle("Automatically check for updates", isOn: $updaterManager.automaticallyChecksForUpdates)
+                .toggleStyle(.switch)
+                .tint(.brandAccentWarm)
+                .speakTooltip("Periodically check for new versions and notify you when updates are available.")
+            } else {
+              Label(updaterManager.updateStatusMessage, systemImage: "app.badge")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            }
             settingsToggle(
               "Show sidebar shortcut hints",
               isOn: settingsBinding(\AppSettings.showSidebarShortcutHints),
@@ -4100,10 +4105,12 @@ struct SettingsView: View {
           VStack(alignment: .leading, spacing: 8) {
             Label("Version \(appVersion)", systemImage: "tag")
             Label("Build \(buildNumber)", systemImage: "hammer")
-            if let latest = updaterManager.latestVersion {
+            if updaterManager.supportsSelfUpdate, let latest = updaterManager.latestVersion {
               Label("Latest \(latest)", systemImage: "arrow.up.circle")
+            } else if updaterManager.supportsSelfUpdate {
+              Label(updaterManager.updateStatusMessage, systemImage: "arrow.up.circle")
             } else {
-              Label("Latest unknown", systemImage: "arrow.up.circle")
+              Label(updaterManager.updateStatusMessage, systemImage: "app.badge")
             }
 
             if let commit = commitRef, !commit.isEmpty {
@@ -4118,18 +4125,22 @@ struct SettingsView: View {
           Divider()
 
           HStack(spacing: 12) {
-            Button {
-              updaterManager.checkForUpdates()
-            } label: {
-              Label("Check for Updates", systemImage: "arrow.triangle.2.circlepath")
+            if updaterManager.supportsSelfUpdate {
+              Button {
+                updaterManager.checkForUpdates()
+              } label: {
+                Label("Check for Updates", systemImage: "arrow.triangle.2.circlepath")
+              }
+              .buttonStyle(.bordered)
+              .disabled(!updaterManager.canCheckForUpdates)
             }
-            .buttonStyle(.bordered)
-            .disabled(!updaterManager.canCheckForUpdates)
 
-            Link(destination: URL(string: "https://github.com/crmitchelmore/justspeaktoit/releases")!) {
-              Label("View Releases", systemImage: "shippingbox")
+            if updaterManager.allowsCrossChannelMessaging {
+              Link(destination: URL(string: "https://github.com/crmitchelmore/justspeaktoit/releases")!) {
+                Label("View Releases", systemImage: "shippingbox")
+              }
+              .buttonStyle(.bordered)
             }
-            .buttonStyle(.bordered)
           }
         }
       }
@@ -4207,7 +4218,14 @@ struct SettingsView: View {
             .foregroundStyle(.secondary)
 
           VStack(alignment: .leading, spacing: 6) {
-            dependencyRow(name: "Sparkle", version: "2.6.0+", url: "https://sparkle-project.org", description: "Auto-update framework")
+            if updaterManager.supportsSelfUpdate {
+              dependencyRow(
+                name: "Sparkle",
+                version: "2.6.0+",
+                url: "https://sparkle-project.org",
+                description: "Auto-update framework"
+              )
+            }
             dependencyRow(name: "SwiftLint", version: "0.55.0+", url: "https://github.com/realm/SwiftLint", description: "Swift linting tool")
             dependencyRow(name: "SwiftFormat", version: "0.53.6+", url: "https://github.com/nicklockwood/SwiftFormat", description: "Code formatting")
           }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -1684,8 +1684,14 @@ struct SettingsView: View {
   }
 
   private var localRuntimeUnavailableNote: some View {
+    channelAvailabilityNote(
+      "Downloaded local runtimes are not available in this build. Local Batch and built-in cleanup remain available."
+    )
+  }
+
+  private func channelAvailabilityNote(_ text: String) -> some View {
     Label(
-      "Downloaded local runtimes are not available in this build. Local Batch and built-in cleanup remain available.",
+      text,
       systemImage: "info.circle"
     )
     .font(.caption)
@@ -4139,19 +4145,31 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 12) {
           ForEach(PermissionType.allCases) { permission in
             let status = environment.permissions.status(for: permission)
-            HStack(spacing: 12) {
-              Label(permission.displayName, systemImage: permission.systemIconName)
-              Spacer()
-              Text(statusLabel(for: status))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(statusColor(status).opacity(0.15), in: Capsule())
-                .foregroundStyle(statusColor(status))
-              Button("Request") {
-                Task { await environment.permissions.request(permission) }
+            VStack(alignment: .leading, spacing: 8) {
+              HStack(spacing: 12) {
+                Label(permission.displayName, systemImage: permission.systemIconName)
+                Spacer()
+                Text(statusLabel(for: status))
+                  .padding(.horizontal, 8)
+                  .padding(.vertical, 4)
+                  .background(statusColor(status).opacity(0.15), in: Capsule())
+                  .foregroundStyle(statusColor(status))
+                Button("Open Settings") {
+                  openSettings(for: permission)
+                }
+                .buttonStyle(.bordered)
+                .speakTooltip("Open the macOS privacy pane for \(permission.displayName).")
+                Button("Request") {
+                  Task { await environment.permissions.request(permission) }
+                }
+                .buttonStyle(.bordered)
+                .speakTooltip("Ask macOS to prompt again for \(permission.displayName) access.")
               }
-              .buttonStyle(.bordered)
-              .speakTooltip("Ask macOS to prompt again for \(permission.displayName) access.")
+
+              if shouldShowManualSetupHelp(for: permission, status: status),
+                 let steps = permission.manualSetupSteps {
+                permissionManualSetupNote(for: permission, steps: steps)
+              }
             }
           }
 
@@ -4173,6 +4191,24 @@ struct SettingsView: View {
     case .restricted: return "Restricted"
     case .notDetermined: return "Pending"
     }
+  }
+
+  private func openSettings(for permission: PermissionType) {
+    NSWorkspace.shared.open(permission.settingsURL)
+  }
+
+  private func shouldShowManualSetupHelp(for permission: PermissionType, status: PermissionStatus) -> Bool {
+    guard permission.manualSetupSteps != nil else { return false }
+    return !DistributionChannel.current.supportsAutomaticAccessibilityPrompt || status == .denied
+  }
+
+  private func permissionManualSetupNote(for permission: PermissionType, steps: [String]) -> some View {
+    let intro = if DistributionChannel.current.supportsAutomaticAccessibilityPrompt {
+      "Add \(permission.displayName) manually:"
+    } else {
+      "This build cannot show the automatic prompt here. Add \(permission.displayName) manually:"
+    }
+    return channelAvailabilityNote("\(intro) \(steps.joined(separator: " "))")
   }
 
   private func volumeLabel(for volume: Float) -> String {
@@ -4230,6 +4266,7 @@ struct SettingsView: View {
             }
             Label(buildType, systemImage: buildType == "Release" ? "checkmark.seal" : "wrench.and.screwdriver")
               .foregroundStyle(buildType == "Release" ? .green : .orange)
+            Label("Distribution: \(DistributionChannel.current.displayName)", systemImage: "shippingbox")
           }
           .font(.callout)
           .foregroundStyle(.secondary)
@@ -4309,16 +4346,20 @@ struct SettingsView: View {
           TipJarView()
             .frame(maxWidth: .infinity)
 
-          HStack(spacing: 12) {
-            Link(destination: URL(string: "https://github.com/sponsors/crmitchelmore")!) {
-              Label("GitHub Sponsors", systemImage: "heart")
-            }
-            .buttonStyle(.bordered)
+          // In-app StoreKit tips work in App Store builds; external donation
+          // links are only shown where cross-channel messaging is permitted.
+          if DistributionChannel.current.allowsCrossChannelMessaging {
+            HStack(spacing: 12) {
+              Link(destination: URL(string: "https://github.com/sponsors/crmitchelmore")!) {
+                Label("GitHub Sponsors", systemImage: "heart")
+              }
+              .buttonStyle(.bordered)
 
-            Link(destination: URL(string: "https://ko-fi.com/crmitchelmore")!) {
-              Label("Ko-fi", systemImage: "cup.and.saucer")
+              Link(destination: URL(string: "https://ko-fi.com/crmitchelmore")!) {
+                Label("Ko-fi", systemImage: "cup.and.saucer")
+              }
+              .buttonStyle(.bordered)
             }
-            .buttonStyle(.bordered)
           }
         }
       }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -57,7 +57,9 @@ struct SettingsView: View {
   @EnvironmentObject private var audioDevices: AudioInputDeviceManager
   @ObservedObject private var updaterManager = UpdaterManager.shared
   @ObservedObject private var localModels = LocalModelManager.shared
+  #if !APP_STORE
   @ObservedObject private var sherpaRuntime = SherpaOnnxRuntimeManager.shared
+  #endif
   @ObservedObject private var localPostProcessingModels = LocalPostProcessingModelManager.shared
   private static let localeOptions: [LocaleOption] = [
     LocaleOption(displayName: "English (United States)", identifier: "en_US"),
@@ -97,16 +99,20 @@ struct SettingsView: View {
   @State private var huggingFaceRepoID: String = "argmaxinc/whisperkit-coreml"
   @State private var huggingFaceModelName: String = "tiny"
   @State private var huggingFaceImportError: String?
+  #if !APP_STORE
   @State private var streamingHuggingFaceRepoID: String =
     "csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26"
   @State private var streamingHuggingFaceModelName: String = "streaming-zipformer-en-2023-06-26"
   @State private var selectedRecommendedStreamingSourceID: String =
     LocalModelManager.recommendedStreamingModelSources.first?.id ?? ""
   @State private var streamingHuggingFaceImportError: String?
+  #endif
+  #if !APP_STORE
   @State private var localPostProcessingRepoID: String = "unsloth/Qwen3-0.6B-GGUF"
   @State private var localPostProcessingFilename: String = "Qwen3-0.6B-Q4_K_M.gguf"
   @State private var localPostProcessingSizeMB: String = "450"
   @State private var localPostProcessingImportError: String?
+  #endif
   private let openRouterKeyIdentifier = "openrouter.apiKey"
 
   private enum TranscriptionLocation: String, CaseIterable, Identifiable {
@@ -138,7 +144,9 @@ struct SettingsView: View {
 
   }
 
-  private let orderedLocalTranscriptionModes: [AppSettings.LocalTranscriptionMode] = [.streaming, .batch]
+  private let orderedLocalTranscriptionModes: [AppSettings.LocalTranscriptionMode] = {
+    DistributionChannel.current.supportsLocalModelRuntime ? [.streaming, .batch] : [.batch]
+  }()
   private let orderedRemoteTranscriptionModes: [RemoteTranscriptionMode] = [.streaming, .batch]
 
   private enum PostProcessingLocation: String, CaseIterable, Identifiable {
@@ -1120,16 +1128,20 @@ struct SettingsView: View {
           .accessibilityLabel("Transcription location picker")
 
           if settings.transcriptionMode == .localModel {
-            Picker("Local transcription type", selection: settingsBinding(\AppSettings.localTranscriptionMode)) {
-              ForEach(orderedLocalTranscriptionModes) { mode in
-                Text(transcriptionModeSegmentLabel(from: mode.displayName)).tag(mode)
+            if DistributionChannel.current.supportsLocalModelRuntime {
+              Picker("Local transcription type", selection: settingsBinding(\AppSettings.localTranscriptionMode)) {
+                ForEach(orderedLocalTranscriptionModes) { mode in
+                  Text(transcriptionModeSegmentLabel(from: mode.displayName)).tag(mode)
+                }
               }
+              .modifier(TranscriptionModeSegmentedPickerStyle())
+              .speakTooltip(
+                "Choose Local Batch for offline transcription after recording, or Local Streaming for live local text."
+              )
+              .accessibilityLabel("Local transcription type picker")
+            } else {
+              localRuntimeUnavailableNote
             }
-            .modifier(TranscriptionModeSegmentedPickerStyle())
-            .speakTooltip(
-              "Choose Local Batch for offline transcription after recording, or Local Streaming for live local text."
-            )
-            .accessibilityLabel("Local transcription type picker")
           } else {
             Picker("Remote transcription type", selection: remoteTranscriptionModeBinding) {
               ForEach(orderedRemoteTranscriptionModes) { mode in
@@ -1478,25 +1490,42 @@ struct SettingsView: View {
             )
 
             Text(
-              """
-              Local Batch and Local Streaming are separate from Apple Speech and cloud providers. \
-              Both stay local-only; Local Batch uses downloaded WhisperKit/Core ML models, while \
-              Local Streaming needs a dedicated streaming ASR runtime.
-              """
+              {
+                #if APP_STORE
+                return """
+                Local transcription is separate from Apple Speech and cloud providers. \
+                Local Batch uses downloaded WhisperKit/Core ML models and stays local-only.
+                """
+                #else
+                return """
+                Local Batch and Local Streaming are separate from Apple Speech and cloud providers. \
+                Both stay local-only; Local Batch uses downloaded WhisperKit/Core ML models, while \
+                Local Streaming needs a dedicated streaming ASR runtime.
+                """
+                #endif
+              }()
             )
             .font(.caption)
             .foregroundStyle(.secondary)
+
+            if !DistributionChannel.current.supportsLocalModelRuntime {
+              localRuntimeUnavailableNote
+            }
 
             localModelQuickStart
             if settings.localTranscriptionMode == .batch {
               selectedLocalModelCallout
             }
 
+            #if APP_STORE
+            huggingFaceModelImport
+            #else
             if settings.localTranscriptionMode == .batch {
               huggingFaceModelImport
             } else {
               localStreamingStatus
             }
+            #endif
 
             if settings.localTranscriptionMode == .batch {
               if localTranscriptionOptions.isEmpty {
@@ -1617,6 +1646,18 @@ struct SettingsView: View {
         title: "Choose Local mode",
         detail: "This switches recordings away from cloud providers."
       )
+      #if APP_STORE
+      localModelStep(
+        number: "2",
+        title: "Download a local batch model",
+        detail: "WhisperKit/Core ML models run locally after recording stops."
+      )
+      localModelStep(
+        number: "3",
+        title: "Record normally",
+        detail: "Speak transcribes after recording stops, offline on this Mac."
+      )
+      #else
       localModelStep(
         number: "2",
         title: settings.localTranscriptionMode == .batch
@@ -1633,12 +1674,22 @@ struct SettingsView: View {
           ? "Speak transcribes after recording stops, offline on this Mac."
           : "Once a compatible streaming runtime is connected, Speak will stream partial text locally."
       )
+      #endif
     }
     .padding(12)
     .background(
       RoundedRectangle(cornerRadius: 12, style: .continuous)
         .fill(Color.green.opacity(0.08))
     )
+  }
+
+  private var localRuntimeUnavailableNote: some View {
+    Label(
+      "Downloaded local runtimes are not available in this build. Local Batch and built-in cleanup remain available.",
+      systemImage: "info.circle"
+    )
+    .font(.caption)
+    .foregroundStyle(.secondary)
   }
 
   private func localModelStep(number: String, title: String, detail: String) -> some View {
@@ -1719,6 +1770,7 @@ struct SettingsView: View {
     )
   }
 
+  #if !APP_STORE
   private var localStreamingStatus: some View {
     VStack(alignment: .leading, spacing: 12) {
       HStack(alignment: .top, spacing: 10) {
@@ -2035,7 +2087,6 @@ struct SettingsView: View {
       return "Experimental prerelease runtime. Requires Python 3 and installs sherpa-onnx locally."
     }
   }
-
   private func localStreamingInstallLabel(for source: LocalStreamingModelSource) -> String {
     switch sherpaRuntime.modelStates[source.id] ?? .notInstalled {
     case .installed:
@@ -2055,6 +2106,7 @@ struct SettingsView: View {
     }
     return "~\(size) MB"
   }
+  #endif
 
   @ViewBuilder
   private var selectedLocalModelCallout: some View {
@@ -2142,10 +2194,14 @@ struct SettingsView: View {
     let builtIn = ModelCatalog.postProcessing.filter {
       PostProcessingManager.isLocalPostProcessingModel($0.id)
     }
+    #if APP_STORE
+    return builtIn
+    #else
     let downloaded = localPostProcessingModels.availableModels
       .filter { localPostProcessingModels.isInstalled($0.id) }
       .map(\.option)
     return builtIn + downloaded
+    #endif
   }
 
   private var cloudPostProcessingOptions: [ModelCatalog.Option] {
@@ -2163,10 +2219,12 @@ struct SettingsView: View {
       && !huggingFaceModelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
 
+  #if !APP_STORE
   private var canAddStreamingModelSource: Bool {
     streamingHuggingFaceRepoID.split(separator: "/").count == 2
       && !streamingHuggingFaceModelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
+  #endif
 
   private var isCustomBatchTranscriptionModel: Bool {
     let model = settings.batchTranscriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2176,11 +2234,13 @@ struct SettingsView: View {
     }
   }
 
+  #if !APP_STORE
   private var selectedRecommendedStreamingSource: LocalStreamingModelSource? {
     LocalModelManager.recommendedStreamingModelSources.first {
       $0.id == selectedRecommendedStreamingSourceID
     } ?? LocalModelManager.recommendedStreamingModelSources.first
   }
+  #endif
 
   private func openHuggingFaceModelSearch() {
     guard let url = URL(
@@ -2189,6 +2249,7 @@ struct SettingsView: View {
     NSWorkspace.shared.open(url)
   }
 
+  #if !APP_STORE
   private func openLocalStreamingModelSearch() {
     guard let url = URL(
       string: "https://huggingface.co/models?pipeline_tag=automatic-speech-recognition&sort=downloads"
@@ -2196,6 +2257,7 @@ struct SettingsView: View {
     ) else { return }
     NSWorkspace.shared.open(url)
   }
+  #endif
 
   private func installHuggingFaceModel() {
     do {
@@ -2210,6 +2272,7 @@ struct SettingsView: View {
     }
   }
 
+  #if !APP_STORE
   private func addStreamingModelSource() {
     do {
       _ = try localModels.addStreamingModelSource(
@@ -2237,6 +2300,7 @@ struct SettingsView: View {
       $0.id != excludedID && (sherpaRuntime.modelStates[$0.id] ?? .notInstalled) == .installed
     }?.id
   }
+  #endif
 
   private func firstInstalledLocalTranscriptionModelID(excluding excludedID: String? = nil) -> String? {
     localModels.availableModels.first {
@@ -2950,6 +3014,16 @@ struct SettingsView: View {
           .fill(Color.green.opacity(0.12))
       )
 
+      #if APP_STORE
+      Text(
+        """
+        Local post-processing is separate from OpenRouter and cloud LLMs. Use the built-in rules \
+        model for instant cleanup with no downloaded runtime.
+        """
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      #else
       Text(
         """
         Local post-processing is separate from OpenRouter and cloud LLMs. Use the built-in rules \
@@ -2958,6 +3032,11 @@ struct SettingsView: View {
       )
       .font(.caption)
       .foregroundStyle(.secondary)
+      #endif
+
+      if !DistributionChannel.current.supportsLocalModelRuntime {
+        localRuntimeUnavailableNote
+      }
 
       Label(
         """
@@ -2970,10 +3049,21 @@ struct SettingsView: View {
       .foregroundStyle(.secondary)
 
       localPostProcessingQuickStart
+      #if !APP_STORE
       if !localPostProcessingModels.runtimeState.isInstalled {
         localPostProcessingRuntimeStatus
       }
+      #endif
 
+      #if APP_STORE
+      ModelPicker(
+        title: "Local Post-processing Model",
+        help: "Used for local-only cleanup after transcription. Built-in rules need no runtime.",
+        options: localPostProcessingOptions,
+        value: localPostProcessingModelBinding,
+        allowsCustom: false
+      )
+      #else
       ModelPicker(
         title: "Local Post-processing Model",
         help: """
@@ -2984,16 +3074,21 @@ struct SettingsView: View {
         value: localPostProcessingModelBinding,
         allowsCustom: false
       )
+      #endif
 
+      #if !APP_STORE
       localPostProcessingManualImport
+      #endif
 
       VStack(spacing: 10) {
         ForEach(ModelCatalog.postProcessing.filter { $0.id == LocalPostProcessingModelManager.builtInRulesModelID }) { option in
           builtInLocalPostProcessingRow(option)
         }
+        #if !APP_STORE
         ForEach(localPostProcessingModels.availableModels) { model in
           localPostProcessingModelRow(model)
         }
+        #endif
       }
     }
     .padding(12)
@@ -3014,6 +3109,18 @@ struct SettingsView: View {
         title: "Choose Local",
         detail: "This switches transcript cleanup away from OpenRouter."
       )
+      #if APP_STORE
+      localModelStep(
+        number: "2",
+        title: "Use the built-in rules model",
+        detail: "The built-in rules model stays available with no download or runtime."
+      )
+      localModelStep(
+        number: "3",
+        title: "Record normally",
+        detail: "Speak runs built-in cleanup locally after transcription."
+      )
+      #else
       localModelStep(
         number: "2",
         title: "Download a local LLM model",
@@ -3027,6 +3134,7 @@ struct SettingsView: View {
         title: "Record normally",
         detail: "Speak runs cleanup locally after transcription. Downloaded models use the app-owned llama.cpp runtime."
       )
+      #endif
     }
     .padding(12)
     .background(
@@ -3035,6 +3143,7 @@ struct SettingsView: View {
     )
   }
 
+  #if !APP_STORE
   private var localPostProcessingRuntimeStatus: some View {
     HStack(alignment: .top, spacing: 12) {
       Image(systemName: localPostProcessingRuntimeIcon)
@@ -3117,6 +3226,7 @@ struct SettingsView: View {
         .fill(Color(nsColor: .controlBackgroundColor))
     )
   }
+  #endif
 
   private func builtInLocalPostProcessingRow(_ option: ModelCatalog.Option) -> some View {
     let isSelected = PostProcessingManager.isLocalPostProcessingModel(settings.postProcessingModel)
@@ -3160,6 +3270,7 @@ struct SettingsView: View {
     }
   }
 
+  #if !APP_STORE
   // swiftlint:disable:next function_body_length
   private func localPostProcessingModelRow(_ model: LocalPostProcessingModel) -> some View {
       let state = localPostProcessingModels.installState(for: model.id)
@@ -3283,6 +3394,7 @@ struct SettingsView: View {
       localPostProcessingImportError = error.localizedDescription
     }
   }
+  #endif
 
   private var apiKeySettings: some View {
     ScrollViewReader { proxy in

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -4199,14 +4199,21 @@ struct SettingsView: View {
 
   private func shouldShowManualSetupHelp(for permission: PermissionType, status: PermissionStatus) -> Bool {
     guard permission.manualSetupSteps != nil else { return false }
-    return !DistributionChannel.current.supportsAutomaticAccessibilityPrompt || status == .denied
+    if status == .denied { return true }
+    // Only Accessibility lacks an automatic prompt in sandboxed (App Store) builds.
+    // Input Monitoring still prompts via CGRequestListenEventAccess even when sandboxed,
+    // so it only needs manual guidance once the user has actively denied it (handled above).
+    return permission == .accessibility
+      && !DistributionChannel.current.supportsAutomaticAccessibilityPrompt
   }
 
   private func permissionManualSetupNote(for permission: PermissionType, steps: [String]) -> some View {
-    let intro = if DistributionChannel.current.supportsAutomaticAccessibilityPrompt {
-      "Add \(permission.displayName) manually:"
-    } else {
+    let cannotAutoPrompt = permission == .accessibility
+      && !DistributionChannel.current.supportsAutomaticAccessibilityPrompt
+    let intro = if cannotAutoPrompt {
       "This build cannot show the automatic prompt here. Add \(permission.displayName) manually:"
+    } else {
+      "Add \(permission.displayName) manually:"
     }
     return channelAvailabilityNote("\(intro) \(steps.joined(separator: " "))")
   }

--- a/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
+++ b/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import OSLog
 
+#if !APP_STORE
 // swiftlint:disable file_length
 enum SherpaOnnxRuntimeError: LocalizedError {
   case pythonUnavailable
@@ -483,3 +484,5 @@ if __name__ == "__main__":
         sys.exit(1)
 """
 }
+
+#endif

--- a/Sources/SpeakApp/SpeakApp.swift
+++ b/Sources/SpeakApp/SpeakApp.swift
@@ -3,7 +3,9 @@ import AVFoundation
 #if canImport(Sentry)
 import Sentry
 #endif
+#if !APP_STORE
 import Sparkle
+#endif
 import SwiftUI
 
 @main
@@ -113,7 +115,11 @@ struct SpeakCommands: Commands {
 
     var body: some Commands {
         CommandGroup(after: .appInfo) {
+#if !APP_STORE
             CheckForUpdatesView(updater: updaterManager.updater)
+#else
+            CheckForUpdatesView()
+#endif
             Divider()
             Button("Start/Stop Recording") {
                 environment.main.toggleRecordingFromUI()
@@ -131,6 +137,7 @@ struct SpeakCommands: Commands {
     }
 }
 
+#if !APP_STORE
 /// SwiftUI view that wraps Sparkle's check for updates action
 struct CheckForUpdatesView: View {
     @StateObject private var checkForUpdatesViewModel: CheckForUpdatesViewModel
@@ -166,6 +173,15 @@ final class CheckForUpdatesViewModel: ObservableObject {
         updater.checkForUpdates()
     }
 }
+#else
+/// App Store builds receive updates through the Mac App Store.
+struct CheckForUpdatesView: View {
+    var body: some View {
+        Button("Updates are delivered through the App Store") {}
+            .disabled(true)
+    }
+}
+#endif
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     var environment: AppEnvironment?

--- a/Sources/SpeakApp/SpeakApp.swift
+++ b/Sources/SpeakApp/SpeakApp.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import AppKit
 import AVFoundation
 #if canImport(Sentry)

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -269,15 +269,20 @@ final class TranscriptionManager: ObservableObject {
   }
 
   private func liveTranscriptionModelForCurrentMode() throws -> String {
-    try Self.resolvedLiveTranscriptionModel(
+    #if APP_STORE
+    let availableStreamingSourceIDs: Set<String> = []
+    #else
+    let availableStreamingSourceIDs = Set(
+      LocalModelManager.recommendedStreamingModelSources.map(\.id)
+        + LocalModelManager.shared.streamingModelSources.map(\.id)
+    )
+    #endif
+    return try Self.resolvedLiveTranscriptionModel(
       transcriptionMode: appSettings.transcriptionMode,
       localTranscriptionMode: appSettings.localTranscriptionMode,
       localStreamingModelSource: appSettings.localStreamingModelSource,
       liveTranscriptionModel: appSettings.liveTranscriptionModel,
-      availableStreamingSourceIDs: Set(
-        LocalModelManager.recommendedStreamingModelSources.map(\.id)
-          + LocalModelManager.shared.streamingModelSources.map(\.id)
-      )
+      availableStreamingSourceIDs: availableStreamingSourceIDs
     )
   }
 
@@ -288,6 +293,11 @@ final class TranscriptionManager: ObservableObject {
     liveTranscriptionModel: String,
     availableStreamingSourceIDs: Set<String>
   ) throws -> String {
+    #if APP_STORE
+    if transcriptionMode == .localModel, localTranscriptionMode == .streaming {
+      return liveTranscriptionModel
+    }
+    #endif
     guard transcriptionMode == .localModel, localTranscriptionMode == .streaming else {
       return liveTranscriptionModel
     }
@@ -696,6 +706,7 @@ final class UnsupportedLocalLiveTranscriber: LiveTranscriptionController {
   }
 }
 
+#if !APP_STORE
 @MainActor
 // swiftlint:disable type_body_length
 final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
@@ -1061,6 +1072,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
   }
 }
 // swiftlint:enable type_body_length
+#endif
 
 struct RemoteAudioTranscriber: BatchTranscriptionClient {
   let client: OpenRouterAPIClient
@@ -3806,7 +3818,9 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private var cartesiaController: CartesiaLiveController
   private var gladiaController: GladiaLiveController
   private var openAIRealtimeController: OpenAIRealtimeLiveController
+  #if !APP_STORE
   private var sherpaOnnxController: SherpaOnnxLiveController
+  #endif
   private var unsupportedLocalLiveController: UnsupportedLocalLiveTranscriber
   private var currentLanguage: String?
   private var currentModel: String?
@@ -3881,12 +3895,14 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       audioDeviceManager: audioDeviceManager,
       secureStorage: secureStorage
     )
+    #if !APP_STORE
     sherpaOnnxController = SherpaOnnxLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
       runtimeManager: SherpaOnnxRuntimeManager.shared
     )
+    #endif
     unsupportedLocalLiveController = UnsupportedLocalLiveTranscriber()
     applyDelegateAndConfiguration()
     startObservingLifecycle()
@@ -3948,13 +3964,17 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     // OpenAI's only live transcription transport is the Realtime WebSocket
     // API. So any openai/* live model is handled by openAIRealtimeController.
     if model.hasPrefix("openai/") { return openAIRealtimeController }
+    #if !APP_STORE
     if model.hasPrefix("local/streaming/") { return sherpaOnnxController }
+    #else
+    if model.hasPrefix("local/streaming/") { return unsupportedLocalLiveController }
+    #endif
     if ModelRouting.family(for: model).isDownloadedLocal { return unsupportedLocalLiveController }
     return nativeController
   }
 
   private func applyDelegateAndConfiguration() {
-    let controllers: [any LiveTranscriptionController] = [
+    var controllers: [any LiveTranscriptionController] = [
       nativeController,
       deepgramController,
       modulateController,
@@ -3964,9 +3984,11 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       cartesiaController,
       gladiaController,
       openAIRealtimeController,
-      sherpaOnnxController,
       unsupportedLocalLiveController
     ]
+    #if !APP_STORE
+    controllers.insert(sherpaOnnxController, at: controllers.count - 1)
+    #endif
     let model = currentModel ?? appSettings.liveTranscriptionModel
     for controller in controllers {
       controller.delegate = delegate
@@ -4038,12 +4060,14 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       audioDeviceManager: audioDeviceManager,
       secureStorage: secureStorage
     )
+    #if !APP_STORE
     sherpaOnnxController = SherpaOnnxLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
       runtimeManager: SherpaOnnxRuntimeManager.shared
     )
+    #endif
     unsupportedLocalLiveController = UnsupportedLocalLiveTranscriber()
     invalidateBeforeNextStart = false
     lastStopDate = nil

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -3952,6 +3952,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     lastStopDate = nowProvider()
   }
 
+  // swiftlint:disable:next cyclomatic_complexity
   private func controller(for model: String) -> any LiveTranscriptionController {
     if model.hasPrefix("assemblyai/") { return assemblyAIController }
     if model.hasPrefix("deepgram/") { return deepgramController }

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -60,6 +60,11 @@ public enum ChannelFeature: String, Sendable, CaseIterable {
     /// Freedom to reference other distribution channels or external purchases in UI copy.
     /// App Store review guidelines discourage this, so App Store builds must not.
     case crossChannelMessaging
+    /// iCloud-backed sync features. Runtime entitlement/account probes still decide
+    /// whether each iCloud service is actually available.
+    case iCloudSync
+    /// Local-network Bonjour transport for cross-device fallback.
+    case localNetworkTransport
 }
 
 public extension DistributionChannel {
@@ -68,6 +73,11 @@ public extension DistributionChannel {
         switch feature {
         case .selfUpdate, .localModelRuntime, .automaticAccessibilityPrompt, .crossChannelMessaging:
             return self == .direct
+        case .iCloudSync, .localNetworkTransport:
+            // Sync transports are compiled into every build; runtime entitlement,
+            // account, and local-network permission probes decide actual availability.
+            // (The macOS Developer ID build also ships CloudKit entitlements.)
+            return true
         }
     }
 
@@ -84,6 +94,13 @@ public extension DistributionChannel {
     /// Whether UI copy may reference other distribution channels (e.g. the direct
     /// download). `false` for App Store builds to stay within review guidelines.
     var allowsCrossChannelMessaging: Bool { supports(.crossChannelMessaging) }
+
+    /// Whether this distribution channel is expected to support iCloud sync when
+    /// the running build also has the required entitlements and account state.
+    var supportsICloudSync: Bool { supports(.iCloudSync) }
+
+    /// Whether Bonjour local-network transport is part of this build.
+    var supportsLocalNetworkTransport: Bool { supports(.localNetworkTransport) }
 
     /// A short, human-readable name for the channel, for diagnostics and about screens.
     var displayName: String {

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -55,8 +55,10 @@ public enum ChannelFeature: String, Sendable, CaseIterable {
     /// Downloaded local model runtimes (Python venv + llama.cpp / sherpa-onnx) that
     /// spawn subprocesses and build/download executable code — impossible when sandboxed.
     case localModelRuntime
-    /// Automatically prompting the user for Accessibility / Input Monitoring. Sandboxed
-    /// builds cannot auto-prompt; the user must add the app manually in System Settings.
+    /// Automatically prompting the user for Accessibility. Sandboxed builds cannot show the
+    /// Accessibility prompt (`AXIsProcessTrustedWithOptions` is inert under the sandbox), so the
+    /// user must add the app manually in System Settings. Input Monitoring is unaffected — it
+    /// still prompts via `CGRequestListenEventAccess` even when sandboxed.
     case automaticAccessibilityPrompt
     /// Freedom to reference other distribution channels or external purchases in UI copy.
     /// App Store review guidelines discourage this, so App Store builds must not.

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// The channel this build is distributed through.
+///
+/// macOS ships in two flavours from one codebase, selected at build time via the
+/// `APP_STORE` Swift active compilation condition (wired in `Project.swift`, set with
+/// `APP_STORE=1 tuist generate`):
+///
+/// - `.direct`   — Developer ID / direct download. Unsandboxed, self-updates via
+///                 Sparkle, can run downloaded local model runtimes.
+/// - `.appStore` — Mac App Store. Sandboxed; no Sparkle; no downloaded local model
+///                 runtimes; some permissions must be granted manually.
+///
+/// iOS is always distributed through the App Store / TestFlight, so it always reports
+/// `.appStore` regardless of the flag.
+///
+/// This is the single, canonical place that answers "is feature X available in this
+/// build?". Reuse `DistributionChannel.current` and the availability helpers below
+/// rather than sprinkling `#if APP_STORE` through feature code — that keeps the policy
+/// in one place and keeps call sites testable.
+public enum DistributionChannel: String, Sendable, CaseIterable {
+    /// Developer ID / direct download (macOS only).
+    case direct
+    /// App Store (macOS Mac App Store, or iOS App Store / TestFlight).
+    case appStore
+
+    /// The channel the current build was compiled for.
+    public static var current: DistributionChannel {
+        #if os(iOS)
+        // iOS only ever ships through the App Store / TestFlight.
+        return .appStore
+        #elseif APP_STORE
+        return .appStore
+        #else
+        return .direct
+        #endif
+    }
+
+    /// Whether the current build runs inside the App Sandbox.
+    /// App Store builds are always sandboxed; direct builds are not.
+    public var isSandboxed: Bool { self == .appStore }
+}
+
+// MARK: - Feature availability
+
+/// A build-time capability that may be unavailable on some distribution channels.
+///
+/// Feature code should branch on `DistributionChannel.current.supports(_:)` (or the
+/// named convenience properties) instead of testing the raw channel, so the *reason*
+/// a feature is gated stays explicit and greppable.
+public enum ChannelFeature: String, Sendable, CaseIterable {
+    /// In-app self-update (Sparkle). App Store builds update through the store instead.
+    case selfUpdate
+    /// Downloaded local model runtimes (Python venv + llama.cpp / sherpa-onnx) that
+    /// spawn subprocesses and build/download executable code — impossible when sandboxed.
+    case localModelRuntime
+    /// Automatically prompting the user for Accessibility / Input Monitoring. Sandboxed
+    /// builds cannot auto-prompt; the user must add the app manually in System Settings.
+    case automaticAccessibilityPrompt
+    /// Freedom to reference other distribution channels or external purchases in UI copy.
+    /// App Store review guidelines discourage this, so App Store builds must not.
+    case crossChannelMessaging
+}
+
+public extension DistributionChannel {
+    /// Whether `feature` is available in this build.
+    func supports(_ feature: ChannelFeature) -> Bool {
+        switch feature {
+        case .selfUpdate, .localModelRuntime, .automaticAccessibilityPrompt, .crossChannelMessaging:
+            return self == .direct
+        }
+    }
+
+    /// In-app self-update via Sparkle (direct builds only).
+    var supportsSelfUpdate: Bool { supports(.selfUpdate) }
+
+    /// Downloaded local model runtimes (direct builds only).
+    var supportsLocalModelRuntime: Bool { supports(.localModelRuntime) }
+
+    /// Whether the app can auto-prompt for Accessibility / Input Monitoring.
+    /// When `false` (App Store), guide the user to add the app manually instead.
+    var supportsAutomaticAccessibilityPrompt: Bool { supports(.automaticAccessibilityPrompt) }
+
+    /// Whether UI copy may reference other distribution channels (e.g. the direct
+    /// download). `false` for App Store builds to stay within review guidelines.
+    var allowsCrossChannelMessaging: Bool { supports(.crossChannelMessaging) }
+
+    /// A short, human-readable name for the channel, for diagnostics and about screens.
+    var displayName: String {
+        switch self {
+        case .direct: return "Direct Download"
+        case .appStore: return "App Store"
+        }
+    }
+}

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -3,8 +3,9 @@ import Foundation
 /// The channel this build is distributed through.
 ///
 /// macOS ships in two flavours from one codebase, selected at build time via the
-/// `APP_STORE` Swift active compilation condition (wired in `Project.swift`, set with
-/// `APP_STORE=1 tuist generate`):
+/// `APP_STORE` Swift active compilation condition. That condition is defined by
+/// `swift build -Xswiftc -DAPP_STORE` (SPM) or by `TUIST_APP_STORE=1 tuist generate`,
+/// which wires it into the generated Xcode project (see `Project.swift`):
 ///
 /// - `.direct`   — Developer ID / direct download. Unsandboxed, self-updates via
 ///                 Sparkle, can run downloaded local model runtimes.

--- a/Sources/SpeakCore/SettingsSync.swift
+++ b/Sources/SpeakCore/SettingsSync.swift
@@ -235,34 +235,133 @@ public enum ConfigTransferError: LocalizedError {
     }
 }
 
+// MARK: - Sync Availability
+
+/// The cross-device sync backend selected by runtime auto-detection.
+public enum SyncBackend: String, CaseIterable, Sendable {
+    /// iCloud settings/history sync is available and preferred.
+    case iCloud
+    /// Bonjour local-network transport is available as the fallback path.
+    case transport
+    /// No cross-device backend is currently available; data remains local.
+    case localOnly
+
+    public var displayName: String {
+        switch self {
+        case .iCloud:
+            return "iCloud"
+        case .transport:
+            return "Bonjour Transport"
+        case .localOnly:
+            return "Local Only"
+        }
+    }
+}
+
+/// Runtime cross-device sync capability summary for UI and app logic.
+public struct SyncAvailability: Equatable, Sendable {
+    public let iCloudKVStoreAvailable: Bool
+    public let iCloudCloudKitAvailable: Bool
+    public let transportAvailable: Bool
+    public let distributionChannel: DistributionChannel
+
+    public init(
+        iCloudKVStoreAvailable: Bool = false,
+        iCloudCloudKitAvailable: Bool = false,
+        transportAvailable: Bool = false,
+        distributionChannel: DistributionChannel = .current
+    ) {
+        self.iCloudKVStoreAvailable = iCloudKVStoreAvailable
+        self.iCloudCloudKitAvailable = iCloudCloudKitAvailable
+        self.transportAvailable = transportAvailable
+        self.distributionChannel = distributionChannel
+    }
+
+    /// Whether any iCloud sync backend is currently usable.
+    public var iCloudAvailable: Bool {
+        iCloudKVStoreAvailable || iCloudCloudKitAvailable
+    }
+
+    /// Prefer iCloud when any iCloud sync path is available, otherwise fall back
+    /// to the canonical Bonjour transport helper, then local-only storage.
+    public var preferredBackend: SyncBackend {
+        if iCloudAvailable {
+            return .iCloud
+        }
+        if transportAvailable {
+            return .transport
+        }
+        return .localOnly
+    }
+
+    /// Checks the build/runtime support for the Bonjour transport fallback.
+    public static var currentTransportAvailable: Bool {
+        DistributionChannel.current.supportsLocalNetworkTransport
+            && !SpeakTransportServiceType.isEmpty
+            && SpeakTransportProtocolVersion > 0
+    }
+
+    /// Checks current sync availability. CloudKit account availability is owned
+    /// by SpeakSync, so callers pass the latest `HistorySyncEngine` state.
+    public static func current(iCloudCloudKitAvailable: Bool = false) -> SyncAvailability {
+        let sync = SettingsSync.shared
+
+        return SyncAvailability(
+            iCloudKVStoreAvailable: sync.isAvailable,
+            iCloudCloudKitAvailable: iCloudCloudKitAvailable,
+            transportAvailable: currentTransportAvailable,
+            distributionChannel: .current
+        )
+    }
+}
+
 // MARK: - Sync Status
 
 /// Represents the current sync status across platforms.
-public struct SyncStatus {
+public struct SyncStatus: Equatable, Sendable {
     public let iCloudKeychainAvailable: Bool
     public let iCloudKVStoreAvailable: Bool
+    public let iCloudCloudKitAvailable: Bool
+    public let transportAvailable: Bool
     public let lastSyncDate: Date?
     public let pendingChanges: Bool
+    public let availability: SyncAvailability
+
+    public var preferredBackend: SyncBackend {
+        availability.preferredBackend
+    }
     
     public init(
         iCloudKeychainAvailable: Bool = false,
         iCloudKVStoreAvailable: Bool = false,
+        iCloudCloudKitAvailable: Bool = false,
+        transportAvailable: Bool = SyncAvailability.currentTransportAvailable,
         lastSyncDate: Date? = nil,
         pendingChanges: Bool = false
     ) {
         self.iCloudKeychainAvailable = iCloudKeychainAvailable
         self.iCloudKVStoreAvailable = iCloudKVStoreAvailable
+        self.iCloudCloudKitAvailable = iCloudCloudKitAvailable
+        self.transportAvailable = transportAvailable
         self.lastSyncDate = lastSyncDate
         self.pendingChanges = pendingChanges
+        self.availability = SyncAvailability(
+            iCloudKVStoreAvailable: iCloudKVStoreAvailable,
+            iCloudCloudKitAvailable: iCloudCloudKitAvailable,
+            transportAvailable: transportAvailable
+        )
     }
     
     /// Checks current sync availability
-    public static func current() -> SyncStatus {
+    public static func current(iCloudCloudKitAvailable: Bool = false) -> SyncStatus {
         let sync = SettingsSync.shared
+        let availability = SyncAvailability.current(iCloudCloudKitAvailable: iCloudCloudKitAvailable)
         
         return SyncStatus(
-            iCloudKeychainAvailable: sync.isAvailable,
-            iCloudKVStoreAvailable: sync.isAvailable,
+            iCloudKeychainAvailable: KeychainSyncAvailability.isAvailable(),
+            iCloudKVStoreAvailable: availability.iCloudKVStoreAvailable,
+            iCloudCloudKitAvailable: availability.iCloudCloudKitAvailable,
+            transportAvailable: availability.transportAvailable,
             lastSyncDate: sync.lastSyncDate,
             pendingChanges: false
         )

--- a/Sources/SpeakSync/SyncConfiguration.swift
+++ b/Sources/SpeakSync/SyncConfiguration.swift
@@ -1,6 +1,6 @@
 import CloudKit
 import Foundation
-#if os(macOS)
+#if os(macOS) || os(iOS)
 import Security
 #endif
 
@@ -40,10 +40,8 @@ public enum SyncConfiguration {
 
     /// Whether this app build has CloudKit entitlements.
     /// Developer ID Sparkle builds may omit CloudKit entitlements.
-    /// iOS builds currently ship without iCloud entitlements until
-    /// the provisioning profile is configured with the correct container.
     static var hasCloudKitEntitlement: Bool {
-#if os(macOS)
+#if os(macOS) || os(iOS)
         guard let task = SecTaskCreateFromSelf(nil) else {
             return false
         }

--- a/Sources/SpeakSync/SyncConfiguration.swift
+++ b/Sources/SpeakSync/SyncConfiguration.swift
@@ -1,6 +1,6 @@
 import CloudKit
 import Foundation
-#if os(macOS) || os(iOS)
+#if os(macOS)
 import Security
 #endif
 
@@ -41,7 +41,15 @@ public enum SyncConfiguration {
     /// Whether this app build has CloudKit entitlements.
     /// Developer ID Sparkle builds may omit CloudKit entitlements.
     static var hasCloudKitEntitlement: Bool {
-#if os(macOS) || os(iOS)
+#if os(iOS)
+        // iOS App Store / TestFlight builds always ship with the managed
+        // provisioning profile that carries the CloudKit entitlements, and the
+        // SecTask entitlement-introspection APIs (SecTaskCreateFromSelf /
+        // SecTaskCopyValueForEntitlement) are not part of the public iOS SDK.
+        // So assume availability on iOS and only probe on macOS, where Developer
+        // ID (Sparkle) builds may legitimately omit CloudKit.
+        return true
+#elseif os(macOS)
         guard let task = SecTaskCreateFromSelf(nil) else {
             return false
         }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -626,13 +626,37 @@ public struct SettingsView: View {
                 CloudKitSyncSettingsSection()
 
                 // Sync status
-                let syncStatus = SyncStatus.current()
+                let syncStatus = SyncStatus.current(iCloudCloudKitAvailable: HistorySyncEngine.shared.state.isCloudAvailable)
 
                 HStack {
-                    Label("iCloud Keychain", systemImage: "icloud")
+                    Label("Preferred Sync", systemImage: "arrow.triangle.branch")
                     Spacer()
-                    Text(syncStatus.iCloudKeychainAvailable ? "Available" : "Unavailable")
+                    Text(syncStatus.preferredBackend.displayName)
+                        .foregroundStyle(syncStatus.preferredBackend == .localOnly ? .secondary : .green)
+                }
+                .accessibilityElement(children: .combine)
+
+                HStack {
+                    Label("iCloud Keychain", systemImage: "key.icloud")
+                    Spacer()
+                    Text(syncStatus.iCloudKeychainAvailable ? "Available" : "Local only")
                         .foregroundStyle(syncStatus.iCloudKeychainAvailable ? .green : .secondary)
+                }
+                .accessibilityElement(children: .combine)
+
+                HStack {
+                    Label("iCloud Settings", systemImage: "icloud")
+                    Spacer()
+                    Text(syncStatus.iCloudKVStoreAvailable ? "Available" : "Local only")
+                        .foregroundStyle(syncStatus.iCloudKVStoreAvailable ? .green : .secondary)
+                }
+                .accessibilityElement(children: .combine)
+
+                HStack {
+                    Label("Bonjour Transport", systemImage: "network")
+                    Spacer()
+                    Text(syncStatus.transportAvailable ? "Ready" : "Unavailable")
+                        .foregroundStyle(syncStatus.transportAvailable ? .green : .secondary)
                 }
                 .accessibilityElement(children: .combine)
 
@@ -656,9 +680,9 @@ public struct SettingsView: View {
                     Label("Import from QR Code", systemImage: "qrcode.viewfinder")
                 }
 
-                Text("Share/Import copies your API keys and settings to another "
-                    + "device — the simplest way to sync with the Mac app. iCloud "
-                    + "Keychain keeps your iPhone and iPad in sync automatically.")
+                Text("Just Speak to It uses iCloud for settings and history when available. "
+                    + "If iCloud is unavailable, Bonjour Transport can send sessions to a paired Mac "
+                    + "on your local network; QR transfer remains available for manual setup.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -1478,18 +1502,20 @@ struct CloudKitSyncSettingsSection: View {
     @State private var isSyncing = false
 
     var body: some View {
+        let availability = SyncAvailability.current(iCloudCloudKitAvailable: syncEngine.state.isCloudAvailable)
+
         // CloudKit status
         HStack {
             Label("iCloud History Sync", systemImage: "icloud")
             Spacer()
-            Text(syncEngine.state.isCloudAvailable ? "Active" : "Unavailable")
+            Text(availability.iCloudCloudKitAvailable ? "Active" : "Unavailable")
                 .foregroundStyle(
-                    syncEngine.state.isCloudAvailable ? .green : .secondary
+                    availability.iCloudCloudKitAvailable ? .green : .secondary
                 )
         }
         .accessibilityElement(children: .combine)
 
-        if syncEngine.state.isCloudAvailable {
+        if availability.iCloudCloudKitAvailable {
             // Sync counts
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
@@ -1555,7 +1581,12 @@ struct CloudKitSyncSettingsSection: View {
             .disabled(isSyncing || syncEngine.state.isSyncing)
         } else {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Sign in to iCloud in Settings to sync transcription history across your devices.")
+                Text(
+                    availability.transportAvailable
+                        ? "Sign in to iCloud to sync history automatically. Until then, Bonjour Transport "
+                            + "can send new sessions to a paired Mac on your local network."
+                        : "Sign in to iCloud in Settings to sync transcription history across your devices."
+                )
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -626,7 +626,9 @@ public struct SettingsView: View {
                 CloudKitSyncSettingsSection()
 
                 // Sync status
-                let syncStatus = SyncStatus.current(iCloudCloudKitAvailable: HistorySyncEngine.shared.state.isCloudAvailable)
+                let syncStatus = SyncStatus.current(
+                    iCloudCloudKitAvailable: HistorySyncEngine.shared.state.isCloudAvailable
+                )
 
                 HStack {
                     Label("Preferred Sync", systemImage: "arrow.triangle.branch")

--- a/SpeakiOS.entitlements
+++ b/SpeakiOS.entitlements
@@ -7,6 +7,18 @@
     <array>
         <string>$(AppIdentifierPrefix)com.justspeaktoit.shared</string>
     </array>
+
+    <!-- iCloud: Enables settings (KVS) and transcription history (CloudKit) sync -->
+    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
+    <string>$(TeamIdentifierPrefix)com.justspeaktoit.ios</string>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array>
+        <string>iCloud.com.justspeaktoit.ios</string>
+    </array>
+    <key>com.apple.developer.icloud-services</key>
+    <array>
+        <string>CloudKit</string>
+    </array>
     
     <!-- App Groups: Enables shared container for widget extension -->
     <key>com.apple.security.application-groups</key>

--- a/Tests/SpeakAppTests/EntitlementsTests.swift
+++ b/Tests/SpeakAppTests/EntitlementsTests.swift
@@ -115,7 +115,7 @@ final class EntitlementsTests: XCTestCase {
 }
 
 /// Verifies the SANDBOXED Mac App Store entitlements file. This is the flavour
-/// selected when the project is generated with `APP_STORE=1` (see Project.swift).
+/// selected when the project is generated with `TUIST_APP_STORE=1` (see Project.swift).
 /// The App Store REQUIRES the sandbox and FORBIDS
 /// `com.apple.security.cs.disable-library-validation`; these tests lock that in so a
 /// mis-edited file can never be submitted.

--- a/Tests/SpeakAppTests/EntitlementsTests.swift
+++ b/Tests/SpeakAppTests/EntitlementsTests.swift
@@ -113,3 +113,87 @@ final class EntitlementsTests: XCTestCase {
             "If intentional, add them to the allowlist in this test.")
     }
 }
+
+/// Verifies the SANDBOXED Mac App Store entitlements file. This is the flavour
+/// selected when the project is generated with `APP_STORE=1` (see Project.swift).
+/// The App Store REQUIRES the sandbox and FORBIDS
+/// `com.apple.security.cs.disable-library-validation`; these tests lock that in so a
+/// mis-edited file can never be submitted.
+final class AppStoreEntitlementsTests: XCTestCase {
+
+    private var entitlements: [String: Any]!
+    private let entitlementsPath = "Config/SpeakMacOS.AppStore.entitlements"
+
+    override func setUpWithError() throws {
+        let url = URL(fileURLWithPath: entitlementsPath)
+        let data = try Data(contentsOf: url)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        entitlements = plist as? [String: Any]
+        XCTAssertNotNil(entitlements, "App Store entitlements file should parse as a dictionary")
+    }
+
+    // MARK: - Required for App Store
+
+    func testSandbox_isEnabled() {
+        let value = entitlements["com.apple.security.app-sandbox"] as? Bool
+        XCTAssertEqual(value, true,
+            "The App Sandbox is REQUIRED for Mac App Store distribution")
+    }
+
+    func testMicrophoneEntitlement_isPresent() {
+        let value = entitlements["com.apple.security.device.audio-input"] as? Bool
+        XCTAssertEqual(value, true, "Audio input is required for microphone access")
+    }
+
+    func testNetworkClientEntitlement_isPresent() {
+        let value = entitlements["com.apple.security.network.client"] as? Bool
+        XCTAssertEqual(value, true,
+            "Outbound network is required to reach transcription/post-processing providers")
+    }
+
+    // MARK: - Forbidden on App Store
+
+    func testDisableLibraryValidation_isAbsent() {
+        // The Mac App Store rejects builds carrying this entitlement.
+        let value = entitlements["com.apple.security.cs.disable-library-validation"]
+        XCTAssertNil(value,
+            "disable-library-validation is FORBIDDEN on the Mac App Store and must not " +
+            "appear in the App Store entitlements file")
+    }
+
+    // MARK: - iCloud (available under the App Store managed profile)
+
+    func testICloud_isConfiguredForSync() {
+        let containers = entitlements["com.apple.developer.icloud-container-identifiers"] as? [String]
+        XCTAssertEqual(containers, ["iCloud.com.justspeaktoit"],
+            "App Store build should be entitled for the CloudKit history-sync container")
+
+        let services = entitlements["com.apple.developer.icloud-services"] as? [String]
+        XCTAssertEqual(services?.contains("CloudKit"), true,
+            "CloudKit service is required for transcription history sync")
+
+        let kvStore = entitlements["com.apple.developer.ubiquity-kvstore-identifier"] as? String
+        XCTAssertNotNil(kvStore, "iCloud KV store identifier is required for settings sync")
+    }
+
+    // MARK: - Integrity
+
+    func testEntitlementsFile_hasNoUnexpectedEntitlements() {
+        let allowedKeys: Set<String> = [
+            "com.apple.security.app-sandbox",
+            "com.apple.security.device.audio-input",
+            "com.apple.security.network.client",
+            "com.apple.security.files.user-selected.read-write",
+            "com.apple.security.automation.apple-events",
+            "keychain-access-groups",
+            "com.apple.developer.ubiquity-kvstore-identifier",
+            "com.apple.developer.icloud-container-identifiers",
+            "com.apple.developer.icloud-services",
+            "aps-environment"
+        ]
+        let unexpected = Set(entitlements.keys).subtracting(allowedKeys)
+        XCTAssertTrue(unexpected.isEmpty,
+            "Unexpected App Store entitlements found: \(unexpected.sorted()). " +
+            "If intentional, add them to the allowlist in this test.")
+    }
+}

--- a/Tests/SpeakCoreTests/DistributionChannelTests.swift
+++ b/Tests/SpeakCoreTests/DistributionChannelTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import SpeakCore
+
+/// Verifies the `DistributionChannel` availability matrix — the single source of
+/// truth for which features a build exposes. These are behavioural checks on the
+/// policy, independent of which flavour the test binary itself was compiled as.
+final class DistributionChannelTests: XCTestCase {
+
+    // MARK: - Availability matrix
+
+    func testDirectChannel_supportsAllGatedFeatures() {
+        // Arrange
+        let channel = DistributionChannel.direct
+
+        // Act & Assert
+        XCTAssertTrue(channel.supportsSelfUpdate)
+        XCTAssertTrue(channel.supportsLocalModelRuntime)
+        XCTAssertTrue(channel.supportsAutomaticAccessibilityPrompt)
+        XCTAssertTrue(channel.allowsCrossChannelMessaging)
+        XCTAssertFalse(channel.isSandboxed)
+    }
+
+    func testAppStoreChannel_gatesSandboxRestrictedFeatures() {
+        // Arrange
+        let channel = DistributionChannel.appStore
+
+        // Act & Assert
+        XCTAssertFalse(channel.supportsSelfUpdate,
+            "App Store builds update through the store, not Sparkle")
+        XCTAssertFalse(channel.supportsLocalModelRuntime,
+            "Downloaded local-model runtimes cannot run in the App Store sandbox")
+        XCTAssertFalse(channel.supportsAutomaticAccessibilityPrompt,
+            "Sandboxed apps cannot auto-prompt for Accessibility/Input Monitoring")
+        XCTAssertFalse(channel.allowsCrossChannelMessaging,
+            "App Store builds must not advertise other distribution channels")
+        XCTAssertTrue(channel.isSandboxed)
+    }
+
+    func testSupports_isConsistentWithNamedConveniences() {
+        // Arrange / Act / Assert
+        for channel in DistributionChannel.allCases {
+            XCTAssertEqual(channel.supports(.selfUpdate), channel.supportsSelfUpdate)
+            XCTAssertEqual(channel.supports(.localModelRuntime), channel.supportsLocalModelRuntime)
+            XCTAssertEqual(channel.supports(.automaticAccessibilityPrompt),
+                           channel.supportsAutomaticAccessibilityPrompt)
+            XCTAssertEqual(channel.supports(.crossChannelMessaging),
+                           channel.allowsCrossChannelMessaging)
+        }
+    }
+
+    // MARK: - Current build
+
+    func testCurrent_matchesCompiledFlavour() {
+        // Arrange
+        let channel = DistributionChannel.current
+
+        // Act & Assert — `current` is derived from compile-time flags, so it must be
+        // one of the two known channels and its sandbox state must agree.
+        #if os(iOS)
+        XCTAssertEqual(channel, .appStore, "iOS always ships through the App Store")
+        #elseif APP_STORE
+        XCTAssertEqual(channel, .appStore)
+        #else
+        XCTAssertEqual(channel, .direct)
+        #endif
+        XCTAssertEqual(channel.isSandboxed, channel == .appStore)
+    }
+
+    func testDisplayNames_areDistinct() {
+        // Arrange / Act / Assert
+        XCTAssertEqual(DistributionChannel.direct.displayName, "Direct Download")
+        XCTAssertEqual(DistributionChannel.appStore.displayName, "App Store")
+    }
+}

--- a/Tests/SpeakCoreTests/SettingsSyncTests.swift
+++ b/Tests/SpeakCoreTests/SettingsSyncTests.swift
@@ -131,4 +131,36 @@ final class SettingsSyncTests: XCTestCase {
         let unique = Set(rawValues)
         XCTAssertEqual(rawValues.count, unique.count, "All SyncKey raw values should be unique")
     }
+
+    // MARK: - Auto-detection
+
+    func testSyncAvailability_prefersICloudWhenCloudKitAvailable() {
+        let availability = SyncAvailability(
+            iCloudKVStoreAvailable: false,
+            iCloudCloudKitAvailable: true,
+            transportAvailable: true
+        )
+
+        XCTAssertEqual(availability.preferredBackend, .iCloud)
+    }
+
+    func testSyncAvailability_fallsBackToTransportWhenICloudUnavailable() {
+        let availability = SyncAvailability(
+            iCloudKVStoreAvailable: false,
+            iCloudCloudKitAvailable: false,
+            transportAvailable: true
+        )
+
+        XCTAssertEqual(availability.preferredBackend, .transport)
+    }
+
+    func testSyncAvailability_usesLocalOnlyWhenNoBackendAvailable() {
+        let availability = SyncAvailability(
+            iCloudKVStoreAvailable: false,
+            iCloudCloudKitAvailable: false,
+            transportAvailable: false
+        )
+
+        XCTAssertEqual(availability.preferredBackend, .localOnly)
+    }
 }


### PR DESCRIPTION
## Dual distribution: Mac App Store + Developer ID from one codebase, plus iOS iCloud sync

Compiles the macOS app into **two flavours from a single codebase** — Developer ID / direct download (Sparkle) and Mac App Store (sandboxed) — selected at build time by the `APP_STORE` Swift compilation condition. Where the App Store sandbox removes a capability, the build degrades gracefully and guides the user to a mitigation. For iOS, settings (KV) and history ("conversation") sync now work over **iCloud** and the Bonjour **Transport** peer channel, auto-detected.

### How the flavour is selected
- **SPM builds:** `swift build -Xswiftc -DAPP_STORE` (App Store) vs plain `swift build` (direct).
- **Xcode/Tuist:** `TUIST_APP_STORE=1 tuist generate` selects `Config/SpeakMacOS.AppStore.entitlements` and defines the `APP_STORE` condition; the default selects the direct entitlements.
- A single canonical capability API — `DistributionChannel` in `SpeakCore` — answers "is feature X available in this build?", instead of scattering `#if APP_STORE` through feature code.

### What changes per channel

| Capability | Direct (Developer ID) | Mac App Store |
| --- | --- | --- |
| Sparkle self-update | ✅ | Compiled out — updates come from the App Store |
| Downloaded local-model **runtimes** (sherpa-onnx, Python, llama.cpp) | ✅ | Compiled out (needs `disable-library-validation`, forbidden by App Store) |
| On-device **WhisperKit** batch transcription | ✅ | ✅ kept (CoreML, sandbox-safe) |
| Built-in rules post-processing | ✅ | ✅ kept |
| StoreKit tips (IAP) | Shown (no products until sold via App Store) | ✅ shown |
| External donation links (GitHub Sponsors, Ko-fi) | ✅ | Hidden (cross-channel messaging not surfaced in App Store builds) |
| Fn hotkey / accessibility insertion | ✅ | ✅ with manual permission — setup helpers added |

### Highlights
- **Foundation (W1):** `DistributionChannel.current` + capability helpers (`supportsSelfUpdate`, `supportsLocalModelRuntime`, `supportsAutomaticAccessibilityPrompt`, `allowsCrossChannelMessaging`, `supportsICloudSync`, `supportsLocalNetworkTransport`), sandboxed App Store entitlements file, and `Project.swift` wiring.
- **Sparkle gating (W2):** self-update compiled out for App Store; Settings explains updates arrive via the App Store.
- **Local-models gating (W3):** downloaded runtimes gated behind `#if !APP_STORE`; routing still compiles (App Store coerces streaming→batch, downloaded post-processing falls back to built-in rules). WhisperKit and built-in rules kept in both.
- **Entitlements + CI (W4):** `AppStoreEntitlementsTests` lock in the sandbox and the absence of `disable-library-validation`; a dedicated App Store release workflow generates and archives the sandboxed build.
- **Permission helpers (W5):** deep links to the exact System Settings privacy panes plus step-by-step manual-add guidance for accessibility / input monitoring (needed under the sandbox).
- **Availability notes (W6):** Settings surfaces channel-appropriate copy about what's available where — without advertising the other channel in App Store builds.
- **iOS sync (W7):** iCloud entitlements enabled (KV store + CloudKit); `SyncAvailability` auto-detects iCloud → Transport → local-only.

### Verification
- `swift build --target SpeakApp` (direct) and with `-Xswiftc -DAPP_STORE` (App Store) both build; the App Store flavour has fewer modules, proving gated symbols compile out (no leaks).
- `swift build --target SpeakiOSLib` builds.
- Full `swift test`: **562 tests, 11 skipped, 0 failures**, including `DistributionChannelTests`, `SettingsSyncTests`, `EntitlementsTests`, and `AppStoreEntitlementsTests`.
- `tuist generate` verified for both flag states: `TUIST_APP_STORE=1` → `Config/SpeakMacOS.AppStore.entitlements` + `APP_STORE` condition; default → direct entitlements, no condition.

### Notes
- Includes `fix(mac): read TUIST_APP_STORE for App Store Xcode generation` — Tuist only forwards `TUIST_`-prefixed env vars into manifest evaluation, so the previous plain `APP_STORE=1` was silently ignored and would have generated a **non-sandboxed** App Store build (an App Store rejection). Now corrected in `Project.swift` and the release workflow.
- Merging to `main` will trigger `auto-release.yml` and cut a new `mac-v*` release (expected).
- The Xcode project is generated (not committed); iOS device/simulator archiving is exercised by the iOS release workflow, not this shared-module test run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added App Store distribution support with dedicated sandboxed entitlements and entitlements validation tests.
  * Improved settings sync reporting with clearer iCloud (CloudKit), Bonjour transport, and local-only fallback selection.
  * Enhanced permissions and update/about screens to reflect build capability and runtime availability, including direct settings deep-links.

* **Bug Fixes**
  * Restricted unsupported local streaming, model runtime, post-processing, and self-update behavior on App Store builds to prevent unavailable features from appearing or running.
  * Refined transcription/model selection and exchange logging to avoid duplicate recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->