### PR TITLE
feat(ios): unify history browsing behavior

### DIFF
--- a/Sources/SpeakApp/HistoryItem.swift
+++ b/Sources/SpeakApp/HistoryItem.swift
@@ -268,3 +268,19 @@ struct HistoryItem: Codable, Identifiable, Hashable {
     errors: []
   )
 }
+
+extension HistoryItem {
+  var presentationItem: HistoryPresentationItem {
+    HistoryPresentationItem(
+      id: id,
+      createdAt: createdAt,
+      rawTranscription: rawTranscription,
+      processedTranscription: postProcessedTranscription,
+      modelIdentifiers: modelUsages.isEmpty ? modelsUsed : modelUsages.map(\.modelIdentifier),
+      recordingDuration: recordingDuration,
+      cost: cost?.total ?? 0,
+      errorCount: errors.count,
+      originPlatform: "macos"
+    )
+  }
+}

--- a/Sources/SpeakApp/HistoryManager.swift
+++ b/Sources/SpeakApp/HistoryManager.swift
@@ -1,17 +1,11 @@
 import AppKit
 import Foundation
+import SpeakCore
 import os.log
 
 // @Implement: This file persists history items to disc and is the interface to fetch a list of them, apply any filtering, sorting, or other standard functions, and surface them to the history view.
 
