### PR TITLE
docs(web): overhaul the multi-platform landing page

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -498,6 +498,7 @@
     .app-choice p { min-height: 72px; margin: .65rem 0 1.2rem; color: var(--muted); }
     .app-choice a { color: var(--link-color); font-weight: 600; text-decoration: none; }
     .app-choice a:hover { text-decoration: underline; text-underline-offset: 4px; }
+    .app-choice__status { color: var(--link-color); font-weight: 600; }
 
     .privacy-band { border-bottom: 1px solid var(--rule); }
     .privacy-band__inner {
@@ -731,8 +732,8 @@
         <div class="app-rail reveal">
           <div class="app-rail__lead"><h2 class="section-title">Native on every Apple screen you use.</h2></div>
           <article class="app-choice" style="--link-color:var(--orange-deep)"><svg class="app-choice__icon" viewBox="0 0 52 52" fill="none" stroke="var(--orange)" stroke-width="2.5" aria-hidden="true"><rect x="8" y="7" width="36" height="27" rx="2"/><path d="M3 42h46M15 34l-4 8m26-8 4 8"/></svg><h3>Mac — Direct download</h3><p>Fast updates and full access to local model support.</p><a href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac →</a></article>
-          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>Mac — App Store</h3><p>Sandboxed store distribution for a familiar install and update path.</p><a href="https://apps.apple.com/app/id6758528955?mt=12">View on the App Store →</a></article>
-          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>iPhone &amp; iPad — App Store</h3><p>Action Button, Shortcuts, Live Activity, and iCloud history.</p><a href="https://apps.apple.com/app/id6758528955">View on the App Store →</a></article>
+          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>Mac — App Store</h3><p>Sandboxed store distribution for a familiar install and update path.</p><span class="app-choice__status">App Store release in progress</span></article>
+          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>iPhone &amp; iPad — App Store</h3><p>Action Button, Shortcuts, Live Activity, and iCloud history.</p><span class="app-choice__status">Preparing for App Review</span></article>
         </div>
       </div>
     </section>

--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -1,1908 +1,765 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>JustSpeakToIt — Local & Live Transcription for Mac & iOS</title>
-  <meta name="description" content="Local and live speech-to-text for Mac & iOS: downloaded WhisperKit batch models, sherpa-onnx local streaming, local LLM post-processing, and cloud providers when you want them.">
-  <meta property="og:title" content="JustSpeakToIt — Local & Live Transcription">
-  <meta property="og:description" content="Native Mac & iOS dictation with downloaded local models, live streaming providers, and bring-your-own-keys pricing.">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Just Speak to It — Dictation for Mac, iPhone & iPad</title>
+  <meta name="description" content="Fast, private dictation for Mac, iPhone and iPad. Run speech models locally, stream with your own provider keys, and paste polished text anywhere.">
+  <meta name="theme-color" content="#0c0d0e">
+  <meta property="og:title" content="Just Speak to It — Your voice. Your model. Your words.">
+  <meta property="og:description" content="Native dictation for Mac, iPhone and iPad with local models, live transcription and bring-your-own-key cloud providers.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://justspeaktoit.com">
-  <meta name="twitter:card" content="summary_large_image">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎙️</text></svg>">
-  
-  <!-- Fonts: Satoshi for headings, General Sans for body -->
   <link rel="preconnect" href="https://api.fontshare.com">
   <link href="https://api.fontshare.com/v2/css?f[]=satoshi@700,900&f[]=general-sans@400,500,600&display=swap" rel="stylesheet">
-  
   <style>
     :root {
-      --color-bg: #0b0f14;
-      --color-bg-elevated: #111a26;
-      --color-bg-card: #1a2533;
-      --color-text: #f8fafc;
-      --color-text-muted: #9aa6bd;
-      --color-accent: #ff6a3d;
-      --color-accent-warm: #ff9b4a;
-      --color-accent-deep: #e4512f;
-      --color-accent-glow: rgba(255, 106, 61, 0.32);
-      --color-secondary: #2dd4bf;
-      --color-success: #4ade80;
-      --color-border: rgba(255, 255, 255, 0.08);
-      --font-display: 'Satoshi', -apple-system, sans-serif;
-      --font-body: 'General Sans', -apple-system, sans-serif;
-      --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
-      --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+      --ink: #0c0d0e;
+      --ink-soft: #17191b;
+      --paper: #ffffff;
+      --muted: #5e6268;
+      --muted-dark: #aeb2b8;
+      --rule: #d9dade;
+      --rule-dark: #303338;
+      --orange: #ff6b3d;
+      --orange-deep: #e95024;
+      --teal: #159c95;
+      --blue: #087af5;
+      --max: 1360px;
+      --gutter: clamp(1.25rem, 4vw, 4rem);
+      --display: "Satoshi", -apple-system, BlinkMacSystemFont, sans-serif;
+      --body: "General Sans", -apple-system, BlinkMacSystemFont, sans-serif;
     }
 
-    *, *::before, *::after {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-    }
-
-    html {
-      scroll-behavior: smooth;
-    }
-
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
     body {
-      font-family: var(--font-body);
-      background: var(--color-bg);
-      color: var(--color-text);
-      line-height: 1.6;
-      overflow-x: hidden;
+      margin: 0;
+      color: var(--ink);
+      background: var(--paper);
+      font-family: var(--body);
+      font-size: 16px;
+      line-height: 1.5;
       -webkit-font-smoothing: antialiased;
     }
+    a { color: inherit; }
+    button, a { -webkit-tap-highlight-color: transparent; }
+    :focus-visible { outline: 3px solid var(--teal); outline-offset: 4px; }
 
-    /* Animated background grain texture */
-    body::before {
-      content: '';
-      position: fixed;
-      inset: 0;
-      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
-      opacity: 0.03;
-      pointer-events: none;
-      z-index: 1000;
+    .shell {
+      width: min(100%, var(--max));
+      margin-inline: auto;
+      padding-inline: var(--gutter);
     }
 
-    /* Gradient orbs in background */
-    .bg-orb {
-      position: fixed;
-      border-radius: 50%;
-      filter: blur(100px);
-      pointer-events: none;
-      z-index: -1;
-    }
-    .bg-orb--1 {
-      width: 600px;
-      height: 600px;
-      background: radial-gradient(circle, var(--color-accent-glow) 0%, transparent 70%);
-      top: -200px;
-      right: -100px;
-      animation: float 20s ease-in-out infinite;
-    }
-    .bg-orb--2 {
-      width: 500px;
-      height: 500px;
-      background: radial-gradient(circle, rgba(45, 212, 191, 0.18) 0%, transparent 70%);
-      bottom: 10%;
-      left: -150px;
-      animation: float 25s ease-in-out infinite reverse;
-    }
-
-    @keyframes float {
-      0%, 100% { transform: translate(0, 0) scale(1); }
-      33% { transform: translate(30px, -30px) scale(1.05); }
-      66% { transform: translate(-20px, 20px) scale(0.95); }
-    }
-
-    /* Navigation */
     .nav {
-      position: fixed;
+      position: absolute;
+      z-index: 20;
       top: 0;
       left: 0;
       right: 0;
-      z-index: 100;
-      padding: 1.25rem 2rem;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      background: linear-gradient(to bottom, var(--color-bg) 0%, transparent 100%);
-      backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
+      color: #fff;
     }
-
-    .nav__logo {
-      font-family: var(--font-display);
-      font-weight: 900;
-      font-size: 1.5rem;
-      color: var(--color-text);
-      text-decoration: none;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-
-    .nav__logo-icon {
-      width: 36px;
-      height: 36px;
-      background: linear-gradient(135deg, var(--color-accent-deep) 0%, var(--color-accent-warm) 100%);
-      border-radius: 10px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.25rem;
-    }
-
-    .nav__links {
-      display: flex;
-      gap: 2rem;
-      list-style: none;
-    }
-
-    .nav__link {
-      color: var(--color-text-muted);
-      text-decoration: none;
-      font-weight: 500;
-      font-size: 0.95rem;
-      transition: color 0.2s ease;
-    }
-
-    .nav__link:hover {
-      color: var(--color-text);
-    }
-
-    .nav__cta {
-      background: linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-warm) 100%);
-      color: var(--color-bg);
-      padding: 0.65rem 1.5rem;
-      border-radius: 100px;
-      font-weight: 600;
-      text-decoration: none;
-      font-size: 0.9rem;
-      transition: all 0.3s var(--ease-spring);
-      box-shadow: 0 0 20px var(--color-accent-glow);
-    }
-
-    .nav__cta:hover {
-      transform: translateY(-2px) scale(1.02);
-      box-shadow: 0 0 30px var(--color-accent-glow);
-    }
-
-    /* Hero Section */
-    .hero {
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      text-align: center;
-      padding: 8rem 2rem 4rem;
-      position: relative;
-    }
-
-    .hero__badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      background: var(--color-bg-card);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      padding: 0.5rem 1rem;
-      border-radius: 100px;
-      font-size: 0.85rem;
-      color: var(--color-text-muted);
-      margin-bottom: 2rem;
-      opacity: 0;
-      animation: fadeInUp 0.8s var(--ease-out-expo) 0.2s forwards;
-    }
-
-    .hero__badge-dot {
-      width: 8px;
-      height: 8px;
-      background: var(--color-success);
-      border-radius: 50%;
-      animation: pulse 2s ease-in-out infinite;
-    }
-
-    @keyframes pulse {
-      0%, 100% { opacity: 1; transform: scale(1); }
-      50% { opacity: 0.5; transform: scale(1.2); }
-    }
-
-    .hero__title {
-      font-family: var(--font-display);
-      font-size: clamp(3rem, 8vw, 6rem);
-      font-weight: 900;
-      line-height: 1.05;
-      max-width: 900px;
-      margin-bottom: 1.5rem;
-      opacity: 0;
-      animation: fadeInUp 0.8s var(--ease-out-expo) 0.4s forwards;
-    }
-
-    .hero__title-accent {
-      background: linear-gradient(135deg, var(--color-accent-deep) 0%, var(--color-accent) 50%, var(--color-accent-warm) 100%);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-    }
-
-    .hero__subtitle {
-      font-size: clamp(1.1rem, 2.5vw, 1.35rem);
-      color: var(--color-text-muted);
-      max-width: 720px;
-      margin-bottom: 3rem;
-      opacity: 0;
-      animation: fadeInUp 0.8s var(--ease-out-expo) 0.6s forwards;
-    }
-
-    .hero__actions {
-      display: flex;
-      gap: 1rem;
-      flex-wrap: wrap;
-      justify-content: center;
-      opacity: 0;
-      animation: fadeInUp 0.8s var(--ease-out-expo) 0.8s forwards;
-    }
-
-    /* Homebrew install block */
-    .brew-install {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      background: rgba(0, 0, 0, 0.5);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      border-radius: 12px;
-      padding: 0.75rem 1.25rem;
-      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-      font-size: 0.85rem;
-      color: var(--color-text-muted);
-      margin-top: 1.5rem;
-      opacity: 0;
-      animation: fadeInUp 0.8s var(--ease-out-expo) 1s forwards;
-      cursor: pointer;
-      transition: all 0.3s ease;
-      position: relative;
-      text-align: left;
-      -webkit-appearance: none;
-      appearance: none;
-      width: auto;
-    }
-    .brew-install:hover {
-      border-color: var(--color-accent);
-      color: var(--color-text);
-    }
-    .brew-install__prompt {
-      color: var(--color-secondary);
-      user-select: none;
-    }
-    .brew-install__copy {
-      color: var(--color-text-muted);
-      font-size: 0.8rem;
-      opacity: 0.6;
-      transition: opacity 0.2s;
-      user-select: none;
-    }
-    .brew-install:hover .brew-install__copy {
-      opacity: 1;
-    }
-
-    .btn {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 1rem 2rem;
-      border-radius: 100px;
-      font-weight: 600;
-      text-decoration: none;
-      font-size: 1rem;
-      transition: all 0.3s var(--ease-spring);
-      cursor: pointer;
-      border: none;
-    }
-
-    .btn--primary {
-      background: linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-warm) 100%);
-      color: var(--color-bg);
-      box-shadow: 0 0 30px var(--color-accent-glow), 0 4px 20px rgba(0,0,0,0.3);
-    }
-
-    .btn--primary:hover {
-      transform: translateY(-3px) scale(1.02);
-      box-shadow: 0 0 50px var(--color-accent-glow), 0 8px 30px rgba(0,0,0,0.4);
-    }
-
-    .btn--secondary {
-      background: var(--color-bg-card);
-      color: var(--color-text);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-    }
-
-    .btn--secondary:hover {
-      background: var(--color-bg-elevated);
-      transform: translateY(-2px);
-      border-color: rgba(255, 255, 255, 0.2);
-    }
-
-    .btn--ghost {
-      background: transparent;
-      color: var(--color-text-muted);
-      border: 1px solid rgba(255, 255, 255, 0.15);
-    }
-
-    .btn--ghost:hover {
-      background: rgba(255, 255, 255, 0.05);
-      color: var(--color-text);
-      transform: translateY(-2px);
-      border-color: rgba(255, 255, 255, 0.25);
-    }
-
-    .btn__icon {
-      font-size: 1.2em;
-    }
-
-    /* Animated Waveform */
-    .hero__waveform {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 4px;
-      margin-top: 4rem;
-      opacity: 0;
-      animation: fadeInUp 0.8s var(--ease-out-expo) 1s forwards;
-    }
-
-    .waveform-bar {
-      width: 4px;
-      background: linear-gradient(to top, var(--color-accent-deep) 0%, var(--color-accent-warm) 100%);
-      border-radius: 4px;
-      animation: wave 1.2s ease-in-out infinite;
-    }
-
-    .waveform-bar:nth-child(1) { height: 20px; animation-delay: 0s; }
-    .waveform-bar:nth-child(2) { height: 35px; animation-delay: 0.1s; }
-    .waveform-bar:nth-child(3) { height: 50px; animation-delay: 0.2s; }
-    .waveform-bar:nth-child(4) { height: 30px; animation-delay: 0.3s; }
-    .waveform-bar:nth-child(5) { height: 45px; animation-delay: 0.4s; }
-    .waveform-bar:nth-child(6) { height: 25px; animation-delay: 0.5s; }
-    .waveform-bar:nth-child(7) { height: 40px; animation-delay: 0.6s; }
-    .waveform-bar:nth-child(8) { height: 20px; animation-delay: 0.7s; }
-
-    @keyframes wave {
-      0%, 100% { transform: scaleY(0.5); opacity: 0.6; }
-      50% { transform: scaleY(1); opacity: 1; }
-    }
-
-    @keyframes fadeInUp {
-      from {
-        opacity: 0;
-        transform: translateY(30px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-
-    /* Pricing Highlight */
-    .pricing-highlight {
-      background: linear-gradient(135deg, var(--color-bg-card) 0%, var(--color-bg-elevated) 100%);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      border-radius: 20px;
-      padding: 3rem;
-      margin: 2rem auto;
-      max-width: 800px;
+    .nav__inner {
+      min-height: 78px;
       display: grid;
       grid-template-columns: 1fr auto 1fr;
+      align-items: center;
       gap: 2rem;
-      align-items: center;
-      opacity: 0;
-      animation: fadeInUp 0.8s var(--ease-out-expo) 1.2s forwards;
     }
-
-    .pricing-highlight__item {
-      text-align: center;
-    }
-
-    .pricing-highlight__value {
-      font-family: var(--font-display);
-      font-size: 2.5rem;
-      font-weight: 900;
-      margin-bottom: 0.25rem;
-    }
-
-    .pricing-highlight__value--accent {
-      color: var(--color-accent);
-    }
-
-    .pricing-highlight__value--secondary {
-      color: var(--color-secondary);
-    }
-
-    .pricing-highlight__label {
-      color: var(--color-text-muted);
-      font-size: 0.9rem;
-    }
-
-    .pricing-highlight__divider {
-      width: 1px;
-      height: 60px;
-      background: linear-gradient(to bottom, transparent, rgba(255,255,255,0.2), transparent);
-    }
-
-    /* Live Models */
-    .live-models {
-      position: relative;
-      isolation: isolate;
-    }
-
-    .live-models::before {
-      content: '';
-      position: absolute;
-      inset: 5rem 1rem auto;
-      height: 420px;
-      background:
-        radial-gradient(circle at 18% 20%, rgba(45, 212, 191, 0.22), transparent 32%),
-        radial-gradient(circle at 86% 12%, rgba(255, 106, 61, 0.26), transparent 38%),
-        linear-gradient(135deg, rgba(255, 255, 255, 0.05), transparent);
-      border-radius: 42px;
-      filter: blur(2px);
-      opacity: 0.85;
-      z-index: -1;
-    }
-
-    .live-models__grid {
-      display: grid;
-      grid-template-columns: repeat(12, 1fr);
-      gap: 1rem;
-    }
-
-    .live-model-card {
-      min-height: 220px;
-      background:
-        linear-gradient(145deg, rgba(26, 37, 51, 0.94), rgba(11, 15, 20, 0.92)),
-        radial-gradient(circle at 15% 15%, rgba(255, 106, 61, 0.16), transparent 45%);
-      border: 1px solid rgba(255, 255, 255, 0.09);
-      border-radius: 24px;
-      padding: 1.5rem;
-      position: relative;
-      overflow: hidden;
-      transition: transform 0.35s var(--ease-out-expo), border-color 0.35s ease, box-shadow 0.35s ease;
-      grid-column: span 4;
-    }
-
-    .live-model-card--hero {
-      grid-column: span 6;
-      min-height: 270px;
-    }
-
-    .live-model-card::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background-image:
-        linear-gradient(rgba(255,255,255,0.035) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255,255,255,0.035) 1px, transparent 1px);
-      background-size: 28px 28px;
-      -webkit-mask-image: linear-gradient(to bottom, black, transparent 78%);
-      mask-image: linear-gradient(to bottom, black, transparent 78%);
-      pointer-events: none;
-    }
-
-    .live-model-card:hover {
-      transform: translateY(-6px);
-      border-color: rgba(45, 212, 191, 0.36);
-      box-shadow: 0 28px 70px rgba(0, 0, 0, 0.36), 0 0 32px rgba(45, 212, 191, 0.08);
-    }
-
-    .live-model-card__meta {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
-      margin-bottom: 2.25rem;
-      position: relative;
-      z-index: 1;
-    }
-
-    .live-model-card__provider {
-      color: var(--color-secondary);
-      font-size: 0.78rem;
-      font-weight: 700;
-      letter-spacing: 0.14em;
-      text-transform: uppercase;
-    }
-
-    .live-model-card__latency {
-      border: 1px solid rgba(74, 222, 128, 0.28);
-      background: rgba(74, 222, 128, 0.08);
-      color: var(--color-success);
-      border-radius: 999px;
-      padding: 0.35rem 0.7rem;
-      font-size: 0.76rem;
-      font-weight: 700;
-      white-space: nowrap;
-    }
-
-    .live-model-card__title {
-      font-family: var(--font-display);
-      font-size: clamp(1.45rem, 3vw, 2rem);
-      font-weight: 900;
-      line-height: 1.08;
-      margin-bottom: 0.85rem;
-      position: relative;
-      z-index: 1;
-    }
-
-    .live-model-card__description {
-      color: var(--color-text-muted);
-      font-size: 0.95rem;
-      line-height: 1.65;
-      position: relative;
-      z-index: 1;
-    }
-
-    .live-model-card__pulse {
-      position: absolute;
-      right: 1.5rem;
-      bottom: 1.5rem;
-      display: flex;
-      align-items: end;
-      gap: 0.25rem;
-      opacity: 0.34;
-    }
-
-    .live-model-card__pulse span {
-      width: 5px;
-      border-radius: 99px;
-      background: linear-gradient(to top, var(--color-secondary), var(--color-accent-warm));
-      animation: wave 1.15s ease-in-out infinite;
-    }
-
-    .live-model-card__pulse span:nth-child(1) { height: 20px; animation-delay: 0s; }
-    .live-model-card__pulse span:nth-child(2) { height: 34px; animation-delay: 0.12s; }
-    .live-model-card__pulse span:nth-child(3) { height: 48px; animation-delay: 0.24s; }
-    .live-model-card__pulse span:nth-child(4) { height: 26px; animation-delay: 0.36s; }
-
-    /* Local model lab */
-    .local-lab {
-      max-width: 1240px;
-      position: relative;
-    }
-
-    .local-lab::before {
-      content: '';
-      position: absolute;
-      inset: 7rem 2rem 4rem;
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      border-radius: 36px;
-      background:
-        linear-gradient(115deg, rgba(45, 212, 191, 0.10), transparent 38%),
-        radial-gradient(circle at 78% 18%, rgba(255, 155, 74, 0.16), transparent 30%),
-        repeating-linear-gradient(90deg, rgba(255,255,255,0.035) 0 1px, transparent 1px 64px);
-      opacity: 0.9;
-      z-index: -1;
-    }
-
-    .local-lab__panel {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(320px, 0.9fr);
-      gap: 1.5rem;
-      align-items: stretch;
-    }
-
-    .local-lab__terminal,
-    .local-lab__stack {
-      background: rgba(7, 10, 15, 0.82);
-      border: 1px solid rgba(255, 255, 255, 0.10);
-      border-radius: 28px;
-      box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
-      overflow: hidden;
-    }
-
-    .local-lab__terminal {
-      padding: 1.25rem;
-    }
-
-    .local-lab__chrome {
-      display: flex;
-      gap: 0.45rem;
-      margin-bottom: 1.25rem;
-    }
-
-    .local-lab__chrome span {
-      width: 11px;
-      height: 11px;
-      border-radius: 50%;
-      background: var(--color-accent);
-      box-shadow: 18px 0 0 var(--color-accent-warm), 36px 0 0 var(--color-secondary);
-    }
-
-    .local-lab__readout {
-      display: grid;
-      gap: 0.85rem;
-      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-      font-size: clamp(0.78rem, 1.8vw, 0.95rem);
-      color: #d9f8f1;
-    }
-
-    .local-lab__line {
-      display: grid;
-      grid-template-columns: 8ch 1fr auto;
-      gap: 0.9rem;
-      align-items: center;
-      padding: 0.8rem 0.9rem;
-      border-radius: 14px;
-      background: rgba(255, 255, 255, 0.045);
-    }
-
-    .local-lab__line strong {
-      color: var(--color-secondary);
-      font-weight: 700;
-    }
-
-    .local-lab__meter {
-      height: 8px;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.08);
-      overflow: hidden;
-    }
-
-    .local-lab__meter span {
-      display: block;
-      height: 100%;
-      border-radius: inherit;
-      background: linear-gradient(90deg, var(--color-secondary), var(--color-accent-warm));
-    }
-
-    .local-lab__stack {
-      padding: 1.25rem;
-      display: grid;
-      gap: 1rem;
-    }
-
-    .local-feature {
-      padding: 1.35rem;
-      border-radius: 20px;
-      background: linear-gradient(135deg, rgba(26, 37, 51, 0.92), rgba(11, 15, 20, 0.82));
-      border: 1px solid rgba(255, 255, 255, 0.08);
-    }
-
-    .local-feature__kicker {
-      color: var(--color-secondary);
-      font-size: 0.75rem;
-      font-weight: 800;
-      letter-spacing: 0.14em;
-      text-transform: uppercase;
-      margin-bottom: 0.55rem;
-    }
-
-    .local-feature__title {
-      font-family: var(--font-display);
-      font-size: 1.25rem;
-      margin-bottom: 0.45rem;
-    }
-
-    .local-feature__copy {
-      color: var(--color-text-muted);
-      font-size: 0.94rem;
-      line-height: 1.65;
-    }
-
-    /* Section styling */
-    section {
-      padding: 6rem 2rem;
-      max-width: 1200px;
-      margin: 0 auto;
-    }
-
-    .section-header {
-      text-align: center;
-      margin-bottom: 4rem;
-    }
-
-    .section-header__eyebrow {
-      font-size: 0.85rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.15em;
-      color: var(--color-accent);
-      margin-bottom: 1rem;
-    }
-
-    .section-header__title {
-      font-family: var(--font-display);
-      font-size: clamp(2rem, 5vw, 3rem);
-      font-weight: 900;
-      margin-bottom: 1rem;
-    }
-
-    .section-header__description {
-      color: var(--color-text-muted);
-      max-width: 600px;
-      margin: 0 auto;
-      font-size: 1.1rem;
-    }
-
-    /* Features Grid */
-    .features-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 1.5rem;
-    }
-
-    .feature-card {
-      background: var(--color-bg-card);
-      border: 1px solid rgba(255, 255, 255, 0.06);
-      border-radius: 20px;
-      padding: 2rem;
-      transition: all 0.4s var(--ease-out-expo);
-      position: relative;
-      overflow: hidden;
-    }
-
-    .feature-card::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(135deg, var(--color-accent-glow) 0%, transparent 50%);
-      opacity: 0;
-      transition: opacity 0.4s ease;
-    }
-
-    .feature-card:hover {
-      transform: translateY(-5px);
-      border-color: rgba(255, 255, 255, 0.12);
-      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
-    }
-
-    .feature-card:hover::before {
-      opacity: 1;
-    }
-
-    .feature-card__icon {
-      width: 56px;
-      height: 56px;
-      background: linear-gradient(135deg, var(--color-bg-elevated) 0%, var(--color-bg) 100%);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      border-radius: 14px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.75rem;
-      margin-bottom: 1.5rem;
-      position: relative;
-      z-index: 1;
-    }
-
-    .feature-card__title {
-      font-family: var(--font-display);
-      font-size: 1.25rem;
-      font-weight: 700;
-      margin-bottom: 0.75rem;
-      position: relative;
-      z-index: 1;
-    }
-
-    .feature-card__description {
-      color: var(--color-text-muted);
-      font-size: 0.95rem;
-      line-height: 1.7;
-      position: relative;
-      z-index: 1;
-    }
-
-    /* How It Works */
-    .how-it-works {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 2rem;
-      counter-reset: step;
-    }
-
-    .step {
-      position: relative;
-      padding: 2rem;
-      background: linear-gradient(135deg, var(--color-bg-card) 0%, transparent 100%);
-      border-radius: 20px;
-      border: 1px solid rgba(255, 255, 255, 0.05);
-    }
-
-    .step::before {
-      counter-increment: step;
-      content: counter(step);
-      font-family: var(--font-display);
-      font-size: 4rem;
-      font-weight: 900;
-      position: absolute;
-      top: -10px;
-      right: 20px;
-      color: var(--color-accent);
-      opacity: 0.15;
-    }
-
-    .step__title {
-      font-family: var(--font-display);
-      font-size: 1.25rem;
-      font-weight: 700;
-      margin-bottom: 0.75rem;
-    }
-
-    .step__description {
-      color: var(--color-text-muted);
-      font-size: 0.95rem;
-    }
-
-    /* BYOK Section */
-    .byok-section {
-      background: linear-gradient(135deg, var(--color-bg-elevated) 0%, var(--color-bg-card) 100%);
-      border-radius: 32px;
-      padding: 4rem;
-      margin: 4rem auto;
-      max-width: 1000px;
-      text-align: center;
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      position: relative;
-      overflow: hidden;
-    }
-
-    .byok-section::before {
-      content: '';
-      position: absolute;
-      top: -50%;
-      left: -50%;
-      width: 200%;
-      height: 200%;
-      background: radial-gradient(circle at 30% 30%, var(--color-accent-glow) 0%, transparent 40%);
-      opacity: 0.3;
-      pointer-events: none;
-    }
-
-    .byok-section__title {
-      font-family: var(--font-display);
-      font-size: clamp(1.75rem, 4vw, 2.5rem);
-      font-weight: 900;
-      margin-bottom: 1rem;
-      position: relative;
-      z-index: 1;
-    }
-
-    .byok-section__description {
-      color: var(--color-text-muted);
-      font-size: 1.1rem;
-      max-width: 700px;
-      margin: 0 auto 2rem;
-      position: relative;
-      z-index: 1;
-    }
-
-    .provider-logos {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 1.5rem;
-      margin-top: 2rem;
-      position: relative;
-      z-index: 1;
-    }
-
-    .provider-logo {
-      background: var(--color-bg);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      padding: 1rem 1.5rem;
-      border-radius: 12px;
-      font-weight: 600;
-      font-size: 0.9rem;
-      color: var(--color-text-muted);
-      transition: all 0.3s ease;
-    }
-
-    .provider-logo:hover {
-      border-color: var(--color-accent);
-      color: var(--color-text);
-      transform: translateY(-2px);
-    }
-
-    /* Platforms Section */
-    .platforms {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 2rem;
-      margin-top: 3rem;
-    }
-
-    .platform-card {
-      background: linear-gradient(180deg, var(--color-bg-card) 0%, var(--color-bg-elevated) 100%);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      border-radius: 24px;
-      padding: 2.5rem;
-      text-align: center;
-      transition: all 0.4s var(--ease-out-expo);
-    }
-
-    .platform-card:hover {
-      transform: translateY(-8px);
-      box-shadow: 0 30px 60px rgba(0, 0, 0, 0.4);
-      border-color: rgba(255, 106, 61, 0.3);
-    }
-
-    .platform-card__icon {
-      font-size: 4rem;
-      margin-bottom: 1.5rem;
-      display: block;
-    }
-
-    .platform-card__title {
-      font-family: var(--font-display);
-      font-size: 1.5rem;
-      font-weight: 700;
-      margin-bottom: 0.75rem;
-    }
-
-    .platform-card__features {
-      list-style: none;
-      color: var(--color-text-muted);
-      font-size: 0.95rem;
-    }
-
-    .platform-card__features li {
-      padding: 0.5rem 0;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-    }
-
-    .platform-card__features li:last-child {
-      border-bottom: none;
-    }
-
-    /* FAQ Section */
-    .faq-list {
-      max-width: 800px;
-      margin: 0 auto;
-    }
-
-    .faq-item {
-      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-      padding: 1.5rem 0;
-    }
-
-    .faq-item__question {
-      font-family: var(--font-display);
-      font-weight: 700;
-      font-size: 1.1rem;
-      cursor: pointer;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-    }
-
-    .faq-item__toggle {
-      font-size: 1.5rem;
-      color: var(--color-accent);
-      transition: transform 0.3s ease;
-    }
-
-    .faq-item[open] .faq-item__toggle {
-      transform: rotate(45deg);
-    }
-
-    .faq-item__answer {
-      color: var(--color-text-muted);
-      padding-top: 1rem;
-      line-height: 1.8;
-    }
-
-    /* CTA Section */
-    .cta-section {
-      text-align: center;
-      padding: 8rem 2rem;
-      position: relative;
-    }
-
-    .cta-section::before {
-      content: '';
-      position: absolute;
-      bottom: 0;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 80%;
-      height: 1px;
-      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
-    }
-
-    .cta-section__title {
-      font-family: var(--font-display);
-      font-size: clamp(2rem, 5vw, 3.5rem);
-      font-weight: 900;
-      margin-bottom: 1.5rem;
-    }
-
-    .cta-section__description {
-      color: var(--color-text-muted);
-      font-size: 1.2rem;
-      margin-bottom: 2.5rem;
-      max-width: 600px;
-      margin-left: auto;
-      margin-right: auto;
-    }
-
-    /* Footer */
-    .footer {
-      padding: 3rem 2rem;
-      text-align: center;
-      border-top: 1px solid rgba(255, 255, 255, 0.05);
-    }
-
-    .footer__logo {
-      font-family: var(--font-display);
-      font-weight: 900;
-      font-size: 1.25rem;
-      margin-bottom: 1rem;
+    .brand {
       display: inline-flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: .72rem;
+      width: max-content;
+      font-family: var(--display);
+      font-weight: 900;
+      letter-spacing: -.02em;
+      text-decoration: none;
+      white-space: nowrap;
     }
-
-    .footer__text {
-      color: var(--color-text-muted);
-      font-size: 0.9rem;
+    .brand__wave {
+      display: inline-flex;
+      align-items: center;
+      gap: 2px;
+      height: 30px;
+      color: var(--orange);
     }
-
-    .footer__links {
-      margin-top: 1.5rem;
+    .brand__wave i {
+      display: block;
+      width: 2px;
+      height: var(--h);
+      border-radius: 2px;
+      background: currentColor;
+    }
+    .nav__links {
       display: flex;
+      align-items: center;
+      gap: clamp(1.15rem, 2.4vw, 2.2rem);
+    }
+    .nav__links a {
+      color: #d8dade;
+      font-size: .92rem;
+      font-weight: 500;
+      text-decoration: none;
+      transition: color .18s ease;
+    }
+    .nav__links a:hover { color: #fff; }
+    .nav__download { justify-self: end; }
+
+    .button {
+      display: inline-flex;
+      min-height: 46px;
+      align-items: center;
       justify-content: center;
+      gap: .55rem;
+      padding: .75rem 1.15rem;
+      border: 1px solid transparent;
+      border-radius: 9px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: transform .18s ease, background-color .18s ease, border-color .18s ease;
+    }
+    .button:hover { transform: translateY(-2px); }
+    .button--orange { color: #fff; background: var(--orange); }
+    .button--orange:hover { background: var(--orange-deep); }
+    .button--outline { color: #fff; border-color: #666b72; background: transparent; }
+    .button--outline:hover { border-color: #fff; }
+
+    .hero {
+      min-height: 820px;
+      position: relative;
+      overflow: hidden;
+      color: #fff;
+      background: var(--ink);
+      border-bottom: 1px solid var(--rule-dark);
+    }
+    .hero__inner {
+      min-height: 820px;
+      display: grid;
+      grid-template-columns: minmax(300px, .8fr) minmax(580px, 1.45fr);
+      gap: clamp(2rem, 5vw, 5.5rem);
+      align-items: center;
+      padding-top: 126px;
+      padding-bottom: 70px;
+    }
+    .hero__copy { position: relative; z-index: 3; }
+    .hero h1 {
+      max-width: 640px;
+      margin: 0;
+      font-family: var(--display);
+      font-size: clamp(4rem, 5.2vw, 5.4rem);
+      font-weight: 900;
+      letter-spacing: -.07em;
+      line-height: .94;
+      white-space: nowrap;
+    }
+    .hero__lede {
+      max-width: 570px;
+      margin: 2rem 0 0;
+      color: #d4d6d9;
+      font-size: clamp(1.08rem, 1.6vw, 1.28rem);
+      line-height: 1.55;
+    }
+    .hero__actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: .75rem;
+      margin-top: 2rem;
+    }
+
+    .product-stage {
+      position: relative;
+      min-height: 550px;
+      align-self: end;
+      z-index: 2;
+    }
+    .stage-wave {
+      position: absolute;
+      left: -18%;
+      right: -18%;
+      top: 55%;
+      height: 90px;
+      display: flex;
+      align-items: center;
+      justify-content: space-around;
+      gap: 3px;
+      opacity: .85;
+      transform: translateY(-50%);
+    }
+    .stage-wave i {
+      display: block;
+      flex: 1;
+      max-width: 5px;
+      height: var(--h);
+      border-radius: 5px;
+      background: var(--c, var(--orange));
+      box-shadow: 0 0 18px color-mix(in srgb, var(--c, var(--orange)) 38%, transparent);
+      animation: breathe 2.4s ease-in-out infinite alternate;
+      animation-delay: var(--d);
+    }
+    @keyframes breathe { to { transform: scaleY(.55); opacity: .62; } }
+
+    .mac-window {
+      position: absolute;
+      z-index: 2;
+      top: 24px;
+      left: 0;
+      right: 90px;
+      overflow: hidden;
+      border: 1px solid #3e4247;
+      border-radius: 12px;
+      background: #151719;
+      box-shadow: 0 38px 90px rgba(0,0,0,.52);
+    }
+    .window-bar {
+      height: 42px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 14px;
+      border-bottom: 1px solid #303338;
+      background: #202225;
+      font-size: .76rem;
+    }
+    .traffic { display: flex; gap: 7px; }
+    .traffic i { width: 10px; height: 10px; border-radius: 50%; background: #ff5f57; }
+    .traffic i:nth-child(2) { background: #febc2e; }
+    .traffic i:nth-child(3) { background: #28c840; }
+    .window-title { color: #d9dbde; font-weight: 600; }
+    .window-live { color: #87d9d0; }
+    .transcript-panel { padding: 1.25rem 1.35rem 1rem; }
+    .transcript-tools {
+      display: flex;
+      align-items: center;
+      gap: .55rem;
+      color: #d9dcde;
+      font-size: .73rem;
+    }
+    .select-chip {
+      padding: .35rem .55rem;
+      border: 1px solid #3d4146;
+      border-radius: 6px;
+      background: #24272a;
+    }
+    .live-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--teal); }
+    .live-copy {
+      min-height: 105px;
+      margin-top: 1rem;
+      padding: 1rem;
+      border: 1px solid #2d3034;
+      border-radius: 8px;
+      color: #f2f3f4;
+      background: #111315;
+      font-size: .98rem;
+      line-height: 1.42;
+    }
+    .cursor { color: var(--orange); animation: blink 1s steps(2,end) infinite; }
+    @keyframes blink { 50% { opacity: 0; } }
+    .history-label {
+      margin-top: 1rem;
+      color: #8e939a;
+      font-size: .67rem;
+      font-weight: 600;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    .history-row {
+      display: grid;
+      grid-template-columns: 1.5fr .8fr .55fr;
+      gap: .7rem;
+      align-items: center;
+      min-height: 46px;
+      border-top: 1px solid #2b2e32;
+      color: #d3d5d8;
+      font-size: .72rem;
+    }
+    .history-row__model { color: #9ba0a6; }
+    .history-row__time { text-align: right; color: #858b92; }
+
+    .phone {
+      position: absolute;
+      z-index: 4;
+      right: 0;
+      bottom: 0;
+      width: 214px;
+      padding: 8px;
+      border: 2px solid #7a7e83;
+      border-radius: 36px;
+      background: #070809;
+      box-shadow: 0 30px 70px rgba(0,0,0,.58);
+    }
+    .phone__screen {
+      min-height: 420px;
+      padding: 14px 15px 18px;
+      border-radius: 28px;
+      background: #121416;
+      text-align: center;
+    }
+    .phone__status { display: flex; justify-content: space-between; color: #e3e4e6; font-size: .58rem; }
+    .phone__title { margin-top: 1.2rem; color: #b9bdc1; font-size: .72rem; }
+    .action-orb {
+      width: 84px;
+      height: 84px;
+      margin: 2rem auto 1.1rem;
+      display: grid;
+      place-items: center;
+      border: 3px solid #fd9d7f;
+      border-radius: 50%;
+      background: var(--orange);
+      box-shadow: 0 0 0 8px rgba(255,107,61,.12);
+    }
+    .orb-bars { display: flex; align-items: center; gap: 3px; height: 36px; }
+    .orb-bars i { width: 3px; height: var(--h); border-radius: 3px; background: #fff; }
+    .phone__state { font-family: var(--display); font-size: 1rem; font-weight: 700; }
+    .phone__timer { color: var(--orange); font-variant-numeric: tabular-nums; }
+    .phone__text { margin-top: 1.4rem; color: #aeb2b7; font-size: .68rem; line-height: 1.45; }
+    .phone__model { margin-top: 1rem; color: #78d4ca; font-size: .62rem; }
+    .phone__stop { margin-top: 1.3rem; padding: .62rem; border-radius: 7px; background: #24272b; font-size: .69rem; }
+
+    .section { border-bottom: 1px solid var(--rule); }
+    .models { padding-block: clamp(4.5rem, 8vw, 7.5rem); }
+    .section-title {
+      margin: 0;
+      font-family: var(--display);
+      font-size: clamp(2.7rem, 5vw, 5rem);
+      font-weight: 900;
+      letter-spacing: -.055em;
+      line-height: .98;
+    }
+    .models__header {
+      display: grid;
+      grid-template-columns: 1.15fr 1fr;
+      gap: clamp(2rem, 6vw, 7rem);
+      align-items: end;
+    }
+    .models__intro { margin: 0; max-width: 720px; color: var(--muted); font-size: 1.08rem; }
+    .model-rails {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      margin-top: 4rem;
+      border-top: 1px solid var(--rule);
+      border-bottom: 1px solid var(--rule);
+    }
+    .model-rail { padding: 2.15rem clamp(1rem, 3vw, 2.6rem); }
+    .model-rail + .model-rail { border-left: 1px solid var(--rule); }
+    .model-rail:first-child { padding-left: 0; }
+    .model-rail:last-child { padding-right: 0; }
+    .model-rail__heading {
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      margin: 0 0 1.35rem;
+      color: var(--rail-color);
+      font-family: var(--display);
+      font-size: 1.12rem;
+      letter-spacing: .03em;
+      text-transform: uppercase;
+    }
+    .rail-icon { width: 28px; height: 28px; }
+    .model-list { margin: 0; padding: 0; list-style: none; }
+    .model-list li {
+      position: relative;
+      padding: .42rem 0 .42rem 1.1rem;
+      line-height: 1.3;
+    }
+    .model-list li::before {
+      content: "";
+      position: absolute;
+      top: .88rem;
+      left: 0;
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background: var(--rail-color);
+    }
+    .model-request {
+      display: inline-flex;
+      margin-top: 1.75rem;
+      color: var(--orange-deep);
+      font-weight: 600;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 4px;
+    }
+
+    .workflow { padding-block: clamp(4rem, 7vw, 6.5rem); }
+    .workflow__head {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
       gap: 2rem;
     }
-
-    .footer__link {
-      color: var(--color-text-muted);
-      text-decoration: none;
-      font-size: 0.9rem;
-      transition: color 0.2s ease;
+    .workflow__head p { max-width: 500px; margin: 0; color: var(--muted); }
+    .steps {
+      position: relative;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: clamp(2rem, 5vw, 5rem);
+      margin-top: 4.5rem;
     }
-
-    .footer__link:hover {
-      color: var(--color-accent);
+    .step { position: relative; z-index: 2; }
+    .step__head { display: flex; gap: .9rem; align-items: center; }
+    .step__number {
+      display: grid;
+      place-items: center;
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      color: #fff;
+      background: var(--step-color);
+      font-family: var(--display);
+      font-weight: 900;
     }
-
-    /* Responsive */
-    .nav__hamburger {
-      display: none;
-      background: none;
-      border: none;
-      cursor: pointer;
-      padding: 0.5rem;
+    .step h3 { margin: 0; font-family: var(--display); font-size: 1.45rem; }
+    .step p { max-width: 330px; margin: .65rem 0 1.5rem 3.1rem; color: var(--muted); }
+    .shortcut-row { display: flex; align-items: center; gap: 1rem; min-height: 126px; }
+    .keycap {
+      padding: .85rem 1rem;
+      border-radius: 9px;
+      color: #fff;
+      background: var(--ink);
+      box-shadow: 0 8px 20px rgba(12,13,14,.12);
+      font-size: 1.2rem;
+      font-weight: 600;
     }
-    .nav__hamburger span {
-      display: block;
-      width: 22px;
-      height: 2px;
-      background: var(--color-text);
-      margin: 5px 0;
-      border-radius: 2px;
-      transition: all 0.3s ease;
+    .mini-orb {
+      width: 64px;
+      height: 64px;
+      display: grid;
+      place-items: center;
+      border-radius: 50%;
+      color: #fff;
+      background: var(--orange);
+      font-size: 1.45rem;
     }
+    .flow-box {
+      min-height: 126px;
+      padding: 1.15rem;
+      border: 1px solid #cfd1d4;
+      border-radius: 10px;
+      background: #fff;
+      box-shadow: 0 10px 28px rgba(12,13,14,.06);
+    }
+    .interim {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: .92rem;
+      line-height: 1.45;
+    }
+    .mini-wave { display: flex; align-items: center; gap: 2px; height: 30px; margin-top: 1.1rem; }
+    .mini-wave i { flex: 1; max-width: 4px; height: var(--h); border-radius: 3px; background: var(--c); }
+    .clipboard-result { display: flex; align-items: center; gap: 1rem; }
+    .clipboard {
+      position: relative;
+      width: 62px;
+      height: 72px;
+      flex: 0 0 auto;
+      border: 4px solid var(--ink);
+      border-radius: 8px;
+    }
+    .clipboard::before {
+      content: "";
+      position: absolute;
+      top: -10px;
+      left: 15px;
+      width: 24px;
+      height: 13px;
+      border: 4px solid var(--ink);
+      border-radius: 7px 7px 0 0;
+      background: #fff;
+    }
+    .check {
+      position: absolute;
+      right: -13px;
+      bottom: -12px;
+      width: 30px;
+      height: 30px;
+      display: grid;
+      place-items: center;
+      border-radius: 50%;
+      color: #fff;
+      background: var(--teal);
+      font-weight: 700;
+    }
+    .copied { color: var(--teal); font-weight: 600; }
 
-    /* Mobile overlay (sibling of nav, avoids iOS Safari backdrop-filter containment) */
-    .mobile-nav-overlay {
-      display: none;
-      position: fixed;
-      inset: 0;
-      background: var(--color-bg);
-      flex-direction: column;
-      justify-content: center;
+    .apps { padding-block: clamp(4.5rem, 8vw, 7rem); }
+    .app-rail {
+      display: grid;
+      grid-template-columns: 1.12fr repeat(3, 1fr);
+      margin-top: 3.5rem;
+      border-top: 1px solid var(--rule);
+      border-bottom: 1px solid var(--rule);
+    }
+    .app-rail__lead { padding: 2.25rem 2rem 2.25rem 0; }
+    .app-rail__lead .section-title { font-size: clamp(2.4rem, 3vw, 3.25rem); }
+    .app-choice { padding: 2.25rem clamp(1.3rem, 2.5vw, 2.4rem); border-left: 1px solid var(--rule); }
+    .app-choice__icon { width: 48px; height: 48px; margin-bottom: 1.35rem; }
+    .app-choice h3 { margin: 0; font-family: var(--display); font-size: 1.22rem; }
+    .app-choice p { min-height: 72px; margin: .65rem 0 1.2rem; color: var(--muted); }
+    .app-choice a { color: var(--link-color); font-weight: 600; text-decoration: none; }
+    .app-choice a:hover { text-decoration: underline; text-underline-offset: 4px; }
+
+    .privacy-band { border-bottom: 1px solid var(--rule); }
+    .privacy-band__inner {
+      display: grid;
+      grid-template-columns: 1.45fr 1fr;
       align-items: center;
-      gap: 2.5rem;
-      z-index: 200;
+      min-height: 250px;
+    }
+    .privacy-claim { display: flex; align-items: center; gap: 2rem; padding-right: 3rem; }
+    .shield { width: 74px; height: 86px; flex: 0 0 auto; color: var(--teal); }
+    .privacy-claim h2 {
+      margin: 0;
+      font-family: var(--display);
+      font-size: clamp(2.1rem, 3.25vw, 3rem);
+      letter-spacing: -.045em;
+      line-height: 1;
+    }
+    .privacy-copy { padding: 2rem 0 2rem 3.5rem; border-left: 1px solid var(--rule); font-size: 1.08rem; }
+    .privacy-copy p { margin: .35rem 0; }
+
+    .creator { padding-block: clamp(4rem, 7vw, 6rem); }
+    .creator__grid { display: grid; grid-template-columns: 1.4fr .6fr; }
+    .creator-profile { display: grid; grid-template-columns: 120px 1fr; gap: 2rem; padding-right: clamp(2rem, 5vw, 5rem); }
+    .portrait {
+      width: 120px;
+      height: 120px;
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      border-radius: 50%;
+      color: #fff;
+      background: var(--ink);
+      font-family: var(--display);
+      font-size: 2.2rem;
+      font-weight: 900;
+      letter-spacing: -.05em;
+    }
+    .creator h2 { margin: 0; font-family: var(--display); font-size: clamp(2.3rem, 3.4vw, 3.35rem); letter-spacing: -.05em; line-height: 1; }
+    .creator-profile p { max-width: 660px; margin: 1rem 0; color: var(--muted); font-size: 1.05rem; }
+    .text-link { color: var(--orange-deep); font-weight: 600; text-underline-offset: 4px; }
+    .other-project { padding-left: clamp(2rem, 5vw, 5rem); border-left: 1px solid var(--rule); }
+    .other-project__label { margin: 0 0 1.25rem; font-family: var(--display); font-weight: 700; }
+    .pasta { display: grid; grid-template-columns: 72px 1fr; gap: 1.25rem; align-items: center; }
+    .pasta-icon {
+      width: 72px;
+      height: 72px;
+      display: grid;
+      place-items: center;
+      border: 2px solid #c79200;
+      border-radius: 16px;
+      color: #17130a;
+      background: #ffc928;
+      font-family: var(--display);
+      font-size: 2rem;
+      font-weight: 900;
+    }
+    .pasta h3 { margin: 0; font-family: var(--display); font-size: 1.55rem; }
+    .pasta p { margin: .2rem 0 .65rem; color: var(--muted); }
+
+    .footer { color: #fff; background: var(--ink); }
+    .footer__main {
+      min-height: 210px;
+      display: grid;
+      grid-template-columns: 1fr 1.15fr 1fr;
+      align-items: center;
+      gap: 2rem;
+    }
+    .footer__cta { padding-inline: 2rem; border-inline: 1px solid var(--rule-dark); text-align: center; }
+    .footer__cta h2 { margin: 0 0 1rem; font-family: var(--display); font-size: clamp(2rem, 3vw, 3rem); letter-spacing: -.04em; }
+    .footer__links { display: flex; justify-content: flex-end; gap: 1.7rem; }
+    .footer__links a { color: #d4d6d8; text-decoration: none; }
+    .footer__links a:hover { color: #fff; }
+    .footer__legal { padding: 1.2rem 0; border-top: 1px solid var(--rule-dark); color: #858a91; font-size: .78rem; }
+
+    .reveal { opacity: 1; transform: none; }
+
+    @media (max-width: 1060px) {
+      .nav__inner { grid-template-columns: 1fr auto; }
+      .nav__links { display: none; }
+      .hero__inner { grid-template-columns: 1fr; padding-top: 130px; }
+      .hero__copy { max-width: 720px; }
+      .product-stage { min-height: 560px; }
+      .models__header { grid-template-columns: 1fr; }
+      .app-rail { grid-template-columns: 1fr 1fr; }
+      .app-rail__lead { grid-column: 1 / -1; }
+      .app-choice:nth-of-type(2) { border-left: 0; }
+      .privacy-band__inner { grid-template-columns: 1fr; }
+      .privacy-claim { padding-block: 3rem; }
+      .privacy-copy { padding: 2.5rem 0; border-top: 1px solid var(--rule); border-left: 0; }
+      .creator__grid { grid-template-columns: 1fr; gap: 3rem; }
+      .other-project { padding: 3rem 0 0; border-top: 1px solid var(--rule); border-left: 0; }
     }
 
-    .mobile-nav-overlay.open {
-      display: flex;
+    @media (max-width: 760px) {
+      .nav__inner { min-height: 68px; gap: .75rem; }
+      .brand { font-size: .9rem; }
+      .brand__wave { height: 24px; }
+      .nav__download { min-height: 40px; padding: .55rem .75rem; font-size: .82rem; }
+      .hero, .hero__inner { min-height: auto; }
+      .hero__inner { padding-top: 120px; padding-bottom: 3rem; }
+      .hero h1 { font-size: clamp(3.4rem, 15.5vw, 5rem); }
+      .hero__lede { font-size: 1rem; }
+      .product-stage { min-height: 530px; margin-top: 2rem; }
+      .mac-window { right: 0; }
+      .history-row { grid-template-columns: 1.35fr .8fr; }
+      .history-row__time { display: none; }
+      .phone { width: 175px; }
+      .phone__screen { min-height: 350px; }
+      .action-orb { width: 67px; height: 67px; }
+      .model-rails, .steps { grid-template-columns: 1fr; }
+      .model-rail { padding: 2rem 0; }
+      .model-rail + .model-rail { border-top: 1px solid var(--rule); border-left: 0; }
+      .workflow__head { display: block; }
+      .workflow__head p { margin-top: 1rem; }
+      .steps { margin-top: 3rem; }
+      .step { padding-bottom: 2.5rem; border-bottom: 1px solid var(--rule); }
+      .step p { margin-left: 0; }
+      .app-rail { grid-template-columns: 1fr; }
+      .app-rail__lead { padding-right: 0; }
+      .app-choice { padding: 2rem 0; border-top: 1px solid var(--rule); border-left: 0; }
+      .app-choice p { min-height: 0; }
+      .privacy-claim { display: block; padding-right: 0; }
+      .privacy-claim h2 { margin-top: 1.5rem; }
+      .creator-profile { grid-template-columns: 1fr; padding-right: 0; }
+      .portrait { width: 92px; height: 92px; }
+      .footer__main { grid-template-columns: 1fr; padding-block: 3rem; text-align: center; }
+      .footer .brand { margin-inline: auto; }
+      .footer__cta { padding-block: 2rem; border-block: 1px solid var(--rule-dark); border-inline: 0; }
+      .footer__links { justify-content: center; flex-wrap: wrap; }
     }
 
-    .mobile-nav-overlay .nav__link {
-      color: var(--color-text-muted);
-      text-decoration: none;
-      font-weight: 500;
-      font-size: 1.25rem;
-      transition: color 0.2s ease;
-    }
-
-    .mobile-nav-overlay .nav__link:hover {
-      color: var(--color-text);
-    }
-
-    @media (max-width: 768px) {
-      .nav__hamburger {
-        display: block;
-        z-index: 210;
-      }
-
-      .nav__cta {
-        display: none;
-      }
-
-      .nav__links {
-        display: none;
-      }
-
-      .nav__links .nav__link {
-        font-size: 1.25rem;
-      }
-
-      .pricing-highlight {
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-        padding: 2rem;
-      }
-
-      .pricing-highlight__divider {
-        width: 60px;
-        height: 1px;
-        margin: 0 auto;
-      }
-
-      .live-models__grid {
-        grid-template-columns: 1fr;
-      }
-
-      .live-model-card,
-      .live-model-card--hero {
-        grid-column: auto;
-        min-height: 0;
-      }
-
-      .local-lab__panel {
-        grid-template-columns: 1fr;
-      }
-
-      .local-lab__line {
-        grid-template-columns: 1fr;
-      }
-
-      .byok-section {
-        padding: 2.5rem 1.5rem;
-        margin: 2rem 1rem;
-      }
-
-      section {
-        padding: 4rem 1.5rem;
-      }
-    }
-
-    /* Scroll reveal animations */
-    .reveal {
-      opacity: 0;
-      transform: translateY(40px);
-      transition: all 0.8s var(--ease-out-expo);
-    }
-
-    .reveal.visible {
-      opacity: 1;
-      transform: translateY(0);
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+      .reveal { opacity: 1; transform: none; }
     }
   </style>
 </head>
 <body>
-  <!-- Background orbs -->
-  <div class="bg-orb bg-orb--1"></div>
-  <div class="bg-orb bg-orb--2"></div>
-
-  <!-- Navigation -->
-  <nav class="nav">
-    <a href="#" class="nav__logo">
-      <span class="nav__logo-icon">🎙️</span>
-      JustSpeakToIt
-    </a>
-    <ul class="nav__links">
-      <li><a href="#models" class="nav__link">Models</a></li>
-      <li><a href="#local" class="nav__link">Local</a></li>
-      <li><a href="#features" class="nav__link">Features</a></li>
-      <li><a href="#pricing" class="nav__link">Pricing</a></li>
-      <li><a href="#platforms" class="nav__link">Platforms</a></li>
-      <li><a href="#faq" class="nav__link">FAQ</a></li>
-    </ul>
-    <a href="#download" class="nav__cta">Download Free</a>
-    <button class="nav__hamburger" aria-label="Toggle menu" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-  </nav>
-
-  <!-- Mobile navigation overlay (sibling of nav to avoid iOS Safari backdrop-filter containment) -->
-  <div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true">
-    <a href="#models" class="nav__link">Models</a>
-    <a href="#local" class="nav__link">Local</a>
-    <a href="#features" class="nav__link">Features</a>
-    <a href="#pricing" class="nav__link">Pricing</a>
-    <a href="#platforms" class="nav__link">Platforms</a>
-    <a href="#faq" class="nav__link">FAQ</a>
-  </div>
-
-  <!-- Hero -->
-  <section class="hero">
-    <div class="hero__badge">
-      <span class="hero__badge-dot"></span>
-      2.0 brings downloaded local models to the Mac
-    </div>
-    <h1 class="hero__title">
-      <span class="hero__title-accent">Speak anywhere.</span> Choose local, live, or both.
-    </h1>
-    <p class="hero__subtitle">
-      Native dictation for Mac and iOS with downloaded WhisperKit batch models, sherpa-onnx local streaming, local LLM post-processing, and cloud engines like Deepgram, AssemblyAI, OpenAI, ElevenLabs, Soniox, and Modulate when you want maximum accuracy.
-    </p>
-    <div class="hero__actions">
-      <a href="https://github.com/crmitchelmore/justspeaktoit/releases/latest" class="btn btn--primary" target="_blank" rel="noopener">
-        <span class="btn__icon">⬇️</span>
-        Download for Mac
+  <header class="nav" aria-label="Primary navigation">
+    <div class="shell nav__inner">
+      <a class="brand" href="#top" aria-label="Just Speak to It home">
+        <span class="brand__wave" aria-hidden="true"><i style="--h:10px"></i><i style="--h:20px"></i><i style="--h:28px"></i><i style="--h:18px"></i><i style="--h:25px"></i><i style="--h:13px"></i></span>
+        <span>Just Speak to It</span>
       </a>
-      <a href="https://testflight.apple.com/join/justspeaktoit" class="btn btn--secondary" target="_blank" rel="noopener">
-        <span class="btn__icon">📱</span>
-        Join iOS TestFlight
-      </a>
-      <a href="https://github.com/crmitchelmore/justspeaktoit" class="btn btn--ghost" target="_blank" rel="noopener">
-        <span class="btn__icon">⭐</span>
-        Star on GitHub
-      </a>
+      <nav class="nav__links">
+        <a href="#models">Models</a><a href="#workflow">How it works</a><a href="#apps">Apps</a><a href="#creator">Creator</a>
+      </nav>
+      <a class="button button--orange nav__download" href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac</a>
     </div>
+  </header>
 
-    <button class="brew-install" title="Click to copy" type="button">
-      <span class="brew-install__prompt">$</span>
-      <code>brew tap crmitchelmore/justspeaktoit && brew install --cask justspeaktoit</code>
-      <span class="brew-install__copy">Click to copy</span>
-    </button>
-    
-    <div class="hero__waveform">
-      <div class="waveform-bar"></div>
-      <div class="waveform-bar"></div>
-      <div class="waveform-bar"></div>
-      <div class="waveform-bar"></div>
-      <div class="waveform-bar"></div>
-      <div class="waveform-bar"></div>
-      <div class="waveform-bar"></div>
-      <div class="waveform-bar"></div>
-    </div>
-
-    <div class="pricing-highlight" id="pricing">
-      <div class="pricing-highlight__item">
-        <div class="pricing-highlight__value pricing-highlight__value--accent">$0</div>
-        <div class="pricing-highlight__label">App download</div>
-      </div>
-      <div class="pricing-highlight__divider"></div>
-      <div class="pricing-highlight__item">
-        <div class="pricing-highlight__value pricing-highlight__value--secondary">Local</div>
-        <div class="pricing-highlight__label">Batch, streaming & cleanup</div>
-      </div>
-      <div class="pricing-highlight__divider"></div>
-      <div class="pricing-highlight__item">
-        <div class="pricing-highlight__value">BYOK</div>
-        <div class="pricing-highlight__label">No price markup</div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Live Models -->
-  <section class="live-models" id="models">
-    <div class="section-header reveal">
-      <div class="section-header__eyebrow">Local + Live</div>
-      <h2 class="section-header__title">Choose the engine for the moment</h2>
-      <p class="section-header__description">
-        Stay offline with local models, stream for instant feedback, or use a cloud model for specialised accuracy. JustSpeakToIt keeps each path explicit so you always know where audio and text are processed.
-      </p>
-    </div>
-
-    <div class="live-models__grid">
-      <article class="live-model-card live-model-card--hero reveal">
-        <div class="live-model-card__meta">
-          <span class="live-model-card__provider">Deepgram</span>
-          <span class="live-model-card__latency">~200ms</span>
-        </div>
-        <h3 class="live-model-card__title">Nova-3 Streaming</h3>
-        <p class="live-model-card__description">
-          Fast WebSocket transcription with interim results for the lowest-friction everyday dictation flow.
-        </p>
-        <div class="live-model-card__pulse" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
-      </article>
-
-      <article class="live-model-card live-model-card--hero reveal">
-        <div class="live-model-card__meta">
-          <span class="live-model-card__provider">AssemblyAI</span>
-          <span class="live-model-card__latency">~250ms</span>
-        </div>
-        <h3 class="live-model-card__title">Universal-3 Pro Streaming</h3>
-        <p class="live-model-card__description">
-          High-accuracy multilingual streaming with formatted turn finalisation when you want cleaner long-form output.
-        </p>
-        <div class="live-model-card__pulse" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
-      </article>
-
-      <article class="live-model-card reveal">
-        <div class="live-model-card__meta">
-          <span class="live-model-card__provider">OpenAI</span>
-          <span class="live-model-card__latency">~250ms</span>
-        </div>
-        <h3 class="live-model-card__title">Realtime Whisper</h3>
-        <p class="live-model-card__description">
-          Streaming transcription with built-in noise reduction using your existing OpenAI API key.
-        </p>
-        <div class="live-model-card__pulse" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
-      </article>
-
-      <article class="live-model-card reveal">
-        <div class="live-model-card__meta">
-          <span class="live-model-card__provider">ElevenLabs</span>
-          <span class="live-model-card__latency">~200ms</span>
-        </div>
-        <h3 class="live-model-card__title">Scribe v2 Streaming</h3>
-        <p class="live-model-card__description">
-          Real-time Scribe transcription for teams already using ElevenLabs speech workflows.
-        </p>
-        <div class="live-model-card__pulse" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
-      </article>
-
-      <article class="live-model-card reveal">
-        <div class="live-model-card__meta">
-          <span class="live-model-card__provider">Soniox</span>
-          <span class="live-model-card__latency">~220ms</span>
-        </div>
-        <h3 class="live-model-card__title">Real-time Preview</h3>
-        <p class="live-model-card__description">
-          Low-latency multilingual WebSocket STT for fast feedback across more languages.
-        </p>
-        <div class="live-model-card__pulse" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
-      </article>
-
-      <article class="live-model-card reveal">
-        <div class="live-model-card__meta">
-          <span class="live-model-card__provider">Modulate</span>
-          <span class="live-model-card__latency">~220ms</span>
-        </div>
-        <h3 class="live-model-card__title">Velma-2 Streaming</h3>
-        <p class="live-model-card__description">
-          Multilingual live transcription with diarization and signal-detection oriented provider support.
-        </p>
-        <div class="live-model-card__pulse" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
-      </article>
-
-      <article class="live-model-card reveal">
-        <div class="live-model-card__meta">
-          <span class="live-model-card__provider">Apple</span>
-          <span class="live-model-card__latency">~50ms</span>
-        </div>
-        <h3 class="live-model-card__title">On-device Speech</h3>
-        <p class="live-model-card__description">
-          Private local recognition for instant, free dictation when cloud accuracy is not required.
-        </p>
-        <div class="live-model-card__pulse" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
-      </article>
-    </div>
-  </section>
-
-  <!-- Local Models -->
-  <section class="local-lab" id="local">
-    <div class="section-header reveal">
-      <div class="section-header__eyebrow">Local Model Lab</div>
-      <h2 class="section-header__title">Downloaded models, no round trip required</h2>
-      <p class="section-header__description">
-        Version 2.0 separates local batch, local streaming, and local post-processing so you can pick the right offline tool without guessing which runtime is active.
-      </p>
-    </div>
-
-    <div class="local-lab__panel reveal">
-      <div class="local-lab__terminal" aria-label="Local model support overview">
-        <div class="local-lab__chrome" aria-hidden="true"><span></span></div>
-        <div class="local-lab__readout">
-          <div class="local-lab__line">
-            <strong>Batch</strong>
-            <span>WhisperKit/Core ML after recording stops</span>
-            <div class="local-lab__meter" aria-hidden="true"><span style="width: 92%;"></span></div>
+  <main id="top">
+    <section class="hero">
+      <div class="shell hero__inner">
+        <div class="hero__copy">
+          <h1>Your voice.<br>Your model.<br>Your words.</h1>
+          <p class="hero__lede">Fast, private dictation for Mac and iPhone. Run speech models locally, stream with your own provider keys, and paste polished text anywhere.</p>
+          <div class="hero__actions">
+            <a class="button button--orange" href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac <span aria-hidden="true">→</span></a>
+            <a class="button button--outline" href="#models">Explore the models</a>
           </div>
-          <div class="local-lab__line">
-            <strong>Live</strong>
-            <span>sherpa-onnx streaming sources with model sizes shown</span>
-            <div class="local-lab__meter" aria-hidden="true"><span style="width: 76%;"></span></div>
+        </div>
+
+        <div class="product-stage" aria-label="Just Speak to It on Mac and iPhone">
+          <div class="stage-wave" aria-hidden="true">
+            <i style="--h:16%;--d:-.2s"></i><i style="--h:28%;--d:-1.1s"></i><i style="--h:52%;--d:-.7s"></i><i style="--h:77%;--d:-1.7s"></i><i style="--h:42%;--d:-.5s"></i><i style="--h:85%;--d:-1.3s"></i><i style="--h:38%;--d:-.9s"></i><i style="--h:64%;--d:-.1s"></i><i style="--h:32%;--d:-1.5s"></i><i style="--h:72%;--d:-.8s"></i><i style="--h:44%;--d:-1.8s"></i><i style="--h:88%;--d:-.4s"></i><i style="--h:56%;--d:-1.2s;--c:#ee7b4f"></i><i style="--h:35%;--d:-.6s;--c:#d98e61"></i><i style="--h:60%;--d:-1.6s;--c:#c29e73"></i><i style="--h:29%;--d:-.3s;--c:#a6ac82"></i><i style="--h:70%;--d:-1s;--c:#80b991"></i><i style="--h:41%;--d:-1.9s;--c:#59bf9d"></i><i style="--h:80%;--d:-.5s;--c:#37b3a2"></i><i style="--h:48%;--d:-1.4s;--c:#159c95"></i><i style="--h:65%;--d:-.8s;--c:#159c95"></i><i style="--h:33%;--d:-.2s;--c:#159c95"></i>
           </div>
-          <div class="local-lab__line">
-            <strong>Polish</strong>
-            <span>downloaded GGUF LLMs for private cleanup prompts</span>
-            <div class="local-lab__meter" aria-hidden="true"><span style="width: 68%;"></span></div>
+          <div class="mac-window">
+            <div class="window-bar">
+              <span class="traffic" aria-hidden="true"><i></i><i></i><i></i></span>
+              <span class="window-title">Just Speak to It</span><span class="window-live">● Connected</span>
+            </div>
+            <div class="transcript-panel">
+              <div class="transcript-tools"><span class="select-chip">Live</span><span class="select-chip">Deepgram Nova-3</span><span class="live-dot"></span><span>00:00:27</span></div>
+              <div class="live-copy">Building great tools is about removing friction. The more natural the interface, the more human the result.<span class="cursor">|</span></div>
+              <div class="history-label">Recent history</div>
+              <div class="history-row"><span>Q3 product strategy notes</span><span class="history-row__model">Deepgram Nova-3</span><span class="history-row__time">Today, 14:42</span></div>
+              <div class="history-row"><span>Interview with Alex</span><span class="history-row__model">WhisperKit local</span><span class="history-row__time">Today, 09:18</span></div>
+              <div class="history-row"><span>Design review — mobile</span><span class="history-row__model">AssemblyAI U3 Pro</span><span class="history-row__time">Yesterday</span></div>
+              <div class="history-row"><span>Weekly engineering sync</span><span class="history-row__model">GPT-4o Transcribe</span><span class="history-row__time">Yesterday</span></div>
+            </div>
           </div>
-          <div class="local-lab__line">
-            <strong>Cloud</strong>
-            <span>optional BYOK providers when accuracy beats locality</span>
-            <div class="local-lab__meter" aria-hidden="true"><span style="width: 84%;"></span></div>
+          <div class="phone" aria-hidden="true">
+            <div class="phone__screen">
+              <div class="phone__status"><span>9:41</span><span>● ●●</span></div><div class="phone__title">Action Button</div>
+              <div class="action-orb"><span class="orb-bars"><i style="--h:14px"></i><i style="--h:28px"></i><i style="--h:21px"></i><i style="--h:34px"></i><i style="--h:17px"></i></span></div>
+              <div class="phone__state">Recording…</div><div class="phone__timer">00:00:27</div>
+              <div class="phone__text">Gathering thoughts and turning them into clear, useful notes without breaking flow.</div>
+              <div class="phone__model">● Live · Deepgram Nova-3</div><div class="phone__stop">■ &nbsp; Stop</div>
+            </div>
           </div>
         </div>
       </div>
+    </section>
 
-      <div class="local-lab__stack">
-        <article class="local-feature">
-          <div class="local-feature__kicker">Offline transcription</div>
-          <h3 class="local-feature__title">Batch models for careful work</h3>
-          <p class="local-feature__copy">
-            Download WhisperKit/Core ML models, record normally, then transcribe locally after capture for private drafts, notes, and sensitive dictation.
-          </p>
-        </article>
-        <article class="local-feature">
-          <div class="local-feature__kicker">Local streaming</div>
-          <h3 class="local-feature__title">Live preview without cloud audio</h3>
-          <p class="local-feature__copy">
-            Use sherpa-onnx streaming models for local live text. The settings UI now shows catalogue/source sections, model sizes, and runtime state consistently.
-          </p>
-        </article>
-        <article class="local-feature">
-          <div class="local-feature__kicker">Private cleanup</div>
-          <h3 class="local-feature__title">Prompt-aware local post-processing</h3>
-          <p class="local-feature__copy">
-            Download local LLMs for cleanup and formatting. Small models can be less obedient, so the app makes the prompt path visible and keeps built-in rules honest.
-          </p>
-        </article>
+    <section class="section models" id="models">
+      <div class="shell">
+        <div class="models__header reveal"><h2 class="section-title">Choose the engine for the moment.</h2><p class="models__intro">Start on-device, switch to specialist streaming, or bring a long-form recording. Just Speak to It keeps the choice visible instead of locking you into one provider.</p></div>
+        <div class="model-rails reveal">
+          <article class="model-rail" style="--rail-color:var(--orange-deep)">
+            <h3 class="model-rail__heading"><svg class="rail-icon" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="2.3" aria-hidden="true"><path d="M3 16h4m3-8v16m5-20v24m5-17v10m5-15v20m4-10h-3"/></svg>Live</h3>
+            <ul class="model-list"><li>Apple Speech</li><li>Deepgram Nova-3 + Flux</li><li>Cartesia Ink-2</li><li>Gladia Solaria-1</li><li>AssemblyAI Universal-3 Pro</li><li>Soniox Real-time v5</li><li>ElevenLabs Scribe v2</li><li>Modulate Velma-2</li><li>OpenAI GPT-4o Transcribe</li></ul>
+          </article>
+          <article class="model-rail" style="--rail-color:var(--teal)">
+            <h3 class="model-rail__heading"><svg class="rail-icon" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="2.3" aria-hidden="true"><ellipse cx="16" cy="7" rx="10" ry="4"/><path d="M6 7v9c0 2 4.5 4 10 4s10-2 10-4V7M6 16v9c0 2 4.5 4 10 4s10-2 10-4v-9"/></svg>Batch</h3>
+            <ul class="model-list"><li>WhisperKit local</li><li>OpenAI Whisper + GPT-4o Transcribe</li><li>Groq Whisper Large v3 Turbo</li><li>Mistral Voxtral</li><li>Soniox Async v5</li><li>Rev.ai</li></ul>
+          </article>
+          <article class="model-rail" style="--rail-color:var(--orange-deep)">
+            <h3 class="model-rail__heading"><svg class="rail-icon" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="2.3" aria-hidden="true"><path d="m7 25 4-12L23 1l8 8-12 12-12 4Z"/><path d="m11 13 8 8M7 25l6-2-4-4-2 6Z"/></svg>Polish</h3>
+            <ul class="model-list"><li>Local Cleanup</li><li>Downloaded GGUF models</li><li>GPT-5.4 Nano</li><li>Gemini 3.1 Flash Lite</li><li>Qwen3.6 Flash</li><li>Mistral Small 4 via OpenRouter</li></ul>
+          </article>
+        </div>
+        <a class="model-request reveal" href="https://github.com/crmitchelmore/justspeaktoit/issues/new?title=Model%20request%3A%20&amp;body=Provider%3A%20%0AModel%3A%20%0APlatform%20%28Mac%2FiOS%29%3A%20%0AWhy%20this%20model%3A%20&amp;labels=enhancement">Missing a model? Raise an issue →</a>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- App Screenshots -->
-  <section id="screenshots" style="padding: 4rem 2rem;">
-    <div class="section-header reveal">
-      <div class="section-header__eyebrow">Preview</div>
-      <h2 class="section-header__title">See it in action</h2>
-    </div>
-    
-    <div class="screenshots-grid reveal" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem; max-width: 900px; margin: 0 auto;">
-      <div class="screenshot-card" style="background: var(--color-bg-card); border-radius: 16px; overflow: hidden; box-shadow: 0 8px 32px rgba(0,0,0,0.3);">
-        <img src="images/app-dashboard.png" alt="JustSpeakToIt Dashboard" style="width: 100%; height: auto; display: block;">
-        <div style="padding: 1rem;">
-          <h4 style="color: var(--color-text); margin-bottom: 0.5rem;">Dashboard</h4>
-          <p style="color: var(--color-text-muted); font-size: 0.9rem; margin: 0;">Monitor usage, check permissions, and start recording in one click.</p>
+    <section class="section workflow" id="workflow">
+      <div class="shell">
+        <div class="workflow__head reveal"><h2 class="section-title">Press. Speak. Done.</h2><p>One clean sequence from intention to useful text. The clipboard changes only when the final transcript is ready.</p></div>
+        <div class="steps">
+          <article class="step reveal" style="--step-color:var(--orange)"><div class="step__head"><span class="step__number">1</span><h3>Activate</h3></div><p>Start from your keyboard, Action Button, Shortcuts, or the app.</p><div class="shortcut-row"><span class="keycap">⌘ ⇧ D</span><span>or</span><span class="mini-orb" aria-hidden="true">▥</span></div></article>
+          <article class="step reveal" style="--step-color:var(--teal)"><div class="step__head"><span class="step__number">2</span><h3>Speak</h3></div><p>Watch live words arrive while you speak.</p><div class="flow-box interim">Ideas become structure,<br>and structure becomes clarity.<span class="cursor">|</span><div class="mini-wave" aria-hidden="true"><i style="--h:8px;--c:#ff6b3d"></i><i style="--h:22px;--c:#ff6b3d"></i><i style="--h:14px;--c:#e98755"></i><i style="--h:27px;--c:#c79d71"></i><i style="--h:12px;--c:#94ae84"></i><i style="--h:20px;--c:#61b898"></i><i style="--h:10px;--c:#159c95"></i><i style="--h:25px;--c:#159c95"></i></div></div></article>
+          <article class="step reveal" style="--step-color:var(--teal)"><div class="step__head"><span class="step__number">3</span><h3>Use it</h3></div><p>Copy or paste the final text only when it is ready.</p><div class="flow-box clipboard-result"><div><strong>Ideas become structure, and structure becomes clarity.</strong><div class="copied">Copied</div></div><div class="clipboard" aria-hidden="true"><span class="check">✓</span></div></div></article>
         </div>
       </div>
-      
-      <div class="screenshot-card" style="background: var(--color-bg-card); border-radius: 16px; overflow: hidden; box-shadow: 0 8px 32px rgba(0,0,0,0.3);">
-        <img src="images/app-history.png" alt="Transcription History" style="width: 100%; height: auto; display: block;">
-        <div style="padding: 1rem;">
-          <h4 style="color: var(--color-text); margin-bottom: 0.5rem;">History</h4>
-          <p style="color: var(--color-text-muted); font-size: 0.9rem; margin: 0;">Browse transcriptions with audio playback, cost tracking, and session details.</p>
+    </section>
+
+    <section class="section apps" id="apps">
+      <div class="shell">
+        <div class="app-rail reveal">
+          <div class="app-rail__lead"><h2 class="section-title">Native on every Apple screen you use.</h2></div>
+          <article class="app-choice" style="--link-color:var(--orange-deep)"><svg class="app-choice__icon" viewBox="0 0 52 52" fill="none" stroke="var(--orange)" stroke-width="2.5" aria-hidden="true"><rect x="8" y="7" width="36" height="27" rx="2"/><path d="M3 42h46M15 34l-4 8m26-8 4 8"/></svg><h3>Mac — Direct download</h3><p>Fast updates and full access to local model support.</p><a href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac →</a></article>
+          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>Mac — App Store</h3><p>Sandboxed store distribution for a familiar install and update path.</p><a href="https://apps.apple.com/app/id6758528955?mt=12">View on the App Store →</a></article>
+          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>iPhone &amp; iPad — App Store</h3><p>Action Button, Shortcuts, Live Activity, and iCloud history.</p><a href="https://apps.apple.com/app/id6758528955">View on the App Store →</a></article>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Features -->
-  <section id="features">
-    <div class="section-header reveal">
-      <div class="section-header__eyebrow">Features</div>
-      <h2 class="section-header__title">Built around live words, not waiting</h2>
-      <p class="section-header__description">
-        A native app that feels immediate. No Electron, no bloat — just fast streaming transcripts, safe key storage, and polished text insertion.
-      </p>
-    </div>
-
-    <div class="features-grid">
-      <div class="feature-card reveal">
-        <div class="feature-card__icon">⚡</div>
-        <h3 class="feature-card__title">Streaming-First Dictation</h3>
-        <p class="feature-card__description">
-          Double-tap Fn, hold-to-record, or use a custom shortcut. Watch live text arrive as you speak, then insert the final transcript where your cursor is.
-        </p>
+    <section class="privacy-band">
+      <div class="shell privacy-band__inner reveal">
+        <div class="privacy-claim"><svg class="shield" viewBox="0 0 80 94" fill="none" stroke="currentColor" stroke-width="4" aria-hidden="true"><path d="M40 4c9 8 20 12 33 14v25c0 22-13 37-33 47C20 80 7 65 7 43V18C20 16 31 12 40 4Z"/></svg><h2>Local when you want it.<br>Cloud when it earns its place.</h2></div>
+        <div class="privacy-copy"><p>Bring Your Own Key (BYOK) for supported providers.</p><p>Your audio and text stay on your device with local models.</p><p>Use the cloud only when you choose to.</p></div>
       </div>
+    </section>
 
-      <div class="feature-card reveal">
-        <div class="feature-card__icon">🔒</div>
-        <h3 class="feature-card__title">Downloaded Local Models</h3>
-        <p class="feature-card__description">
-          Keep sensitive recordings offline with Apple Speech, WhisperKit batch models, sherpa-onnx streaming, and local LLM cleanup.
-        </p>
+    <section class="section creator" id="creator">
+      <div class="shell creator__grid reveal">
+        <div class="creator-profile"><div class="portrait" aria-hidden="true">CM</div><div><h2>Made by Chris Mitchelmore.</h2><p>I build focused tools that respect your attention and your data. Just Speak to It is the dictation app I’ve always wanted.</p><a class="text-link" href="https://mitchelmore.uk">Read the blog at mitchelmore.uk →</a></div></div>
+        <div class="other-project"><p class="other-project__label">Other project</p><div class="pasta"><div class="pasta-icon" aria-hidden="true">P</div><div><h3>Pasta</h3><p>A calmer way to manage your clipboard.</p><a class="text-link" href="https://pasta-app.com">pasta-app.com →</a></div></div></div>
       </div>
+    </section>
+  </main>
 
-      <div class="feature-card reveal">
-        <div class="feature-card__icon">🎯</div>
-        <h3 class="feature-card__title">Smart Text Insertion</h3>
-        <p class="feature-card__description">
-          Transcripts are automatically typed into any app using accessibility APIs. Insert at cursor or replace selection—works with any text field.
-        </p>
-      </div>
-
-      <div class="feature-card reveal">
-        <div class="feature-card__icon">🧠</div>
-        <h3 class="feature-card__title">AI Post-Processing</h3>
-        <p class="feature-card__description">
-          Optional Live Polish and post-processing using downloaded local LLMs or GPT-4o, Claude, Gemini, and Mistral--removes filler words, fixes punctuation, and polishes your prose.
-        </p>
-      </div>
-
-      <div class="feature-card reveal">
-        <div class="feature-card__icon">💬</div>
-        <h3 class="feature-card__title">OpenClaw AI Chat</h3>
-        <p class="feature-card__description">
-          Have voice-powered conversations with AI. Speak your questions and hear responses read back—complete with conversation history.
-        </p>
-      </div>
-
-      <div class="feature-card reveal">
-        <div class="feature-card__icon">🎙️</div>
-        <h3 class="feature-card__title">Hands-Free Mode</h3>
-        <p class="feature-card__description">
-          Full voice-to-voice conversation loop: record, send, listen to the response, and auto-resume recording. No tapping required.
-        </p>
-      </div>
-
-      <div class="feature-card reveal">
-        <div class="feature-card__icon">🔊</div>
-        <h3 class="feature-card__title">Text-to-Speech</h3>
-        <p class="feature-card__description">
-          Hear responses with natural voices from OpenAI, ElevenLabs, Deepgram, Azure, or Apple's built-in system voices.
-        </p>
-      </div>
-
-      <div class="feature-card reveal">
-        <div class="feature-card__icon">📚</div>
-        <h3 class="feature-card__title">Personal Lexicon</h3>
-        <p class="feature-card__description">
-          Teach the app your jargon, names, and acronyms. Your custom dictionary improves accuracy across all providers.
-        </p>
-      </div>
-
-      <div class="feature-card reveal">
-        <div class="feature-card__icon">☁️</div>
-        <h3 class="feature-card__title">iCloud History Sync</h3>
-        <p class="feature-card__description">
-          Your transcription history syncs seamlessly between Mac and iOS via iCloud. Pick up right where you left off on any device.
-        </p>
-      </div>
-    </div>
-  </section>
-
-  <!-- How It Works -->
-  <section>
-    <div class="section-header reveal">
-      <div class="section-header__eyebrow">How It Works</div>
-      <h2 class="section-header__title">Three steps to live text</h2>
-    </div>
-
-    <div class="how-it-works">
-      <div class="step reveal">
-        <h3 class="step__title">Activate</h3>
-        <p class="step__description">
-          Double-tap Fn or click the menu bar icon. A subtle HUD appears with your active live model.
-        </p>
-      </div>
-
-      <div class="step reveal">
-        <h3 class="step__title">Speak</h3>
-        <p class="step__description">
-          Just talk naturally. Streaming providers return interim text while you are still speaking.
-        </p>
-      </div>
-
-      <div class="step reveal">
-        <h3 class="step__title">Done</h3>
-        <p class="step__description">
-          Stop recording and your polished text appears instantly in any app, right at your cursor.
-        </p>
-      </div>
-    </div>
-  </section>
-
-  <!-- BYOK Section -->
-  <div class="byok-section reveal" id="byok">
-    <h2 class="byok-section__title">Local first. Bring keys only when you need them.</h2>
-    <p class="byok-section__description">
-      Download local models for offline work, then use your existing API keys from supported live transcription providers when cloud accuracy, diarisation, or specialist languages matter.
-      Pay only for what you use--typically <strong>$0.36 per hour</strong> or less with low-cost streaming providers. No subscriptions, no hidden fees, no data selling.
-    </p>
-    <div class="provider-logos">
-      <span class="provider-logo">WhisperKit Local Batch</span>
-      <span class="provider-logo">sherpa-onnx Local Streaming</span>
-      <span class="provider-logo">GGUF Local Cleanup</span>
-      <span class="provider-logo">Deepgram Nova-3 Streaming</span>
-      <span class="provider-logo">AssemblyAI Universal-3 Pro</span>
-      <span class="provider-logo">OpenAI Realtime Whisper</span>
-      <span class="provider-logo">ElevenLabs Scribe v2</span>
-      <span class="provider-logo">Soniox Real-time</span>
-      <span class="provider-logo">Modulate Velma-2</span>
-      <span class="provider-logo">Apple Speech (Free)</span>
-    </div>
-  </div>
-
-  <!-- Platforms -->
-  <section id="platforms">
-    <div class="section-header reveal">
-      <div class="section-header__eyebrow">Platforms</div>
-      <h2 class="section-header__title">Native apps, native performance</h2>
-      <p class="section-header__description">
-        Built with SwiftUI for the best experience on every Apple device.
-      </p>
-    </div>
-
-    <div class="platforms">
-      <div class="platform-card reveal">
-        <span class="platform-card__icon">💻</span>
-        <h3 class="platform-card__title">macOS</h3>
-        <ul class="platform-card__features">
-          <li>Menu bar app with global hotkeys</li>
-          <li>Direct text insertion via Accessibility</li>
-          <li>Live transcription preview HUD</li>
-          <li>Downloaded WhisperKit batch models and sherpa-onnx local streaming</li>
-          <li>Downloaded local LLM post-processing for private cleanup</li>
-          <li>Deepgram, AssemblyAI, OpenAI, ElevenLabs, Soniox, Modulate, and Apple live models</li>
-          <li>Live Polish + AI post-processing</li>
-          <li>OpenClaw AI chat with hands-free mode</li>
-          <li>Install via Homebrew or direct download</li>
-          <li>Requires macOS 14+</li>
-        </ul>
-      </div>
-
-      <div class="platform-card reveal">
-        <span class="platform-card__icon">📱</span>
-        <h3 class="platform-card__title">iOS <span style="font-size: 0.7em; color: var(--color-secondary);">(TestFlight Beta)</span></h3>
-        <ul class="platform-card__features">
-          <li>Live Activity with Dynamic Island</li>
-          <li>Apple Speech, Deepgram, ElevenLabs, and OpenAI live transcription</li>
-          <li>OpenClaw AI chat with voice input</li>
-          <li>Audio recording & playback</li>
-          <li>Home Screen widgets</li>
-          <li>iCloud history sync with Mac</li>
-          <li>Requires iOS 17+</li>
-        </ul>
-      </div>
-    </div>
-  </section>
-
-  <!-- FAQ -->
-  <section id="faq">
-    <div class="section-header reveal">
-      <div class="section-header__eyebrow">FAQ</div>
-      <h2 class="section-header__title">Questions? We've got answers.</h2>
-    </div>
-
-    <div class="faq-list">
-      <details class="faq-item reveal">
-        <summary class="faq-item__question">
-          Is my audio data private?
-          <span class="faq-item__toggle">+</span>
-        </summary>
-        <p class="faq-item__answer">
-          Yes! When using on-device transcription with Apple Speech, your audio never leaves your device. 
-          When using downloaded local models or Apple Speech, audio stays on your device. When using cloud providers like Deepgram, AssemblyAI, Soniox, ElevenLabs, OpenAI, or Modulate, audio is sent directly to their APIs using your own API keys—we never see or store your audio.
-        </p>
-      </details>
-
-      <details class="faq-item reveal">
-        <summary class="faq-item__question">
-          How much does it actually cost?
-          <span class="faq-item__toggle">+</span>
-        </summary>
-        <p class="faq-item__answer">
-          The app is free to download. On-device transcription and downloaded local models are free to run after installation.
-          Cloud transcription with your own API keys typically costs around $0.006/minute (about $0.36/hour) with low-cost streaming providers such as Deepgram.
-          You pay the provider directly—we don't add any markup.
-        </p>
-      </details>
-
-      <details class="faq-item reveal">
-        <summary class="faq-item__question">
-          What's the difference between on-device and cloud transcription?
-          <span class="faq-item__toggle">+</span>
-        </summary>
-        <p class="faq-item__answer">
-          Local modes include Apple Speech, downloaded WhisperKit batch models, sherpa-onnx local streaming, and downloaded local LLM cleanup. They prioritise privacy and offline use.
-          Cloud providers like Deepgram, AssemblyAI, Soniox, ElevenLabs, OpenAI, and Modulate offer higher accuracy, lower-latency streaming, broader language support, and provider-specific features like diarisation or formatted turns.
-        </p>
-      </details>
-
-      <details class="faq-item reveal">
-        <summary class="faq-item__question">
-          Do small local models follow custom formatting prompts?
-          <span class="faq-item__toggle">+</span>
-        </summary>
-        <p class="faq-item__answer">
-          Larger local LLMs tend to follow cleanup instructions better. Very small downloaded models are useful for private, lightweight cleanup, but they may ignore strict formatting requests. The app shows the prompt path so you can tell whether the issue is model capability or configuration.
-        </p>
-      </details>
-
-      <details class="faq-item reveal">
-        <summary class="faq-item__question">
-          Can I use this for meetings?
-          <span class="faq-item__toggle">+</span>
-        </summary>
-        <p class="faq-item__answer">
-          On Mac, you can capture system audio from meeting apps like Zoom or Teams. 
-          On iOS, the app captures audio from your device's microphone—place your phone near the speaker for best results, or use the hands-free conversation mode to interact with AI directly.
-        </p>
-      </details>
-
-      <details class="faq-item reveal">
-        <summary class="faq-item__question">
-          How do I set up my API keys?
-          <span class="faq-item__toggle">+</span>
-        </summary>
-        <p class="faq-item__answer">
-          Open the app's Settings and enter your API keys in the Providers section. 
-          Keys are stored securely in your Mac's Keychain. 
-          We never see or transmit your keys—they go directly to the provider's API.
-        </p>
-      </details>
-
-      <details class="faq-item reveal">
-        <summary class="faq-item__question">
-          What is OpenClaw?
-          <span class="faq-item__toggle">+</span>
-        </summary>
-        <p class="faq-item__answer">
-          OpenClaw is the built-in AI chat feature. You can have voice-powered conversations with AI assistants—
-          speak your questions, get spoken responses, and use hands-free mode for a completely voice-driven experience.
-          Conversations are saved locally and can sync via iCloud.
-        </p>
-      </details>
-    </div>
-  </section>
-
-  <!-- CTA -->
-  <section class="cta-section" id="download">
-    <h2 class="cta-section__title reveal">Ready to speak freely?</h2>
-    <p class="cta-section__description reveal">
-      Download JustSpeakToIt 2.0 and pick the transcription path that fits the moment: offline local, instant live, or cloud accuracy.
-    </p>
-    <div class="hero__actions reveal">
-      <a href="https://github.com/crmitchelmore/justspeaktoit/releases/latest" class="btn btn--primary" target="_blank" rel="noopener">
-        <span class="btn__icon">⬇️</span>
-        Download for Mac
-      </a>
-      <a href="https://testflight.apple.com/join/justspeaktoit" class="btn btn--secondary" target="_blank" rel="noopener">
-        <span class="btn__icon">📱</span>
-        Join iOS TestFlight
-      </a>
-    </div>
-    <p class="reveal" style="margin-top: 1.5rem; color: var(--color-text-muted); font-size: 0.95rem;">
-      Have a feature request, bug report, or want to contribute? <a href="https://github.com/crmitchelmore/justspeaktoit/issues" style="color: var(--color-accent);">Open an issue on GitHub</a> — we'd love to hear from you!
-    </p>
-  </section>
-
-  <!-- Footer -->
   <footer class="footer">
-    <div class="footer__logo">
-      <span>🎙️</span>
-      JustSpeakToIt
+    <div class="shell footer__main">
+      <a class="brand" href="#top"><span class="brand__wave" aria-hidden="true"><i style="--h:10px"></i><i style="--h:20px"></i><i style="--h:28px"></i><i style="--h:18px"></i><i style="--h:25px"></i><i style="--h:13px"></i></span><span>Just Speak to It</span></a>
+      <div class="footer__cta"><h2>Ready when you are.</h2><a class="button button--orange" href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac</a></div>
+      <nav class="footer__links" aria-label="Footer"><a href="https://github.com/crmitchelmore/justspeaktoit">GitHub</a><a href="/privacy">Privacy</a><a href="mailto:hello@justspeaktoit.com">Contact</a></nav>
     </div>
-    <p class="footer__text">
-      Local and live transcription for Mac & iOS · Open Source
-    </p>
-    <div class="footer__links">
-      <a href="/privacy" class="footer__link">Privacy Policy</a>
-      <a href="#" class="footer__link">Terms of Service</a>
-      <a href="mailto:hello@justspeaktoit.com" class="footer__link">Contact</a>
-      <a href="https://github.com/crmitchelmore/justspeaktoit" class="footer__link">GitHub</a>
-    </div>
-
-    <div class="footer__support" style="margin-top: 2rem; display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
-      <a href="https://ko-fi.com/crmitchelmore" target="_blank" rel="noopener" class="support-button" style="display: inline-flex; align-items: center; gap: 0.5rem; background: #ff5e5b; color: white; padding: 0.75rem 1.5rem; border-radius: 999px; text-decoration: none; font-weight: 600; transition: transform 0.2s, box-shadow 0.2s;">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M23.881 8.948c-.773-4.085-4.859-4.593-4.859-4.593H.723c-.604 0-.679.798-.679.798s-.082 7.324-.022 11.822c.164 2.424 2.586 2.672 2.586 2.672s8.267-.023 11.966-.049c2.438-.426 2.683-2.566 2.658-3.734 4.352.24 7.422-2.831 6.649-6.916zm-11.062 3.511c-1.246 1.453-4.011 3.976-4.011 3.976s-.121.119-.31.023c-.076-.057-.108-.09-.108-.09-.443-.441-3.368-3.049-4.034-3.954-.709-.965-1.041-2.7-.091-3.71.951-1.01 3.005-1.086 4.363.407 0 0 1.565-1.782 3.468-.963 1.904.82 1.832 3.011.723 4.311z"/></svg>
-        Support on Ko-fi
-      </a>
-      <a href="https://github.com/sponsors/crmitchelmore" target="_blank" rel="noopener" class="support-button" style="display: inline-flex; align-items: center; gap: 0.5rem; background: #c96198; color: white; padding: 0.75rem 1.5rem; border-radius: 999px; text-decoration: none; font-weight: 600; transition: transform 0.2s, box-shadow 0.2s;">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
-        GitHub Sponsors
-      </a>
-    </div>
-
-    <p class="footer__text" style="margin-top: 2rem; opacity: 0.5;">
-      © 2026 JustSpeakToIt. All rights reserved.
-    </p>
+    <div class="shell footer__legal">© 2026 Chris Mitchelmore. Just Speak to It is open source.</div>
   </footer>
 
-  <script>
-    // Scroll reveal animation
-    const revealElements = document.querySelectorAll('.reveal');
-    
-    const revealOnScroll = () => {
-      const windowHeight = window.innerHeight;
-      revealElements.forEach(el => {
-        const elementTop = el.getBoundingClientRect().top;
-        const revealPoint = 100;
-        
-        if (elementTop < windowHeight - revealPoint) {
-          el.classList.add('visible');
-        }
-      });
-    };
-
-    window.addEventListener('scroll', revealOnScroll);
-    window.addEventListener('load', revealOnScroll);
-
-    // Smooth scroll for nav links
-    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-      anchor.addEventListener('click', function(e) {
-        e.preventDefault();
-        const target = document.querySelector(this.getAttribute('href'));
-        if (target) {
-          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-      });
-    });
-
-    // Add staggered animation delay to feature cards and other elements
-    document.querySelectorAll('.features-grid .feature-card').forEach((card, i) => {
-      card.style.transitionDelay = `${i * 0.1}s`;
-    });
-
-    document.querySelectorAll('.live-models__grid .live-model-card').forEach((card, i) => {
-      card.style.transitionDelay = `${i * 0.08}s`;
-    });
-
-    document.querySelectorAll('.how-it-works .step').forEach((step, i) => {
-      step.style.transitionDelay = `${i * 0.15}s`;
-    });
-
-    document.querySelectorAll('.faq-item').forEach((item, i) => {
-      item.style.transitionDelay = `${i * 0.1}s`;
-    });
-
-    // Mobile menu toggle
-    const hamburger = document.querySelector('.nav__hamburger');
-    const mobileOverlay = document.getElementById('mobile-nav-overlay');
-
-    function openMenu() {
-      mobileOverlay.classList.add('open');
-      mobileOverlay.setAttribute('aria-hidden', 'false');
-      hamburger.setAttribute('aria-expanded', 'true');
-      document.body.style.overflow = 'hidden';
-    }
-
-    function closeMenu() {
-      mobileOverlay.classList.remove('open');
-      mobileOverlay.setAttribute('aria-hidden', 'true');
-      hamburger.setAttribute('aria-expanded', 'false');
-      document.body.style.overflow = '';
-    }
-
-    hamburger.addEventListener('click', () => {
-      if (mobileOverlay.classList.contains('open')) {
-        closeMenu();
-      } else {
-        openMenu();
-      }
-    });
-
-    // Close when a nav link is tapped
-    mobileOverlay.querySelectorAll('.nav__link').forEach(link => {
-      link.addEventListener('click', closeMenu);
-    });
-
-    // Close on backdrop tap (click outside the links)
-    mobileOverlay.addEventListener('click', (e) => {
-      if (e.target === mobileOverlay) {
-        closeMenu();
-      }
-    });
-
-    // Close on Escape key
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && mobileOverlay.classList.contains('open')) {
-        closeMenu();
-      }
-    });
-
-    // Brew install copy-to-clipboard
-    const brewInstallBlock = document.querySelector('.brew-install');
-    if (brewInstallBlock) {
-      brewInstallBlock.addEventListener('click', () => {
-        const copyText = brewInstallBlock.querySelector('.brew-install__copy');
-        navigator.clipboard.writeText('brew tap crmitchelmore/justspeaktoit && brew install --cask justspeaktoit').then(() => {
-          if (copyText) {
-            copyText.textContent = 'Copied!';
-            setTimeout(() => { copyText.textContent = 'Click to copy'; }, 1500);
-          }
-        }).catch(() => {
-          if (copyText) {
-            copyText.textContent = 'Copy failed';
-            setTimeout(() => { copyText.textContent = 'Click to copy'; }, 1500);
-          }
-        });
-      });
-    }
-  </script>
 </body>
 </html>

--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -577,8 +577,16 @@
 
     @media (max-width: 1060px) {
       .nav__inner { grid-template-columns: 1fr auto; }
-      .nav__links { display: none; }
-      .hero__inner { grid-template-columns: 1fr; padding-top: 130px; }
+      .nav__links {
+        grid-column: 1 / -1;
+        width: 100%;
+        justify-content: flex-start;
+        overflow-x: auto;
+        padding-bottom: .85rem;
+        scrollbar-width: none;
+      }
+      .nav__links::-webkit-scrollbar { display: none; }
+      .hero__inner { grid-template-columns: 1fr; padding-top: 160px; }
       .hero__copy { max-width: 720px; }
       .product-stage { min-height: 560px; }
       .models__header { grid-template-columns: 1fr; }
@@ -599,7 +607,7 @@
       .nav__download { min-height: 40px; padding: .55rem .75rem; font-size: .82rem; }
       .hero, .hero__inner { min-height: auto; }
       .hero__inner { padding-top: 120px; padding-bottom: 3rem; }
-      .hero h1 { font-size: clamp(3.4rem, 15.5vw, 5rem); }
+      .hero h1 { font-size: clamp(3.4rem, 15.5vw, 5rem); white-space: normal; }
       .hero__lede { font-size: 1rem; }
       .product-stage { min-height: 530px; margin-top: 2rem; }
       .mac-window { right: 0; }
@@ -638,13 +646,13 @@
   </style>
 </head>
 <body>
-  <header class="nav" aria-label="Primary navigation">
+  <header class="nav">
     <div class="shell nav__inner">
       <a class="brand" href="#top" aria-label="Just Speak to It home">
         <span class="brand__wave" aria-hidden="true"><i style="--h:10px"></i><i style="--h:20px"></i><i style="--h:28px"></i><i style="--h:18px"></i><i style="--h:25px"></i><i style="--h:13px"></i></span>
         <span>Just Speak to It</span>
       </a>
-      <nav class="nav__links">
+      <nav class="nav__links" aria-label="Primary navigation">
         <a href="#models">Models</a><a href="#workflow">How it works</a><a href="#apps">Apps</a><a href="#creator">Creator</a>
       </nav>
       <a class="button button--orange nav__download" href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac</a>
@@ -656,7 +664,7 @@
       <div class="shell hero__inner">
         <div class="hero__copy">
           <h1>Your voice.<br>Your model.<br>Your words.</h1>
-          <p class="hero__lede">Fast, private dictation for Mac and iPhone. Run speech models locally, stream with your own provider keys, and paste polished text anywhere.</p>
+          <p class="hero__lede">Fast, private dictation for Mac, iPhone, and iPad. Run speech models locally, stream with your own provider keys, and paste polished text anywhere.</p>
           <div class="hero__actions">
             <a class="button button--orange" href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac <span aria-hidden="true">→</span></a>
             <a class="button button--outline" href="#models">Explore the models</a>
@@ -667,7 +675,7 @@
           <div class="stage-wave" aria-hidden="true">
             <i style="--h:16%;--d:-.2s"></i><i style="--h:28%;--d:-1.1s"></i><i style="--h:52%;--d:-.7s"></i><i style="--h:77%;--d:-1.7s"></i><i style="--h:42%;--d:-.5s"></i><i style="--h:85%;--d:-1.3s"></i><i style="--h:38%;--d:-.9s"></i><i style="--h:64%;--d:-.1s"></i><i style="--h:32%;--d:-1.5s"></i><i style="--h:72%;--d:-.8s"></i><i style="--h:44%;--d:-1.8s"></i><i style="--h:88%;--d:-.4s"></i><i style="--h:56%;--d:-1.2s;--c:#ee7b4f"></i><i style="--h:35%;--d:-.6s;--c:#d98e61"></i><i style="--h:60%;--d:-1.6s;--c:#c29e73"></i><i style="--h:29%;--d:-.3s;--c:#a6ac82"></i><i style="--h:70%;--d:-1s;--c:#80b991"></i><i style="--h:41%;--d:-1.9s;--c:#59bf9d"></i><i style="--h:80%;--d:-.5s;--c:#37b3a2"></i><i style="--h:48%;--d:-1.4s;--c:#159c95"></i><i style="--h:65%;--d:-.8s;--c:#159c95"></i><i style="--h:33%;--d:-.2s;--c:#159c95"></i>
           </div>
-          <div class="mac-window">
+          <div class="mac-window" aria-hidden="true">
             <div class="window-bar">
               <span class="traffic" aria-hidden="true"><i></i><i></i><i></i></span>
               <span class="window-title">Just Speak to It</span><span class="window-live">● Connected</span>


### PR DESCRIPTION
## Motivation
The public site no longer reflects the current transcription and cleanup catalog, and it still frames iOS as a TestFlight beta. This rebuild gives the Mac, Mac App Store, iPhone, and iPad release tracks a clear home while making the local/BYOK model choice understandable.

## What changed
- rebuilt the landing page around a product-led editorial design
- added current live, batch, and cleanup model families from `ModelCatalog`
- added a prefilled “raise an issue” path for missing models
- added direct Mac, Mac App Store, and iPhone/iPad App Store distribution surfaces
- shows accurate in-progress status instead of linking to unpublished App Store URLs
- added the Action Button-to-clipboard workflow
- added creator links to mitchelmore.uk and Pasta
- preserved the deployed privacy route

## Things learned
The previous reveal animation hid all off-screen content from static full-page renders and no-JavaScript visitors, so the new page renders all sections by default. Apple public product URLs return 404 until a first release is approved, so the App Store cards now show release status without publishing dead links.

## How to test
- serve `landing-page` locally
- verify at 1440x1000 and 390x844
- confirm `scrollWidth === clientWidth` at both breakpoints
- click “Explore the models” and confirm the `#models` section is visible
- confirm the model-request, creator, Pasta, privacy, and direct-download destinations
- confirm there are no console or page errors

## Review confidence
High confidence. Desktop and mobile rendered QA pass with no document overflow, runtime errors, or material visual drift from the accepted v3 render. The store-status labels intentionally remain non-links until Apple publishes the products.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the landing page with a streamlined, modern layout.
  * Added prominent marketing sections: Models, Workflow, Apps, Privacy, and Creator.
  * Refreshed the hero area with a product-style interface preview.
  * Updated SEO and social sharing metadata.

* **Changes**
  * Simplified the footer and removed extensive prior marketing elements.
  * Removed interactive behaviors such as scroll-based reveals, mobile menu interactions, smooth hash navigation, and click-to-copy functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->