### PR TITLE
fix(ios): harden Action Button App Store release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,13 @@ jobs:
       - name: Build iOS Library
         run: swift build --disable-dependency-cache --target SpeakiOSLib
 
-      - name: Test SpeakCore (iOS Simulator)
+      - name: Select iOS Simulator
         run: |
-          xcodebuild test \
-            -scheme SpeakCore \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
-            -skipPackagePluginValidation \
-            -quiet \
-            2>&1 | tail -20
+          SIMULATOR_ID=$(xcrun simctl list devices available -j | jq -r \
+            '([.devices[][] | select(.name == "iPhone 17 Pro")][0].udid) //
+             ([.devices[][] | select(.name | startswith("iPhone"))][0].udid)')
+          test -n "$SIMULATOR_ID"
+          echo "SIMULATOR_ID=$SIMULATOR_ID" >> "$GITHUB_ENV"
 
       - name: Generate iOS App Project
         run: tuist generate --no-open
@@ -85,7 +84,7 @@ jobs:
           xcodebuild test \
             -workspace "Just Speak to It.xcworkspace" \
             -scheme SpeakiOS \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
             -only-testing:SpeakiOSTests \
             -only-testing:SpeakiOSUITests \
             -skipPackagePluginValidation \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           fi
 
   build-ios:
-    name: Build & Test (iOS)
+    name: Build iOS Library
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Tuist
         run: brew install tuist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,13 @@ jobs:
           fi
 
   build-ios:
-    name: Build iOS Library
+    name: Build & Test (iOS)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
+
+      - name: Install Tuist
+        run: brew install tuist
 
       - name: Build iOS Library
         run: swift build --disable-dependency-cache --target SpeakiOSLib
@@ -72,6 +75,22 @@ jobs:
             -skipPackagePluginValidation \
             -quiet \
             2>&1 | tail -20
+
+      - name: Generate iOS App Project
+        run: tuist generate --no-open
+
+      - name: Test iOS App and Action Button Settings
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -workspace "Just Speak to It.xcworkspace" \
+            -scheme SpeakiOS \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -only-testing:SpeakiOSTests \
+            -only-testing:SpeakiOSUITests \
+            -skipPackagePluginValidation \
+            -quiet \
+            2>&1 | tail -50
 
   lint:
     name: Lint

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -198,6 +198,31 @@ jobs:
             MARKETING_VERSION="$VERSION" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
 
+      - name: Verify Archived App Metadata
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BUILD_NUMBER: ${{ steps.build_number.outputs.build }}
+        run: |
+          APP_PATH="build/SpeakiOS.xcarchive/Products/Applications/JustSpeakToIt.app"
+          WIDGET_PATH="$APP_PATH/PlugIns/JustSpeakToItWidgetExtension.appex"
+
+          APP_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_PATH/Info.plist")
+          WIDGET_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$WIDGET_PATH/Info.plist")
+          APP_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_PATH/Info.plist")
+          WIDGET_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$WIDGET_PATH/Info.plist")
+
+          test "$APP_VERSION" = "$VERSION"
+          test "$WIDGET_VERSION" = "$VERSION"
+          test "$APP_BUILD" = "$BUILD_NUMBER"
+          test "$WIDGET_BUILD" = "$BUILD_NUMBER"
+
+          codesign -d --entitlements :- "$APP_PATH" > "$RUNNER_TEMP/app-entitlements.plist" 2>/dev/null
+          codesign -d --entitlements :- "$WIDGET_PATH" > "$RUNNER_TEMP/widget-entitlements.plist" 2>/dev/null
+          plutil -extract com.apple.security.application-groups xml1 -o - "$RUNNER_TEMP/app-entitlements.plist" \
+            | grep -q 'group.com.justspeaktoit.ios'
+          plutil -extract com.apple.security.application-groups xml1 -o - "$RUNNER_TEMP/widget-entitlements.plist" \
+            | grep -q 'group.com.justspeaktoit.ios'
+
       - name: Export IPA
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -211,17 +211,19 @@ jobs:
           APP_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_PATH/Info.plist")
           WIDGET_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$WIDGET_PATH/Info.plist")
 
-          test "$APP_VERSION" = "$VERSION"
-          test "$WIDGET_VERSION" = "$VERSION"
-          test "$APP_BUILD" = "$BUILD_NUMBER"
-          test "$WIDGET_BUILD" = "$BUILD_NUMBER"
+          [ "$APP_VERSION" = "$VERSION" ] || { echo "App version mismatch: expected '$VERSION', got '$APP_VERSION'"; exit 1; }
+          [ "$WIDGET_VERSION" = "$VERSION" ] || { echo "Widget version mismatch: expected '$VERSION', got '$WIDGET_VERSION'"; exit 1; }
+          [ "$APP_BUILD" = "$BUILD_NUMBER" ] || { echo "App build mismatch: expected '$BUILD_NUMBER', got '$APP_BUILD'"; exit 1; }
+          [ "$WIDGET_BUILD" = "$BUILD_NUMBER" ] || { echo "Widget build mismatch: expected '$BUILD_NUMBER', got '$WIDGET_BUILD'"; exit 1; }
 
-          codesign -d --entitlements :- "$APP_PATH" > "$RUNNER_TEMP/app-entitlements.plist" 2>/dev/null
-          codesign -d --entitlements :- "$WIDGET_PATH" > "$RUNNER_TEMP/widget-entitlements.plist" 2>/dev/null
+          codesign -d --entitlements :- "$APP_PATH" > "$RUNNER_TEMP/app-entitlements.plist"
+          codesign -d --entitlements :- "$WIDGET_PATH" > "$RUNNER_TEMP/widget-entitlements.plist"
           plutil -extract com.apple.security.application-groups xml1 -o - "$RUNNER_TEMP/app-entitlements.plist" \
-            | grep -q 'group.com.justspeaktoit.ios'
+            | grep -q 'group.com.justspeaktoit.ios' \
+            || { echo "Missing group.com.justspeaktoit.ios in app entitlements"; exit 1; }
           plutil -extract com.apple.security.application-groups xml1 -o - "$RUNNER_TEMP/widget-entitlements.plist" \
-            | grep -q 'group.com.justspeaktoit.ios'
+            | grep -q 'group.com.justspeaktoit.ios' \
+            || { echo "Missing group.com.justspeaktoit.ios in widget entitlements"; exit 1; }
 
       - name: Export IPA
         env:

--- a/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtension.entitlements
+++ b/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.justspeaktoit.ios</string>
+    </array>
+</dict>
+</plist>

--- a/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtensionControl.swift
+++ b/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtensionControl.swift
@@ -48,9 +48,7 @@ extension JustSpeakToItWidgetExtensionControl {
         }
 
         func currentValue(configuration: TranscriptionControlConfiguration) async throws -> Value {
-            let defaults = UserDefaults(suiteName: SharedTranscriptionState.appGroupIdentifier)
-            let isRecording = defaults?.bool(forKey: "isRecording") ?? false
-            return Value(isRecording: isRecording)
+            Value(isRecording: SharedTranscriptionState.shared.isRecording)
         }
     }
 }

