### PR TITLE
fix(mac): prepare Mac App Store release channel

### DIFF
--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -1,5 +1,15 @@
 name: Release to Mac App Store
 
+# Manual signing prerequisites:
+# - APPLE_TEAM_ID
+# - APP_STORE_CONNECT_API_KEY (base64 App Store Connect AuthKey .p8)
+# - APP_STORE_CONNECT_ISSUER_ID
+# - MAC_APP_DISTRIBUTION_P12 and MAC_APP_DISTRIBUTION_PASSWORD
+# - MAC_INSTALLER_DISTRIBUTION_P12 and MAC_INSTALLER_DISTRIBUTION_PASSWORD
+# - MAC_APP_STORE_PROFILE (base64 Mac App Store provisioning profile)
+# This workflow reuses existing signing assets only; it does not create certificates
+# or provisioning profiles.
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,11 +22,14 @@ env:
   PRODUCT_NAME: JustSpeakToIt
   WORKSPACE: "Just Speak to It.xcworkspace"
   BUNDLE_ID: com.justspeaktoit.mac
+  # Matches the existing Release iOS workflow convention. This is the ASC key ID,
+  # not the private key; the private key must remain in APP_STORE_CONNECT_API_KEY.
+  APP_STORE_CONNECT_KEY_ID: S747NJ9DZY
 
 jobs:
   build-and-upload:
     runs-on: macos-15
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -29,8 +42,18 @@ jobs:
           xcode-version: latest-stable
 
       - name: Install Tuist
+        run: brew install tuist
+
+      - name: Install App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         run: |
-          brew install tuist
+          if [ -z "$APP_STORE_CONNECT_API_KEY" ]; then
+            echo "::error::APP_STORE_CONNECT_API_KEY secret is required"
+            exit 1
+          fi
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$APP_STORE_CONNECT_API_KEY" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8
 
       - name: Import Code Signing Certificates
         env:
@@ -39,84 +62,168 @@ jobs:
           MAC_INSTALLER_DISTRIBUTION_P12: ${{ secrets.MAC_INSTALLER_DISTRIBUTION_P12 }}
           MAC_INSTALLER_DISTRIBUTION_PASSWORD: ${{ secrets.MAC_INSTALLER_DISTRIBUTION_PASSWORD }}
         run: |
-          # Create temporary keychain
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-          
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          
-          # Import Mac App Distribution certificate
-          if [ -n "$MAC_APP_DISTRIBUTION_P12" ]; then
-            echo -n "$MAC_APP_DISTRIBUTION_P12" | base64 --decode -o $RUNNER_TEMP/mac-app-dist.p12
-            security import $RUNNER_TEMP/mac-app-dist.p12 -P "$MAC_APP_DISTRIBUTION_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-            rm -f $RUNNER_TEMP/mac-app-dist.p12
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+          if [ -z "$MAC_APP_DISTRIBUTION_P12" ]; then
+            echo "::error::MAC_APP_DISTRIBUTION_P12 secret is required"
+            exit 1
           fi
-          
-          # Import Mac Installer Distribution certificate (optional, for pkg)
-          if [ -n "$MAC_INSTALLER_DISTRIBUTION_P12" ]; then
-            echo -n "$MAC_INSTALLER_DISTRIBUTION_P12" | base64 --decode -o $RUNNER_TEMP/mac-installer-dist.p12
-            security import $RUNNER_TEMP/mac-installer-dist.p12 -P "$MAC_INSTALLER_DISTRIBUTION_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-            rm -f $RUNNER_TEMP/mac-installer-dist.p12
+          if [ -z "$MAC_APP_DISTRIBUTION_PASSWORD" ]; then
+            echo "::error::MAC_APP_DISTRIBUTION_PASSWORD secret is required"
+            exit 1
           fi
-          
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+          CERT_PATH="$RUNNER_TEMP/mac-app-dist.p12"
+          echo -n "$MAC_APP_DISTRIBUTION_P12" | base64 --decode -o "$CERT_PATH"
+          security import "$CERT_PATH" -P "$MAC_APP_DISTRIBUTION_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
+          if [ -z "$MAC_INSTALLER_DISTRIBUTION_P12" ]; then
+            echo "::error::MAC_INSTALLER_DISTRIBUTION_P12 secret is required"
+            exit 1
+          fi
+          if [ -z "$MAC_INSTALLER_DISTRIBUTION_PASSWORD" ]; then
+            echo "::error::MAC_INSTALLER_DISTRIBUTION_PASSWORD secret is required"
+            exit 1
+          fi
+          INSTALLER_CERT_PATH="$RUNNER_TEMP/mac-installer-dist.p12"
+          echo -n "$MAC_INSTALLER_DISTRIBUTION_P12" | base64 --decode -o "$INSTALLER_CERT_PATH"
+          security import "$INSTALLER_CERT_PATH" -P "$MAC_INSTALLER_DISTRIBUTION_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          rm -f "$INSTALLER_CERT_PATH"
+
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
       - name: Install Provisioning Profile
         env:
           MAC_APP_STORE_PROFILE: ${{ secrets.MAC_APP_STORE_PROFILE }}
         run: |
+          if [ -z "$MAC_APP_STORE_PROFILE" ]; then
+            echo "::error::MAC_APP_STORE_PROFILE secret is required"
+            exit 1
+          fi
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo -n "$MAC_APP_STORE_PROFILE" | base64 --decode -o ~/Library/MobileDevice/Provisioning\ Profiles/mac-app-store.provisionprofile
+          PROFILE_PATH="$HOME/Library/MobileDevice/Provisioning Profiles/mac-app-store.provisionprofile"
+          echo -n "$MAC_APP_STORE_PROFILE" | base64 --decode -o "$PROFILE_PATH"
+          MAC_PROFILE_UUID=$(security cms -D -i "$PROFILE_PATH" | plutil -extract UUID raw -)
+          MAC_PROFILE_NAME=$(security cms -D -i "$PROFILE_PATH" | plutil -extract Name raw -)
+          echo "MAC_PROFILE_UUID=$MAC_PROFILE_UUID" >> "$GITHUB_ENV"
+          echo "MAC_PROFILE_NAME=$MAC_PROFILE_NAME" >> "$GITHUB_ENV"
 
       - name: Generate Xcode Project
         env:
           TUIST_APP_STORE: "1"
         run: |
