### PR TITLE
feat(ios): add shared batch model selection

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -300,13 +300,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     case selectedHotKey
   }
 
-  private static let defaultBatchTranscriptionModel = "google/gemini-2.0-flash-001"
   private static let defaultLocalTranscriptionModel = "local/whisperkit/tiny"
-  private static let legacyWhisperModelIDs: Set<String> = [
-    "openrouter/whisper-large-v3",
-    "openrouter/whisper-medium",
-    "openrouter/whisper-small"
-  ]
 
   @Published var appearance: Appearance {
     didSet { store(appearance.rawValue, key: .appearance) }
@@ -1055,10 +1049,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   private static func normalizedBatchModel(_ identifier: String?) -> String {
-    let trimmed = identifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    guard !trimmed.isEmpty else { return defaultBatchTranscriptionModel }
-    if legacyWhisperModelIDs.contains(trimmed) { return defaultBatchTranscriptionModel }
-    return trimmed
+    ModelCatalog.normalizedBatchTranscriptionModel(identifier)
   }
 
   private static func normalizedLocalTranscriptionModel(_ identifier: String?) -> String {

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -275,6 +275,24 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             estimatedLatencyMs: 900, latencyTier: .fast)
     ]
 
+    public static let defaultBatchTranscriptionModel = "google/gemini-2.0-flash-001"
+
+    private static let retiredBatchTranscriptionModels: Set<String> = [
+        "openrouter/whisper-large-v3",
+        "openrouter/whisper-medium",
+        "openrouter/whisper-small"
+    ]
+
+    /// Keeps catalogue defaults and retired-model migration identical on Mac and iPhone.
+    /// Unknown identifiers remain valid because the Mac supports custom OpenRouter batch models.
+    public static func normalizedBatchTranscriptionModel(_ identifier: String?) -> String {
+        let trimmed = identifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty, !retiredBatchTranscriptionModels.contains(trimmed) else {
+            return defaultBatchTranscriptionModel
+        }
+        return trimmed
+    }
+
     // Curated, static set for transcript cleanup (OpenRouter) with pricing + tags.
     // Pricing is based on OpenRouter's /api/v1/models at time of writing.
     public static let postProcessing: [Option] = [

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -65,6 +65,17 @@ public final class AppSettings: ObservableObject {
         didSet { UserDefaults.standard.set(selectedModel, forKey: "selectedModel") }
     }
 
+    @Published public var batchTranscriptionModel: String {
+        didSet {
+            let normalized = ModelCatalog.normalizedBatchTranscriptionModel(batchTranscriptionModel)
+            if normalized != batchTranscriptionModel {
+                batchTranscriptionModel = normalized
+            } else {
+                UserDefaults.standard.set(batchTranscriptionModel, forKey: "batchTranscriptionModel")
+            }
+        }
+    }
+
     @Published public var deepgramAPIKey: String {
         didSet { persistSecret(deepgramAPIKey, identifier: Self.deepgramKeyID) }
     }
@@ -256,8 +267,12 @@ public final class AppSettings: ObservableObject {
             : ModelCatalog.defaultPostProcessingModel
         let postPrompt = UserDefaults.standard.string(forKey: "postProcessingPrompt") ?? ""
         let autoPost = UserDefaults.standard.bool(forKey: "autoPostProcess")
+        let batchModel = ModelCatalog.normalizedBatchTranscriptionModel(
+            UserDefaults.standard.string(forKey: "batchTranscriptionModel")
+        )
 
         self.selectedModel = selected
+        self.batchTranscriptionModel = batchModel
         self.deepgramAPIKey = ""
         self.openRouterAPIKey = ""
         self.openAIAPIKey = ""
@@ -529,6 +544,41 @@ private struct LiveModelGroup: Identifiable {
     }
 }
 
+private struct BatchModelGroup: Identifiable {
+    let id: String
+    let title: String
+    let options: [ModelCatalog.Option]
+
+    static func grouped(_ options: [ModelCatalog.Option]) -> [BatchModelGroup] {
+        let grouped = Dictionary(grouping: options) { option in
+            String(option.id.prefix { $0 != "/" })
+        }
+        return grouped.keys.sorted().map { provider in
+            BatchModelGroup(
+                id: provider,
+                title: providerDisplayName(provider),
+                options: grouped[provider, default: []]
+            )
+        }
+    }
+
+    private static func providerDisplayName(_ provider: String) -> String {
+        let names = [
+            "openai": "OpenAI",
+            "groq": "Groq",
+            "revai": "Rev.ai",
+            "mistral": "Mistral",
+            "soniox": "Soniox",
+            "deepgram": "Deepgram",
+            "assemblyai": "AssemblyAI",
+            "elevenlabs": "ElevenLabs",
+            "modulate": "Modulate",
+            "google": "Google via OpenRouter"
+        ]
+        return names[provider] ?? provider.capitalized
+    }
+}
+
 // swiftlint:disable:next type_body_length
 public struct SettingsView: View {
     @StateObject private var settings = AppSettings.shared
@@ -552,6 +602,24 @@ public struct SettingsView: View {
                     }
                 }
                 .pickerStyle(.navigationLink)
+
+                Picker("Batch Model", selection: $settings.batchTranscriptionModel) {
+                    ForEach(BatchModelGroup.grouped(ModelCatalog.batchTranscription)) { group in
+                        Section(group.title) {
+                            ForEach(group.options) { option in
+                                LiveModelRow(option: option).tag(option.id)
+                            }
+                        }
+                    }
+                }
+                .pickerStyle(.navigationLink)
+
+                Text(
+                    "Used for imported and saved-audio transcription. "
+                        + "The same catalogue and model IDs are shared with Mac."
+                )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
                 if let route = LiveTranscriptionRouting.route(for: settings.selectedModel),
                    !route.isSupportedOnIOS {

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -607,7 +607,7 @@ public struct SettingsView: View {
                     ForEach(BatchModelGroup.grouped(ModelCatalog.batchTranscription)) { group in
                         Section(group.title) {
                             ForEach(group.options) { option in
-                                LiveModelRow(option: option).tag(option.id)
+                                Text(ModelCatalog.friendlyName(for: option.id)).tag(option.id)
                             }
                         }
                     }

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -143,6 +143,20 @@ final class ModelCatalogTests: XCTestCase {
         XCTAssertTrue(ids.contains("qwen/qwen3.6-flash"))
     }
 
+    func testBatchTranscription_defaultAndRetiredMigrationStayInCatalogue() {
+        let ids = Set(ModelCatalog.batchTranscription.map(\.id))
+
+        XCTAssertTrue(ids.contains(ModelCatalog.defaultBatchTranscriptionModel))
+        XCTAssertEqual(
+            ModelCatalog.normalizedBatchTranscriptionModel("openrouter/whisper-large-v3"),
+            ModelCatalog.defaultBatchTranscriptionModel
+        )
+        XCTAssertEqual(
+            ModelCatalog.normalizedBatchTranscriptionModel(" custom/provider-model "),
+            "custom/provider-model"
+        )
+    }
+
     func testPostProcessing_includesGPT56ModelsWithCurrentMetadata() {
         let expected: [String: ModelCatalog.Pricing] = [
             "openai/gpt-5.6-luna": .init(promptPerMTokens: 1.0, completionPerMTokens: 6.0),


### PR DESCRIPTION
## Summary

- makes SpeakCore authoritative for the batch default and retired-ID migration
- switches macOS settings to the shared normalizer
- adds the full shared batch catalogue to iOS with a native navigation picker grouped by provider
- persists the iOS batch selection using the same canonical model IDs as macOS
- retains custom batch model identifiers on Mac while migrating retired Whisper aliases

## Validation

- 21 ModelCatalog tests pass
- SpeakiOSLib builds successfully
- strict repository-wide SwiftLint passes with zero violations
- diff validation passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Batch Model picker in Transcription settings with friendly names grouped by provider.
  - Batch transcription model selections are shared consistently across macOS and iOS.

- **Bug Fixes**
  - Existing, retired model identifiers are automatically migrated to the current default.
  - Whitespace and empty model values are normalized automatically.
  - Custom model identifiers remain supported and are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->