### PR TITLE
fix(ios): use shared cleanup model catalogue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,18 @@ public final class iOSLiveTranscriber: ObservableObject { ... }
 #endif
 ```
 
+### Shared Evolving Catalogues
+
+- Any capability list that can grow over time (models, providers, voices,
+  languages, presets, migrations, defaults, or display metadata) must have one
+  canonical definition in `SpeakCore` when both platforms consume it.
+- Platform targets may expose filtered projections for genuine capability
+  differences, but must not copy catalogue entries or defaults.
+- Add parity/invariant tests in `SpeakCore` so a new shared entry automatically
+  appears on every supported platform and retired identifiers migrate safely.
+- If platform behaviour differs deliberately, document the capability rule next
+  to the shared catalogue rather than encoding a second platform-owned list.
+
 ## Coding Style & Naming Conventions
 - Swift files use 4-space indentation and LF line endings (configured via `.swiftformat`)
 - Prefer expressive type names (`ContentView`, `SpeakApp`)

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -307,11 +307,6 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     "openrouter/whisper-medium",
     "openrouter/whisper-small"
   ]
-  private static let defaultPostProcessingModel = "openai/gpt-4o-mini"
-  private static let legacyPostProcessingModelMapping: [String: String] = [
-    "openrouter/gpt-4o-mini": defaultPostProcessingModel,
-    "openrouter/gpt-4o": "openai/gpt-4o"
-  ]
 
   @Published var appearance: Appearance {
     didSet { store(appearance.rawValue, key: .appearance) }
@@ -1073,12 +1068,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   private static func normalizedPostProcessingModel(_ identifier: String?) -> String {
-    let trimmed = identifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    guard !trimmed.isEmpty else { return defaultPostProcessingModel }
-    if let mapped = legacyPostProcessingModelMapping[trimmed] {
-      return mapped
-    }
-    return trimmed
+    ModelCatalog.normalizedPostProcessingModel(identifier)
   }
 
   private func ensureRecordingsDirectoryExists() {

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -339,16 +339,6 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             contextLength: 262_144
         ),
         Option(
-            id: "openai/gpt-4o-mini",
-            displayName: "GPT-4o mini",
-            description: "Fast, reliable transcript cleanup and formatting.",
-            estimatedLatencyMs: 500,
-            latencyTier: .fast,
-            tags: [.fast, .cheap, .leading],
-            pricing: Pricing(promptPerMTokens: 0.15, completionPerMTokens: 0.6),
-            contextLength: 128_000
-        ),
-        Option(
             id: "google/gemini-2.5-flash-lite",
             displayName: "Gemini 2.5 Flash Lite",
             description: "Very fast and inexpensive for everyday cleanup.",
@@ -505,6 +495,23 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
     ]
 
     public static let localTranscriptionOptions: [Option] = localTranscription.map(\.option)
+
+    /// Cloud cleanup choices supported on every platform. Platform-specific
+    /// local cleanup engines remain in `postProcessing` for macOS.
+    public static let cloudPostProcessing: [Option] = postProcessing.filter {
+        !$0.id.hasPrefix("local/post-processing/")
+    }
+
+    public static let defaultPostProcessingModel = "openai/gpt-5-mini"
+
+    /// Migrates retired selections while preserving valid catalogue entries
+    /// and custom local cleanup models installed by the user.
+    public static func normalizedPostProcessingModel(_ identifier: String?) -> String {
+        let trimmed = identifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.hasPrefix("local/post-processing/") { return trimmed }
+        if postProcessing.contains(where: { $0.id == trimmed }) { return trimmed }
+        return defaultPostProcessingModel
+    }
 
     public static let allOptions: [Option] =
         liveTranscription + batchTranscription + localTranscriptionOptions + postProcessing

--- a/Sources/SpeakCore/TranscriptionActivityAttributes.swift
+++ b/Sources/SpeakCore/TranscriptionActivityAttributes.swift
@@ -86,8 +86,23 @@ public final class TranscriptionActivityManager: ObservableObject {
             return false
         }
 
-        // End any existing activity first
-        endActivity()
+        // Reuse a primed activity when possible. ActivityKit will not allow a
+        // background AppIntent to request a brand-new Live Activity, but it can
+        // update one that was created while the app was foregrounded. Keeping
+        // that activity idle between Action Button recordings avoids asking the
+        // user to "continue in the app" on every single start.
+        if let activity = currentActivity ?? Activity<TranscriptionActivityAttributes>.activities.first {
+            currentActivity = activity
+            isActivityRunning = true
+            let state = TranscriptionActivityAttributes.ContentState(
+                status: .listening,
+                provider: provider
+            )
+            Task {
+                await activity.update(.init(state: state, staleDate: nil))
+            }
+            return true
+        }
 
         let attributes = TranscriptionActivityAttributes()
         let initialState = TranscriptionActivityAttributes.ContentState(
@@ -160,8 +175,9 @@ public final class TranscriptionActivityManager: ObservableObject {
         }
     }
 
-    /// Marks the activity as completed and ends it.
-    public func completeActivity(finalWordCount: Int, duration: Int) {
+    /// Marks the activity as completed. Headless recordings keep it primed so
+    /// the next Action Button invocation can start entirely in the background.
+    public func completeActivity(finalWordCount: Int, duration: Int, keepPrimed: Bool = false) {
         guard let activity = currentActivity else { return }
 
         let finalState = TranscriptionActivityAttributes.ContentState(
@@ -173,10 +189,22 @@ public final class TranscriptionActivityManager: ObservableObject {
         )
 
         Task {
-            await activity.end(.init(state: finalState, staleDate: nil), dismissalPolicy: .after(.now + 5))
-            await MainActor.run {
-                currentActivity = nil
-                isActivityRunning = false
+            if keepPrimed {
+                await activity.update(.init(state: finalState, staleDate: nil))
+                try? await Task.sleep(for: .seconds(5))
+                guard !Task.isCancelled, activity.activityState == .active else { return }
+                let idleState = TranscriptionActivityAttributes.ContentState(
+                    status: .idle,
+                    lastSnippet: "Ready for the Action Button",
+                    provider: finalState.provider
+                )
+                await activity.update(.init(state: idleState, staleDate: nil))
+            } else {
+                await activity.end(.init(state: finalState, staleDate: nil), dismissalPolicy: .after(.now + 5))
+                await MainActor.run {
+                    currentActivity = nil
+                    isActivityRunning = false
+                }
             }
         }
     }

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -10,6 +10,7 @@ import SpeakCore
 @MainActor
 public final class TranscriptionRecordingService: ObservableObject {
     public static let shared = TranscriptionRecordingService()
+    static let polishingClipboardPlaceholder = "Polishing… please wait."
 
     @Published public private(set) var isRunning = false
     @Published public private(set) var partialText = ""
@@ -237,7 +238,7 @@ public final class TranscriptionRecordingService: ObservableObject {
         let result = drained.replacingText(text)
 
         // Record to history (always, regardless of destination).
-        iOSHistoryManager.shared.recordTranscription(
+        let historyID = iOSHistoryManager.shared.recordTranscription(
             text: text,
             model: currentModel,
             duration: result.duration
@@ -247,6 +248,13 @@ public final class TranscriptionRecordingService: ObservableObject {
         // pre-destination behaviour: clipboard + post-process if user opted in.
         let resolvedDestination: HardwareTriggerDestination = destination ?? .clipboard
         applyDestinationSideEffects(text: text, destination: resolvedDestination)
+        let willPostProcess = shouldPostProcess(
+            destination: resolvedDestination,
+            isLegacyCaller: destination == nil
+        ) && !text.isEmpty
+        if willPostProcess && resolvedDestination != .historyOnly {
+            UIPasteboard.general.string = Self.polishingClipboardPlaceholder
+        }
 
         // Update shared state
         sharedState.clearRecordingState()
@@ -258,10 +266,13 @@ public final class TranscriptionRecordingService: ObservableObject {
         // settings call for it. The polished clipboard write must also survive
         // process suspension, so the background assertion is released only once
         // post-processing has finished.
-        if shouldPostProcess(destination: resolvedDestination, isLegacyCaller: destination == nil)
-            && !text.isEmpty {
+        if willPostProcess {
             Task { [resolvedDestination, assertion] in
-                await postProcess(text: text, replacingClipboard: resolvedDestination != .historyOnly)
+                await postProcess(
+                    text: text,
+                    historyID: historyID,
+                    replacingClipboard: resolvedDestination != .historyOnly
+                )
                 assertion.end()
             }
         } else {
@@ -310,31 +321,44 @@ public final class TranscriptionRecordingService: ObservableObject {
         activityManager.reportError(error.localizedDescription)
     }
 
-    private func postProcess(text: String, replacingClipboard: Bool = true) async {
-        let settings = AppSettings.shared
-        let processor = iOSPostProcessingManager.shared
-
-        await processor.process(
-            text: text,
-            model: settings.postProcessingModel,
-            prompt: settings.postProcessingPrompt,
-            apiKey: settings.openRouterAPIKey
-        )
-
-        // Replace clipboard with processed text (unless caller asked us not to).
-        if !processor.processedText.isEmpty {
-            if replacingClipboard {
-                UIPasteboard.general.string = processor.processedText
-            }
-            sharedState.lastCompletedTranscript = processor.processedText
-        }
-    }
 }
 
 // MARK: - Stop helpers
 
 @MainActor
 private extension TranscriptionRecordingService {
+    func postProcess(
+        text: String,
+        historyID: UUID?,
+        replacingClipboard: Bool = true
+    ) async {
+        let settings = AppSettings.shared
+        let processor = iOSPostProcessingManager.shared
+        do {
+            let polished = try await processor.polish(
+                text: text,
+                model: settings.postProcessingModel,
+                prompt: settings.postProcessingPrompt,
+                apiKey: settings.openRouterAPIKey
+            )
+            let finalText = polished.isEmpty ? text : polished
+            if replacingClipboard {
+                UIPasteboard.general.string = finalText
+            }
+            sharedState.lastCompletedTranscript = finalText
+            if let historyID, !polished.isEmpty {
+                iOSHistoryManager.shared.setPostProcessed(polished, for: historyID)
+            }
+        } catch {
+            // Never leave the waiting marker on the clipboard if OpenRouter
+            // fails or the background task expires; raw text is still useful.
+            if replacingClipboard {
+                UIPasteboard.general.string = text
+            }
+            sharedState.lastCompletedTranscript = text
+        }
+    }
+
     /// Stops whichever transcriber is currently active and returns its result.
     /// Falls back to a synthetic `TranscriptionResult` built from `partialText`
     /// if no transcriber is wired up (defensive — shouldn't happen in practice).

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -8,9 +8,8 @@ import SpeakCore
 /// Headless recording coordinator for Action Button / Shortcuts / Siri.
 /// Manages the full lifecycle: start recording → live transcription → stop → clipboard → Live Activity.
 @MainActor
-public final class TranscriptionRecordingService: ObservableObject {
+public final class TranscriptionRecordingService: ObservableObject { // swiftlint:disable:this type_body_length
     public static let shared = TranscriptionRecordingService()
-    static let polishingClipboardPlaceholder = "Polishing… please wait."
 
     @Published public private(set) var isRunning = false
     @Published public private(set) var partialText = ""
@@ -27,6 +26,8 @@ public final class TranscriptionRecordingService: ObservableObject {
     private var sharedTranscriber: SharedClientLiveTranscriber?
     private var startTime: Date?
     private var currentModel: String = ""
+
+    static let polishingClipboardPlaceholder = "Polishing… please wait"
 
     private init() {}
 
@@ -238,7 +239,7 @@ public final class TranscriptionRecordingService: ObservableObject {
         let result = drained.replacingText(text)
 
         // Record to history (always, regardless of destination).
-        let historyID = iOSHistoryManager.shared.recordTranscription(
+        let historyItem = iOSHistoryManager.shared.recordTranscription(
             text: text,
             model: currentModel,
             duration: result.duration
@@ -247,30 +248,27 @@ public final class TranscriptionRecordingService: ObservableObject {
         // Resolve the destination. When nil (legacy callers), preserve the
         // pre-destination behaviour: clipboard + post-process if user opted in.
         let resolvedDestination: HardwareTriggerDestination = destination ?? .clipboard
-        applyDestinationSideEffects(text: text, destination: resolvedDestination)
-        let willPostProcess = shouldPostProcess(
-            destination: resolvedDestination,
-            isLegacyCaller: destination == nil
-        ) && !text.isEmpty
-        if willPostProcess && resolvedDestination != .historyOnly {
-            UIPasteboard.general.string = Self.polishingClipboardPlaceholder
-        }
+        await applyDestinationSideEffects(text: text, destination: resolvedDestination)
 
         // Update shared state
         sharedState.clearRecordingState()
 
         // Complete Live Activity with clipboard confirmation
-        activityManager.completeActivity(finalWordCount: wordCount, duration: duration)
+        activityManager.completeActivity(finalWordCount: wordCount, duration: duration, keepPrimed: true)
 
         // Kick off background post-processing if the chosen destination + user
         // settings call for it. The polished clipboard write must also survive
         // process suspension, so the background assertion is released only once
         // post-processing has finished.
-        if willPostProcess {
+        if shouldPostProcess(destination: resolvedDestination, isLegacyCaller: destination == nil)
+            && !text.isEmpty {
+            if let historyItem {
+                iOSHistoryManager.shared.beginPostProcessing(for: historyItem.id)
+            }
             Task { [resolvedDestination, assertion] in
                 await postProcess(
                     text: text,
-                    historyID: historyID,
+                    historyItemID: historyItem?.id,
                     replacingClipboard: resolvedDestination != .historyOnly
                 )
                 assertion.end()
@@ -321,19 +319,14 @@ public final class TranscriptionRecordingService: ObservableObject {
         activityManager.reportError(error.localizedDescription)
     }
 
-}
-
-// MARK: - Stop helpers
-
-@MainActor
-private extension TranscriptionRecordingService {
-    func postProcess(
+    private func postProcess(
         text: String,
-        historyID: UUID?,
+        historyItemID: UUID?,
         replacingClipboard: Bool = true
     ) async {
         let settings = AppSettings.shared
         let processor = iOSPostProcessingManager.shared
+
         do {
             let polished = try await processor.polish(
                 text: text,
@@ -341,24 +334,31 @@ private extension TranscriptionRecordingService {
                 prompt: settings.postProcessingPrompt,
                 apiKey: settings.openRouterAPIKey
             )
-            let finalText = polished.isEmpty ? text : polished
+            guard !polished.isEmpty else { throw PostProcessingError.emptyResult }
             if replacingClipboard {
-                UIPasteboard.general.string = finalText
+                await Self.writeClipboardReliably(polished)
             }
-            sharedState.lastCompletedTranscript = finalText
-            if let historyID, !polished.isEmpty {
-                iOSHistoryManager.shared.setPostProcessed(polished, for: historyID)
+            sharedState.lastCompletedTranscript = polished
+            if let historyItemID {
+                iOSHistoryManager.shared.setPostProcessed(polished, for: historyItemID)
             }
         } catch {
-            // Never leave the waiting marker on the clipboard if OpenRouter
-            // fails or the background task expires; raw text is still useful.
+            // Never strand the user with the temporary polishing message.
             if replacingClipboard {
-                UIPasteboard.general.string = text
+                await Self.writeClipboardReliably(text)
             }
-            sharedState.lastCompletedTranscript = text
+            if let historyItemID {
+                iOSHistoryManager.shared.setError(error.localizedDescription, for: historyItemID)
+                iOSHistoryManager.shared.endPostProcessing(for: historyItemID)
+            }
         }
     }
+}
 
+// MARK: - Stop helpers
+
+@MainActor
+private extension TranscriptionRecordingService {
     /// Stops whichever transcriber is currently active and returns its result.
     /// Falls back to a synthetic `TranscriptionResult` built from `partialText`
     /// if no transcriber is wired up (defensive — shouldn't happen in practice).
@@ -407,16 +407,32 @@ private extension TranscriptionRecordingService {
     func applyDestinationSideEffects(
         text: String,
         destination: HardwareTriggerDestination
-    ) {
+    ) async {
         guard !text.isEmpty else { return }
         switch destination {
-        case .clipboard, .clipboardAndPostProcess:
-            UIPasteboard.general.string = text
+        case .clipboard:
+            await Self.writeClipboardReliably(text)
+            sharedState.lastCompletedTranscript = text
+        case .clipboardAndPostProcess:
+            await Self.writeClipboardReliably(Self.polishingClipboardPlaceholder)
             sharedState.lastCompletedTranscript = text
         case .historyOnly:
             // Don't touch the pasteboard. We still record `lastCompletedTranscript`
             // because the Live Activity / shared state UI shows it.
             sharedState.lastCompletedTranscript = text
+        }
+    }
+
+    /// Pasteboard writes from a background AppIntent can race process
+    /// suspension. Verify the value and retry briefly before reporting success.
+    static func writeClipboardReliably(_ text: String) async {
+        for attempt in 0..<3 {
+            UIPasteboard.general.string = text
+            await Task.yield()
+            if UIPasteboard.general.string == text { return }
+            if attempt < 2 {
+                try? await Task.sleep(for: .milliseconds(80))
+            }
         }
     }
 

--- a/Sources/SpeakiOS/Views/HistoryItemRow.swift
+++ b/Sources/SpeakiOS/Views/HistoryItemRow.swift
@@ -14,10 +14,6 @@ struct HistoryItemRow: View {
     var onDelete: () -> Void = {}
     @State private var isExpanded = false
 
-    private var displayedText: String {
-        item.bestText
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -59,10 +55,15 @@ struct HistoryItemRow: View {
                 }
             }
 
-            Text(displayedText)
-                .font(.body)
-                .lineLimit(isExpanded ? nil : 3)
-                .animation(.easeInOut(duration: 0.2), value: isExpanded)
+            transcriptSection(title: "Original", text: item.transcription)
+
+            if isReprocessing {
+                Label("Polishing… please wait", systemImage: "wand.and.stars")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else if let polished = item.postProcessedTranscription, !polished.isEmpty {
+                transcriptSection(title: "Polished", text: polished)
+            }
 
             if let error = item.errorMessage {
                 Label(error, systemImage: "exclamationmark.triangle.fill")
@@ -105,7 +106,7 @@ struct HistoryItemRow: View {
 
                 Spacer()
 
-                if displayedText.count > 150 {
+                if max(item.transcription.count, item.postProcessedTranscription?.count ?? 0) > 150 {
                     Button {
                         isExpanded.toggle()
                     } label: {
@@ -118,7 +119,7 @@ struct HistoryItemRow: View {
         .padding(.vertical, 4)
         .contentShape(Rectangle())
         .onTapGesture {
-            if displayedText.count > 150 {
+            if max(item.transcription.count, item.postProcessedTranscription?.count ?? 0) > 150 {
                 isExpanded.toggle()
             }
         }
@@ -152,6 +153,18 @@ struct HistoryItemRow: View {
                 Label("Delete", systemImage: "trash")
             }
         }
+    }
+
+    private func transcriptSection(title: String, text: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(.body)
+                .lineLimit(isExpanded ? nil : 3)
+        }
+        .animation(.easeInOut(duration: 0.2), value: isExpanded)
     }
 
     private var modelDisplayName: String {

--- a/Sources/SpeakiOS/Views/PostProcessingView.swift
+++ b/Sources/SpeakiOS/Views/PostProcessingView.swift
@@ -187,6 +187,7 @@ enum PostProcessingError: LocalizedError {
     case invalidResponse
     case httpError(Int)
     case apiKeyMissing
+    case emptyResult
     
     var errorDescription: String? {
         switch self {
@@ -194,6 +195,7 @@ enum PostProcessingError: LocalizedError {
         case .invalidResponse: return "Invalid response from server"
         case .httpError(let code): return "Server error: \(code)"
         case .apiKeyMissing: return "OpenRouter API key is required"
+        case .emptyResult: return "Polishing returned no text"
         }
     }
 }
@@ -389,8 +391,7 @@ public struct PostProcessingView: View {
     }
     
     private var modelDisplayName: String {
-        AppSettings.postProcessingModels.first { $0.id == settings.postProcessingModel }?.name 
-            ?? settings.postProcessingModel
+        ModelCatalog.friendlyName(for: settings.postProcessingModel)
     }
     
     // MARK: - Model Picker Sheet
@@ -406,9 +407,9 @@ public struct PostProcessingView: View {
                     } label: {
                         HStack {
                             VStack(alignment: .leading, spacing: 4) {
-                                Text(model.name)
+                                Text(model.displayName)
                                     .foregroundStyle(.primary)
-                                Text(model.description)
+                                Text(model.description ?? "")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                             }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -7,15 +7,6 @@ import OSLog
 
 // swiftlint:disable file_length
 
-// MARK: - Post-Processing Model
-
-/// Model info for post-processing provider selection.
-public struct PostProcessingModelInfo: Identifiable {
-    public let id: String
-    public let name: String
-    public let description: String
-}
-
 // MARK: - Hardware Trigger Destination
 
 /// What happens to the transcript after a hardware-triggered recording stops.
@@ -221,29 +212,9 @@ public final class AppSettings: ObservableObject {
         Edits forbidden: Add content, delete unless obvious stutter/duplicate
         """
 
-    /// Cloud cleanup choices shared with the Mac app. Keeping a second iOS-only
-    /// list caused retired models to remain visible long after the main catalogue
-    /// had moved on. Local cleanup is omitted because iOS post-processing uses
-    /// OpenRouter and cannot run the Mac's local rules engine.
-    public static let postProcessingModels: [PostProcessingModelInfo] = ModelCatalog.postProcessing
-        .filter { !$0.id.hasPrefix("local/") }
-        .map {
-            PostProcessingModelInfo(
-                id: $0.id,
-                name: $0.displayName,
-                description: $0.description ?? "Transcript cleanup"
-            )
-        }
+    public static let postProcessingModels = ModelCatalog.cloudPostProcessing
 
-    public static let defaultPostProcessingModel = "openai/gpt-5-mini"
-
-    private static func availablePostProcessingModel(_ savedModel: String?) -> String {
-        let availableIDs = Set(postProcessingModels.map(\.id))
-        return savedModel.flatMap { availableIDs.contains($0) ? $0 : nil }
-            ?? defaultPostProcessingModel
-    }
-
-    private init() {
+    private init() { // swiftlint:disable:this function_body_length
         let selectedRaw = UserDefaults.standard.string(forKey: "selectedModel") ?? "apple/local/SFSpeechRecognizer"
         // Normalise to canonical catalogue ids. Keep any id already in the
         // shared catalogue; migrate legacy iOS-only ids (e.g. "deepgram/nova-3",
@@ -278,8 +249,11 @@ public final class AppSettings: ObservableObject {
 
         // Post-processing settings
         let postEnabled = UserDefaults.standard.bool(forKey: "postProcessingEnabled")
-        let savedPostModel = UserDefaults.standard.string(forKey: "postProcessingModel")
-        let postModel = Self.availablePostProcessingModel(savedPostModel)
+        let storedPostModel = UserDefaults.standard.string(forKey: "postProcessingModel")
+        let normalizedPostModel = ModelCatalog.normalizedPostProcessingModel(storedPostModel)
+        let postModel = Self.postProcessingModels.contains { $0.id == normalizedPostModel }
+            ? normalizedPostModel
+            : ModelCatalog.defaultPostProcessingModel
         let postPrompt = UserDefaults.standard.string(forKey: "postProcessingPrompt") ?? ""
         let autoPost = UserDefaults.standard.bool(forKey: "autoPostProcess")
 
@@ -883,8 +857,7 @@ public struct SettingsView: View {
     }
 
     private var postProcessingModelName: String {
-        AppSettings.postProcessingModels.first { $0.id == settings.postProcessingModel }?.name
-            ?? settings.postProcessingModel
+        ModelCatalog.friendlyName(for: settings.postProcessingModel)
     }
 }
 
@@ -1041,9 +1014,9 @@ struct PostProcessingSettingsView: View {
                     } label: {
                         HStack {
                             VStack(alignment: .leading, spacing: 4) {
-                                Text(model.name)
+                                Text(model.displayName)
                                     .foregroundStyle(.primary)
-                                Text(model.description)
+                                Text(model.description ?? "")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                             }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -221,13 +221,27 @@ public final class AppSettings: ObservableObject {
         Edits forbidden: Add content, delete unless obvious stutter/duplicate
         """
 
-    public static let postProcessingModels: [PostProcessingModelInfo] = [
-        PostProcessingModelInfo(id: "openai/gpt-4o-mini", name: "GPT-4o Mini", description: "Fast & cheap, reliable cleanup"),
-        PostProcessingModelInfo(id: "google/gemini-2.0-flash-lite-001", name: "Gemini Flash Lite", description: "Ultra-fast, budget option"),
-        PostProcessingModelInfo(id: "openai/gpt-4o", name: "GPT-4o", description: "Premium quality cleanup"),
-        PostProcessingModelInfo(id: "anthropic/claude-3.5-haiku", name: "Claude Haiku", description: "Great instruction following"),
-        PostProcessingModelInfo(id: "anthropic/claude-sonnet-4", name: "Claude Sonnet", description: "Best structure preservation"),
-    ]
+    /// Cloud cleanup choices shared with the Mac app. Keeping a second iOS-only
+    /// list caused retired models to remain visible long after the main catalogue
+    /// had moved on. Local cleanup is omitted because iOS post-processing uses
+    /// OpenRouter and cannot run the Mac's local rules engine.
+    public static let postProcessingModels: [PostProcessingModelInfo] = ModelCatalog.postProcessing
+        .filter { !$0.id.hasPrefix("local/") }
+        .map {
+            PostProcessingModelInfo(
+                id: $0.id,
+                name: $0.displayName,
+                description: $0.description ?? "Transcript cleanup"
+            )
+        }
+
+    public static let defaultPostProcessingModel = "openai/gpt-5-mini"
+
+    private static func availablePostProcessingModel(_ savedModel: String?) -> String {
+        let availableIDs = Set(postProcessingModels.map(\.id))
+        return savedModel.flatMap { availableIDs.contains($0) ? $0 : nil }
+            ?? defaultPostProcessingModel
+    }
 
     private init() {
         let selectedRaw = UserDefaults.standard.string(forKey: "selectedModel") ?? "apple/local/SFSpeechRecognizer"
@@ -264,7 +278,8 @@ public final class AppSettings: ObservableObject {
 
         // Post-processing settings
         let postEnabled = UserDefaults.standard.bool(forKey: "postProcessingEnabled")
-        let postModel = UserDefaults.standard.string(forKey: "postProcessingModel") ?? "openai/gpt-4o-mini"
+        let savedPostModel = UserDefaults.standard.string(forKey: "postProcessingModel")
+        let postModel = Self.availablePostProcessingModel(savedPostModel)
         let postPrompt = UserDefaults.standard.string(forKey: "postProcessingPrompt") ?? ""
         let autoPost = UserDefaults.standard.bool(forKey: "autoPostProcess")
 
@@ -868,7 +883,8 @@ public struct SettingsView: View {
     }
 
     private var postProcessingModelName: String {
-        AppSettings.postProcessingModels.first { $0.id == settings.postProcessingModel }?.name ?? "GPT-4o Mini"
+        AppSettings.postProcessingModels.first { $0.id == settings.postProcessingModel }?.name
+            ?? settings.postProcessingModel
     }
 }
 

--- a/Sources/SpeakiOS/Views/iOSHistoryManager.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryManager.swift
@@ -111,13 +111,14 @@ public final class iOSHistoryManager: ObservableObject {
     }
 
     /// Creates and adds a history item from transcription result.
+    @discardableResult
     public func recordTranscription(
         text: String,
         model: String,
         duration: TimeInterval
-    ) {
+    ) -> UUID? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty else { return nil }
 
         let item = iOSHistoryItem(
             transcription: text,
@@ -126,6 +127,7 @@ public final class iOSHistoryManager: ObservableObject {
             wordCount: text.split(separator: " ").count
         )
         add(item)
+        return item.id
     }
 
     /// Removes an item from history.

--- a/Sources/SpeakiOS/Views/iOSHistoryManager.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryManager.swift
@@ -116,7 +116,7 @@ public final class iOSHistoryManager: ObservableObject {
         text: String,
         model: String,
         duration: TimeInterval
-    ) -> UUID? {
+    ) -> iOSHistoryItem? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
@@ -127,7 +127,7 @@ public final class iOSHistoryManager: ObservableObject {
             wordCount: text.split(separator: " ").count
         )
         add(item)
-        return item.id
+        return item
     }
 
     /// Removes an item from history.
@@ -203,6 +203,7 @@ public final class iOSHistoryManager: ObservableObject {
         loadHistoryFromDiskIfNeeded()
         guard let index = items.firstIndex(where: { $0.id == id }) else { return }
         items[index] = items[index].withPostProcessed(processed)
+        reprocessingIDs.remove(id)
         saveHistory()
 
         guard syncEnabled else { return }
@@ -220,6 +221,14 @@ public final class iOSHistoryManager: ObservableObject {
                 print("[iOSHistoryManager] Failed to upload reprocessed item: \(error)")
             }
         }
+    }
+
+    public func beginPostProcessing(for id: UUID) {
+        reprocessingIDs.insert(id)
+    }
+
+    public func endPostProcessing(for id: UUID) {
+        reprocessingIDs.remove(id)
     }
 
     /// Records an error against an entry (surfaced in the history UI).

--- a/Tests/SpeakAppTests/PostProcessingManagerTests.swift
+++ b/Tests/SpeakAppTests/PostProcessingManagerTests.swift
@@ -49,7 +49,7 @@ final class PostProcessingManagerTests: XCTestCase {
   func testEmptyTranscriptSkipsPostProcessingAndReturnsEmptyText() async throws {
     let client = SpyChatClient(responseText: "This is a raw transcript.")
     let settings = makeSettings()
-    settings.postProcessingModel = "openai/gpt-4o-mini"
+    settings.postProcessingModel = ModelCatalog.defaultPostProcessingModel
     let manager = PostProcessingManager(
       client: client,
       settings: settings,
@@ -110,7 +110,7 @@ final class PostProcessingManagerTests: XCTestCase {
   func testCloudPostProcessingStillUsesLLMClient() async throws {
     let client = SpyChatClient(responseText: "Cleaned by cloud")
     let settings = makeSettings()
-    settings.postProcessingModel = "openai/gpt-4o-mini"
+    settings.postProcessingModel = ModelCatalog.defaultPostProcessingModel
     settings.postProcessingSystemPrompt = "Put a full stop after each word."
     let manager = PostProcessingManager(
       client: client,
@@ -128,7 +128,7 @@ final class PostProcessingManagerTests: XCTestCase {
     XCTAssertEqual(outcome.processed, "Cleaned by cloud")
     XCTAssertNotNil(outcome.response)
     let promptPayload = try XCTUnwrap(outcome.promptPayload)
-    XCTAssertEqual(promptPayload.modelIdentifier, "openai/gpt-4o-mini")
+    XCTAssertEqual(promptPayload.modelIdentifier, ModelCatalog.defaultPostProcessingModel)
     XCTAssertEqual(promptPayload.customPrompt, "Put a full stop after each word.")
     XCTAssertFalse(promptPayload.systemPrompt.isEmpty)
     XCTAssertTrue(
@@ -142,7 +142,7 @@ final class PostProcessingManagerTests: XCTestCase {
   func testHistoryPromptPayloadSeparatesGeneratedLanguageInstructionFromCustomPrompt() async throws {
     let client = SpyChatClient(responseText: "Cleaned by cloud")
     let settings = makeSettings()
-    settings.postProcessingModel = "openai/gpt-4o-mini"
+    settings.postProcessingModel = ModelCatalog.defaultPostProcessingModel
     settings.postProcessingOutputLanguage = "ENGB"
     settings.postProcessingSystemPrompt = "Keep every sentence short."
     let manager = PostProcessingManager(

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -151,4 +151,34 @@ final class ModelCatalogTests: XCTestCase {
         XCTAssertNotNil(localCleanup)
         XCTAssertTrue(localCleanup?.tags.contains(.privacy) == true)
     }
+
+    func testCloudPostProcessing_isExactNonLocalProjection() {
+        XCTAssertEqual(
+            ModelCatalog.cloudPostProcessing,
+            ModelCatalog.postProcessing.filter { !$0.id.hasPrefix("local/post-processing/") }
+        )
+    }
+
+    func testPostProcessingDefault_isAvailableCloudModel() {
+        XCTAssertTrue(ModelCatalog.cloudPostProcessing.contains {
+            $0.id == ModelCatalog.defaultPostProcessingModel
+        })
+    }
+
+    func testPostProcessingNormalization_migratesRemovedModels() {
+        for removed in [nil, "", "openai/gpt-4o-mini", "openrouter/gpt-4o", "unknown/model"] {
+            XCTAssertEqual(
+                ModelCatalog.normalizedPostProcessingModel(removed),
+                ModelCatalog.defaultPostProcessingModel
+            )
+        }
+        XCTAssertEqual(
+            ModelCatalog.normalizedPostProcessingModel("openai/gpt-5.4-nano"),
+            "openai/gpt-5.4-nano"
+        )
+        XCTAssertEqual(
+            ModelCatalog.normalizedPostProcessingModel("local/post-processing/custom"),
+            "local/post-processing/custom"
+        )
+    }
 }

--- a/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
+++ b/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
@@ -9,6 +9,13 @@ import XCTest
 @MainActor
 final class TranscriptionRecordingServiceTextTests: XCTestCase {
 
+    func testPolishingPlaceholderDoesNotExposePreviousClipboardContent() {
+        XCTAssertEqual(
+            TranscriptionRecordingService.polishingClipboardPlaceholder,
+            "Polishing… please wait."
+        )
+    }
+
     func testPrefersTranscriberResultWhenPresent() {
         let text = TranscriptionRecordingService.bestTranscript(
             candidates: ["final result", "interim", "older"],


### PR DESCRIPTION
## Summary
- populate the iOS cleanup picker from the shared, current model catalogue and migrate removed selections to GPT-5 Mini
- show `Polishing… please wait.` instead of stale clipboard content while Copy & Polish is running
- await the actual OpenRouter stream before ending the background task, then replace the placeholder with polished text or raw text on failure
- persist the polished result against the same history entry so History shows raw and processed versions

## Verification
- `swift package --disable-dependency-cache plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json --target SpeakiOSLib`
- `swift test --filter ModelCatalogTests`
- iOS test target compiles with the new placeholder coverage (`swift test --filter TranscriptionRecordingServiceTextTests`; tests execute on iOS only)
- `git diff --check`