### PR TITLE
fix(ios): keep Action Button status off clipboard

### DIFF
--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -99,6 +99,17 @@ public struct StartTranscriptionIntent: AudioRecordingIntent, ForegroundContinua
 /// and shows the recording indicator. Requires iOS 18+.
 @available(iOS 18, *)
 public struct StartTranscriptionRecordingIntent: AudioRecordingIntent, ForegroundContinuableIntent {
+    private enum ToggleRecordingError: LocalizedError {
+        case alreadyRecordingInApp
+
+        var errorDescription: String? {
+            switch self {
+            case .alreadyRecordingInApp:
+                return "A recording is already in progress in the app. Use the in-app stop button."
+            }
+        }
+    }
+
     public static var title: LocalizedStringResource = "Toggle Recording"
     public static var description = IntentDescription(
         "Start or stop voice transcription. Result lands in the destination you chose in Settings."
@@ -108,30 +119,25 @@ public struct StartTranscriptionRecordingIntent: AudioRecordingIntent, Foregroun
 
     public init() {}
 
-    public func perform() async throws -> some IntentResult & ProvidesDialog {
+    /// Returns no Shortcuts value or dialog. Shortcuts promotes textual intent
+    /// feedback to the next action's input, so a shortcut containing an extra
+    /// Copy to Clipboard step could overwrite the completed transcript with
+    /// "Recording started" or "Copied N words" after this intent finished.
+    /// Recording feedback already lives in the Live Activity; the pasteboard is
+    /// owned exclusively by `stopRecording(destination:)`.
+    public func perform() async throws -> IntentResultContainer<Never, Never, Never, Never> {
         let service = await TranscriptionRecordingService.shared
         let isRunning = await service.isRunning
-        let destination = await AppSettings.shared.hardwareTriggerDestination
-        let canPostProcess = await AppSettings.shared.hasOpenRouterKey
 
         if isRunning {
-            let result = await service.stopRecording(destination: destination)
-            return .result(dialog: stopResultDialog(
-                for: result,
-                destination: destination,
-                canPostProcess: canPostProcess
-            ))
+            let destination = await AppSettings.shared.hardwareTriggerDestination
+            await service.stopRecording(destination: destination)
+            return .result()
         } else if SharedTranscriptionState.shared.isRecording {
-            return .result(dialog: "A recording is already in progress in the app. Use the in-app stop button.")
+            throw ToggleRecordingError.alreadyRecordingInApp
         } else {
-            do {
-                try await startRecordingContinuingInForegroundIfNeeded(from: self)
-            } catch {
-                return .result(
-                    dialog: "Couldn’t start recording. Check microphone and speech-recognition access, then try again."
-                )
-            }
-            return .result(dialog: "Recording started. Tap Done, then press again to stop.")
+            try await startRecordingContinuingInForegroundIfNeeded(from: self)
+            return .result()
         }
     }
 }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -1050,7 +1050,9 @@ struct HardwareTriggerSettingsView: View {
                 StepRow(
                     number: 2,
                     text: "Search for JustSpeakToIt and choose Toggle Recording for a single-button flow. "
-                        + "Use Start Recording only if you also create a separate Stop Recording shortcut."
+                        + "Do not add a separate Copy to Clipboard action — JustSpeakToIt copies the transcript "
+                        + "when you stop. Use Start Recording only if you also create a separate Stop Recording "
+                        + "shortcut."
                 )
                 StepRow(number: 3, text: "Name the shortcut and tap Done.")
                 StepRow(

--- a/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
+++ b/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
@@ -66,6 +66,21 @@ final class TranscriptionRecordingServiceTextTests: XCTestCase {
         XCTAssertTrue(intentType == StopTranscriptionRecordingIntent.self)
     }
 
+    @available(iOS 18, *)
+    func testToggleIntentDoesNotExposeStatusTextAsShortcutOutput() {
+        // The closure is intentionally not executed: this is a compile-time
+        // assertion that the toggle intent's Result.Dialog type is Never.
+        func requireDialogFreeResult<Result: IntentResult>(
+            _ operation: @escaping () async throws -> Result
+        ) where Result.Dialog == Never {
+            _ = operation
+        }
+
+        requireDialogFreeResult {
+            try await StartTranscriptionRecordingIntent().perform()
+        }
+    }
+
     func testPrefersTranscriberResultWhenPresent() {
         let text = TranscriptionRecordingService.bestTranscript(
             candidates: ["final result", "interim", "older"],

--- a/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
+++ b/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
@@ -18,13 +18,31 @@ final class ActionButtonSettingsUITests: XCTestCase {
         hardwareTriggerLink.tap()
 
         XCTAssertTrue(app.navigationBars["Action Button & Shortcuts"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["openShortcutsAppButton"].exists)
 
         let historyDestination = app.buttons["Save to History Only"]
         XCTAssertTrue(historyDestination.waitForExistence(timeout: 5))
         historyDestination.tap()
 
+        let clipboardGuidance = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@", "Do not add a separate Copy to Clipboard action")
+        ).firstMatch
+        XCTAssertTrue(scrollUpUntilExists(clipboardGuidance))
+        XCTAssertTrue(scrollUpUntilExists(app.buttons["openShortcutsAppButton"]))
+
         app.navigationBars.buttons.element(boundBy: 0).tap()
         XCTAssertTrue(app.staticTexts["Save to History Only"].waitForExistence(timeout: 5))
+    }
+
+    private func scrollUpUntilExists(_ element: XCUIElement, maxSwipes: Int = 6) -> Bool {
+        if element.waitForExistence(timeout: 1) {
+            return true
+        }
+        for _ in 0..<maxSwipes {
+            app.swipeUp()
+            if element.waitForExistence(timeout: 1) {
+                return true
+            }
+        }
+        return false
     }
 }


### PR DESCRIPTION
## Motivation

Action Button shortcuts could expose the toggle intent dialog as textual output. If Shortcuts fed that output into a Copy to Clipboard action, it overwrote the transcript with `Recording started` or `Copied N words` after JustSpeakToIt had already written the real transcription.

## What changed

- Make `Toggle Recording` return a value-free, dialog-free intent result.
- Keep the pasteboard owned exclusively by stop-time transcript routing.
- Preserve spoken dialogs on the separate Start/Stop intents used with Siri.
- Tell users not to add a second Copy to Clipboard action.
- Add a compile-time regression asserting the toggle result has `Dialog == Never`, plus UI coverage for the setup guidance.

## What changed direction

The app never writes `Recording started` to `UIPasteboard`; that exact text came from the App Intent result boundary, not the transcription service. The fix therefore removes textual output from the Action Button toggle instead of adding more pasteboard retries.

## How to test

- `xcrun swiftc -parse` on all four changed Swift files: passed.
- `git diff --check`: passed.
- Focused Simulator XCTest/UI run started locally; dependency resolution was interrupted by a GitHub connection reset after package caches were cleared, so protected CI is the authoritative full run.
- On Simulator, run a shortcut containing Toggle Recording and a trailing Copy to Clipboard action; start must not place `Recording started` on the pasteboard, and stop must leave the deterministic transcript written by JustSpeakToIt.

## Review confidence

High confidence in the narrow boundary fix; please review the intentional removal of toggle dialogue output. The dedicated Siri Start/Stop intents retain their dialogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified the recording toggle shortcut by removing status dialogs and text output.
  * Updated Action Button setup guidance to clarify that a separate “Copy to Clipboard” action is unnecessary.
* **Bug Fixes**
  * Improved shortcut behavior so recording can start or stop without displaying redundant feedback.
* **Tests**
  * Added coverage confirming dialog-free shortcut results and updated setup guidance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->