### PR TITLE
fix(ios): validate app group entitlement keys

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -218,12 +218,17 @@ jobs:
 
           codesign -d --entitlements - --xml "$APP_PATH" > "$RUNNER_TEMP/app-entitlements.plist"
           codesign -d --entitlements - --xml "$WIDGET_PATH" > "$RUNNER_TEMP/widget-entitlements.plist"
-          plutil -extract com.apple.security.application-groups xml1 -o - "$RUNNER_TEMP/app-entitlements.plist" \
-            | grep -q 'group.com.justspeaktoit.ios' \
-            || { echo "Missing group.com.justspeaktoit.ios in app entitlements"; exit 1; }
-          plutil -extract com.apple.security.application-groups xml1 -o - "$RUNNER_TEMP/widget-entitlements.plist" \
-            | grep -q 'group.com.justspeaktoit.ios' \
-            || { echo "Missing group.com.justspeaktoit.ios in widget entitlements"; exit 1; }
+          APP_GROUP=$(/usr/libexec/PlistBuddy \
+            -c 'Print :com.apple.security.application-groups:0' \
+            "$RUNNER_TEMP/app-entitlements.plist" 2>/dev/null || true)
+          WIDGET_GROUP=$(/usr/libexec/PlistBuddy \
+            -c 'Print :com.apple.security.application-groups:0' \
+            "$RUNNER_TEMP/widget-entitlements.plist" 2>/dev/null || true)
+
+          [ "$APP_GROUP" = "group.com.justspeaktoit.ios" ] \
+            || { echo "App group mismatch: expected 'group.com.justspeaktoit.ios', got '${APP_GROUP:-missing}'"; exit 1; }
+          [ "$WIDGET_GROUP" = "group.com.justspeaktoit.ios" ] \
+            || { echo "Widget group mismatch: expected 'group.com.justspeaktoit.ios', got '${WIDGET_GROUP:-missing}'"; exit 1; }
 
       - name: Export IPA
         env:


### PR DESCRIPTION
## Motivation

The iOS release archive is signed with the required App Group, but the release workflow stops before IPA export because `plutil -extract` interprets the dotted entitlement name as a key path. Two otherwise-valid archives (builds 174 and 175) were rejected by this false-negative verifier.

## What changed

- Read the literal `com.apple.security.application-groups` array with PlistBuddy.
- Compare index 0 exactly for both the app and widget.
- Report the actual extracted value when validation fails.

## Things we learnt that changed the direction

Updating `codesign` to its supported stdout syntax fixed entitlement extraction itself, but the second release run proved the remaining failure was the dotted plist key lookup. A local reproduction confirmed `plutil -extract` splits the entitlement name on dots, while PlistBuddy reads it correctly.

## How to test

- Parsed `.github/workflows/release-ios.yml` as YAML locally.
- Ran the exact PlistBuddy extraction against the checked-in app and widget entitlements; both return `group.com.justspeaktoit.ios`.
- Ran `git diff --check`.
- After merge, dispatch Release iOS (TestFlight) for version 2.23.1 and confirm metadata verification, IPA export, and upload complete.

## Review confidence

High confidence. This is a narrowly scoped verifier correction with a deterministic local reproduction. The post-merge release run is the authoritative integration check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS release validation to verify that the app and widget use the expected App Group entitlement.
  * Releases now fail earlier when required entitlement metadata is missing or incorrect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->