-struct HistoryFilter: Equatable {
-  var searchText: String?
-  var modelIdentifiers: Set<String> = []
-  var includeErrorsOnly: Bool = false
-  var dateRange: ClosedRange<Date>?
-
-  static let none = HistoryFilter()
-}
+typealias HistoryFilter = HistorySearchQuery
 
 struct HistoryStatistics: Equatable {
   let totalSessions: Int
@@ -482,35 +476,7 @@ final class HistoryManager: ObservableObject {
   }
 
   func items(matching filter: HistoryFilter) -> [HistoryItem] {
-    // Filter from the currently loaded items only
-    items.filter { item in
-      if let text = filter.searchText?.lowercased(), !text.isEmpty {
-        let combined = [item.rawTranscription, item.postProcessedTranscription]
-          .compactMap { $0?.lowercased() }
-          .joined(separator: "\n")
-        if !combined.contains(text) {
-          return false
-        }
-      }
-
-      if !filter.modelIdentifiers.isEmpty,
-        filter.modelIdentifiers.intersection(item.modelsUsed).isEmpty
-      {
-        return false
-      }
-
-      if filter.includeErrorsOnly && item.errors.isEmpty {
-        return false
-      }
-
-      if let range = filter.dateRange {
-        if !range.contains(item.createdAt) {
-          return false
-        }
-      }
-
-      return true
-    }
+    items.filter { filter.matches($0.presentationItem) }
   }
 
   private nonisolated static func calculateStatistics(for items: [HistoryItem]) -> HistoryStatistics {

--- a/Sources/SpeakApp/HistoryManager.swift
+++ b/Sources/SpeakApp/HistoryManager.swift
@@ -5,7 +5,7 @@ import os.log
 
 // Existing persistence implementation exceeds the project defaults; keep this
 // explicit until it is split by responsibility in a dedicated refactor.
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length
 
 // @Implement: This file persists history items to disc and is the interface to fetch a list of them, apply any filtering, sorting, or other standard functions, and surface them to the history view.
 
@@ -42,6 +42,7 @@ private struct WALEntry: Codable {
 }
 
 @MainActor
+// swiftlint:disable:next type_body_length
 final class HistoryManager: ObservableObject {
   @Published private(set) var items: [HistoryItem] = []
   @Published private(set) var statistics: HistoryStatistics = .init(
@@ -594,3 +595,5 @@ final class HistoryManager: ObservableObject {
     statistics = updated
   }
 }
+
+// swiftlint:enable file_length

--- a/Sources/SpeakApp/HistoryManager.swift
+++ b/Sources/SpeakApp/HistoryManager.swift
@@ -3,6 +3,10 @@ import Foundation
 import SpeakCore
 import os.log
 
+// Existing persistence implementation exceeds the project defaults; keep this
+// explicit until it is split by responsibility in a dedicated refactor.
+// swiftlint:disable file_length type_body_length
+
 // @Implement: This file persists history items to disc and is the interface to fetch a list of them, apply any filtering, sorting, or other standard functions, and surface them to the history view.
 
 typealias HistoryFilter = HistorySearchQuery

--- a/Sources/SpeakApp/HistoryView.swift
+++ b/Sources/SpeakApp/HistoryView.swift
@@ -447,45 +447,7 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
   }
 
   private func apply(filter: HistoryFilter, to items: [HistoryItem]) -> [HistoryItem] {
-    guard filter != .none else { return items }
-
-    // Pre-lower the model filter identifiers once, outside the per-item loop.
-    let requestedModels: Set<String> = filter.modelIdentifiers.isEmpty
-      ? []
-      : Set(filter.modelIdentifiers.map { $0.lowercased() })
-
-    return items.filter { item in
-      if let text = filter.searchText?.lowercased(), !text.isEmpty {
-        // Check each transcription field directly to avoid building intermediate arrays/strings.
-        let inTranscript = item.rawTranscription?.lowercased().contains(text) == true
-          || item.postProcessedTranscription?.lowercased().contains(text) == true
-        // Only inspect model names when the transcript fields didn't already match.
-        if !inTranscript {
-          let inModels = item.modelsUsed.contains { model in
-            model.lowercased().contains(text)
-              || ModelCatalog.friendlyName(for: model).lowercased().contains(text)
-          }
-          if !inModels { return false }
-        }
-      }
-
-      if !requestedModels.isEmpty {
-        let itemModels = Set(item.modelsUsed.map { $0.lowercased() })
-        if requestedModels.isDisjoint(with: itemModels) {
-          return false
-        }
-      }
-
-      if filter.includeErrorsOnly && item.errors.isEmpty {
-        return false
-      }
-
-      if let range = filter.dateRange, !range.contains(item.createdAt) {
-        return false
-      }
-
-      return true
-    }
+    items.filter { filter.matches($0.presentationItem) }
   }
 }
 

--- a/Sources/SpeakApp/HistoryView.swift
+++ b/Sources/SpeakApp/HistoryView.swift
@@ -133,10 +133,7 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
   }
 
   private var normalizedDateRange: ClosedRange<Date> {
-    let calendar = Calendar.current
-    let start = calendar.startOfDay(for: startDate)
-    let end = calendar.date(bySettingHour: 23, minute: 59, second: 59, of: endDate) ?? endDate
-    return start...end
+    HistorySearchQuery.normalizedDayRange(from: startDate, through: endDate)
   }
 
   var body: some View {

--- a/Sources/SpeakCore/HistoryPresentation.swift
+++ b/Sources/SpeakCore/HistoryPresentation.swift
@@ -60,7 +60,7 @@ public struct HistorySearchQuery: Equatable, Sendable {
         includeErrorsOnly: Bool = false,
         dateRange: ClosedRange<Date>? = nil
     ) {
-        self.searchText = searchText
+        self.searchText = searchText?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         self.modelIdentifiers = modelIdentifiers
         self.includeErrorsOnly = includeErrorsOnly
         self.dateRange = dateRange
@@ -68,9 +68,19 @@ public struct HistorySearchQuery: Equatable, Sendable {
 
     public static let none = HistorySearchQuery()
 
+    public static func normalizedDayRange(
+        from startDate: Date,
+        through endDate: Date,
+        calendar: Calendar = .current
+    ) -> ClosedRange<Date> {
+        let lower = calendar.startOfDay(for: startDate)
+        let endStart = calendar.startOfDay(for: max(startDate, endDate))
+        let upper = calendar.date(byAdding: DateComponents(day: 1, second: -1), to: endStart) ?? endStart
+        return lower...upper
+    }
+
     public func matches(_ item: HistoryPresentationItem) -> Bool {
-        if let term = searchText?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-           !term.isEmpty {
+        if let term = searchText, !term.isEmpty {
             let transcriptMatches = item.rawTranscription?.lowercased().contains(term) == true
                 || item.processedTranscription?.lowercased().contains(term) == true
             let modelMatches = item.modelIdentifiers.contains { identifier in
@@ -101,11 +111,22 @@ public struct HistoryPresentationStatistics: Equatable, Sendable {
     public let totalWords: Int
 
     public init(items: [HistoryPresentationItem]) {
+        var duration: TimeInterval = 0
+        var spend: Decimal = 0
+        var errorSessions = 0
+        var words = 0
+        for item in items {
+            duration += max(0, item.recordingDuration)
+            spend += item.cost
+            if item.errorCount > 0 { errorSessions += 1 }
+            words += item.wordCount
+        }
+
         totalSessions = items.count
-        cumulativeRecordingDuration = items.reduce(0) { $0 + max(0, $1.recordingDuration) }
-        totalSpend = items.reduce(Decimal(0)) { $0 + $1.cost }
-        averageSessionLength = items.isEmpty ? 0 : cumulativeRecordingDuration / Double(items.count)
-        sessionsWithErrors = items.filter { $0.errorCount > 0 }.count
-        totalWords = items.reduce(0) { $0 + $1.wordCount }
+        cumulativeRecordingDuration = duration
+        totalSpend = spend
+        averageSessionLength = items.isEmpty ? 0 : duration / Double(items.count)
+        sessionsWithErrors = errorSessions
+        totalWords = words
     }
 }

--- a/Sources/SpeakCore/HistoryPresentation.swift
+++ b/Sources/SpeakCore/HistoryPresentation.swift
@@ -68,6 +68,7 @@ public struct HistorySearchQuery: Equatable, Sendable {
 
     public static let none = HistorySearchQuery()
 
+    /// Expands two user-selected dates into an inclusive, daylight-saving-safe day range.
     public static func normalizedDayRange(
         from startDate: Date,
         through endDate: Date,
@@ -79,6 +80,7 @@ public struct HistorySearchQuery: Equatable, Sendable {
         return lower...upper
     }
 
+    /// Returns whether an entry satisfies every active search and filter constraint.
     public func matches(_ item: HistoryPresentationItem) -> Bool {
         if let term = searchText, !term.isEmpty {
             let transcriptMatches = item.rawTranscription?.lowercased().contains(term) == true
@@ -110,6 +112,7 @@ public struct HistoryPresentationStatistics: Equatable, Sendable {
     public let sessionsWithErrors: Int
     public let totalWords: Int
 
+    /// Aggregates all user-facing history metrics in one pass over the supplied entries.
     public init(items: [HistoryPresentationItem]) {
         var duration: TimeInterval = 0
         var spend: Decimal = 0

--- a/Sources/SpeakCore/HistoryPresentation.swift
+++ b/Sources/SpeakCore/HistoryPresentation.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Cross-platform projection used for history search, filtering and statistics.
+/// Platform history records can retain richer persistence details while sharing
+/// the behaviour users expect on Mac and iPhone.
+public struct HistoryPresentationItem: Identifiable, Hashable, Sendable {
+    public let id: UUID
+    public let createdAt: Date
+    public let rawTranscription: String?
+    public let processedTranscription: String?
+    public let modelIdentifiers: [String]
+    public let recordingDuration: TimeInterval
+    public let cost: Decimal
+    public let errorCount: Int
+    public let originPlatform: String
+
+    public init(
+        id: UUID,
+        createdAt: Date,
+        rawTranscription: String?,
+        processedTranscription: String?,
+        modelIdentifiers: [String],
+        recordingDuration: TimeInterval,
+        cost: Decimal = 0,
+        errorCount: Int = 0,
+        originPlatform: String
+    ) {
+        self.id = id
+        self.createdAt = createdAt
+        self.rawTranscription = rawTranscription
+        self.processedTranscription = processedTranscription
+        self.modelIdentifiers = modelIdentifiers
+        self.recordingDuration = recordingDuration
+        self.cost = cost
+        self.errorCount = errorCount
+        self.originPlatform = originPlatform
+    }
+
+    public var bestTranscription: String? {
+        let processed = processedTranscription?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let processed, !processed.isEmpty { return processed }
+        let raw = rawTranscription?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return raw?.isEmpty == false ? raw : nil
+    }
+
+    public var wordCount: Int {
+        bestTranscription?.split(whereSeparator: \.isWhitespace).count ?? 0
+    }
+}
+
+public struct HistorySearchQuery: Equatable, Sendable {
+    public var searchText: String?
+    public var modelIdentifiers: Set<String>
+    public var includeErrorsOnly: Bool
+    public var dateRange: ClosedRange<Date>?
+
+    public init(
+        searchText: String? = nil,
+        modelIdentifiers: Set<String> = [],
+        includeErrorsOnly: Bool = false,
+        dateRange: ClosedRange<Date>? = nil
+    ) {
+        self.searchText = searchText
+        self.modelIdentifiers = modelIdentifiers
+        self.includeErrorsOnly = includeErrorsOnly
+        self.dateRange = dateRange
+    }
+
+    public static let none = HistorySearchQuery()
+
+    public func matches(_ item: HistoryPresentationItem) -> Bool {
+        if let term = searchText?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           !term.isEmpty {
+            let transcriptMatches = item.rawTranscription?.lowercased().contains(term) == true
+                || item.processedTranscription?.lowercased().contains(term) == true
+            let modelMatches = item.modelIdentifiers.contains { identifier in
+                identifier.lowercased().contains(term)
+                    || ModelCatalog.friendlyName(for: identifier).lowercased().contains(term)
+            }
+            guard transcriptMatches || modelMatches else { return false }
+        }
+
+        if !modelIdentifiers.isEmpty {
+            let requested = Set(modelIdentifiers.map { $0.lowercased() })
+            let actual = Set(item.modelIdentifiers.map { $0.lowercased() })
+            guard !requested.isDisjoint(with: actual) else { return false }
+        }
+
+        if includeErrorsOnly, item.errorCount == 0 { return false }
+        if let dateRange, !dateRange.contains(item.createdAt) { return false }
+        return true
+    }
+}
+
+public struct HistoryPresentationStatistics: Equatable, Sendable {
+    public let totalSessions: Int
+    public let cumulativeRecordingDuration: TimeInterval
+    public let totalSpend: Decimal
+    public let averageSessionLength: TimeInterval
+    public let sessionsWithErrors: Int
+    public let totalWords: Int
+
+    public init(items: [HistoryPresentationItem]) {
+        totalSessions = items.count
+        cumulativeRecordingDuration = items.reduce(0) { $0 + max(0, $1.recordingDuration) }
+        totalSpend = items.reduce(Decimal(0)) { $0 + $1.cost }
+        averageSessionLength = items.isEmpty ? 0 : cumulativeRecordingDuration / Double(items.count)
+        sessionsWithErrors = items.filter { $0.errorCount > 0 }.count
+        totalWords = items.reduce(0) { $0 + $1.wordCount }
+    }
+}

--- a/Sources/SpeakiOS/Views/HistoryView.swift
+++ b/Sources/SpeakiOS/Views/HistoryView.swift
@@ -5,6 +5,7 @@ import SpeakSync
 
 // MARK: - History View
 
+// swiftlint:disable type_body_length
 public struct HistoryView: View {
     @StateObject private var historyManager = iOSHistoryManager.shared
     @ObservedObject private var syncEngine = HistorySyncEngine.shared
@@ -50,7 +51,11 @@ public struct HistoryView: View {
                     Button {
                         showingFilters = true
                     } label: {
-                        Image(systemName: hasActiveFilters ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                        Image(
+                            systemName: hasActiveFilters
+                                ? "line.3.horizontal.decrease.circle.fill"
+                                : "line.3.horizontal.decrease.circle"
+                        )
                     }
                     .accessibilityLabel("Filter history")
                 }

--- a/Sources/SpeakiOS/Views/HistoryView.swift
+++ b/Sources/SpeakiOS/Views/HistoryView.swift
@@ -5,7 +5,7 @@ import SpeakSync
 
 // MARK: - History View
 
-// swiftlint:disable type_body_length
+// swiftlint:disable:next type_body_length
 public struct HistoryView: View {
     @StateObject private var historyManager = iOSHistoryManager.shared
     @ObservedObject private var syncEngine = HistorySyncEngine.shared

--- a/Sources/SpeakiOS/Views/HistoryView.swift
+++ b/Sources/SpeakiOS/Views/HistoryView.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import SwiftUI
+import SpeakCore
 import SpeakSync
 
 // MARK: - History View
@@ -9,6 +10,13 @@ public struct HistoryView: View {
     @ObservedObject private var syncEngine = HistorySyncEngine.shared
     @State private var showingClearConfirmation = false
     @State private var showSkeletonLoading = false
+    @State private var showingFilters = false
+    @State private var searchText = ""
+    @State private var errorsOnly = false
+    @State private var selectedModel: String?
+    @State private var dateRangeEnabled = false
+    @State private var startDate = Calendar.current.date(byAdding: .month, value: -1, to: Date()) ?? Date()
+    @State private var endDate = Date()
 
     public init() {}
 
@@ -20,6 +28,8 @@ public struct HistoryView: View {
                 ProgressView("Loading history...")
             } else if historyManager.items.isEmpty {
                 emptyState
+            } else if filteredItems.isEmpty {
+                noMatchesState
             } else {
                 historyList
             }
@@ -31,6 +41,14 @@ public struct HistoryView: View {
             }
             if !historyManager.items.isEmpty {
                 ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showingFilters = true
+                    } label: {
+                        Image(systemName: hasActiveFilters ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                    }
+                    .accessibilityLabel("Filter history")
+                }
+                ToolbarItem(placement: .topBarTrailing) {
                     Button(role: .destructive) {
                         showingClearConfirmation = true
                     } label: {
@@ -38,6 +56,20 @@ public struct HistoryView: View {
                     }
                 }
             }
+        }
+        .searchable(text: $searchText, prompt: "Transcripts or models")
+        .sheet(isPresented: $showingFilters) {
+            NavigationStack {
+                HistoryFilterSheet(
+                    errorsOnly: $errorsOnly,
+                    selectedModel: $selectedModel,
+                    dateRangeEnabled: $dateRangeEnabled,
+                    startDate: $startDate,
+                    endDate: $endDate,
+                    availableModels: availableModels
+                )
+            }
+            .presentationDetents([.medium, .large])
         }
         .refreshable {
             await historyManager.triggerSync()
@@ -104,6 +136,10 @@ public struct HistoryView: View {
         }
     }
 
+    private var noMatchesState: some View {
+        ContentUnavailableView.search(text: searchText)
+    }
+
     private var historyList: some View {
         List {
             if syncEngine.state.isCloudAvailable {
@@ -120,7 +156,7 @@ public struct HistoryView: View {
                 statsHeader
             }
             Section {
-                ForEach(historyManager.items) { item in
+                ForEach(filteredItems) { item in
                     HistoryItemRow(
                         item: item,
                         isSynced: historyManager.isSynced(item),
@@ -153,19 +189,15 @@ public struct HistoryView: View {
     }
 
     private var statsHeader: some View {
-        HStack(spacing: 20) {
-            statBadge(
-                value: "\(historyManager.items.count)",
-                label: "Transcriptions"
-            )
-            statBadge(
-                value: formatDuration(totalDuration),
-                label: "Total Time"
-            )
-            statBadge(
-                value: "\(totalWords)",
-                label: "Words"
-            )
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 24) {
+                statBadge(value: "\(statistics.totalSessions)", label: "Sessions")
+                statBadge(value: formatDuration(statistics.averageSessionLength), label: "Average")
+                statBadge(value: formatDuration(statistics.cumulativeRecordingDuration), label: "Total Time")
+                statBadge(value: "\(statistics.totalWords)", label: "Words")
+                statBadge(value: "\(statistics.sessionsWithErrors)", label: "Errors")
+            }
+            .padding(.horizontal, 4)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
@@ -182,12 +214,41 @@ public struct HistoryView: View {
         }
     }
 
-    private var totalDuration: TimeInterval {
-        historyManager.items.reduce(0) { $0 + $1.duration }
+    private var availableModels: [String] {
+        Array(Set(historyManager.items.map(\.model))).sorted {
+            ModelCatalog.friendlyName(for: $0) < ModelCatalog.friendlyName(for: $1)
+        }
     }
 
-    private var totalWords: Int {
-        historyManager.items.reduce(0) { $0 + $1.wordCount }
+    private var query: HistorySearchQuery {
+        let range: ClosedRange<Date>?
+        if dateRangeEnabled {
+            let calendar = Calendar.current
+            let lower = calendar.startOfDay(for: startDate)
+            let upper = calendar.date(byAdding: DateComponents(day: 1, second: -1), to: calendar.startOfDay(for: endDate))
+                ?? endDate
+            range = lower...upper
+        } else {
+            range = nil
+        }
+        return HistorySearchQuery(
+            searchText: searchText,
+            modelIdentifiers: selectedModel.map { [$0] } ?? [],
+            includeErrorsOnly: errorsOnly,
+            dateRange: range
+        )
+    }
+
+    private var filteredItems: [iOSHistoryItem] {
+        historyManager.items.filter { query.matches($0.presentationItem) }
+    }
+
+    private var statistics: HistoryPresentationStatistics {
+        HistoryPresentationStatistics(items: filteredItems.map(\.presentationItem))
+    }
+
+    private var hasActiveFilters: Bool {
+        errorsOnly || selectedModel != nil || dateRangeEnabled
     }
 
     private func formatDuration(_ seconds: TimeInterval) -> String {
@@ -197,6 +258,55 @@ public struct HistoryView: View {
             return "\(minutes)m \(secs)s"
         }
         return "\(secs)s"
+    }
+}
+
+private struct HistoryFilterSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var errorsOnly: Bool
+    @Binding var selectedModel: String?
+    @Binding var dateRangeEnabled: Bool
+    @Binding var startDate: Date
+    @Binding var endDate: Date
+    let availableModels: [String]
+
+    var body: some View {
+        Form {
+            Section("Show") {
+                Toggle("Errors only", isOn: $errorsOnly)
+                Picker("Model", selection: $selectedModel) {
+                    Text("All Models").tag(String?.none)
+                    ForEach(availableModels, id: \.self) { model in
+                        Text(ModelCatalog.friendlyName(for: model)).tag(String?.some(model))
+                    }
+                }
+            }
+
+            Section("Date Range") {
+                Toggle("Limit by date", isOn: $dateRangeEnabled)
+                if dateRangeEnabled {
+                    DatePicker("From", selection: $startDate, displayedComponents: .date)
+                    DatePicker("To", selection: $endDate, in: startDate..., displayedComponents: .date)
+                }
+            }
+
+            if errorsOnly || selectedModel != nil || dateRangeEnabled {
+                Section {
+                    Button("Reset Filters", role: .destructive) {
+                        errorsOnly = false
+                        selectedModel = nil
+                        dateRangeEnabled = false
+                    }
+                }
+            }
+        }
+        .navigationTitle("Filter History")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
     }
 }
 

--- a/Sources/SpeakiOS/Views/HistoryView.swift
+++ b/Sources/SpeakiOS/Views/HistoryView.swift
@@ -17,6 +17,10 @@ public struct HistoryView: View {
     @State private var dateRangeEnabled = false
     @State private var startDate = Calendar.current.date(byAdding: .month, value: -1, to: Date()) ?? Date()
     @State private var endDate = Date()
+    @State private var filteredItems: [iOSHistoryItem] = []
+    @State private var statistics = HistoryPresentationStatistics(items: [])
+    @State private var availableModels: [String] = []
+    @State private var derivedStateReady = false
 
     public init() {}
 
@@ -28,6 +32,8 @@ public struct HistoryView: View {
                 ProgressView("Loading history...")
             } else if historyManager.items.isEmpty {
                 emptyState
+            } else if !derivedStateReady {
+                ProgressView("Preparing history...")
             } else if filteredItems.isEmpty {
                 noMatchesState
             } else {
@@ -73,6 +79,9 @@ public struct HistoryView: View {
         }
         .refreshable {
             await historyManager.triggerSync()
+        }
+        .task(id: refreshKey) {
+            refreshDerivedState()
         }
         .confirmationDialog(
             "Clear History",
@@ -214,20 +223,10 @@ public struct HistoryView: View {
         }
     }
 
-    private var availableModels: [String] {
-        Array(Set(historyManager.items.map(\.model))).sorted {
-            ModelCatalog.friendlyName(for: $0) < ModelCatalog.friendlyName(for: $1)
-        }
-    }
-
     private var query: HistorySearchQuery {
         let range: ClosedRange<Date>?
         if dateRangeEnabled {
-            let calendar = Calendar.current
-            let lower = calendar.startOfDay(for: startDate)
-            let upper = calendar.date(byAdding: DateComponents(day: 1, second: -1), to: calendar.startOfDay(for: endDate))
-                ?? endDate
-            range = lower...upper
+            range = HistorySearchQuery.normalizedDayRange(from: startDate, through: endDate)
         } else {
             range = nil
         }
@@ -239,12 +238,27 @@ public struct HistoryView: View {
         )
     }
 
-    private var filteredItems: [iOSHistoryItem] {
-        historyManager.items.filter { query.matches($0.presentationItem) }
+    private var refreshKey: HistoryRefreshKey {
+        HistoryRefreshKey(
+            items: historyManager.items.map(\.presentationItem),
+            searchText: searchText,
+            errorsOnly: errorsOnly,
+            selectedModel: selectedModel,
+            dateRangeEnabled: dateRangeEnabled,
+            startDate: startDate,
+            endDate: endDate
+        )
     }
 
-    private var statistics: HistoryPresentationStatistics {
-        HistoryPresentationStatistics(items: filteredItems.map(\.presentationItem))
+    private func refreshDerivedState() {
+        let currentQuery = query
+        let newItems = historyManager.items.filter { currentQuery.matches($0.presentationItem) }
+        filteredItems = newItems
+        statistics = HistoryPresentationStatistics(items: newItems.map(\.presentationItem))
+        availableModels = Array(Set(historyManager.items.map(\.model))).sorted {
+            ModelCatalog.friendlyName(for: $0) < ModelCatalog.friendlyName(for: $1)
+        }
+        derivedStateReady = true
     }
 
     private var hasActiveFilters: Bool {
@@ -259,6 +273,16 @@ public struct HistoryView: View {
         }
         return "\(secs)s"
     }
+}
+
+private struct HistoryRefreshKey: Hashable {
+    let items: [HistoryPresentationItem]
+    let searchText: String
+    let errorsOnly: Bool
+    let selectedModel: String?
+    let dateRangeEnabled: Bool
+    let startDate: Date
+    let endDate: Date
 }
 
 private struct HistoryFilterSheet: View {

--- a/Sources/SpeakiOS/Views/iOSHistoryModels.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryModels.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import Foundation
+import SpeakCore
 import SpeakSync
 
 // MARK: - History Item Model
@@ -107,6 +108,21 @@ public struct iOSHistoryItem: Identifiable, Codable {
             duration: entry.duration,
             wordCount: entry.wordCount,
             originPlatform: entry.originPlatform
+        )
+    }
+}
+
+extension iOSHistoryItem {
+    var presentationItem: HistoryPresentationItem {
+        HistoryPresentationItem(
+            id: id,
+            createdAt: createdAt,
+            rawTranscription: transcription,
+            processedTranscription: postProcessedTranscription,
+            modelIdentifiers: [model],
+            recordingDuration: duration,
+            errorCount: errorMessage == nil ? 0 : 1,
+            originPlatform: originPlatform
         )
     }
 }

--- a/Tests/SpeakCoreTests/HistoryPresentationTests.swift
+++ b/Tests/SpeakCoreTests/HistoryPresentationTests.swift
@@ -36,6 +36,19 @@ final class HistoryPresentationTests: XCTestCase {
         XCTAssertEqual(statistics.totalSpend, Decimal(string: "0.3"))
     }
 
+    func testNormalizedDayRange_includesWholeEndDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Europe/London")!
+        let start = Date(timeIntervalSince1970: 1_709_251_200)
+        let end = calendar.date(byAdding: .day, value: 2, to: start)!
+
+        let range = HistorySearchQuery.normalizedDayRange(from: start, through: end, calendar: calendar)
+
+        XCTAssertEqual(range.lowerBound, calendar.startOfDay(for: start))
+        XCTAssertTrue(range.contains(calendar.date(bySettingHour: 23, minute: 59, second: 59, of: end)!))
+        XCTAssertFalse(range.contains(calendar.date(byAdding: .second, value: 1, to: range.upperBound)!))
+    }
+
     private func makeItem(
         raw: String,
         processed: String? = nil,

--- a/Tests/SpeakCoreTests/HistoryPresentationTests.swift
+++ b/Tests/SpeakCoreTests/HistoryPresentationTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import SpeakCore
+
+final class HistoryPresentationTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func testQuery_matchesProcessedTextFriendlyModelAndFilters() {
+        let item = makeItem(
+            raw: "raw words",
+            processed: "Polished sentence",
+            models: ["openai/gpt-5.6-luna"],
+            errors: 1
+        )
+
+        XCTAssertTrue(HistorySearchQuery(searchText: "polished").matches(item))
+        XCTAssertTrue(HistorySearchQuery(searchText: "GPT-5.6 Luna").matches(item))
+        XCTAssertTrue(HistorySearchQuery(includeErrorsOnly: true).matches(item))
+        XCTAssertTrue(HistorySearchQuery(modelIdentifiers: ["OPENAI/GPT-5.6-LUNA"]).matches(item))
+        XCTAssertFalse(HistorySearchQuery(modelIdentifiers: ["openai/gpt-5-mini"]).matches(item))
+    }
+
+    func testStatistics_usesBestTranscriptAndAggregatesSharedMetrics() {
+        let items = [
+            makeItem(raw: "one two", processed: "one two three", duration: 20, cost: 0.1, errors: 1),
+            makeItem(raw: "four five", duration: 40, cost: 0.2)
+        ]
+
+        let statistics = HistoryPresentationStatistics(items: items)
+
+        XCTAssertEqual(statistics.totalSessions, 2)
+        XCTAssertEqual(statistics.cumulativeRecordingDuration, 60)
+        XCTAssertEqual(statistics.averageSessionLength, 30)
+        XCTAssertEqual(statistics.totalWords, 5)
+        XCTAssertEqual(statistics.sessionsWithErrors, 1)
+        XCTAssertEqual(statistics.totalSpend, Decimal(string: "0.3"))
+    }
+
+    private func makeItem(
+        raw: String,
+        processed: String? = nil,
+        models: [String] = ["apple/local/SFSpeechRecognizer"],
+        duration: TimeInterval = 10,
+        cost: Decimal = 0,
+        errors: Int = 0
+    ) -> HistoryPresentationItem {
+        HistoryPresentationItem(
+            id: UUID(),
+            createdAt: now,
+            rawTranscription: raw,
+            processedTranscription: processed,
+            modelIdentifiers: models,
+            recordingDuration: duration,
+            cost: cost,
+            errorCount: errors,
+            originPlatform: "test"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- introduces a shared SpeakCore history presentation, search, filter, and statistics layer
- switches both macOS and iOS filtering to the same matching semantics
- adds iOS-native searchable history, model/error/date filters, and richer filtered statistics
- preserves raw/polished copy, reprocessing, sync, swipe actions, and platform badges
- keeps sensitive Mac-only network diagnostics local rather than syncing request payloads through iCloud

## Validation

- full Swift test suite passes
- strict SpeakApp SwiftLint passes
- SpeakiOSLib builds successfully
- shared history behavior has focused unit coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search and filtering to history, including text, model, error-only, and date-range filters.
  * Added filtered history statistics for sessions, duration, words, spending, and errors.
  * Added clearer empty-state messaging when filters return no results.
  * Added shared history presentation and search capabilities across platforms.

* **Tests**
  * Added coverage for history filtering and statistics calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->