### PR TITLE
feat(ios): add batch transcription and full history tools

### DIFF
--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -24,6 +24,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     private var elevenLabsTranscriber: ElevenLabsLiveTranscriber?
     private var openAITranscriber: OpenAIRealtimeLiveTranscriber?
     private var sharedTranscriber: SharedClientLiveTranscriber?
+    private var batchTranscriber: IOSBatchTranscriber?
     private var startTime: Date?
     private var currentModel: String = ""
 
@@ -48,6 +49,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     }
 
     private var modelDisplayName: String {
+        if batchTranscriber != nil { return ModelCatalog.friendlyName(for: currentModel) }
         if currentModel.hasPrefix("deepgram") { return "Deepgram" }
         if currentModel.hasPrefix("elevenlabs") { return "ElevenLabs" }
         if currentModel.hasPrefix("openai") { return "OpenAI gpt-realtime-whisper" }
@@ -62,7 +64,9 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         guard !isRunning else { return }
 
         let settings = AppSettings.shared
-        currentModel = settings.selectedModel
+        currentModel = settings.transcriptionMode == .batch
+            ? settings.batchTranscriptionModel
+            : settings.selectedModel
         partialText = ""
         wordCount = 0
         startTime = Date()
@@ -72,7 +76,8 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
 
         // Fall back to Apple Speech if the selected provider needs an API key we
         // don't have (covers every cloud provider via the shared routing).
-        if let route = LiveTranscriptionRouting.route(for: currentModel),
+        if settings.transcriptionMode == .streaming,
+           let route = LiveTranscriptionRouting.route(for: currentModel),
            route.apiKeyIdentifier != nil,
            settings.liveAPIKey(for: route).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             currentModel = "apple/local/SFSpeechRecognizer"
@@ -90,7 +95,20 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         }
 
         do {
-            if currentModel.hasPrefix("deepgram") {
+            if settings.transcriptionMode == .batch {
+                let transcriber = IOSBatchTranscriber(
+                    audioSessionManager: audioSessionManager,
+                    model: currentModel,
+                    apiKey: settings.batchAPIKey
+                )
+                batchTranscriber = transcriber
+                appleTranscriber = nil
+                deepgramTranscriber = nil
+                elevenLabsTranscriber = nil
+                openAITranscriber = nil
+                sharedTranscriber = nil
+                try await transcriber.start()
+            } else if currentModel.hasPrefix("deepgram") {
                 let transcriber = DeepgramLiveTranscriber(audioSessionManager: audioSessionManager)
                 transcriber.configure(apiKey: settings.deepgramAPIKey)
                 transcriber.model = LiveTranscriptionRouting.route(for: currentModel)?.apiModelName
@@ -206,6 +224,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
             openAITranscriber = nil
             appleTranscriber = nil
             sharedTranscriber = nil
+            batchTranscriber = nil
             sharedState.clearRecordingState()
             activityManager.endActivity()
             throw error
@@ -230,6 +249,15 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         // landed, so "Copied N words" was reported but nothing arrived.
         let assertion = beginBackgroundAssertion("Finalise transcription")
 
+        if batchTranscriber != nil {
+            activityManager.updateActivity(
+                status: .processing,
+                lastSnippet: "Transcribing recording…",
+                wordCount: 0,
+                duration: duration
+            )
+        }
+
         let drained = await drainActiveTranscriber(duration: duration)
         startTime = nil
 
@@ -237,6 +265,8 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         // entry, the clipboard, and the spoken dialog all agree on it.
         let text = bestAvailableText(from: drained)
         let result = drained.replacingText(text)
+        partialText = text
+        wordCount = text.split(whereSeparator: \.isWhitespace).count
 
         // Record to history (always, regardless of destination).
         let historyItem = iOSHistoryManager.shared.recordTranscription(
@@ -287,11 +317,13 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         openAITranscriber?.cancel()
         appleTranscriber?.cancel()
         sharedTranscriber?.cancel()
+        batchTranscriber?.cancel()
         deepgramTranscriber = nil
         elevenLabsTranscriber = nil
         openAITranscriber = nil
         appleTranscriber = nil
         sharedTranscriber = nil
+        batchTranscriber = nil
         isRunning = false
         startTime = nil
         partialText = ""
@@ -369,6 +401,24 @@ private extension TranscriptionRecordingService {
     /// and otherwise both calls would see the same non-nil transcriber and try
     /// to stop it twice.
     func drainActiveTranscriber(duration: Int) async -> TranscriptionResult {
+        if let batch = batchTranscriber {
+            batchTranscriber = nil
+            do {
+                return try await batch.stop(language: Locale.current.identifier)
+            } catch {
+                handleError(error)
+                return TranscriptionResult(
+                    text: "",
+                    segments: [],
+                    confidence: nil,
+                    duration: TimeInterval(duration),
+                    modelIdentifier: currentModel,
+                    cost: nil,
+                    rawPayload: nil,
+                    debugInfo: nil
+                )
+            }
+        }
         if let deepgram = deepgramTranscriber {
             deepgramTranscriber = nil
             return await deepgram.stop()

--- a/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
+++ b/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
@@ -1,0 +1,320 @@
+#if os(iOS)
+import AVFoundation
+import Foundation
+import SpeakCore
+
+/// Records a complete audio file and uploads it after the user stops recording.
+/// Batch mode deliberately has no interim transcript: its result arrives once
+/// the selected remote model has processed the saved recording.
+@MainActor
+public final class IOSBatchTranscriber {
+    private let audioSessionManager: AudioSessionManager
+    private let audioEngine = AVAudioEngine()
+    private let audioRecorder = AudioRecordingPersistence()
+    private let client: IOSBatchTranscriptionClient
+    private var startTime: Date?
+
+    public let model: String
+
+    public init(
+        audioSessionManager: AudioSessionManager,
+        model: String,
+        apiKey: String,
+        session: URLSession = .shared
+    ) {
+        self.audioSessionManager = audioSessionManager
+        self.model = model
+        self.client = IOSBatchTranscriptionClient(apiKey: apiKey, session: session)
+    }
+
+    public func start() async throws {
+        guard await ensureMicrophonePermission() else {
+            throw iOSTranscriptionError.permissionDenied(.microphone)
+        }
+        try await audioSessionManager.configureForRecording()
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        try audioRecorder.startRecording(format: format)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [audioRecorder] buffer, _ in
+            audioRecorder.writeBuffer(buffer)
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+            startTime = Date()
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            audioRecorder.cancelRecording()
+            audioSessionManager.deactivate()
+            throw error
+        }
+    }
+
+    public func stop(language: String?) async throws -> TranscriptionResult {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        guard let recording = audioRecorder.stopRecording() else {
+            audioSessionManager.deactivate()
+            throw IOSBatchTranscriptionError.missingRecording
+        }
+        audioSessionManager.deactivate()
+        startTime = nil
+        return try await client.transcribeFile(at: recording.url, model: model, language: language)
+    }
+
+    public func cancel() {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioRecorder.cancelRecording()
+        audioSessionManager.deactivate()
+        startTime = nil
+    }
+
+    private func ensureMicrophonePermission() async -> Bool {
+        if audioSessionManager.hasMicrophonePermission() { return true }
+        return await audioSessionManager.requestMicrophonePermission()
+    }
+}
+
+private struct IOSBatchTranscriptionClient {
+    let apiKey: String
+    let session: URLSession
+
+    func transcribeFile(at url: URL, model: String, language: String?) async throws -> TranscriptionResult {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { throw IOSBatchTranscriptionError.apiKeyMissing }
+
+        if AppSettings.openAIBatchModelIDs.contains(model) {
+            return try await transcribeWithOpenAI(
+                at: url,
+                model: model,
+                language: language,
+                apiKey: trimmedKey
+            )
+        }
+        return try await transcribeWithOpenRouter(
+            at: url,
+            model: model,
+            language: language,
+            apiKey: trimmedKey
+        )
+    }
+
+    private func transcribeWithOpenAI(
+        at url: URL,
+        model: String,
+        language: String?,
+        apiKey: String
+    ) async throws -> TranscriptionResult {
+        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/audio/transcriptions")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        let modelName = model.split(separator: "/").last.map(String.init) ?? model
+        var body = Data()
+        body.appendFormField(name: "model", value: modelName, boundary: boundary)
+        body.appendFormField(
+            name: "response_format",
+            value: modelName == "gpt-4o-transcribe-diarize" ? "diarized_json" : "json",
+            boundary: boundary
+        )
+        if modelName == "gpt-4o-transcribe-diarize" {
+            body.appendFormField(name: "chunking_strategy", value: "auto", boundary: boundary)
+        }
+        if let languageCode = language?.split(whereSeparator: { $0 == "_" || $0 == "-" }).first {
+            body.appendFormField(name: "language", value: String(languageCode), boundary: boundary)
+        }
+        body.appendFile(
+            name: "file",
+            filename: url.lastPathComponent,
+            mimeType: "audio/m4a",
+            data: try Data(contentsOf: url),
+            boundary: boundary
+        )
+        body.appendString("--\(boundary)--\r\n")
+        request.httpBody = body
+
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data, service: "OpenAI")
+        let payload = try JSONDecoder().decode(OpenAIResponse.self, from: data)
+        let text = payload.transcriptText
+        guard !text.isEmpty else { throw IOSBatchTranscriptionError.emptyTranscript }
+        return await result(text: text, url: url, model: model, rawPayload: data)
+    }
+
+    private func transcribeWithOpenRouter(
+        at url: URL,
+        model: String,
+        language: String?,
+        apiKey: String
+    ) async throws -> TranscriptionResult {
+        let audioData = try Data(contentsOf: url)
+        guard audioData.count <= 50 * 1024 * 1024 else {
+            throw IOSBatchTranscriptionError.audioTooLarge
+        }
+        var request = URLRequest(url: URL(string: "https://openrouter.ai/api/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("Just Speak to It (iOS)", forHTTPHeaderField: "X-Title")
+        request.setValue("https://github.com/crmitchelmore/justspeaktoit", forHTTPHeaderField: "HTTP-Referer")
+
+        let locale = language?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let prompt = locale.isEmpty
+            ? "Transcribe this audio file. Return only the transcript text, with no commentary."
+            : "Transcribe this audio file using locale \(locale). Return only the transcript text, with no commentary."
+        request.httpBody = try JSONEncoder().encode(
+            OpenRouterRequest(
+                model: model,
+                messages: [OpenRouterMessage(role: "user", content: [
+                    OpenRouterContent(type: "text", text: prompt, inputAudio: nil),
+                    OpenRouterContent(
+                        type: "input_audio",
+                        text: nil,
+                        inputAudio: OpenRouterAudio(
+                            data: audioData.base64EncodedString(),
+                            format: "m4a"
+                        )
+                    )
+                ])]
+            )
+        )
+
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data, service: "OpenRouter")
+        let payload = try JSONDecoder().decode(OpenRouterResponse.self, from: data)
+        let text = payload.choices.compactMap(\.message?.content)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { !$0.isEmpty }) ?? ""
+        guard !text.isEmpty else { throw IOSBatchTranscriptionError.emptyTranscript }
+        return await result(text: text, url: url, model: model, rawPayload: data)
+    }
+
+    private func validate(response: URLResponse, data: Data, service: String) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw IOSBatchTranscriptionError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? "No response body"
+            throw IOSBatchTranscriptionError.httpError(service, http.statusCode, body)
+        }
+    }
+
+    private func result(text: String, url: URL, model: String, rawPayload: Data) async -> TranscriptionResult {
+        let asset = AVURLAsset(url: url)
+        let duration = (try? await asset.load(.duration).seconds) ?? 0
+        return TranscriptionResult(
+            text: text,
+            segments: [.init(startTime: 0, endTime: duration, text: text)],
+            confidence: nil,
+            duration: duration,
+            modelIdentifier: model,
+            cost: nil,
+            rawPayload: String(data: rawPayload, encoding: .utf8),
+            debugInfo: nil
+        )
+    }
+}
+
+private struct OpenAIResponse: Decodable {
+    let text: String?
+    let segments: [OpenAIResponseSegment]?
+
+    var transcriptText: String {
+        guard let segments, segments.contains(where: { $0.speaker != nil }) else {
+            return text ?? segments?.map(\.text).joined(separator: " ") ?? ""
+        }
+        return segments.map { segment in
+            guard let speaker = segment.speaker else { return segment.text }
+            return "\(speaker.replacingOccurrences(of: "_", with: " ").capitalized): \(segment.text)"
+        }.joined(separator: "\n")
+    }
+}
+
+private struct OpenAIResponseSegment: Decodable {
+    let text: String
+    let speaker: String?
+}
+
+private struct OpenRouterRequest: Encodable {
+    let model: String
+    let temperature = 0
+    let stream = false
+    let messages: [OpenRouterMessage]
+}
+
+private struct OpenRouterMessage: Encodable {
+    let role: String
+    let content: [OpenRouterContent]
+}
+
+private struct OpenRouterContent: Encodable {
+    let type: String
+    let text: String?
+    let inputAudio: OpenRouterAudio?
+
+    enum CodingKeys: String, CodingKey { case type, text; case inputAudio = "input_audio" }
+}
+
+private struct OpenRouterAudio: Encodable {
+    let data: String
+    let format: String
+}
+
+private struct OpenRouterResponse: Decodable {
+    let choices: [OpenRouterChoice]
+}
+
+private struct OpenRouterChoice: Decodable {
+    let message: OpenRouterResponseMessage?
+}
+
+private struct OpenRouterResponseMessage: Decodable {
+    let content: String
+}
+
+public enum IOSBatchTranscriptionError: LocalizedError {
+    case apiKeyMissing
+    case missingRecording
+    case audioTooLarge
+    case invalidResponse
+    case emptyTranscript
+    case httpError(String, Int, String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .apiKeyMissing: return "The selected batch model needs an API key."
+        case .missingRecording: return "The audio recording could not be saved."
+        case .audioTooLarge: return "This recording is too large for OpenRouter's 50 MB upload limit."
+        case .invalidResponse: return "The transcription service returned an invalid response."
+        case .emptyTranscript: return "The transcription service returned an empty transcript."
+        case .httpError(let service, let status, let body):
+            return "\(service) returned HTTP \(status): \(body)"
+        }
+    }
+}
+
+private extension Data {
+    mutating func appendString(_ value: String) {
+        if let data = value.data(using: .utf8) { append(data) }
+    }
+
+    mutating func appendFormField(name: String, value: String, boundary: String) {
+        appendString("--\(boundary)\r\n")
+        appendString("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        appendString("\(value)\r\n")
+    }
+
+    mutating func appendFile(name: String, filename: String, mimeType: String, data: Data, boundary: String) {
+        appendString("--\(boundary)\r\n")
+        appendString("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+        appendString("Content-Type: \(mimeType)\r\n\r\n")
+        append(data)
+        appendString("\r\n")
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -6,6 +6,7 @@ import SpeakCore
 /// Unified transcriber that switches between Apple Speech and Deepgram.
 /// Integrates with Live Activity for lock screen presence.
 @MainActor
+// swiftlint:disable:next type_body_length
 final class TranscriberCoordinator: ObservableObject {
     @Published private(set) var isRunning = false
     @Published private(set) var partialText = ""
@@ -23,6 +24,7 @@ final class TranscriberCoordinator: ObservableObject {
     private var elevenLabsTranscriber: ElevenLabsLiveTranscriber?
     private var openAITranscriber: OpenAIRealtimeLiveTranscriber?
     private var sharedTranscriber: SharedClientLiveTranscriber?
+    private var batchTranscriber: IOSBatchTranscriber?
     private var startTime: Date?
 
     init() {
@@ -30,6 +32,9 @@ final class TranscriberCoordinator: ObservableObject {
     }
 
     var modelDisplayName: String {
+        if batchTranscriber != nil {
+            return ModelCatalog.friendlyName(for: currentModel)
+        }
         if currentModel.hasPrefix("deepgram") {
             return "Deepgram"
         }
@@ -50,7 +55,9 @@ final class TranscriberCoordinator: ObservableObject {
     // swiftlint:disable:next function_body_length
     func start() async throws {
         let settings = AppSettings.shared
-        currentModel = settings.selectedModel
+        currentModel = settings.transcriptionMode == .batch
+            ? settings.batchTranscriptionModel
+            : settings.selectedModel
         partialText = ""
         wordCount = 0
         startTime = Date()
@@ -58,7 +65,8 @@ final class TranscriberCoordinator: ObservableObject {
 
         // Fall back to Apple Speech if the selected provider needs an API key we
         // don't have (covers every cloud provider via the shared routing).
-        if let route = LiveTranscriptionRouting.route(for: currentModel),
+        if settings.transcriptionMode == .streaming,
+           let route = LiveTranscriptionRouting.route(for: currentModel),
            route.apiKeyIdentifier != nil,
            settings.liveAPIKey(for: route).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             currentModel = "apple/local/SFSpeechRecognizer"
@@ -69,7 +77,21 @@ final class TranscriberCoordinator: ObservableObject {
             activityManager.startActivity(provider: modelDisplayName)
         }
 
-        if currentModel.hasPrefix("deepgram") {
+        if settings.transcriptionMode == .batch {
+            let transcriber = IOSBatchTranscriber(
+                audioSessionManager: audioSessionManager,
+                model: currentModel,
+                apiKey: settings.batchAPIKey
+            )
+            batchTranscriber = transcriber
+            appleTranscriber = nil
+            deepgramTranscriber = nil
+            elevenLabsTranscriber = nil
+            openAITranscriber = nil
+            sharedTranscriber = nil
+            try await transcriber.start()
+            isRunning = true
+        } else if currentModel.hasPrefix("deepgram") {
             // Use Deepgram
             let transcriber = DeepgramLiveTranscriber(audioSessionManager: audioSessionManager)
             transcriber.configure(apiKey: settings.deepgramAPIKey)
@@ -201,16 +223,40 @@ final class TranscriberCoordinator: ObservableObject {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     func stop() async -> TranscriptionResult {
         isRunning = false
         let duration = elapsedSeconds
 
-        // Complete Live Activity (if enabled)
+        // Streaming results can complete immediately. Batch recordings remain
+        // in a processing state until the upload returns.
         if AppSettings.shared.liveActivitiesEnabled {
-            activityManager.completeActivity(finalWordCount: wordCount, duration: duration)
+            if batchTranscriber != nil {
+                activityManager.updateActivity(
+                    status: .processing,
+                    lastSnippet: "Transcribing recording…",
+                    wordCount: 0,
+                    duration: duration
+                )
+            } else {
+                activityManager.completeActivity(finalWordCount: wordCount, duration: duration)
+            }
         }
 
-        if let deepgram = deepgramTranscriber {
+        if let batch = batchTranscriber {
+            batchTranscriber = nil
+            do {
+                let result = try await batch.stop(language: Locale.current.identifier)
+                partialText = result.text
+                wordCount = result.text.split(whereSeparator: \.isWhitespace).count
+                if AppSettings.shared.liveActivitiesEnabled {
+                    activityManager.completeActivity(finalWordCount: wordCount, duration: duration)
+                }
+                return finishStop(with: result)
+            } catch {
+                handleError(error)
+            }
+        } else if let deepgram = deepgramTranscriber {
             let result = await deepgram.stop()
             deepgramTranscriber = nil
             return finishStop(with: result)
@@ -261,11 +307,13 @@ final class TranscriberCoordinator: ObservableObject {
         openAITranscriber?.cancel()
         appleTranscriber?.cancel()
         sharedTranscriber?.cancel()
+        batchTranscriber?.cancel()
         deepgramTranscriber = nil
         elevenLabsTranscriber = nil
         openAITranscriber = nil
         appleTranscriber = nil
         sharedTranscriber = nil
+        batchTranscriber = nil
         isRunning = false
         startTime = nil
         if AppSettings.shared.liveActivitiesEnabled {

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -55,6 +55,20 @@ public enum HardwareTriggerDestination: String, CaseIterable, Identifiable, Send
 
 // MARK: - Settings Storage
 
+public enum IOSTranscriptionMode: String, CaseIterable, Identifiable, Sendable {
+    case streaming
+    case batch
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .streaming: return "Streaming"
+        case .batch: return "Batch"
+        }
+    }
+}
+
 /// Simple UserDefaults-based settings for iOS app.
 @MainActor
 public final class AppSettings: ObservableObject {
@@ -63,6 +77,10 @@ public final class AppSettings: ObservableObject {
 
     @Published public var selectedModel: String {
         didSet { UserDefaults.standard.set(selectedModel, forKey: "selectedModel") }
+    }
+
+    @Published public var transcriptionMode: IOSTranscriptionMode {
+        didSet { UserDefaults.standard.set(transcriptionMode.rawValue, forKey: "transcriptionMode") }
     }
 
     @Published public var batchTranscriptionModel: String {
@@ -207,6 +225,7 @@ public final class AppSettings: ObservableObject {
         didSet { UserDefaults.standard.set(autoPostProcess, forKey: "autoPostProcess") }
     }
 
+    // swiftlint:disable line_length
     public static let defaultPostProcessingPrompt = """
         You are a transcription formatter.
 
@@ -222,6 +241,7 @@ public final class AppSettings: ObservableObject {
         Edits allowed: Fix spelling, typos, capitalization, punctuation, grammar
         Edits forbidden: Add content, delete unless obvious stutter/duplicate
         """
+    // swiftlint:enable line_length
 
     public static let postProcessingModels = ModelCatalog.cloudPostProcessing
 
@@ -270,8 +290,12 @@ public final class AppSettings: ObservableObject {
         let batchModel = ModelCatalog.normalizedBatchTranscriptionModel(
             UserDefaults.standard.string(forKey: "batchTranscriptionModel")
         )
+        let mode = IOSTranscriptionMode(
+            rawValue: UserDefaults.standard.string(forKey: "transcriptionMode") ?? ""
+        ) ?? .streaming
 
         self.selectedModel = selected
+        self.transcriptionMode = mode
         self.batchTranscriptionModel = batchModel
         self.deepgramAPIKey = ""
         self.openRouterAPIKey = ""
@@ -445,6 +469,30 @@ public final class AppSettings: ObservableObject {
         }
     }
 
+    public var batchAPIKey: String {
+        if Self.openAIBatchModelIDs.contains(batchTranscriptionModel) {
+            return openAIAPIKey
+        }
+        return openRouterAPIKey
+    }
+
+    public static let openAIBatchModelIDs: Set<String> = [
+        "openai/whisper-1",
+        "openai/gpt-4o-mini-transcribe",
+        "openai/gpt-4o-transcribe",
+        "openai/gpt-4o-transcribe-diarize"
+    ]
+
+    /// iOS currently supports OpenAI's transcription endpoint and OpenRouter's
+    /// audio-capable batch models. Other catalogue entries remain shared with
+    /// Mac but are hidden until their upload clients are available on iPhone.
+    public static let supportedBatchModels: [ModelCatalog.Option] =
+        ModelCatalog.batchTranscription.filter { option in
+            openAIBatchModelIDs.contains(option.id)
+                || option.id.hasPrefix("google/")
+                || option.id == "openai/gpt-4o-audio-preview-2024-12-17"
+        }
+
     // MARK: - Legacy migration
 
     /// One-time migration of API keys from the pre-unification iOS keychain
@@ -592,36 +640,45 @@ public struct SettingsView: View {
     public var body: some View {
         Form {
             Section("Transcription") {
-                Picker("Live Model", selection: selectedModelBinding) {
-                    ForEach(LiveModelGroup.grouped(ModelCatalog.liveTranscription)) { group in
-                        Section(group.title) {
-                            ForEach(group.options) { option in
-                                LiveModelRow(option: option).tag(option.id)
+                Picker("Mode", selection: $settings.transcriptionMode) {
+                    ForEach(IOSTranscriptionMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                if settings.transcriptionMode == .streaming {
+                    Picker("Streaming Model", selection: selectedModelBinding) {
+                        ForEach(LiveModelGroup.grouped(ModelCatalog.liveTranscription)) { group in
+                            Section(group.title) {
+                                ForEach(group.options) { option in
+                                    LiveModelRow(option: option).tag(option.id)
+                                }
                             }
                         }
                     }
-                }
-                .pickerStyle(.navigationLink)
-
-                Picker("Batch Model", selection: $settings.batchTranscriptionModel) {
-                    ForEach(BatchModelGroup.grouped(ModelCatalog.batchTranscription)) { group in
-                        Section(group.title) {
-                            ForEach(group.options) { option in
-                                Text(ModelCatalog.friendlyName(for: option.id)).tag(option.id)
+                    .pickerStyle(.navigationLink)
+                } else {
+                    Picker("Batch Model", selection: $settings.batchTranscriptionModel) {
+                        ForEach(BatchModelGroup.grouped(AppSettings.supportedBatchModels)) { group in
+                            Section(group.title) {
+                                ForEach(group.options) { option in
+                                    Text(ModelCatalog.friendlyName(for: option.id)).tag(option.id)
+                                }
                             }
                         }
                     }
+                    .pickerStyle(.navigationLink)
                 }
-                .pickerStyle(.navigationLink)
 
-                Text(
-                    "Used for imported and saved-audio transcription. "
-                        + "The same catalogue and model IDs are shared with Mac."
-                )
+                Text(settings.transcriptionMode == .streaming
+                    ? "Text appears while you speak."
+                    : "Audio is recorded first, then uploaded when you stop for a more complete transcript.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                if let route = LiveTranscriptionRouting.route(for: settings.selectedModel),
+                if settings.transcriptionMode == .streaming,
+                   let route = LiveTranscriptionRouting.route(for: settings.selectedModel),
                    !route.isSupportedOnIOS {
                     Label(
                         "Not available on iPhone yet — recording falls back to Apple Speech.",
@@ -631,12 +688,25 @@ public struct SettingsView: View {
                     .font(.caption)
                 }
 
-                if let route = LiveTranscriptionRouting.route(for: settings.selectedModel),
+                if settings.transcriptionMode == .streaming,
+                   let route = LiveTranscriptionRouting.route(for: settings.selectedModel),
                    route.isSupportedOnIOS,
                    route.apiKeyIdentifier != nil,
                    settings.liveAPIKey(for: route).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Label(
                         "Add this provider's API key below to use this model.",
+                        systemImage: "exclamationmark.triangle"
+                    )
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+                }
+
+                if settings.transcriptionMode == .batch,
+                   settings.batchAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Label(
+                        AppSettings.openAIBatchModelIDs.contains(settings.batchTranscriptionModel)
+                            ? "Add an OpenAI API key below to use this model."
+                            : "Add an OpenRouter API key below to use this model.",
                         systemImage: "exclamationmark.triangle"
                     )
                     .foregroundStyle(.orange)
@@ -1487,6 +1557,7 @@ struct PrivacyView: View {
         Form {
             Section {
                 VStack(alignment: .leading, spacing: 12) {
+                    // swiftlint:disable:next line_length
                     Text("Speak is designed with privacy in mind. Your audio and transcripts are processed according to the provider you select.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
@@ -1523,6 +1594,7 @@ struct PrivacyView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Label("Secure Storage", systemImage: "lock.fill")
                         .font(.headline)
+                    // swiftlint:disable:next line_length
                     Text("API keys are encrypted in your device Keychain and never leave your device except when syncing via iCloud Keychain (end-to-end encrypted).")
                         .font(.caption)
                         .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- add a Streaming / Batch mode selector on iOS and share the Mac batch model catalogue
- record locally and upload completed audio to OpenAI or OpenRouter batch transcription models
- bring iOS history browsing in line with Mac: search, model/date/error filters, aggregate stats, raw/polished text, copy/delete/reprocess actions, and sync status
- share history presentation/search/statistics logic across macOS and iOS

## Validation
- `swift build --target SpeakiOSLib`
- focused SwiftLint on the four changed batch integration files: 0 violations
- `swift test --filter "HistoryPresentationTests|ModelCatalogTests|HistoryManagerPersistenceTests|HistoryItemModelTests|HardwareTriggerDestinationTests"` (24 tests passed)
- simulator app build reaches the existing widget target, then fails because the generated Xcode project does not link `SpeakCore` / `SpeakiOSLib` into the widget extension; the iOS library target itself builds successfully