-          # TUIST_APP_STORE=1 makes Project.swift define the APP_STORE compilation
-          # condition (compiling out Sparkle self-update and the downloaded
-          # local-model runtimes) and select the sandboxed entitlements file
-          # Config/SpeakMacOS.AppStore.entitlements. Mac App Store REQUIRES the sandbox.
-          # The var MUST be TUIST_-prefixed: Tuist only forwards TUIST_* env vars into
-          # manifest evaluation, so a plain APP_STORE=1 would be silently ignored.
+          # TUIST_APP_STORE=1 selects the sandboxed App Store flavour: APP_STORE
+          # compilation, Config/SpeakMacOS.AppStore.entitlements,
+          # Config/AppInfo.AppStore.plist, and no Sparkle target dependency.
+          export TUIST_MAC_PROFILE_NAME="$MAC_PROFILE_NAME"
           tuist generate --no-open
 
       - name: Update Version
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          # Update VERSION file
           echo "$VERSION" > VERSION
-          
-          # Update Info.plist
-          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" Config/AppInfo.plist
-          
-          # Increment build number based on run number
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" Config/AppInfo.AppStore.plist
           BUILD_NUMBER=${{ github.run_number }}
-          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" Config/AppInfo.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" Config/AppInfo.AppStore.plist
 
       - name: Build Release Archive
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          if [ -z "$APPLE_TEAM_ID" ]; then
+            echo "::error::APPLE_TEAM_ID secret is required"
+            exit 1
+          fi
+          if [ -z "$MAC_PROFILE_NAME" ]; then
+            echo "::error::Installed Mac App Store provisioning profile name is required"
+            exit 1
+          fi
           xcodebuild archive \
             -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \
             -configuration Release \
-            -archivePath $RUNNER_TEMP/$PRODUCT_NAME.xcarchive \
+            -archivePath "$RUNNER_TEMP/$PRODUCT_NAME.xcarchive" \
             -destination "generic/platform=macOS" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CODE_SIGN_STYLE=Automatic \
-            PRODUCT_BUNDLE_IDENTIFIER=$BUNDLE_ID \
-            -allowProvisioningUpdates
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            PROVISIONING_PROFILE_SPECIFIER="$MAC_PROFILE_NAME" \
+            PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID"
 
-      - name: Export for App Store
+      - name: Validate App Store Archive
+        run: |
+          APP_PATH="$RUNNER_TEMP/$PRODUCT_NAME.xcarchive/Products/Applications/$PRODUCT_NAME.app"
+          INFO_PLIST="$APP_PATH/Contents/Info.plist"
+          ENTITLEMENTS_PLIST="build/appstore-archive-entitlements.plist"
+          mkdir -p build
+
+          if [ ! -d "$APP_PATH" ]; then
+            echo "::error::Archived app not found at $APP_PATH"
+            exit 1
+          fi
+
+          codesign -d --entitlements :- "$APP_PATH" > "$ENTITLEMENTS_PLIST"
+
+          expect_entitlement_true() {
+            key="$1"
+            value=$(/usr/libexec/PlistBuddy -c "Print :$key" "$ENTITLEMENTS_PLIST" 2>/dev/null || true)
+            if [ "$value" != "true" ]; then
+              echo "::error::Missing required true entitlement: $key"
+              exit 1
+            fi
+          }
+
+          expect_entitlement_absent() {
+            key="$1"
+            if /usr/libexec/PlistBuddy -c "Print :$key" "$ENTITLEMENTS_PLIST" >/dev/null 2>&1; then
+              echo "::error::Forbidden entitlement present: $key"
+              exit 1
+            fi
+          }
+
+          expect_info_key_absent() {
+            key="$1"
+            if /usr/libexec/PlistBuddy -c "Print :$key" "$INFO_PLIST" >/dev/null 2>&1; then
+              echo "::error::Forbidden Info.plist key present in App Store build: $key"
+              exit 1
+            fi
+          }
+
+          expect_entitlement_true com.apple.security.app-sandbox
+          expect_entitlement_true com.apple.security.network.server
+          expect_entitlement_absent com.apple.security.cs.disable-library-validation
+
+          if [ -d "$APP_PATH/Contents/Frameworks/Sparkle.framework" ]; then
+            echo "::error::Sparkle.framework must not be embedded in the App Store build"
+            exit 1
+          fi
+
+          expect_info_key_absent SUEnableAutomaticChecks
+          expect_info_key_absent SUFeedURL
+          expect_info_key_absent SUPublicEDKey
+          expect_info_key_absent SUScheduledCheckInterval
+
+      - name: Export and Upload to App Store Connect
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
-          # Create export options plist for App Store
-          cat > $RUNNER_TEMP/ExportOptions.plist << EOF
+          if [ -z "$APP_STORE_CONNECT_ISSUER_ID" ]; then
+            echo "::error::APP_STORE_CONNECT_ISSUER_ID secret is required"
+            exit 1
+          fi
+          if [ -z "$MAC_PROFILE_UUID" ]; then
+            echo "::error::Installed Mac App Store provisioning profile UUID is required"
+            exit 1
+          fi
+
+          cat > build/ExportOptions-AppStore.plist << 'PLIST'
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -124,49 +231,40 @@ jobs:
               <key>method</key>
               <string>app-store-connect</string>
               <key>teamID</key>
-              <string>$APPLE_TEAM_ID</string>
+              <string>APPLE_TEAM_ID_PLACEHOLDER</string>
               <key>signingStyle</key>
