### PR TITLE
ci(mac): scope App Store profile to app target

### DIFF
--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -158,10 +158,6 @@ jobs:
             -archivePath "$RUNNER_TEMP/$PRODUCT_NAME.xcarchive" \
             -destination "generic/platform=macOS" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="$MAC_PROFILE_NAME" \
-            PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
             OTHER_CODE_SIGN_FLAGS="--keychain $RUNNER_TEMP/app-signing.keychain-db"
 
       - name: Validate App Store Archive


### PR DESCRIPTION
## Motivation
The Mac App Store archive failed because workflow-level signing overrides applied the app provisioning profile to Swift package dependency targets.

## What changed
- Let the Tuist app target own manual App Store signing and profile selection.
- Keep only the team and temporary keychain overrides at archive time.

## What changed direction
The current Project.swift already scopes the App Store profile correctly when TUIST_APP_STORE is enabled, so the duplicate xcodebuild overrides were both unnecessary and harmful. The Mac App Store identifier capabilities and profile were also refreshed separately in Apple Developer.

## How to test
- Parsed the workflow YAML successfully.
- Generated the App Store workspace with the new profile name.
- Ran an unsigned Release build for the SpeakApp macOS scheme: BUILD SUCCEEDED.
- Rerun Release Mac App Store after merge to verify signed archive and upload.

## Review confidence
Focused, high-confidence release fix. Deep review is not required; the App Store upload run is the final verification.