### PR TITLE
feat: add GPT-5.6 cleanup models

### DIFF
--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -309,36 +309,6 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             contextLength: 400_000
         ),
         Option(
-            id: "openai/gpt-5.6-luna",
-            displayName: "GPT-5.6 Luna",
-            description: "Fastest GPT-5.6 model for efficient, high-volume transcript cleanup.",
-            estimatedLatencyMs: 450,
-            latencyTier: .fast,
-            tags: [.fast, .quality],
-            pricing: Pricing(promptPerMTokens: 1.0, completionPerMTokens: 6.0),
-            contextLength: 1_000_000
-        ),
-        Option(
-            id: "openai/gpt-5.6-terra",
-            displayName: "GPT-5.6 Terra",
-            description: "Balanced GPT-5.6 capability and cost for high-quality transcript cleanup.",
-            estimatedLatencyMs: 750,
-            latencyTier: .medium,
-            tags: [.quality, .leading],
-            pricing: Pricing(promptPerMTokens: 2.5, completionPerMTokens: 15.0),
-            contextLength: 1_000_000
-        ),
-        Option(
-            id: "openai/gpt-5.6-sol",
-            displayName: "GPT-5.6 Sol",
-            description: "Flagship GPT-5.6 model for the highest-quality transcript cleanup.",
-            estimatedLatencyMs: 1_200,
-            latencyTier: .slow,
-            tags: [.quality, .leading],
-            pricing: Pricing(promptPerMTokens: 5.0, completionPerMTokens: 30.0),
-            contextLength: 1_000_000
-        ),
-        Option(
             id: "google/gemini-3.1-flash-lite",
             displayName: "Gemini 3.1 Flash Lite",
             description: "Latest Gemini Flash Lite generation with low cost and a long context window.",
@@ -411,6 +381,16 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             contextLength: 200_000
         ),
         Option(
+            id: "openai/gpt-5.6-luna",
+            displayName: "GPT-5.6 Luna",
+            description: "Fastest GPT-5.6 model for efficient, high-volume transcript cleanup.",
+            estimatedLatencyMs: 450,
+            latencyTier: .fast,
+            tags: [.fast, .quality],
+            pricing: Pricing(promptPerMTokens: 1.0, completionPerMTokens: 6.0),
+            contextLength: 1_050_000
+        ),
+        Option(
             id: "openai/gpt-5.4-mini",
             displayName: "GPT-5.4 Mini",
             description: "Recent OpenAI mini model for higher-quality cleanup at moderate cost.",
@@ -438,6 +418,26 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             description: "Latest OpenAI generation for top-tier transcript cleanup quality.",
             estimatedLatencyMs: 1200,
             latencyTier: .medium,
+            tags: [.quality, .leading],
+            pricing: Pricing(promptPerMTokens: 5.0, completionPerMTokens: 30.0),
+            contextLength: 1_050_000
+        ),
+        Option(
+            id: "openai/gpt-5.6-terra",
+            displayName: "GPT-5.6 Terra",
+            description: "Balanced GPT-5.6 capability and cost for high-quality transcript cleanup.",
+            estimatedLatencyMs: 750,
+            latencyTier: .medium,
+            tags: [.quality, .leading],
+            pricing: Pricing(promptPerMTokens: 2.5, completionPerMTokens: 15.0),
+            contextLength: 1_050_000
+        ),
+        Option(
+            id: "openai/gpt-5.6-sol",
+            displayName: "GPT-5.6 Sol",
+            description: "Flagship GPT-5.6 model for the highest-quality transcript cleanup.",
+            estimatedLatencyMs: 1_200,
+            latencyTier: .slow,
             tags: [.quality, .leading],
             pricing: Pricing(promptPerMTokens: 5.0, completionPerMTokens: 30.0),
             contextLength: 1_050_000

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -309,6 +309,36 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             contextLength: 400_000
         ),
         Option(
+            id: "openai/gpt-5.6-luna",
+            displayName: "GPT-5.6 Luna",
+            description: "Fastest GPT-5.6 model for efficient, high-volume transcript cleanup.",
+            estimatedLatencyMs: 450,
+            latencyTier: .fast,
+            tags: [.fast, .quality],
+            pricing: Pricing(promptPerMTokens: 1.0, completionPerMTokens: 6.0),
+            contextLength: 1_000_000
+        ),
+        Option(
+            id: "openai/gpt-5.6-terra",
+            displayName: "GPT-5.6 Terra",
+            description: "Balanced GPT-5.6 capability and cost for high-quality transcript cleanup.",
+            estimatedLatencyMs: 750,
+            latencyTier: .medium,
+            tags: [.quality, .leading],
+            pricing: Pricing(promptPerMTokens: 2.5, completionPerMTokens: 15.0),
+            contextLength: 1_000_000
+        ),
+        Option(
+            id: "openai/gpt-5.6-sol",
+            displayName: "GPT-5.6 Sol",
+            description: "Flagship GPT-5.6 model for the highest-quality transcript cleanup.",
+            estimatedLatencyMs: 1_200,
+            latencyTier: .slow,
+            tags: [.quality, .leading],
+            pricing: Pricing(promptPerMTokens: 5.0, completionPerMTokens: 30.0),
+            contextLength: 1_000_000
+        ),
+        Option(
             id: "google/gemini-3.1-flash-lite",
             displayName: "Gemini 3.1 Flash Lite",
             description: "Latest Gemini Flash Lite generation with low cost and a long context window.",

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -139,6 +139,9 @@ final class ModelCatalogTests: XCTestCase {
         XCTAssertTrue(ids.contains("openai/gpt-5-mini"))
         XCTAssertTrue(ids.contains("openai/gpt-5.4-mini"))
         XCTAssertTrue(ids.contains("openai/gpt-5.4-nano"))
+        XCTAssertTrue(ids.contains("openai/gpt-5.6-luna"))
+        XCTAssertTrue(ids.contains("openai/gpt-5.6-terra"))
+        XCTAssertTrue(ids.contains("openai/gpt-5.6-sol"))
         XCTAssertTrue(ids.contains("google/gemini-3.1-flash-lite"))
         XCTAssertTrue(ids.contains("qwen/qwen3.6-flash"))
     }

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -139,11 +139,23 @@ final class ModelCatalogTests: XCTestCase {
         XCTAssertTrue(ids.contains("openai/gpt-5-mini"))
         XCTAssertTrue(ids.contains("openai/gpt-5.4-mini"))
         XCTAssertTrue(ids.contains("openai/gpt-5.4-nano"))
-        XCTAssertTrue(ids.contains("openai/gpt-5.6-luna"))
-        XCTAssertTrue(ids.contains("openai/gpt-5.6-terra"))
-        XCTAssertTrue(ids.contains("openai/gpt-5.6-sol"))
         XCTAssertTrue(ids.contains("google/gemini-3.1-flash-lite"))
         XCTAssertTrue(ids.contains("qwen/qwen3.6-flash"))
+    }
+
+    func testPostProcessing_includesGPT56ModelsWithCurrentMetadata() {
+        let expected: [String: ModelCatalog.Pricing] = [
+            "openai/gpt-5.6-luna": .init(promptPerMTokens: 1.0, completionPerMTokens: 6.0),
+            "openai/gpt-5.6-terra": .init(promptPerMTokens: 2.5, completionPerMTokens: 15.0),
+            "openai/gpt-5.6-sol": .init(promptPerMTokens: 5.0, completionPerMTokens: 30.0)
+        ]
+
+        for (id, pricing) in expected {
+            let option = ModelCatalog.postProcessing.first { $0.id == id }
+            XCTAssertNotNil(option, "Missing \(id)")
+            XCTAssertEqual(option?.pricing, pricing, "Incorrect pricing for \(id)")
+            XCTAssertEqual(option?.contextLength, 1_050_000, "Incorrect context length for \(id)")
+        }
     }
 
     func testPostProcessing_keepsLocalCleanupVisible() {


### PR DESCRIPTION
Adds GPT-5.6 Luna, Terra, and Sol to the shared SpeakCore cleanup catalogue so both iOS and macOS receive the same options. Includes current standard API pricing, latency/quality metadata, and catalogue invariant coverage.\n\nValidation: swift test --filter ModelCatalogTests (19 passed); git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three GPT-5.6 post-processing model options: Luna, Terra, and Sol.
  * Added model details including descriptions, pricing, supported context lengths, latency estimates, and performance tags.

* **Tests**
  * Updated model availability coverage to include the new GPT-5.6 options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->