-              <string>automatic</string>
+              <string>manual</string>
+              <key>signingCertificate</key>
+              <string>Apple Distribution</string>
+              <key>installerSigningCertificate</key>
+              <string>Mac Installer Distribution</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>com.justspeaktoit.mac</key>
+                  <string>MAC_PROFILE_UUID_PLACEHOLDER</string>
+              </dict>
               <key>uploadSymbols</key>
               <true/>
               <key>destination</key>
               <string>upload</string>
           </dict>
           </plist>
-          EOF
-          
-          xcodebuild -exportArchive \
-            -archivePath $RUNNER_TEMP/$PRODUCT_NAME.xcarchive \
-            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist \
-            -exportPath $RUNNER_TEMP/export \
-            -allowProvisioningUpdates
+          PLIST
 
-      - name: Upload to App Store Connect
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          # Find the pkg or app
-          if [ -f "$RUNNER_TEMP/export/$PRODUCT_NAME.pkg" ]; then
-            UPLOAD_FILE="$RUNNER_TEMP/export/$PRODUCT_NAME.pkg"
-          else
-            UPLOAD_FILE="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
-          fi
-          
-          xcrun notarytool store-credentials "AC_PASSWORD" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_ID_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID"
-          
-          xcrun altool --upload-app \
-            --file "$UPLOAD_FILE" \
-            --type macos \
-            --apiKey "$APPLE_ID" \
-            --apiIssuer "$APPLE_TEAM_ID" \
-            || echo "Upload via altool - check App Store Connect for status"
+          sed -i '' "s/APPLE_TEAM_ID_PLACEHOLDER/${APPLE_TEAM_ID}/g" build/ExportOptions-AppStore.plist
+          sed -i '' "s/MAC_PROFILE_UUID_PLACEHOLDER/${MAC_PROFILE_UUID}/g" build/ExportOptions-AppStore.plist
+
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/$PRODUCT_NAME.xcarchive" \
+            -exportOptionsPlist build/ExportOptions-AppStore.plist \
+            -exportPath build/appstore-export \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8 \
+            -authenticationKeyID ${{ env.APP_STORE_CONNECT_KEY_ID }} \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
+
+          echo "✅ Build exported and uploaded to App Store Connect"
 
       - name: Cleanup Keychain
         if: always()
         run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
+          security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" || true

--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -1,14 +1,13 @@
 name: Release to Mac App Store
 
-# Manual signing prerequisites:
+# Release prerequisites:
 # - APPLE_TEAM_ID
 # - APP_STORE_CONNECT_API_KEY (base64 App Store Connect AuthKey .p8)
 # - APP_STORE_CONNECT_ISSUER_ID
-# - MAC_APP_DISTRIBUTION_P12 and MAC_APP_DISTRIBUTION_PASSWORD
-# - MAC_INSTALLER_DISTRIBUTION_P12 and MAC_INSTALLER_DISTRIBUTION_PASSWORD
-# - MAC_APP_STORE_PROFILE (base64 Mac App Store provisioning profile)
-# This workflow reuses existing signing assets only; it does not create certificates
-# or provisioning profiles.
+# - IOS_DISTRIBUTION_P12 and IOS_DISTRIBUTION_PASSWORD (the existing Apple
+#   Distribution certificate is valid for both iOS and Mac App Store apps)
+# Xcode manages the Mac App Store provisioning profile and installer signing
+# through the App Store Connect API key. No duplicate Mac-only secrets are needed.
 
 on:
   workflow_dispatch:
@@ -57,10 +56,8 @@ jobs:
 
       - name: Import Code Signing Certificates
         env:
-          MAC_APP_DISTRIBUTION_P12: ${{ secrets.MAC_APP_DISTRIBUTION_P12 }}
-          MAC_APP_DISTRIBUTION_PASSWORD: ${{ secrets.MAC_APP_DISTRIBUTION_PASSWORD }}
-          MAC_INSTALLER_DISTRIBUTION_P12: ${{ secrets.MAC_INSTALLER_DISTRIBUTION_P12 }}
-          MAC_INSTALLER_DISTRIBUTION_PASSWORD: ${{ secrets.MAC_INSTALLER_DISTRIBUTION_PASSWORD }}
+          APPLE_DISTRIBUTION_P12: ${{ secrets.IOS_DISTRIBUTION_P12 }}
+          APPLE_DISTRIBUTION_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_PASSWORD }}
         run: |
           KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
@@ -70,49 +67,19 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH"
 
-          if [ -z "$MAC_APP_DISTRIBUTION_P12" ]; then
-            echo "::error::MAC_APP_DISTRIBUTION_P12 secret is required"
+          if [ -z "$APPLE_DISTRIBUTION_P12" ]; then
+            echo "::error::IOS_DISTRIBUTION_P12 secret is required"
             exit 1
           fi
-          if [ -z "$MAC_APP_DISTRIBUTION_PASSWORD" ]; then
-            echo "::error::MAC_APP_DISTRIBUTION_PASSWORD secret is required"
+          if [ -z "$APPLE_DISTRIBUTION_PASSWORD" ]; then
+            echo "::error::IOS_DISTRIBUTION_PASSWORD secret is required"
             exit 1
           fi
