### PR TITLE
docs(ios): fix privacy policy route

### DIFF
--- a/landing-page/_redirects
+++ b/landing-page/_redirects
@@ -1,3 +1,2 @@
-/privacy       /privacy.html   200
 /index.html   /   200
 /*            /index.html   200


### PR DESCRIPTION
## Motivation
The first privacy-page deployment returned a self-redirecting HTTP 308 for `/privacy`, so the App Store privacy URL was unusable.

## What changed
- remove the explicit `/privacy -> /privacy.html` proxy rule
- rely on Cloudflare Pages native clean-URL serving for `privacy.html`

## Things learned that changed the direction
Cloudflare Pages redirects `.html` paths to their extensionless equivalents. Combining that behavior with the proxy rule created a loop.

## How to test
- `git diff --check`
- after deployment, `curl -L https://justspeaktoit.com/privacy` returns HTTP 200 and the privacy-policy page

## Review confidence
High confidence. This is the exact one-line removal recommended by Cloudflare Pages clean-URL behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated privacy page routing to prevent the previous redirect behavior and allow direct access to the privacy page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->