### PR TITLE
fix(ios): record from Action Button when Live Activity can't start in background

### DIFF
--- a/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtensionControl.swift
+++ b/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtensionControl.swift
@@ -59,23 +59,3 @@ extension JustSpeakToItWidgetExtensionControl {
 struct TranscriptionControlConfiguration: ControlConfigurationIntent {
     static let title: LocalizedStringResource = "Transcription Configuration"
 }
-
-@available(iOS 18.0, *)
-struct ToggleTranscriptionControlIntent: SetValueIntent {
-    static let title: LocalizedStringResource = "Toggle Transcription"
-
-    @Parameter(title: "Recording")
-    var value: Bool
-
-    init() {}
-
-    func perform() async throws -> some IntentResult {
-        let service = await TranscriptionRecordingService.shared
-        if value {
-            try await service.startRecording()
-        } else {
-            await service.stopRecording()
-        }
-        return .result()
-    }
-}

--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -175,7 +175,7 @@ public struct ToggleTranscriptionControlIntent: SetValueIntent, AudioRecordingIn
         if value {
             try await startRecordingContinuingInForegroundIfNeeded(from: self)
         } else {
-            await service.stopRecording()
+            await service.stopRecording(destination: AppSettings.shared.hardwareTriggerDestination)
         }
         return .result()
     }

--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -28,11 +28,39 @@ private func stopResultDialog(
     }
 }
 
+/// Starts recording, transparently recovering when the *background* Live Activity
+/// can't be started.
+///
+/// When the Action Button / a Shortcut / Siri launches the app in the background,
+/// ActivityKit refuses to start a Live Activity (`Activity.request` throws), so
+/// `startRecording()` reports `iOSTranscriptionError.liveActivityUnavailable`
+/// rather than record without the mandatory Live Activity (which the AppIntents
+/// system-policy check would kill). Previously the user just saw a "turn on Live
+/// Activities" error even when they *were* enabled.
+///
+/// Here we recover by continuing in the foreground: the app briefly comes to the
+/// front, where starting a Live Activity is permitted, and recording proceeds.
+/// The foreground hop only happens on that specific failure — when the headless
+/// background start succeeds, recording stays fully headless.
+@available(iOS 18, *)
+private func startRecordingContinuingInForegroundIfNeeded(
+    from intent: some ForegroundContinuableIntent
+) async throws {
+    let service = await TranscriptionRecordingService.shared
+    do {
+        try await service.startRecording()
+    } catch iOSTranscriptionError.liveActivityUnavailable {
+        try await intent.requestToContinueInForeground {
+            try await TranscriptionRecordingService.shared.startRecording()
+        }
+    }
+}
+
 /// Idempotent start intent for users who wire their Action Button / Shortcut
 /// to a one-shot start (and a separate one to stop). If a recording is already
 /// in progress this intent leaves it running and reports the state.
 @available(iOS 18, *)