-          CERT_PATH="$RUNNER_TEMP/mac-app-dist.p12"
-          echo -n "$MAC_APP_DISTRIBUTION_P12" | base64 --decode -o "$CERT_PATH"
-          security import "$CERT_PATH" -P "$MAC_APP_DISTRIBUTION_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          CERT_PATH="$RUNNER_TEMP/apple-distribution.p12"
+          echo -n "$APPLE_DISTRIBUTION_P12" | base64 --decode -o "$CERT_PATH"
+          security import "$CERT_PATH" -P "$APPLE_DISTRIBUTION_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           rm -f "$CERT_PATH"
-
-          if [ -z "$MAC_INSTALLER_DISTRIBUTION_P12" ]; then
-            echo "::error::MAC_INSTALLER_DISTRIBUTION_P12 secret is required"
-            exit 1
-          fi
-          if [ -z "$MAC_INSTALLER_DISTRIBUTION_PASSWORD" ]; then
-            echo "::error::MAC_INSTALLER_DISTRIBUTION_PASSWORD secret is required"
-            exit 1
-          fi
-          INSTALLER_CERT_PATH="$RUNNER_TEMP/mac-installer-dist.p12"
-          echo -n "$MAC_INSTALLER_DISTRIBUTION_P12" | base64 --decode -o "$INSTALLER_CERT_PATH"
-          security import "$INSTALLER_CERT_PATH" -P "$MAC_INSTALLER_DISTRIBUTION_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          rm -f "$INSTALLER_CERT_PATH"
-
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-      - name: Install Provisioning Profile
-        env:
-          MAC_APP_STORE_PROFILE: ${{ secrets.MAC_APP_STORE_PROFILE }}
-        run: |
-          if [ -z "$MAC_APP_STORE_PROFILE" ]; then
-            echo "::error::MAC_APP_STORE_PROFILE secret is required"
-            exit 1
-          fi
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          PROFILE_PATH="$HOME/Library/MobileDevice/Provisioning Profiles/mac-app-store.provisionprofile"
-          echo -n "$MAC_APP_STORE_PROFILE" | base64 --decode -o "$PROFILE_PATH"
-          MAC_PROFILE_UUID=$(security cms -D -i "$PROFILE_PATH" | plutil -extract UUID raw -)
-          MAC_PROFILE_NAME=$(security cms -D -i "$PROFILE_PATH" | plutil -extract Name raw -)
-          echo "MAC_PROFILE_UUID=$MAC_PROFILE_UUID" >> "$GITHUB_ENV"
-          echo "MAC_PROFILE_NAME=$MAC_PROFILE_NAME" >> "$GITHUB_ENV"
 
       - name: Generate Xcode Project
         env:
@@ -121,7 +88,6 @@ jobs:
           # TUIST_APP_STORE=1 selects the sandboxed App Store flavour: APP_STORE
           # compilation, Config/SpeakMacOS.AppStore.entitlements,
           # Config/AppInfo.AppStore.plist, and no Sparkle target dependency.
-          export TUIST_MAC_PROFILE_NAME="$MAC_PROFILE_NAME"
           tuist generate --no-open
 
       - name: Update Version
@@ -135,13 +101,14 @@ jobs:
       - name: Build Release Archive
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           if [ -z "$APPLE_TEAM_ID" ]; then
             echo "::error::APPLE_TEAM_ID secret is required"
             exit 1
           fi
-          if [ -z "$MAC_PROFILE_NAME" ]; then
-            echo "::error::Installed Mac App Store provisioning profile name is required"
+          if [ -z "$APP_STORE_CONNECT_ISSUER_ID" ]; then
+            echo "::error::APP_STORE_CONNECT_ISSUER_ID secret is required"
             exit 1
           fi
           xcodebuild archive \
@@ -151,10 +118,12 @@ jobs:
             -archivePath "$RUNNER_TEMP/$PRODUCT_NAME.xcarchive" \
             -destination "generic/platform=macOS" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="$MAC_PROFILE_NAME" \
-            PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID"
+            CODE_SIGN_STYLE=Automatic \
+            PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
+            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
 
       - name: Validate App Store Archive
         run: |
@@ -218,11 +187,6 @@ jobs:
             echo "::error::APP_STORE_CONNECT_ISSUER_ID secret is required"
             exit 1
           fi
-          if [ -z "$MAC_PROFILE_UUID" ]; then
-            echo "::error::Installed Mac App Store provisioning profile UUID is required"
-            exit 1
-          fi
-
           cat > build/ExportOptions-AppStore.plist << 'PLIST'
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -233,16 +197,7 @@ jobs:
               <key>teamID</key>
               <string>APPLE_TEAM_ID_PLACEHOLDER</string>
               <key>signingStyle</key>
-              <string>manual</string>
-              <key>signingCertificate</key>
-              <string>Apple Distribution</string>
-              <key>installerSigningCertificate</key>
-              <string>Mac Installer Distribution</string>
-              <key>provisioningProfiles</key>
-              <dict>
-                  <key>com.justspeaktoit.mac</key>
-                  <string>MAC_PROFILE_UUID_PLACEHOLDER</string>
-              </dict>
+              <string>automatic</string>
               <key>uploadSymbols</key>
               <true/>
               <key>destination</key>
@@ -252,12 +207,12 @@ jobs:
           PLIST
 
           sed -i '' "s/APPLE_TEAM_ID_PLACEHOLDER/${APPLE_TEAM_ID}/g" build/ExportOptions-AppStore.plist
-          sed -i '' "s/MAC_PROFILE_UUID_PLACEHOLDER/${MAC_PROFILE_UUID}/g" build/ExportOptions-AppStore.plist
 
           xcodebuild -exportArchive \
             -archivePath "$RUNNER_TEMP/$PRODUCT_NAME.xcarchive" \
             -exportOptionsPlist build/ExportOptions-AppStore.plist \
             -exportPath build/appstore-export \
+            -allowProvisioningUpdates \
             -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8 \
             -authenticationKeyID ${{ env.APP_STORE_CONNECT_KEY_ID }} \
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"

--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -110,8 +110,30 @@ jobs:
           tuist generate --no-open
 
       - name: Update Version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must use X.Y.Z format"
+            exit 1
+          fi
+
+          LATEST_TAG="$(gh release list \
+            --repo "${{ github.repository }}" \
+            --exclude-drafts \
+            --limit 100 \
+            --json tagName \
+            --jq '[.[] | select(.tagName | startswith("mac-v"))][0].tagName // empty')"
+          if [ -z "$LATEST_TAG" ]; then
+            echo "::error::No published mac-v* GitHub release found"
+            exit 1
+          fi
+          if [ "$LATEST_TAG" != "mac-v$VERSION" ]; then
+            echo "::error::Version $VERSION does not match latest macOS release $LATEST_TAG"
+            exit 1
+          fi
+
           echo "$VERSION" > VERSION
           /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" Config/AppInfo.AppStore.plist
           BUILD_NUMBER=${{ github.run_number }}

