### PR TITLE
fix(ios): use supported entitlement extraction

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -216,8 +216,8 @@ jobs:
           [ "$APP_BUILD" = "$BUILD_NUMBER" ] || { echo "App build mismatch: expected '$BUILD_NUMBER', got '$APP_BUILD'"; exit 1; }
           [ "$WIDGET_BUILD" = "$BUILD_NUMBER" ] || { echo "Widget build mismatch: expected '$BUILD_NUMBER', got '$WIDGET_BUILD'"; exit 1; }
 
-          codesign -d --entitlements :- "$APP_PATH" > "$RUNNER_TEMP/app-entitlements.plist"
-          codesign -d --entitlements :- "$WIDGET_PATH" > "$RUNNER_TEMP/widget-entitlements.plist"
+          codesign -d --entitlements - --xml "$APP_PATH" > "$RUNNER_TEMP/app-entitlements.plist"
+          codesign -d --entitlements - --xml "$WIDGET_PATH" > "$RUNNER_TEMP/widget-entitlements.plist"
           plutil -extract com.apple.security.application-groups xml1 -o - "$RUNNER_TEMP/app-entitlements.plist" \
             | grep -q 'group.com.justspeaktoit.ios' \
             || { echo "Missing group.com.justspeaktoit.ios in app entitlements"; exit 1; }


### PR DESCRIPTION
## Motivation

The iOS 2.23.1 release archive signed successfully, but the post-archive verifier used deprecated `codesign --entitlements :-` syntax. On Xcode 26 that produced a false negative even though the archive log showed the required App Group in the signed entitlement block.

## What changed

- Extract app and widget entitlements with the supported `codesign --entitlements - --xml` form.
- Keep the existing version, build-number, and App Group assertions unchanged.

## Things we learned

The archive and provisioning profiles are correct; only the verifier extraction syntax was stale. The release stopped before IPA export, so no invalid build reached App Store Connect.

## How to test

- Ruby YAML parse succeeds.
- `codesign --display --entitlements - --xml` is accepted locally without the deprecated-colon warning.
- Rerun Release iOS (TestFlight) for 2.23.1 after merge and confirm Verify Archived App Metadata and Export IPA pass.

## Review confidence

High confidence; this is a two-line compatibility fix matching the Xcode 26 `codesign` manual.