-public struct StartTranscriptionIntent: AudioRecordingIntent {
+public struct StartTranscriptionIntent: AudioRecordingIntent, ForegroundContinuableIntent {
     public static var title: LocalizedStringResource = "Start Recording"
     public static var description = IntentDescription(
         "Start a fresh transcription. No-op if already recording. Pair with Stop Recording to finish."
@@ -48,7 +76,7 @@ public struct StartTranscriptionIntent: AudioRecordingIntent {
         if isRunning {
             return .result(dialog: "Recording already in progress.")
         }
-        try await service.startRecording()
+        try await startRecordingContinuingInForegroundIfNeeded(from: self)
         return .result(dialog: "Recording started. Run \"Stop Recording\" to finish.")
     }
 }
@@ -57,7 +85,7 @@ public struct StartTranscriptionIntent: AudioRecordingIntent {
 /// Conforms to AudioRecordingIntent so the system allows background audio recording
 /// and shows the recording indicator. Requires iOS 18+.
 @available(iOS 18, *)
-public struct StartTranscriptionRecordingIntent: AudioRecordingIntent {
+public struct StartTranscriptionRecordingIntent: AudioRecordingIntent, ForegroundContinuableIntent {
     public static var title: LocalizedStringResource = "Toggle Recording"
     public static var description = IntentDescription(
         "Start or stop voice transcription. Result lands in the destination you chose in Settings."
@@ -81,7 +109,7 @@ public struct StartTranscriptionRecordingIntent: AudioRecordingIntent {
                 canPostProcess: canPostProcess
             ))
         } else {
-            try await service.startRecording()
+            try await startRecordingContinuingInForegroundIfNeeded(from: self)
             return .result(dialog: "Recording started. Press again to stop.")
         }
     }
@@ -119,6 +147,40 @@ public struct StopTranscriptionRecordingIntent: AppIntent {
     }
 }
 
+/// Control Center toggle intent for one-tap start/stop of transcription.
+///
+/// This lives in SpeakiOSLib (not the widget extension) so it can adopt
+/// `ForegroundContinuableIntent` and reuse the same background-recovery path as
+/// the Action Button. Control Center runs this intent in the app's *background*
+/// process, where ActivityKit refuses to start the mandatory Live Activity, so a
+/// plain `startRecording()` would fail with `liveActivityUnavailable`. Conforming
+/// to `AudioRecordingIntent` requests the background-audio grant, and the
+/// foreground fallback brings the app forward when the headless start is refused.
+///
+/// The widget extension only ever uses this as a `SetValueIntent` (via
+/// `ControlWidgetToggle`), so it never references `ForegroundContinuableIntent`
+/// itself — that protocol is unavailable to app extensions, but merely using a
+/// type that conforms to it is allowed.
+@available(iOS 18, *)
+public struct ToggleTranscriptionControlIntent: SetValueIntent, AudioRecordingIntent, ForegroundContinuableIntent {
+    public static var title: LocalizedStringResource = "Toggle Transcription"
+
+    @Parameter(title: "Recording")
+    public var value: Bool
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult {
+        let service = await TranscriptionRecordingService.shared
+        if value {
+            try await startRecordingContinuingInForegroundIfNeeded(from: self)
+        } else {
+            await service.stopRecording()
+        }
+        return .result()
+    }
+}
+
 // MARK: - Copy Intents
 
 /// App Intent to copy the last transcribed sentence to clipboard.
@@ -126,23 +188,23 @@ public struct StopTranscriptionRecordingIntent: AppIntent {
 struct CopyLastSentenceIntent: AppIntent {
     static var title: LocalizedStringResource = "Copy Last Sentence"
     static var description = IntentDescription("Copies the most recent transcribed sentence to the clipboard")
-    
+
     // Make this available from Live Activity
     static var openAppWhenRun: Bool = false
-    
+
     func perform() async throws -> some IntentResult {
         // Get the last sentence from UserDefaults (shared between app and extension)
         let defaults = UserDefaults(suiteName: "group.com.speak.ios")
         let lastSentence = defaults?.string(forKey: "lastTranscribedSentence") ?? ""
-        
+
         guard !lastSentence.isEmpty else {
             return .result(value: "No recent transcription to copy")
         }
-        
+
         await MainActor.run {
             UIPasteboard.general.string = lastSentence
         }
-        
+
         return .result(value: "Copied: \(lastSentence.prefix(50))...")
     }
 }
@@ -151,21 +213,21 @@ struct CopyLastSentenceIntent: AppIntent {
 struct CopyFullTranscriptIntent: AppIntent {
     static var title: LocalizedStringResource = "Copy Full Transcript"
     static var description = IntentDescription("Copies the entire transcription to the clipboard")
-    
+
     static var openAppWhenRun: Bool = false
-    
+
     func perform() async throws -> some IntentResult {
         let defaults = UserDefaults(suiteName: "group.com.speak.ios")
         let fullText = defaults?.string(forKey: "currentTranscriptText") ?? ""
-        
+
         guard !fullText.isEmpty else {
             return .result(value: "No transcription to copy")
         }
-        
+
         await MainActor.run {
             UIPasteboard.general.string = fullText
         }
-        
+
         let wordCount = fullText.split(separator: " ").count
         return .result(value: "Copied \(wordCount) words")
     }
@@ -233,38 +295,38 @@ struct TranscriptionShortcuts: AppShortcutsProvider {
 /// Manages state shared between main app and extensions via App Group.
 public final class SharedTranscriptionState {
     public static let shared = SharedTranscriptionState()
-    
+
     private let defaults: UserDefaults?
     private let groupIdentifier = "group.com.speak.ios"
-    
+
     private init() {
         defaults = UserDefaults(suiteName: groupIdentifier)
     }
-    
+
     /// Updates the current transcript text (for copy action)
     public func updateTranscript(_ text: String) {
         defaults?.set(text, forKey: "currentTranscriptText")
-        
+
         // Extract and store last sentence
         if let lastSentence = extractLastSentence(from: text) {
             defaults?.set(lastSentence, forKey: "lastTranscribedSentence")
         }
     }
-    
+
     /// Clears all shared state
     public func clear() {
         defaults?.removeObject(forKey: "currentTranscriptText")
         defaults?.removeObject(forKey: "lastTranscribedSentence")
     }
-    
+
     // MARK: - Recording State
-    
+
     /// Whether a headless recording session is currently active.
     public var isRecording: Bool {
         get { defaults?.bool(forKey: "isRecording") ?? false }
         set { defaults?.set(newValue, forKey: "isRecording") }
     }
-    
+
     /// Start time of the current recording session.
     public var recordingStartTime: Date? {
         get { defaults?.object(forKey: "recordingStartTime") as? Date }
@@ -276,7 +338,7 @@ public final class SharedTranscriptionState {
             }
         }
     }
-    
+
     /// The most recently completed transcript (for clipboard result).
     public var lastCompletedTranscript: String? {
         get { defaults?.string(forKey: "lastCompletedTranscript") }
@@ -320,13 +382,13 @@ public final class SharedTranscriptionState {
         isRecording = false
         recordingStartTime = nil
     }
-    
+
     private func extractLastSentence(from text: String) -> String? {
         // Split by sentence-ending punctuation
         let sentences = text.components(separatedBy: CharacterSet(charactersIn: ".!?"))
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
-        
+
         return sentences.last
     }
 }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -634,7 +634,7 @@ public struct SettingsView: View {
                     Label("Preferred Sync", systemImage: "arrow.triangle.branch")
                     Spacer()
                     Text(syncStatus.preferredBackend.displayName)
-                        .foregroundStyle(syncStatus.preferredBackend == .localOnly ? .secondary : .green)
+                        .foregroundStyle(syncStatus.preferredBackend != .localOnly ? .green : .secondary)
                 }
                 .accessibilityElement(children: .combine)
 


### PR DESCRIPTION
## Problem

Two issues reported for the iOS app:

1. **Holding the Action Button (via a Shortcut) shows "Turn on Live Activities for Just Speak to It in Settings…" even though that toggle is already on.**
2. **Request:** trigger recording with a single tap instead of holding the Action Button.

## Root cause of #1

The Action Button, a Shortcut, Siri and the Control Center toggle all run the recording `AppIntent` while the app is in the **background**. `AudioRecordingIntent` requires a Live Activity to record headlessly, but **ActivityKit refuses to start a Live Activity from the background** in this context, so `Activity.request()` throws. `startRecording()` then bails with `iOSTranscriptionError.liveActivityUnavailable`, whose message is the misleading "turn on Live Activities" text.

The setting *is* respected (`areActivitiesEnabled == true`); the real failure is "can't start a Live Activity from the background". Wrapping the intent in a user Shortcut (rather than a direct App Shortcut) also drops the background-audio grant, which is why it reproduces reliably.

## Fix

Conform the recording intents to **`ForegroundContinuableIntent`** and, on that specific failure, continue in the foreground:

- `StartTranscriptionRecordingIntent` (Toggle Recording — Action Button / Siri / Shortcuts)
- `StartTranscriptionIntent` (Start Recording)
- `ToggleTranscriptionControlIntent` (Control Center toggle)

When the headless background start is refused, `requestToContinueInForeground { … }` briefly brings the app forward, where the Live Activity starts and recording proceeds. **Successful headless background starts are unchanged** — the foreground hop only happens on the `liveActivityUnavailable` failure.

`ToggleTranscriptionControlIntent` moved from the widget extension into `SpeakiOSLib` so it can adopt `ForegroundContinuableIntent` (that protocol is unavailable to app extensions). The extension still references it only as a `SetValueIntent` via `ControlWidgetToggle`, which is allowed — verified with an isolated `swiftc -application-extension` repro (referencing a type that conforms to an extension-unavailable protocol compiles; naming the protocol does not).

## #2 — one-tap triggers

The hardware Action Button is hold-to-activate by iOS design; there is no app-side way to make it a light tap. The genuine one-tap paths, all now fixed by the change above:

- **Control Center** — the app's "Transcribe Voice" control (fixed here).
- **Home Screen / Lock Screen Shortcuts widget** — add a widget running the "Toggle Recording" / "Start Recording" App Shortcut (both fixed here).
- **Back Tap** (Settings → Accessibility → Touch → Back Tap → run the shortcut) — also one tap.

## Verification

- ✅ `SpeakiOSLib` compiles for iOS (`xcodebuild -scheme SpeakiOSLib -destination 'generic/platform=iOS Simulator'`), including the `AudioRecordingIntent + ForegroundContinuableIntent` and `SetValueIntent + AudioRecordingIntent + ForegroundContinuableIntent` compositions.
- ✅ SwiftLint passes with the repo baseline (`--strict --baseline .swiftlint-baseline.json`).
- ✅ Extension-availability rule proven with an isolated `swiftc` repro.
- ⚠️ **Needs on-device testing:** the widget extension target and Control Center **runtime** behaviour can't be exercised here (CI's `build-ios` only runs `swift build --target SpeakiOSLib`, which excludes the `#if os(iOS)` intent code; the local CoreSimulator is out of date). Please test on device.

### On-device checklist
- Hold Action Button (mapped to the JustSpeakToIt shortcut) → app should come forward and start recording, **not** show the "turn on Live Activities" error.
- Control Center "Transcribe Voice" toggle → starts/stops recording.
- Add a Shortcuts widget bound to "Toggle Recording" → one tap starts recording.


### Incidental iOS build fix (unblocks iOS releases)
While verifying the full iOS build of this branch I hit a pre-existing compile error introduced by #505 (now on `main`): in `SettingsView.swift` the *Preferred Sync* status label used a ternary whose branches mixed `HierarchicalShapeStyle` (`.secondary`) and `Color` (`.green`) with `.secondary` first, which fails to type-check for the iOS target and breaks the iOS release build. CI didn't catch it because the `Build iOS Library` job compiles `SpeakiOSLib` for the **macOS host**, not an iOS destination.

Fixed by inverting the condition so the `Color` branch comes first (`!= .localOnly ? .green : .secondary`), matching the colour-first ordering every other status row already uses. Committed separately (`fix(ios): resolve foregroundStyle type mismatch in Settings sync status`) so it's easy to spot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Control Center transcription toggle to start and stop recording.

* **Bug Fixes**
  * Improved transcription start reliability by recovering when background Live Activities aren’t available, continuing the start flow in the foreground when needed.
  * Removed conflicting widget-side intent behavior to keep transcription controls consistent across entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