--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -6,8 +6,10 @@ name: Release to Mac App Store
 # - APP_STORE_CONNECT_ISSUER_ID
 # - IOS_DISTRIBUTION_P12 and IOS_DISTRIBUTION_PASSWORD (the existing Apple
 #   Distribution certificate is valid for both iOS and Mac App Store apps)
-# Xcode manages the Mac App Store provisioning profile and installer signing
-# through the App Store Connect API key. No duplicate Mac-only secrets are needed.
+# - MAC_APP_STORE_PROFILE (base64 Mac App Store provisioning profile)
+# The archive reuses the existing cross-platform Apple Distribution identity.
+# The App Store Connect API key remains responsible only for the upload, matching
+# the working iOS release lane; it does not need provisioning-resource access.
 
 on:
   workflow_dispatch:
@@ -81,6 +83,22 @@ jobs:
           rm -f "$CERT_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
+      - name: Install Mac App Store Provisioning Profile
+        env:
+          MAC_APP_STORE_PROFILE: ${{ secrets.MAC_APP_STORE_PROFILE }}
+        run: |
+          if [ -z "$MAC_APP_STORE_PROFILE" ]; then
+            echo "::error::MAC_APP_STORE_PROFILE secret is required"
+            exit 1
+          fi
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          PROFILE_PATH="$HOME/Library/MobileDevice/Provisioning Profiles/mac-app-store.provisionprofile"
+          echo -n "$MAC_APP_STORE_PROFILE" | base64 --decode -o "$PROFILE_PATH"
+          MAC_PROFILE_UUID=$(security cms -D -i "$PROFILE_PATH" | plutil -extract UUID raw -)
+          MAC_PROFILE_NAME=$(security cms -D -i "$PROFILE_PATH" | plutil -extract Name raw -)
+          echo "MAC_PROFILE_UUID=$MAC_PROFILE_UUID" >> "$GITHUB_ENV"
+          echo "MAC_PROFILE_NAME=$MAC_PROFILE_NAME" >> "$GITHUB_ENV"
+
       - name: Generate Xcode Project
         env:
           TUIST_APP_STORE: "1"
@@ -88,6 +106,7 @@ jobs:
           # TUIST_APP_STORE=1 selects the sandboxed App Store flavour: APP_STORE
           # compilation, Config/SpeakMacOS.AppStore.entitlements,
           # Config/AppInfo.AppStore.plist, and no Sparkle target dependency.
+          export TUIST_MAC_PROFILE_NAME="$MAC_PROFILE_NAME"
           tuist generate --no-open
 
       - name: Update Version
@@ -101,14 +120,13 @@ jobs:
       - name: Build Release Archive
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           if [ -z "$APPLE_TEAM_ID" ]; then
             echo "::error::APPLE_TEAM_ID secret is required"
             exit 1
           fi
-          if [ -z "$APP_STORE_CONNECT_ISSUER_ID" ]; then
-            echo "::error::APP_STORE_CONNECT_ISSUER_ID secret is required"
+          if [ -z "$MAC_PROFILE_NAME" ]; then
+            echo "::error::Installed Mac App Store provisioning profile name is required"
             exit 1
           fi
           xcodebuild archive \
@@ -118,12 +136,11 @@ jobs:
             -archivePath "$RUNNER_TEMP/$PRODUCT_NAME.xcarchive" \
             -destination "generic/platform=macOS" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            PROVISIONING_PROFILE_SPECIFIER="$MAC_PROFILE_NAME" \
             PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8" \
-            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
-            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
+            OTHER_CODE_SIGN_FLAGS="--keychain $RUNNER_TEMP/app-signing.keychain-db"
 
       - name: Validate App Store Archive
         run: |
@@ -187,6 +204,10 @@ jobs:
             echo "::error::APP_STORE_CONNECT_ISSUER_ID secret is required"
             exit 1
           fi
+          if [ -z "$MAC_PROFILE_UUID" ]; then
+            echo "::error::Installed Mac App Store provisioning profile UUID is required"
+            exit 1
+          fi
           cat > build/ExportOptions-AppStore.plist << 'PLIST'
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -197,7 +218,14 @@ jobs:
               <key>teamID</key>
               <string>APPLE_TEAM_ID_PLACEHOLDER</string>
               <key>signingStyle</key>
-              <string>automatic</string>
+              <string>manual</string>
+              <key>signingCertificate</key>
+              <string>Apple Distribution</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>com.justspeaktoit.mac</key>
+                  <string>MAC_PROFILE_UUID_PLACEHOLDER</string>
+              </dict>
               <key>uploadSymbols</key>
               <true/>
               <key>destination</key>
@@ -207,12 +235,12 @@ jobs:
           PLIST
 
           sed -i '' "s/APPLE_TEAM_ID_PLACEHOLDER/${APPLE_TEAM_ID}/g" build/ExportOptions-AppStore.plist
+          sed -i '' "s/MAC_PROFILE_UUID_PLACEHOLDER/${MAC_PROFILE_UUID}/g" build/ExportOptions-AppStore.plist
 
           xcodebuild -exportArchive \
             -archivePath "$RUNNER_TEMP/$PRODUCT_NAME.xcarchive" \
             -exportOptionsPlist build/ExportOptions-AppStore.plist \
             -exportPath build/appstore-export \
-            -allowProvisioningUpdates \
             -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8 \
             -authenticationKeyID ${{ env.APP_STORE_CONNECT_KEY_ID }} \
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"

--- a/Config/AppInfo.AppStore.plist
+++ b/Config/AppInfo.AppStore.plist
@@ -24,6 +24,13 @@
 	<string>1</string>
 	<key>GitCommitSHA</key>
 	<string></string>