--- a/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtensionControl.swift
+++ b/JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtensionControl.swift
@@ -48,7 +48,7 @@ extension JustSpeakToItWidgetExtensionControl {
         }
 
         func currentValue(configuration: TranscriptionControlConfiguration) async throws -> Value {
-            let defaults = UserDefaults(suiteName: "group.com.speak.ios")
+            let defaults = UserDefaults(suiteName: SharedTranscriptionState.appGroupIdentifier)
             let isRecording = defaults?.bool(forKey: "isRecording") ?? false
             return Value(isRecording: isRecording)
         }

--- a/Project.swift
+++ b/Project.swift
@@ -213,6 +213,10 @@ let project = Project(
             bundleId: "com.justspeaktoit.ios.tests",
             deploymentTargets: .iOS("17.0"),
             sources: ["Tests/SpeakiOSTests/**"],
+            resources: [
+                "SpeakiOS.entitlements",
+                "JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtension.entitlements"
+            ],
             dependencies: [
                 .target(name: "SpeakiOS"),
                 .package(product: "SpeakiOSLib")

--- a/Project.swift
+++ b/Project.swift
@@ -127,6 +127,8 @@ let project = Project(
                 "UILaunchStoryboardName": "LaunchScreen",
                 "UIRequiresFullScreen": false,
                 "CFBundleDisplayName": "Just Speak to It",
+                "CFBundleShortVersionString": "$(MARKETING_VERSION)",
+                "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
                 "NSMicrophoneUsageDescription": "Just Speak to It needs microphone access for voice transcription.",
                 "NSSpeechRecognitionUsageDescription": "Just Speak to It uses speech recognition to transcribe your voice.",
                 "NSCameraUsageDescription": "Just Speak to It does not use the camera, but a linked library requires this declaration.",
@@ -176,6 +178,7 @@ let project = Project(
             deploymentTargets: .iOS("17.0"),
             infoPlist: .file(path: "JustSpeakToItWidgetExtension/Info.plist"),
             sources: ["JustSpeakToItWidgetExtension/**"],
+            entitlements: .file(path: "JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtension.entitlements"),
             dependencies: [
                 .package(product: "SpeakCore"),
                 .package(product: "SpeakiOSLib")
@@ -190,6 +193,29 @@ let project = Project(
             sources: ["Tests/SpeakAppUITests/**"],
             dependencies: [
                 .target(name: "SpeakApp")
+            ]
+        ),
+        .target(
+            name: "SpeakiOSUITests",
+            destinations: .iOS,
+            product: .uiTests,
+            bundleId: "com.justspeaktoit.ios.uitests",
+            deploymentTargets: .iOS("17.0"),
+            sources: ["Tests/SpeakiOSUITests/**"],
+            dependencies: [
+                .target(name: "SpeakiOS")
+            ]
+        ),
+        .target(
+            name: "SpeakiOSTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "com.justspeaktoit.ios.tests",
+            deploymentTargets: .iOS("17.0"),
+            sources: ["Tests/SpeakiOSTests/**"],
+            dependencies: [
+                .target(name: "SpeakiOS"),
+                .package(product: "SpeakiOSLib")
             ]
         )
     ]

--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -194,7 +194,7 @@ struct CopyLastSentenceIntent: AppIntent {
 
     func perform() async throws -> some IntentResult {
         // Get the last sentence from UserDefaults (shared between app and extension)
-        let defaults = UserDefaults(suiteName: "group.com.speak.ios")
+        let defaults = UserDefaults(suiteName: SharedTranscriptionState.appGroupIdentifier)
         let lastSentence = defaults?.string(forKey: "lastTranscribedSentence") ?? ""
 
         guard !lastSentence.isEmpty else {
@@ -217,7 +217,7 @@ struct CopyFullTranscriptIntent: AppIntent {
     static var openAppWhenRun: Bool = false
 
     func perform() async throws -> some IntentResult {
-        let defaults = UserDefaults(suiteName: "group.com.speak.ios")
+        let defaults = UserDefaults(suiteName: SharedTranscriptionState.appGroupIdentifier)
         let fullText = defaults?.string(forKey: "currentTranscriptText") ?? ""
 
         guard !fullText.isEmpty else {
@@ -295,12 +295,12 @@ struct TranscriptionShortcuts: AppShortcutsProvider {
 /// Manages state shared between main app and extensions via App Group.
 public final class SharedTranscriptionState {
     public static let shared = SharedTranscriptionState()
+    public static let appGroupIdentifier = "group.com.justspeaktoit.ios"
 
     private let defaults: UserDefaults?
-    private let groupIdentifier = "group.com.speak.ios"
 
     private init() {
-        defaults = UserDefaults(suiteName: groupIdentifier)
+        defaults = UserDefaults(suiteName: Self.appGroupIdentifier)
     }
 
     /// Updates the current transcript text (for copy action)

--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -193,9 +193,7 @@ struct CopyLastSentenceIntent: AppIntent {
     static var openAppWhenRun: Bool = false
 
     func perform() async throws -> some IntentResult {
-        // Get the last sentence from UserDefaults (shared between app and extension)
-        let defaults = UserDefaults(suiteName: SharedTranscriptionState.appGroupIdentifier)
-        let lastSentence = defaults?.string(forKey: "lastTranscribedSentence") ?? ""
+        let lastSentence = SharedTranscriptionState.shared.lastTranscribedSentence
 
         guard !lastSentence.isEmpty else {
             return .result(value: "No recent transcription to copy")
@@ -217,8 +215,7 @@ struct CopyFullTranscriptIntent: AppIntent {
     static var openAppWhenRun: Bool = false
 
     func perform() async throws -> some IntentResult {
-        let defaults = UserDefaults(suiteName: SharedTranscriptionState.appGroupIdentifier)
-        let fullText = defaults?.string(forKey: "currentTranscriptText") ?? ""
+        let fullText = SharedTranscriptionState.shared.currentTranscriptText
 
         guard !fullText.isEmpty else {
             return .result(value: "No transcription to copy")
@@ -302,6 +299,12 @@ public final class SharedTranscriptionState {
     private init() {
         defaults = UserDefaults(suiteName: Self.appGroupIdentifier)
     }
+
+    /// The full transcript currently shared with extensions and App Intents.
+    public var currentTranscriptText: String { defaults?.string(forKey: "currentTranscriptText") ?? "" }
+
+    /// The most recent sentence shared with extensions and App Intents.
+    public var lastTranscribedSentence: String { defaults?.string(forKey: "lastTranscribedSentence") ?? "" }
 
     /// Updates the current transcript text (for copy action)
     public func updateTranscript(_ text: String) {

--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -3,6 +3,10 @@ import AppIntents
 import SpeakCore
 import UIKit
 
+// App Intent declarations intentionally stay together so Shortcuts metadata and
+// foreground-continuation behavior remain auditable in one place.
+// swiftlint:disable file_length
+
 // MARK: - Audio Recording Intent (Action Button / Shortcuts)
 
 @available(iOS 18, *)
@@ -76,7 +80,16 @@ public struct StartTranscriptionIntent: AudioRecordingIntent, ForegroundContinua
         if isRunning {
             return .result(dialog: "Recording already in progress.")
         }
-        try await startRecordingContinuingInForegroundIfNeeded(from: self)
+        if SharedTranscriptionState.shared.isRecording {
+            return .result(dialog: "A recording is already in progress in the app. Use the in-app stop button.")
+        }
+        do {
+            try await startRecordingContinuingInForegroundIfNeeded(from: self)
+        } catch {
+            return .result(
+                dialog: "Couldn’t start recording. Check microphone and speech-recognition access, then try again."
+            )
+        }
         return .result(dialog: "Recording started. Run \"Stop Recording\" to finish.")
     }
 }
@@ -108,9 +121,17 @@ public struct StartTranscriptionRecordingIntent: AudioRecordingIntent, Foregroun
                 destination: destination,
                 canPostProcess: canPostProcess
             ))
+        } else if SharedTranscriptionState.shared.isRecording {
+            return .result(dialog: "A recording is already in progress in the app. Use the in-app stop button.")
         } else {
-            try await startRecordingContinuingInForegroundIfNeeded(from: self)
-            return .result(dialog: "Recording started. Press again to stop.")
+            do {
+                try await startRecordingContinuingInForegroundIfNeeded(from: self)
+            } catch {
+                return .result(
+                    dialog: "Couldn’t start recording. Check microphone and speech-recognition access, then try again."
+                )
+            }
+            return .result(dialog: "Recording started. Tap Done, then press again to stop.")
         }
     }
 }
@@ -118,7 +139,7 @@ public struct StartTranscriptionRecordingIntent: AudioRecordingIntent, Foregroun
 /// Intent to stop an active recording from a Live Activity button or a dedicated
 /// Shortcut paired with `StartTranscriptionIntent`.
 @available(iOS 18, *)
-public struct StopTranscriptionRecordingIntent: AppIntent {
+public struct StopTranscriptionRecordingIntent: AudioRecordingIntent {
     public static var title: LocalizedStringResource = "Stop Recording"
     public static var description = IntentDescription(
         "Stops the current transcription and routes the result to the destination you chose in Settings."
@@ -133,6 +154,9 @@ public struct StopTranscriptionRecordingIntent: AppIntent {
         let isRunning = await service.isRunning
 
         guard isRunning else {
+            if SharedTranscriptionState.shared.isRecording {
+                return .result(dialog: "A recording is active in the app. Use the in-app stop button.")
+            }
             return .result(dialog: "No active recording.")
         }
 
@@ -298,7 +322,26 @@ public final class SharedTranscriptionState {
 
     private init() {
         defaults = UserDefaults(suiteName: Self.appGroupIdentifier)
+        #if DEBUG && targetEnvironment(simulator)
+        if let value = ProcessInfo.processInfo.environment["JUSTSPEAKTOIT_SIMULATOR_TRANSCRIPT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !value.isEmpty {
+            defaults?.set(value, forKey: "simulatorValidationTranscript")
+        }
+        #endif
     }
+
+    #if DEBUG && targetEnvironment(simulator)
+    /// Deterministic transcript used only by Simulator UX validation. App Intent
+    /// execution does not reliably inherit launchd environment variables, so the
+    /// App Group value keeps the real Shortcut lifecycle testable across hosts.
+    var simulatorValidationTranscript: String? {
+        let environmentValue = ProcessInfo.processInfo.environment["JUSTSPEAKTOIT_SIMULATOR_TRANSCRIPT"]
+        let value = environmentValue ?? defaults?.string(forKey: "simulatorValidationTranscript")
+        let trimmedValue = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue?.isEmpty == false ? trimmedValue : nil
+    }
+    #endif
 
     /// The full transcript currently shared with extensions and App Intents.
     public var currentTranscriptText: String { defaults?.string(forKey: "currentTranscriptText") ?? "" }

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -94,6 +94,14 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
             throw iOSTranscriptionError.liveActivityUnavailable
         }
 
+        #if DEBUG && targetEnvironment(simulator)
+        if let transcript = sharedState.simulatorValidationTranscript {
+            handlePartialResult(text: transcript)
+            isRunning = true
+            return
+        }
+        #endif
+
         do {
             if settings.transcriptionMode == .batch {
                 let transcriber = IOSBatchTranscriber(
@@ -390,6 +398,27 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
 // MARK: - Stop helpers
 
 @MainActor
+extension TranscriptionRecordingService {
+    /// The pasteboard value that should be committed synchronously when the
+    /// recording stops. Polishing gets a non-sensitive placeholder only when a
+    /// post-processor can actually replace it; without a key, the raw transcript
+    /// must be copied instead of leaving "Polishing… please wait" forever.
+    static func clipboardTextAtStop(
+        transcript: String,
+        destination: HardwareTriggerDestination,
+        canPostProcess: Bool
+    ) -> String? {
+        switch destination {
+        case .clipboard:
+            return transcript
+        case .clipboardAndPostProcess:
+            return canPostProcess ? polishingClipboardPlaceholder : transcript
+        case .historyOnly:
+            return nil
+        }
+    }
+}
+
 private extension TranscriptionRecordingService {
     /// Stops whichever transcriber is currently active and returns its result.
     /// Falls back to a synthetic `TranscriptionResult` built from `partialText`
@@ -459,18 +488,18 @@ private extension TranscriptionRecordingService {
         destination: HardwareTriggerDestination
     ) async {
         guard !text.isEmpty else { return }
-        switch destination {
-        case .clipboard:
-            await Self.writeClipboardReliably(text)
-            sharedState.lastCompletedTranscript = text
-        case .clipboardAndPostProcess:
-            await Self.writeClipboardReliably(Self.polishingClipboardPlaceholder)
-            sharedState.lastCompletedTranscript = text
-        case .historyOnly:
-            // Don't touch the pasteboard. We still record `lastCompletedTranscript`
-            // because the Live Activity / shared state UI shows it.
-            sharedState.lastCompletedTranscript = text
+        if let clipboardText = Self.clipboardTextAtStop(
+            transcript: text,
+            destination: destination,
+            canPostProcess: AppSettings.shared.hasOpenRouterKey
+        ) {
+            await Self.writeClipboardReliably(clipboardText)
         }
+
+        // History-only intentionally leaves the pasteboard untouched. Every
+        // destination still publishes the completed transcript so the Live
+        // Activity and foreground handoff can surface it.
+        sharedState.lastCompletedTranscript = text
     }
 
     /// Pasteboard writes from a background AppIntent can race process

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -77,6 +77,14 @@ final class TranscriberCoordinator: ObservableObject {
             activityManager.startActivity(provider: modelDisplayName)
         }
 
+        #if DEBUG && targetEnvironment(simulator)
+        if let transcript = sharedState.simulatorValidationTranscript {
+            handlePartialResult(text: transcript, isFinal: true)
+            markRecordingStarted()
+            return
+        }
+        #endif
+
         if settings.transcriptionMode == .batch {
             let transcriber = IOSBatchTranscriber(
                 audioSessionManager: audioSessionManager,
@@ -90,7 +98,7 @@ final class TranscriberCoordinator: ObservableObject {
             openAITranscriber = nil
             sharedTranscriber = nil
             try await transcriber.start()
-            isRunning = true
+            markRecordingStarted()
         } else if currentModel.hasPrefix("deepgram") {
             // Use Deepgram
             let transcriber = DeepgramLiveTranscriber(audioSessionManager: audioSessionManager)
@@ -110,7 +118,7 @@ final class TranscriberCoordinator: ObservableObject {
             elevenLabsTranscriber = nil
 
             try await transcriber.start()
-            isRunning = true
+            markRecordingStarted()
         } else if currentModel.hasPrefix("elevenlabs") {
             // Use ElevenLabs
             let transcriber = ElevenLabsLiveTranscriber(audioSessionManager: audioSessionManager)
@@ -130,7 +138,7 @@ final class TranscriberCoordinator: ObservableObject {
             appleTranscriber = nil
 
             try await transcriber.start()
-            isRunning = true
+            markRecordingStarted()
         } else if currentModel.hasPrefix("openai") {
             // Use OpenAI Realtime
             let transcriber = OpenAIRealtimeLiveTranscriber(audioSessionManager: audioSessionManager)
@@ -151,7 +159,7 @@ final class TranscriberCoordinator: ObservableObject {
             appleTranscriber = nil
 
             try await transcriber.start()
-            isRunning = true
+            markRecordingStarted()
         } else if let route = LiveTranscriptionRouting.route(for: currentModel),
                   route.provider.isSupportedOnIOS {
             // Generic shared-client path (Cartesia, and future ported providers).
@@ -174,7 +182,7 @@ final class TranscriberCoordinator: ObservableObject {
             appleTranscriber = nil
 
             try await transcriber.start()
-            isRunning = true
+            markRecordingStarted()
         } else {
             // Use Apple Speech
             let transcriber = iOSLiveTranscriber(audioSessionManager: audioSessionManager)
@@ -194,8 +202,14 @@ final class TranscriberCoordinator: ObservableObject {
             sharedTranscriber = nil
 
             try await transcriber.start()
-            isRunning = true
+            markRecordingStarted()
         }
+    }
+
+    private func markRecordingStarted() {
+        isRunning = true
+        sharedState.isRecording = true
+        sharedState.recordingStartTime = startTime
     }
 
     private func handlePartialResult(text: String, isFinal: Bool) {
@@ -226,6 +240,7 @@ final class TranscriberCoordinator: ObservableObject {
     // swiftlint:disable:next function_body_length
     func stop() async -> TranscriptionResult {
         isRunning = false
+        sharedState.clearRecordingState()
         let duration = elapsedSeconds
 
         // Streaming results can complete immediately. Batch recordings remain
@@ -320,6 +335,7 @@ final class TranscriberCoordinator: ObservableObject {
             activityManager.endActivity()
         }
         sharedState.clear()
+        sharedState.clearRecordingState()
     }
 }
 
@@ -415,12 +431,12 @@ public struct ContentView: View {
                                 Text("\(Int(confidence * 100))%")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
-                            } else if backgroundService.isRunning {
-                                Text("Action Button")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
                             }
                         }
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel(
+                            backgroundService.isRunning ? "Recording via Action Button" : "Recording"
+                        )
                     }
                 }
 
@@ -517,17 +533,17 @@ public struct ContentView: View {
                         await toggleRecording()
                     }
                 } label: {
-                    Image(systemName: coordinator.isRunning ? "stop.fill" : "mic.fill")
+                    Image(systemName: isAnyRecording ? "stop.fill" : "mic.fill")
                         .font(.system(size: 28))
                         .frame(width: 64, height: 64)
                 }
                 .buttonStyle(.glassProminent)
-                .tint(coordinator.isRunning ? .red : .brandAccent)
+                .tint(isAnyRecording ? .red : .brandAccent)
                 .clipShape(Circle())
-                .accessibilityLabel(coordinator.isRunning ? "Stop recording" : "Start recording")
+                .accessibilityLabel(isAnyRecording ? "Stop recording" : "Start recording")
 
                 // Secondary actions (only visible when there's text and not recording)
-                if hasTextToShow && !coordinator.isRunning {
+                if hasTextToShow && !isAnyRecording {
                     // Polish/Post-process button
                     Button {
                         showingPostProcessing = true
@@ -560,6 +576,7 @@ public struct ContentView: View {
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: hasTextToShow)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: coordinator.isRunning)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: backgroundService.isRunning)
     }
     #endif
 
@@ -572,17 +589,17 @@ public struct ContentView: View {
                     await toggleRecording()
                 }
             } label: {
-                Image(systemName: coordinator.isRunning ? "stop.fill" : "mic.fill")
+                Image(systemName: isAnyRecording ? "stop.fill" : "mic.fill")
                     .font(.system(size: 28))
                     .frame(width: 64, height: 64)
             }
             .buttonStyle(.borderedProminent)
-            .tint(coordinator.isRunning ? .red : .accentColor)
+            .tint(isAnyRecording ? .red : .accentColor)
             .clipShape(Circle())
-            .accessibilityLabel(coordinator.isRunning ? "Stop recording" : "Start recording")
+            .accessibilityLabel(isAnyRecording ? "Stop recording" : "Start recording")
 
             // Secondary actions (only visible when there's text and not recording)
-            if hasTextToShow && !coordinator.isRunning {
+            if hasTextToShow && !isAnyRecording {
                 // Polish/Post-process button
                 Button {
                     showingPostProcessing = true
@@ -613,12 +630,17 @@ public struct ContentView: View {
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: hasTextToShow)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: coordinator.isRunning)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: backgroundService.isRunning)
     }
 
     // MARK: - Computed Properties
 
     private var hasTextToShow: Bool {
         !currentText.isEmpty
+    }
+
+    private var isAnyRecording: Bool {
+        coordinator.isRunning || backgroundService.isRunning
     }
 
     private var currentText: String {
@@ -668,7 +690,12 @@ public struct ContentView: View {
     // MARK: - Actions
 
     private func toggleRecording() async {
-        if coordinator.isRunning {
+        if backgroundService.isRunning {
+            let result = await backgroundService.stopRecording(
+                destination: settings.hardwareTriggerDestination
+            )
+            displayText = result.text
+        } else if coordinator.isRunning {
             let result = await coordinator.stop()
             print("[ContentView] Final result: \(result.text.count) chars, duration: \(result.duration)s")
 

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -753,6 +753,7 @@ public struct SettingsView: View {
                             .lineLimit(1)
                     }
                 }
+                .accessibilityIdentifier("hardwareTriggerSettingsLink")
 
                 Text("Trigger transcription from the Action Button, Siri, Lock Screen, Control Center, or Back Tap.")
                     .font(.caption)
@@ -1013,9 +1014,12 @@ struct HardwareTriggerSettingsView: View {
             Section("When Recording Stops") {
                 Picker("Destination", selection: $settings.hardwareTriggerDestination) {
                     ForEach(HardwareTriggerDestination.allCases) { destination in
-                        Text(destination.displayName).tag(destination)
+                        Text(destination.displayName)
+                            .accessibilityIdentifier("hardwareTriggerDestination.\(destination.rawValue)")
+                            .tag(destination)
                     }
                 }
+                .accessibilityIdentifier("hardwareTriggerDestinationPicker")
                 .pickerStyle(.inline)
                 .labelsHidden()
 
@@ -1061,6 +1065,7 @@ struct HardwareTriggerSettingsView: View {
                 } label: {
                     Label("Open Shortcuts App", systemImage: "arrow.up.right.square")
                 }
+                .accessibilityIdentifier("openShortcutsAppButton")
             }
 
             Section("Other Trigger Options") {

--- a/Tests/SpeakiOSTests/AppGroupConfigurationTests.swift
+++ b/Tests/SpeakiOSTests/AppGroupConfigurationTests.swift
@@ -6,25 +6,22 @@ import XCTest
 
 final class AppGroupConfigurationTests: XCTestCase {
     func testSharedStateUsesEntitledAppGroup() throws {
-        let entitledGroups = try appGroups(
-            in: repositoryRoot.appendingPathComponent("SpeakiOS.entitlements")
-        )
+        let entitledGroups = try appGroups(inResourceNamed: "SpeakiOS")
 
         XCTAssertEqual(SharedTranscriptionState.appGroupIdentifier, "group.com.justspeaktoit.ios")
         XCTAssertTrue(entitledGroups.contains(SharedTranscriptionState.appGroupIdentifier))
     }
 
     func testWidgetUsesSameEntitledAppGroup() throws {
-        let entitledGroups = try appGroups(
-            in: repositoryRoot
-                .appendingPathComponent("JustSpeakToItWidgetExtension")
-                .appendingPathComponent("JustSpeakToItWidgetExtension.entitlements")
-        )
+        let entitledGroups = try appGroups(inResourceNamed: "JustSpeakToItWidgetExtension")
 
         XCTAssertTrue(entitledGroups.contains(SharedTranscriptionState.appGroupIdentifier))
     }
 
-    private func appGroups(in entitlementsURL: URL) throws -> [String] {
+    private func appGroups(inResourceNamed resourceName: String) throws -> [String] {
+        let entitlementsURL = try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: resourceName, withExtension: "entitlements")
+        )
         let data = try Data(contentsOf: entitlementsURL)
         let plist = try XCTUnwrap(
             PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
@@ -34,13 +31,6 @@ final class AppGroupConfigurationTests: XCTestCase {
         )
 
         return entitledGroups
-    }
-
-    private var repositoryRoot: URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
     }
 }
 #endif

--- a/Tests/SpeakiOSTests/AppGroupConfigurationTests.swift
+++ b/Tests/SpeakiOSTests/AppGroupConfigurationTests.swift
@@ -1,0 +1,46 @@
+#if os(iOS)
+import Foundation
+import XCTest
+
+@testable import SpeakiOSLib
+
+final class AppGroupConfigurationTests: XCTestCase {
+    func testSharedStateUsesEntitledAppGroup() throws {
+        let entitledGroups = try appGroups(
+            in: repositoryRoot.appendingPathComponent("SpeakiOS.entitlements")
+        )
+
+        XCTAssertEqual(SharedTranscriptionState.appGroupIdentifier, "group.com.justspeaktoit.ios")
+        XCTAssertTrue(entitledGroups.contains(SharedTranscriptionState.appGroupIdentifier))
+    }
+
+    func testWidgetUsesSameEntitledAppGroup() throws {
+        let entitledGroups = try appGroups(
+            in: repositoryRoot
+                .appendingPathComponent("JustSpeakToItWidgetExtension")
+                .appendingPathComponent("JustSpeakToItWidgetExtension.entitlements")
+        )
+
+        XCTAssertTrue(entitledGroups.contains(SharedTranscriptionState.appGroupIdentifier))
+    }
+
+    private func appGroups(in entitlementsURL: URL) throws -> [String] {
+        let data = try Data(contentsOf: entitlementsURL)
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+        let entitledGroups = try XCTUnwrap(
+            plist["com.apple.security.application-groups"] as? [String]
+        )
+
+        return entitledGroups
+    }
+
+    private var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}
+#endif

--- a/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
+++ b/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
@@ -12,7 +12,7 @@ final class TranscriptionRecordingServiceTextTests: XCTestCase {
     func testPolishingPlaceholderDoesNotExposePreviousClipboardContent() {
         XCTAssertEqual(
             TranscriptionRecordingService.polishingClipboardPlaceholder,
-            "Polishing… please wait."
+            "Polishing… please wait"
         )
     }
 

--- a/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
+++ b/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
@@ -1,4 +1,5 @@
 #if os(iOS)
+import AppIntents
 import XCTest
 
 @testable import SpeakiOSLib
@@ -14,6 +15,55 @@ final class TranscriptionRecordingServiceTextTests: XCTestCase {
             TranscriptionRecordingService.polishingClipboardPlaceholder,
             "Polishing… please wait"
         )
+    }
+
+    func testClipboardDestinationCopiesTranscriptAtStop() {
+        XCTAssertEqual(
+            TranscriptionRecordingService.clipboardTextAtStop(
+                transcript: "Action button transcript",
+                destination: .clipboard,
+                canPostProcess: false
+            ),
+            "Action button transcript"
+        )
+    }
+
+    func testPolishWithoutAPIKeyCopiesRawTranscriptInsteadOfPermanentPlaceholder() {
+        XCTAssertEqual(
+            TranscriptionRecordingService.clipboardTextAtStop(
+                transcript: "Action button transcript",
+                destination: .clipboardAndPostProcess,
+                canPostProcess: false
+            ),
+            "Action button transcript"
+        )
+    }
+
+    func testPolishWithAPIKeyUsesPlaceholderUntilReplacementLands() {
+        XCTAssertEqual(
+            TranscriptionRecordingService.clipboardTextAtStop(
+                transcript: "Action button transcript",
+                destination: .clipboardAndPostProcess,
+                canPostProcess: true
+            ),
+            TranscriptionRecordingService.polishingClipboardPlaceholder
+        )
+    }
+
+    func testHistoryOnlyDoesNotTouchClipboard() {
+        XCTAssertNil(
+            TranscriptionRecordingService.clipboardTextAtStop(
+                transcript: "Action button transcript",
+                destination: .historyOnly,
+                canPostProcess: false
+            )
+        )
+    }
+
+    @available(iOS 18, *)
+    func testLiveActivityStopIntentKeepsAudioRecordingExecutionContext() {
+        let intentType: any AudioRecordingIntent.Type = StopTranscriptionRecordingIntent.self
+        XCTAssertTrue(intentType == StopTranscriptionRecordingIntent.self)
     }
 
     func testPrefersTranscriberResultWhenPresent() {

--- a/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
+++ b/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+final class ActionButtonSettingsUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_GB"]
+        app.launch()
+    }
+
+    func testActionButtonDestinationCanBeConfigured() {
+        app.buttons["Settings"].tap()
+
+        let hardwareTriggerLink = app.buttons["hardwareTriggerSettingsLink"]
+        XCTAssertTrue(hardwareTriggerLink.waitForExistence(timeout: 5))
+        hardwareTriggerLink.tap()
+
+        XCTAssertTrue(app.navigationBars["Action Button & Shortcuts"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["openShortcutsAppButton"].exists)
+
+        let historyDestination = app.buttons["Save to History Only"]
+        XCTAssertTrue(historyDestination.waitForExistence(timeout: 5))
+        historyDestination.tap()
+
+        app.navigationBars.buttons.element(boundBy: 0).tap()
+        XCTAssertTrue(app.staticTexts["Save to History Only"].waitForExistence(timeout: 5))
+    }
+}


### PR DESCRIPTION
## Motivation

The iOS App Store release audit found two concrete blockers:

- App Intents and the widget were reading `group.com.speak.ios`, while the signed app entitlement uses `group.com.justspeaktoit.ios`.
- The generated app Info.plist could retain Tuist's default `1.0` marketing version while the widget used the release version, causing App Store validation drift.

## What changed

- Use one canonical App Group identifier across App Intents and the control widget.
- Entitle the widget extension for the shared App Group.
- Bind the generated app version/build fields to `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`.
- Fail the iOS release workflow if app/widget versions, build numbers, or signed App Groups do not match.
- Add iOS unit and UI test targets to Tuist and CI.
- Add an Action Button settings UI test and App Group regression tests.
- Correct one stale punctuation assertion exposed by running the complete iOS suite.

## Things learned that changed the direction

The app already exposes the intended Start, Stop, Toggle Recording, and copy actions to Shortcuts. The highest-risk gaps were release configuration and shared-container wiring, so this PR hardens those paths instead of adding another Action Button implementation.

The existing iOS tests were not part of the generated project/CI gate. Adding them exposed the stale assertion and gives future releases real app-level coverage.

## How to test

- `tuist generate --no-open`
- `xcodebuild test -workspace "Just Speak to It.xcworkspace" -scheme SpeakiOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=latest' -only-testing:SpeakiOSTests -only-testing:SpeakiOSUITests`
- Local result: 46 passed, 0 failed, 0 skipped.
- SwiftLint: 0 violations across changed Swift files.
- SwiftFormat: 0 changed files.
- Simulator build/install/launch succeeded on iOS 26.2.
- Apple Shortcuts discovered all Just Speak to It actions and created a Toggle Recording shortcut.
- Generated build settings confirm both app and widget use version 2.0.0/build 1 and their expected entitlement files.

## Review confidence

Confident in the focused source/configuration changes. The CI UI suite and the new signed-archive metadata gate should be treated as the final deep verification before merge and upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transcription polishing placeholder text formatting.
  * Improved recording start/stop prompts and clipboard behavior to consistently use the shared in-app recording state (including when recording is already in progress).

* **Improvements**
  * Updated iOS CI to use a Tuist-driven build/test flow with automatic simulator selection.
  * Added iOS archive verification for version/build metadata and app-group entitlements (app + widget), and ensured Info.plist version/build values are explicit.

* **Accessibility**
  * Added accessibility identifiers for Hardware Trigger settings, destination rows, and the Shortcuts button.

* **Testing**
  * Expanded iOS test coverage with app-group entitlement checks and a new Action Button settings UI test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->