### PR TITLE
ci(mac): import installer certificate for App Store export

### DIFF
--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -254,6 +254,8 @@ jobs:
               <string>manual</string>
               <key>signingCertificate</key>
               <string>Apple Distribution</string>
+              <key>installerSigningCertificate</key>
+              <string>Mac Installer Distribution</string>
               <key>provisioningProfiles</key>
               <dict>
                   <key>com.justspeaktoit.mac</key>

--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -6,6 +6,8 @@ name: Release to Mac App Store
 # - APP_STORE_CONNECT_ISSUER_ID
 # - IOS_DISTRIBUTION_P12 and IOS_DISTRIBUTION_PASSWORD (the existing Apple
 #   Distribution certificate is valid for both iOS and Mac App Store apps)
+# - MAC_INSTALLER_P12 and MAC_INSTALLER_PASSWORD (Mac Installer Distribution
+#   identity required when exporting the signed installer package)
 # - MAC_APP_STORE_PROFILE (base64 Mac App Store provisioning profile)
 # The archive reuses the existing cross-platform Apple Distribution identity.
 # The App Store Connect API key remains responsible only for the upload, matching
@@ -60,6 +62,8 @@ jobs:
         env:
           APPLE_DISTRIBUTION_P12: ${{ secrets.IOS_DISTRIBUTION_P12 }}
           APPLE_DISTRIBUTION_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_PASSWORD }}
+          MAC_INSTALLER_P12: ${{ secrets.MAC_INSTALLER_P12 }}
+          MAC_INSTALLER_PASSWORD: ${{ secrets.MAC_INSTALLER_PASSWORD }}
         run: |
           KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
@@ -77,10 +81,21 @@ jobs:
             echo "::error::IOS_DISTRIBUTION_PASSWORD secret is required"
             exit 1
           fi
+          if [ -z "$MAC_INSTALLER_P12" ]; then
+            echo "::error::MAC_INSTALLER_P12 secret is required"
+            exit 1
+          fi
+          if [ -z "$MAC_INSTALLER_PASSWORD" ]; then
+            echo "::error::MAC_INSTALLER_PASSWORD secret is required"
+            exit 1
+          fi
           CERT_PATH="$RUNNER_TEMP/apple-distribution.p12"
+          INSTALLER_CERT_PATH="$RUNNER_TEMP/mac-installer-distribution.p12"
           echo -n "$APPLE_DISTRIBUTION_P12" | base64 --decode -o "$CERT_PATH"
+          echo -n "$MAC_INSTALLER_P12" | base64 --decode -o "$INSTALLER_CERT_PATH"
           security import "$CERT_PATH" -P "$APPLE_DISTRIBUTION_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          rm -f "$CERT_PATH"
+          security import "$INSTALLER_CERT_PATH" -P "$MAC_INSTALLER_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH" "$INSTALLER_CERT_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
       - name: Install Mac App Store Provisioning Profile


### PR DESCRIPTION
## Motivation
The signed Mac App Store archive and binary validation now pass, but Xcode export requires a separate Mac Installer Distribution identity to create the installer package.

## What changed
- Import the dedicated Mac Installer Distribution PKCS#12 into the temporary signing keychain.
- Fail clearly when either installer-certificate secret is missing.
- Remove both temporary certificate files after import.

## What changed direction
The Apple Distribution identity signs the app archive, while App Store export additionally signs the installer package with a Mac Installer Distribution identity. The first corrected run proved the app-signing path and exposed this separate requirement.

## How to test
- Workflow YAML parses successfully and diff checks pass.
- Generated Apple certificate is valid through July 2027.
- PKCS#12 imported into a clean temporary keychain and produced one valid Mac installer identity.
- Rerun Release to Mac App Store after merge; the previous run already proved signed archive and App Store-specific validation.

## Review confidence
Focused, high-confidence CI fix. The rerun export/upload is the final validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mac App Store release signing to support both Apple Distribution and Mac Installer Distribution certificates.
  * Added validation and cleanup for the additional signing credentials.
  * Documented the additional release prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->