+	<!-- Export compliance: the app uses only standard, published encryption
+	     (AES-GCM and PBKDF2 via CryptoKit) to protect the user's own API keys for
+	     end-to-end encrypted iCloud/CloudKit key sync, alongside OS-provided HTTPS
+	     and Keychain. This qualifies for the U.S. EAR Category 5 Part 2 export
+	     exemption, so the app uses no *non-exempt* encryption. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSArchitecturePriority</key>

--- a/Config/AppInfo.AppStore.plist
+++ b/Config/AppInfo.AppStore.plist
@@ -24,13 +24,6 @@
 	<string>1</string>
 	<key>GitCommitSHA</key>
 	<string></string>
-	<!-- Export compliance: the app uses only standard, published encryption
-	     (AES-GCM and PBKDF2 via CryptoKit) to protect the user's own API keys for
-	     end-to-end encrypted iCloud/CloudKit key sync, alongside OS-provided HTTPS
-	     and Keychain. This qualifies for the U.S. EAR Category 5 Part 2 export
-	     exemption, so the app uses no *non-exempt* encryption. -->
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSArchitecturePriority</key>
@@ -62,13 +55,5 @@
 	<true/>
 	<key>NSSupportsSuddenTermination</key>
 	<false/>
-	<key>SUEnableAutomaticChecks</key>
-	<true/>
-	<key>SUFeedURL</key>
-	<string>https://justspeaktoit.com/appcast.xml</string>
-	<key>SUPublicEDKey</key>
-	<string>amLMkCNmSNgwrbpuN+cW6RFxKApcZL/ylhCS5JZLXRE=</string>
-	<key>SUScheduledCheckInterval</key>
-	<integer>86400</integer>
 </dict>
 </plist>

--- a/Config/SpeakMacOS.AppStore.entitlements
+++ b/Config/SpeakMacOS.AppStore.entitlements
@@ -14,9 +14,10 @@
   build. SyncConfiguration/SettingsSync detect these at runtime and fall back
   gracefully when absent.
 
-  NOTE: Sandboxed apps cannot auto-prompt for Accessibility / Input Monitoring;
-  users must add the app manually in System Settings. The in-app permission
-  helpers guide them through this (see PermissionsManager + onboarding).
+  NOTE: Only Accessibility lacks an automatic prompt in sandboxed builds; users
+  must add the app manually in System Settings. Input Monitoring can still prompt
+  via CGRequestListenEventAccess. The in-app permission helpers guide users
+  through this (see PermissionsManager + onboarding).
 -->
 <plist version="1.0">
 <dict>
@@ -32,12 +33,12 @@
 	<key>com.apple.security.network.client</key>
 	<true/>
 
-	<!-- User-selected files (import/export audio + transcripts) -->
-	<key>com.apple.security.files.user-selected.read-write</key>
+	<!-- Inbound Bonjour listener for Send to Mac local-network transfer -->
+	<key>com.apple.security.network.server</key>
 	<true/>
 
-	<!-- AppleScript/Automation - send events to other apps for text insertion -->
-	<key>com.apple.security.automation.apple-events</key>
+	<!-- User-selected files (import/export audio + transcripts) -->
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 
 	<!-- Shared keychain (App Store managed profile supports this) -->

--- a/Project.swift
+++ b/Project.swift
@@ -80,6 +80,7 @@ if let widgetProfileName {
 
 if isAppStoreBuild {
     macAppSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) APP_STORE"
+    macAppSettings["CODE_SIGN_IDENTITY"] = "Apple Distribution"
     if let macAppStoreProfileName, !macAppStoreProfileName.isEmpty {
         configureManualSigning(for: &macAppSettings, profileName: macAppStoreProfileName)
     }

--- a/Project.swift
+++ b/Project.swift
@@ -12,6 +12,8 @@ let version: String = {
 
 let appProfileName = ProcessInfo.processInfo.environment["APP_PROFILE_NAME"]
 let widgetProfileName = ProcessInfo.processInfo.environment["WIDGET_PROFILE_NAME"]
+let macAppStoreProfileName = ProcessInfo.processInfo.environment["TUIST_MAC_PROFILE_NAME"]
+    ?? ProcessInfo.processInfo.environment["MAC_PROFILE_NAME"]
 
 var iosAppSettings: [String: SettingValue] = [
     "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
@@ -47,15 +49,15 @@ let isAppStoreBuild = ["1", "true", "yes"].contains(appStoreFlag)
 let macEntitlementsPath = isAppStoreBuild
     ? "Config/SpeakMacOS.AppStore.entitlements"
     : "Config/SpeakMacOS.entitlements"
+let macInfoPlistPath = isAppStoreBuild
+    ? "Config/AppInfo.AppStore.plist"
+    : "Config/AppInfo.plist"
 var macAppSettings: [String: SettingValue] = [
     "DEVELOPMENT_TEAM": "8X4ZN58TYH",
     "CODE_SIGN_STYLE": "Automatic",
     "CODE_SIGN_IDENTITY": "Apple Development",
     "PRODUCT_BUNDLE_IDENTIFIER": "com.justspeaktoit.mac"
 ]
-if isAppStoreBuild {
-    macAppSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) APP_STORE"
-}
 
 var iosWidgetSettings: [String: SettingValue] = [
     "CURRENT_PROJECT_VERSION": "1",
@@ -76,15 +78,40 @@ if let widgetProfileName {
     configureManualSigning(for: &iosWidgetSettings, profileName: widgetProfileName)
 }
 
+if isAppStoreBuild {
+    macAppSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) APP_STORE"
+    if let macAppStoreProfileName, !macAppStoreProfileName.isEmpty {
+        configureManualSigning(for: &macAppSettings, profileName: macAppStoreProfileName)
+    }
+}
+
+var projectPackages: [Package] = [
+    .package(path: .relativeToRoot(".")),
+    .remote(url: "https://github.com/getsentry/sentry-cocoa.git", requirement: .upToNextMajor(from: "9.3.0")),
+    .remote(url: "https://github.com/argmaxinc/argmax-oss-swift.git", requirement: .upToNextMajor(from: "0.9.0"))
+]
+if !isAppStoreBuild {
+    projectPackages.insert(
+        .remote(url: "https://github.com/sparkle-project/Sparkle.git", requirement: .upToNextMajor(from: "2.6.0")),
+        at: 1
+    )
+}
+
+var macAppDependencies: [TargetDependency] = [
+    .package(product: "SpeakCore"),
+    .package(product: "SpeakSync"),
+    .package(product: "SpeakHotKeys"),
+    .package(product: "WhisperKit"),
+    .package(product: "Sentry")
+]
+if !isAppStoreBuild {
+    macAppDependencies.insert(.package(product: "Sparkle"), at: macAppDependencies.count - 1)
+}
+
 let project = Project(
     name: "Just Speak to It",
     organizationName: "Just Speak to It",
-    packages: [
-        .package(path: .relativeToRoot(".")),
-        .remote(url: "https://github.com/sparkle-project/Sparkle.git", requirement: .upToNextMajor(from: "2.6.0")),
-        .remote(url: "https://github.com/getsentry/sentry-cocoa.git", requirement: .upToNextMajor(from: "9.3.0")),
-        .remote(url: "https://github.com/argmaxinc/argmax-oss-swift.git", requirement: .upToNextMajor(from: "0.9.0"))
-    ],
+    packages: projectPackages,
     settings: .settings(
         base: [
             "DEVELOPMENT_TEAM": "8X4ZN58TYH",
@@ -99,21 +126,14 @@ let project = Project(
             productName: "JustSpeakToIt",
             bundleId: "com.justspeaktoit.mac",
             deploymentTargets: .macOS("14.0"),
-            infoPlist: .file(path: "Config/AppInfo.plist"),
+            infoPlist: .file(path: .relativeToRoot(macInfoPlistPath)),
             sources: ["Sources/SpeakApp/**"],
             resources: [
                 .glob(pattern: "Resources/AppIcon.icns"),
                 .glob(pattern: "Resources/Sounds/**")
             ],
             entitlements: .file(path: .relativeToRoot(macEntitlementsPath)),
-            dependencies: [
-                .package(product: "SpeakCore"),
-                .package(product: "SpeakSync"),
-                .package(product: "SpeakHotKeys"),
-                .package(product: "WhisperKit"),
-                .package(product: "Sparkle"),
-                .package(product: "Sentry")
-            ],
+            dependencies: macAppDependencies,
             settings: .settings(base: macAppSettings)
         ),
         .target(
@@ -131,6 +151,9 @@ let project = Project(
                 "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
                 "NSMicrophoneUsageDescription": "Just Speak to It needs microphone access for voice transcription.",
                 "NSSpeechRecognitionUsageDescription": "Just Speak to It uses speech recognition to transcribe your voice.",
+                "NSLocalNetworkUsageDescription":
+                    "Just Speak to It uses your local network to connect iPhone and Mac for Send to Mac transcription transfer.",
+                "NSBonjourServices": ["_speaktransport._tcp"],
                 "NSCameraUsageDescription": "Just Speak to It does not use the camera, but a linked library requires this declaration.",
                 // Export compliance: the app uses only standard, published encryption
                 // (AES-GCM and PBKDF2 via CryptoKit) to protect the user's own API keys

--- a/Project.swift
+++ b/Project.swift
@@ -92,9 +92,8 @@ var projectPackages: [Package] = [
     .remote(url: "https://github.com/argmaxinc/argmax-oss-swift.git", requirement: .upToNextMajor(from: "0.9.0"))
 ]
 if !isAppStoreBuild {
-    projectPackages.insert(
-        .remote(url: "https://github.com/sparkle-project/Sparkle.git", requirement: .upToNextMajor(from: "2.6.0")),
-        at: 1
+    projectPackages.append(
+        .remote(url: "https://github.com/sparkle-project/Sparkle.git", requirement: .upToNextMajor(from: "2.6.0"))
     )
 }
 
@@ -106,7 +105,7 @@ var macAppDependencies: [TargetDependency] = [
     .package(product: "Sentry")
 ]
 if !isAppStoreBuild {
-    macAppDependencies.insert(.package(product: "Sparkle"), at: macAppDependencies.count - 1)
+    macAppDependencies.append(.package(product: "Sparkle"))
 }
 
 let project = Project(

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -90,7 +90,7 @@ public extension DistributionChannel {
     /// Downloaded local model runtimes (direct builds only).
     var supportsLocalModelRuntime: Bool { supports(.localModelRuntime) }
 
-    /// Whether the app can auto-prompt for Accessibility / Input Monitoring.
+    /// Whether the app can auto-prompt for Accessibility.
     /// When `false` (App Store), guide the user to add the app manually instead.
     var supportsAutomaticAccessibilityPrompt: Bool { supports(.automaticAccessibilityPrompt) }
 

--- a/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
+++ b/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+final class AppStoreInfoPlistTests: XCTestCase {
+
+    private var directPlist: [String: Any]!
+    private var appStorePlist: [String: Any]!
+
+    override func setUpWithError() throws {
+        directPlist = try Self.loadPlist(at: "Config/AppInfo.plist")
+        appStorePlist = try Self.loadPlist(at: "Config/AppInfo.AppStore.plist")
+    }
+
+    func testAppStorePlist_omitsSparkleUpdateKeys() {
+        let sparkleKeys = [
+            "SUEnableAutomaticChecks",
+            "SUFeedURL",
+            "SUPublicEDKey",
+            "SUScheduledCheckInterval"
+        ]
+
+        for key in sparkleKeys {
+            XCTAssertNil(appStorePlist[key], "App Store plist must not ship Sparkle key \(key)")
+        }
+    }
+
+    func testAppStorePlist_declaresLocalNetworkUsage() {
+        let value = appStorePlist["NSLocalNetworkUsageDescription"] as? String
+        let expected = "Just Speak to It uses your local network to connect iPhone and Mac for Send to Mac transcription transfer."
+        XCTAssertEqual(value, expected)
+    }
+
+    func testAppStorePlist_declaresBonjourService() {
+        let services = appStorePlist["NSBonjourServices"] as? [String]
+        XCTAssertEqual(services, ["_speaktransport._tcp"])
+    }
+
+    func testAppStorePlist_matchesDirectPlistExceptSparkleKeys() {
+        let sparkleKeys = [
+            "SUEnableAutomaticChecks",
+            "SUFeedURL",
+            "SUPublicEDKey",
+            "SUScheduledCheckInterval"
+        ]
+        var directWithoutSparkle = directPlist!
+        sparkleKeys.forEach { directWithoutSparkle.removeValue(forKey: $0) }
+
+        XCTAssertEqual(
+            appStorePlist as NSDictionary,
+            directWithoutSparkle as NSDictionary,
+            "Distribution plists should differ only by the direct build's Sparkle metadata"
+        )
+    }
+
+    private static func loadPlist(at path: String) throws -> [String: Any] {
+        let url = URL(fileURLWithPath: path)
+        let data = try Data(contentsOf: url)
+        let parsed = try PropertyListSerialization.propertyList(from: data, format: nil)
+        guard let plist = parsed as? [String: Any] else {
+            throw XCTSkip("Expected \(path) to parse as a dictionary")
+        }
+        return plist
+    }
+}

--- a/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
+++ b/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
@@ -25,7 +25,8 @@ final class AppStoreInfoPlistTests: XCTestCase {
 
     func testAppStorePlist_declaresLocalNetworkUsage() {
         let value = appStorePlist["NSLocalNetworkUsageDescription"] as? String
-        let expected = "Just Speak to It uses your local network to connect iPhone and Mac for Send to Mac transcription transfer."
+        let expected = "Just Speak to It uses your local network to connect iPhone and Mac "
+            + "for Send to Mac transcription transfer."
         XCTAssertEqual(value, expected)
     }
 

--- a/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
+++ b/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
@@ -57,7 +57,11 @@ final class AppStoreInfoPlistTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let parsed = try PropertyListSerialization.propertyList(from: data, format: nil)
         guard let plist = parsed as? [String: Any] else {
-            throw XCTSkip("Expected \(path) to parse as a dictionary")
+            throw NSError(
+                domain: "AppStoreInfoPlistTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Expected \(path) to parse as a dictionary"]
+            )
         }
         return plist
     }

--- a/Tests/SpeakAppTests/EntitlementsTests.swift
+++ b/Tests/SpeakAppTests/EntitlementsTests.swift
@@ -151,6 +151,12 @@ final class AppStoreEntitlementsTests: XCTestCase {
             "Outbound network is required to reach transcription/post-processing providers")
     }
 
+    func testNetworkServerEntitlement_isPresent() {
+        let value = entitlements["com.apple.security.network.server"] as? Bool
+        XCTAssertEqual(value, true,
+            "Inbound network is required for the Bonjour Send to Mac listener")
+    }
+
     // MARK: - Forbidden on App Store
 
     func testDisableLibraryValidation_isAbsent() {
@@ -183,8 +189,8 @@ final class AppStoreEntitlementsTests: XCTestCase {
             "com.apple.security.app-sandbox",
             "com.apple.security.device.audio-input",
             "com.apple.security.network.client",
+            "com.apple.security.network.server",
             "com.apple.security.files.user-selected.read-write",
-            "com.apple.security.automation.apple-events",
             "keychain-access-groups",
             "com.apple.developer.ubiquity-kvstore-identifier",
             "com.apple.developer.icloud-container-identifiers",


### PR DESCRIPTION
## Motivation

Ship the existing macOS product through a separate Mac App Store-safe distribution channel without weakening the direct-download Sparkle build.

## What changed

- Adds the `APP_STORE` distribution channel and disables update checks for that flavour.
- Generates a sandboxed App Store target with the dedicated plist and entitlements, and excludes Sparkle from the target graph.
- Adds archive-time guards for sandboxing, forbidden entitlements, Sparkle framework/metadata, and required network service support.
- Reuses the existing Apple Distribution certificate and App Store Connect API credentials, while letting Xcode manage Mac provisioning automatically.
- Declares exempt encryption consistently in both direct and App Store metadata.

## Things we learnt that changed the direction

The repository has working cross-platform Apple Distribution and App Store Connect secrets, but none of the Mac-only secrets expected by the original workflow. Reusing the existing Apple Distribution identity and automatic provisioning removes an unnecessary duplicate-secret dependency while preserving App Store signing requirements.

## How to test

- `TUIST_APP_STORE=1 tuist generate --no-open`
- Release build of the generated `SpeakApp` target with signing disabled
- Inspect built bundle: sandbox/network entitlements present, `Sparkle.framework` absent, all `SU*` keys absent
- `codesign --verify --deep --strict` after local ad-hoc signing
- `builtin-validationUtility -validate-for-store`
- 11 focused App Store plist/entitlement tests executed; 10 passed initially and the one metadata-drift failure was corrected, then verified with exact normalized plist comparison
- `plutil -lint Config/AppInfo.AppStore.plist Config/AppInfo.plist`
- GitHub workflow YAML parses successfully

## Review confidence

High confidence in the channel split and bundle validation. The first signed archive/upload run is the remaining production proof and will be dispatched immediately after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added App Store distribution metadata and support for local-network transfers between devices.
  - Added Bonjour service discovery for Send to Mac functionality.
  - Updated privacy disclosures for local network, accessibility, and input monitoring access.

- **Bug Fixes**
  - Improved App Store build validation and signing to help prevent invalid uploads.

- **Tests**
  - Added coverage verifying App Store metadata, privacy settings, and required entitlements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->