### PR TITLE
feat: [mac][ios] add Apple on-device models

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -307,7 +307,23 @@ jobs:
             --team-id "${{ secrets.APPLE_TEAM_ID }}" \
             --wait
           
-          xcrun stapler staple "$DMG_PATH"
+          # Accepted notarization tickets can take a short time to propagate to
+          # CloudKit. Retry stapling before treating the release as failed.
+          for ATTEMPT in {1..5}; do
+            if xcrun stapler staple "$DMG_PATH"; then
+              break
+            fi
+
+            if [ "$ATTEMPT" -eq 5 ]; then
+              echo "Failed to staple DMG after $ATTEMPT attempts"
+              exit 1
+            fi
+
+            echo "Notarization ticket not available yet; retrying in 15s..."
+            sleep 15
+          done
+
+          xcrun stapler validate "$DMG_PATH"
           
           echo "DMG_PATH=$DMG_PATH" >> $GITHUB_ENV
 

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -805,7 +805,8 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       TranscriptionMode(
         rawValue: defaults.string(forKey: DefaultsKey.transcriptionMode.rawValue)
           ?? TranscriptionMode.liveNative.rawValue) ?? .liveNative
-    let liveModel = defaults.string(forKey: "liveTranscriptionModel") ?? "apple/local/SFSpeechRecognizer"
+    let liveModel = defaults.string(forKey: "liveTranscriptionModel")
+      ?? AppleLocalModels.preferredSpeechModelID
     let legacyAssemblyAILiveIDs: Set<String> = [
       "universal-streaming",
       "universal-streaming-english",
@@ -824,7 +825,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     } else {
       migratedLive = liveModel
     }
-    liveTranscriptionModel = migratedLive
+    liveTranscriptionModel = ModelCatalog.normalizedLiveTranscriptionModel(migratedLive)
     batchTranscriptionModel =
       Self.normalizedBatchModel(
         defaults.string(forKey: DefaultsKey.batchTranscriptionModel.rawValue))

--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -259,7 +259,7 @@ final class OnboardingState: ObservableObject {
         // on-device speech) so re-running onboarding never clobbers a returning
         // user's deliberately configured model / batch / post-processing setup.
         if let liveModel = selectedProvider.defaultLiveTranscriptionModel,
-           settings.liveTranscriptionModel == "apple/local/SFSpeechRecognizer" {
+           AppleLocalModels.isAppleSpeechModel(settings.liveTranscriptionModel) {
             settings.transcriptionMode = .liveNative
             settings.liveTranscriptionModel = liveModel
             settings.postProcessingEnabled = false

--- a/Sources/SpeakApp/PostProcessingManager.swift
+++ b/Sources/SpeakApp/PostProcessingManager.swift
@@ -91,59 +91,12 @@ final class PostProcessingManager: ObservableObject {
       ? "inception/mercury"
       : settings.postProcessingModel
 
-    if Self.isBuiltInLocalPostProcessingModel(model) {
-      let cleaned = Self.processLocally(rawText)
-      return .success(
-        .init(
-          original: rawText,
-          processed: cleaned,
-          response: nil,
-          systemPrompt: "Local offline transcript cleanup",
-          promptPayload: nil
-        )
-      )
-    }
-
-    if Self.isDownloadedLocalPostProcessingModel(model) {
-      #if APP_STORE
-      let cleaned = Self.processLocally(rawText)
-      return .success(
-        .init(
-          original: rawText,
-          processed: cleaned,
-          response: nil,
-          systemPrompt: "Local offline transcript cleanup",
-          promptPayload: nil
-        )
-      )
-      #else
-      do {
-        let cleaned = try await LocalPostProcessingModelManager.shared.process(
-          modelID: model,
-          rawText: rawText,
-          systemPrompt: systemPrompt,
-          temperature: settings.postProcessingTemperature
-        )
-        let promptPayload = PostProcessingPromptPayload(
-          modelIdentifier: model,
-          customPrompt: customPromptForDebug(),
-          systemPrompt: LocalPostProcessingModelManager.localSystemPrompt(systemPrompt),
-          userPrompt: LocalPostProcessingModelManager.localUserPrompt(systemPrompt: systemPrompt, rawText: rawText)
-        )
-        return .success(
-          .init(
-            original: rawText,
-            processed: cleaned,
-            response: nil,
-            systemPrompt: systemPrompt,
-            promptPayload: promptPayload
-          )
-        )
-      } catch {
-        log.error("Local post-processing failed: \(error.localizedDescription, privacy: .public)")
-        return .failure(error)
-      }
-      #endif
+    if let localResult = await processWithLocalModelIfNeeded(
+      model: model,
+      rawText: rawText,
+      systemPrompt: systemPrompt
+    ) {
+      return localResult
     }
 
     let userMessage = """
@@ -220,6 +173,118 @@ final class PostProcessingManager: ObservableObject {
     }
   }
 
+  private func processWithLocalModelIfNeeded(
+    model: String,
+    rawText: String,
+    systemPrompt: String
+  ) async -> Result<PostProcessingOutcome, Error>? {
+    guard Self.isLocalPostProcessingModel(model) else { return nil }
+
+    if Self.isAppleFoundationModel(model) {
+      return await processWithAppleFoundationModel(
+        model: model,
+        rawText: rawText,
+        systemPrompt: systemPrompt
+      )
+    }
+
+    if Self.isBuiltInLocalPostProcessingModel(model) {
+      let cleaned = Self.processLocally(rawText)
+      return .success(
+        .init(
+          original: rawText,
+          processed: cleaned,
+          response: nil,
+          systemPrompt: "Local offline transcript cleanup",
+          promptPayload: nil
+        )
+      )
+    }
+
+    return await processWithDownloadedLocalModel(
+      model: model,
+      rawText: rawText,
+      systemPrompt: systemPrompt
+    )
+  }
+
+  private func processWithAppleFoundationModel(
+    model: String,
+    rawText: String,
+    systemPrompt: String
+  ) async -> Result<PostProcessingOutcome, Error> {
+    do {
+      let cleaned = try await AppleFoundationModelPolisher.process(
+        text: rawText,
+        systemPrompt: systemPrompt
+      )
+      let promptPayload = PostProcessingPromptPayload(
+        modelIdentifier: model,
+        customPrompt: customPromptForDebug(),
+        systemPrompt: systemPrompt,
+        userPrompt: rawText
+      )
+      return .success(
+        .init(
+          original: rawText,
+          processed: cleaned.isEmpty ? rawText : cleaned,
+          response: nil,
+          systemPrompt: systemPrompt,
+          promptPayload: promptPayload
+        )
+      )
+    } catch {
+      log.error("Apple Intelligence post-processing failed: \(error.localizedDescription, privacy: .public)")
+      return .failure(error)
+    }
+  }
+
+  private func processWithDownloadedLocalModel(
+    model: String,
+    rawText: String,
+    systemPrompt: String
+  ) async -> Result<PostProcessingOutcome, Error> {
+    #if APP_STORE
+    let cleaned = Self.processLocally(rawText)
+    return .success(
+      .init(
+        original: rawText,
+        processed: cleaned,
+        response: nil,
+        systemPrompt: "Local offline transcript cleanup",
+        promptPayload: nil
+      )
+    )
+    #else
+    do {
+      let cleaned = try await LocalPostProcessingModelManager.shared.process(
+        modelID: model,
+        rawText: rawText,
+        systemPrompt: systemPrompt,
+        temperature: settings.postProcessingTemperature
+      )
+      let promptPayload = PostProcessingPromptPayload(
+        modelIdentifier: model,
+        customPrompt: customPromptForDebug(),
+        systemPrompt: LocalPostProcessingModelManager.localSystemPrompt(systemPrompt),
+        userPrompt: LocalPostProcessingModelManager.localUserPrompt(systemPrompt: systemPrompt, rawText: rawText)
+      )
+      return .success(
+        .init(
+          original: rawText,
+          processed: cleaned,
+          response: nil,
+          systemPrompt: systemPrompt,
+          promptPayload: promptPayload
+        )
+      )
+    } catch {
+      log.error("Local post-processing failed: \(error.localizedDescription, privacy: .public)")
+      return .failure(error)
+    }
+    #endif
+  }
+
   func hasRequiredAPIKey() async -> Bool {
     let configuredModel = settings.postProcessingModel
       .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -242,7 +307,13 @@ final class PostProcessingManager: ObservableObject {
   }
 
   static func isLocalPostProcessingModel(_ model: String) -> Bool {
-    isBuiltInLocalPostProcessingModel(model) || isDownloadedLocalPostProcessingModel(model)
+    isAppleFoundationModel(model)
+      || isBuiltInLocalPostProcessingModel(model)
+      || isDownloadedLocalPostProcessingModel(model)
+  }
+
+  static func isAppleFoundationModel(_ model: String) -> Bool {
+    model.trimmingCharacters(in: .whitespacesAndNewlines) == AppleLocalModels.foundationModelID
   }
 
   static func isBuiltInLocalPostProcessingModel(_ model: String) -> Bool {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -201,6 +201,15 @@ final class TranscriptionManager: ObservableObject {
 
   func transcribeFile(at url: URL) async throws -> TranscriptionResult {
     let model = offlineTranscriptionModel
+    if model == AppleLocalModels.speechTranscriberModelID {
+      if #available(macOS 26.0, *) {
+        return try await AppleSpeechAnalyzerTranscriber.transcribeFile(
+          at: url,
+          localeIdentifier: appSettings.preferredLocaleIdentifier
+        )
+      }
+      throw AppleLocalModelError.speechTranscriberUnavailable
+    }
     if ModelRouting.family(for: model).isDownloadedLocal {
       return try await LocalModelManager.shared.transcribeFile(
         at: url,
@@ -232,6 +241,9 @@ final class TranscriptionManager: ObservableObject {
 
   func batchTranscriptionUsesRemoteService() async -> Bool {
     let model = offlineTranscriptionModel
+    if ModelRouting.family(for: model) == .appleSpeech {
+      return false
+    }
     if ModelRouting.family(for: model).isDownloadedLocal {
       return false
     }
@@ -517,7 +529,7 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
           segments: [],
           confidence: nil,
           duration: 0,
-          modelIdentifier: self.currentModel ?? "apple/local/SFSpeechRecognizer",
+          modelIdentifier: self.currentModel ?? AppleLocalModels.legacySpeechModelID,
           cost: nil,
           rawPayload: nil,
           debugInfo: nil
@@ -532,7 +544,7 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
           segments: [],
           confidence: nil,
           duration: 0,
-          modelIdentifier: self.currentModel ?? "apple/local/SFSpeechRecognizer",
+          modelIdentifier: self.currentModel ?? AppleLocalModels.legacySpeechModelID,
           cost: nil,
           rawPayload: nil,
           debugInfo: nil
@@ -579,7 +591,7 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
         : result
           .transcriptionSegmentsConfidence,
       duration: duration,
-      modelIdentifier: currentModel ?? "apple/local/SFSpeechRecognizer",
+      modelIdentifier: currentModel ?? AppleLocalModels.legacySpeechModelID,
       cost: nil,
       rawPayload: nil,
       debugInfo: nil
@@ -688,6 +700,152 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
     let microphone = await permissionsManager.ensureGranted(.microphone)
     let speech = await permissionsManager.ensureGranted(.speechRecognition)
     return microphone.isGranted && speech.isGranted
+  }
+}
+
+final class AppleSpeechAnalyzerLiveController: LiveTranscriptionController {
+  weak var delegate: LiveTranscriptionSessionDelegate?
+  private(set) var isRunning = false
+
+  private let permissionsManager: PermissionsManager
+  private let appSettings: AppSettings
+  private let audioDeviceManager: AudioInputDeviceManager
+  private var audioEngine = AVAudioEngine()
+  private var analyzerSession: Any?
+  private var audioConverter: Any?
+  private var activeInputSession: AudioInputDeviceManager.SessionContext?
+  private var currentLanguage: String?
+  private var latestUpdate = LiveTranscriptionUpdate(text: "")
+
+  init(
+    permissionsManager: PermissionsManager,
+    appSettings: AppSettings,
+    audioDeviceManager: AudioInputDeviceManager
+  ) {
+    self.permissionsManager = permissionsManager
+    self.appSettings = appSettings
+    self.audioDeviceManager = audioDeviceManager
+  }
+
+  func configure(language: String?, model: String) {
+    currentLanguage = language
+  }
+
+  func start() async throws {
+    guard await ensurePermissions() else {
+      throw TranscriptionManagerError.permissionsMissing
+    }
+    guard #available(macOS 26.0, *) else {
+      throw AppleLocalModelError.speechTranscriberUnavailable
+    }
+
+    let inputSession = await audioDeviceManager.beginUsingPreferredInput()
+    audioEngine = AVAudioEngine()
+    do {
+      try await startSpeechAnalyzer()
+      activeInputSession = inputSession
+      latestUpdate = LiveTranscriptionUpdate(text: "")
+      isRunning = true
+    } catch {
+      audioEngine.stop()
+      audioEngine.inputNode.removeTap(onBus: 0)
+      await audioDeviceManager.endUsingPreferredInput(session: inputSession)
+      throw error
+    }
+  }
+
+  @available(macOS 26.0, *)
+  private func startSpeechAnalyzer() async throws {
+    let session = try await AppleSpeechAnalyzerLiveSession(
+      localeIdentifier: currentLanguage ?? appSettings.preferredLocaleIdentifier
+    ) { [weak self] update in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        self.latestUpdate = LiveTranscriptionUpdate(
+          text: update.text,
+          isFinal: update.isFinal,
+          confidence: update.confidence
+        )
+        self.delegate?.liveTranscriber(self, didUpdateWith: self.latestUpdate)
+        self.delegate?.liveTranscriber(self, didUpdatePartial: update.text)
+      }
+    }
+
+    let inputNode = audioEngine.inputNode
+    inputNode.removeTap(onBus: 0)
+    let inputFormat = inputNode.outputFormat(forBus: 0)
+    guard audioInputFormatIsUsable(inputFormat) else {
+      await session.cancel()
+      throw TranscriptionManagerError.noUsableAudioInput
+    }
+    do {
+      let converter = try AppleSpeechAudioConverter(
+        sourceFormat: inputFormat,
+        targetFormat: session.audioFormat
+      )
+      inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
+        guard let converted = converter.convert(buffer) else { return }
+        session.send(converted)
+      }
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
+      analyzerSession = session
+      audioConverter = converter
+    } catch {
+      audioEngine.stop()
+      inputNode.removeTap(onBus: 0)
+      await session.cancel()
+      throw error
+    }
+  }
+
+  func stop() async {
+    guard isRunning else { return }
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    isRunning = false
+
+    defer {
+      analyzerSession = nil
+      audioConverter = nil
+    }
+
+    if #available(macOS 26.0, *),
+      let session = analyzerSession as? AppleSpeechAnalyzerLiveSession {
+      do {
+        let result = try await session.finish()
+        delegate?.liveTranscriber(self, didFinishWith: result)
+      } catch {
+        delegate?.liveTranscriber(self, didFail: error)
+      }
+    } else {
+      delegate?.liveTranscriber(
+        self,
+        didFinishWith: TranscriptionResult(
+          text: latestUpdate.text,
+          segments: [],
+          confidence: latestUpdate.confidence,
+          duration: 0,
+          modelIdentifier: AppleLocalModels.speechTranscriberModelID,
+          cost: nil,
+          rawPayload: nil,
+          debugInfo: nil
+        )
+      )
+    }
+
+    await endActiveInputSession()
+  }
+
+  private func ensurePermissions() async -> Bool {
+    let microphone = await permissionsManager.ensureGranted(.microphone)
+    let speech = await permissionsManager.ensureGranted(.speechRecognition)
+    return microphone.isGranted && speech.isGranted
+  }
+
+  private func endActiveInputSession() async {
+    guard let activeInputSession else { return }
+    self.activeInputSession = nil
+    await audioDeviceManager.endUsingPreferredInput(session: activeInputSession)
   }
 }
 
@@ -1736,8 +1894,7 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
       let segment = TranscriptionSegment(startTime: 0, endTime: 0, text: turn.transcript)
 
       if let existingIndex = finalSegmentIndexByTurnOrder[turn.turn_order],
-        finalSegments.indices.contains(existingIndex)
-      {
+        finalSegments.indices.contains(existingIndex) {
         finalSegments[existingIndex] = segment
         // Replaced an existing turn — must rebuild from scratch
         fullTranscript = finalSegments.map(\.text).joined(separator: " ")
@@ -3810,6 +3967,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private let nowProvider: () -> Date
   private var activeController: (any LiveTranscriptionController)?
   private var nativeController: NativeOSXLiveTranscriber
+  private var speechAnalyzerController: AppleSpeechAnalyzerLiveController
   private var deepgramController: DeepgramLiveController
   private var modulateController: ModulateLiveController
   private var assemblyAIController: AssemblyAILiveController
@@ -3844,6 +4002,11 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     self.secureStorage = secureStorage
     self.nowProvider = nowProvider
     nativeController = NativeOSXLiveTranscriber(
+      permissionsManager: permissionsManager,
+      appSettings: appSettings,
+      audioDeviceManager: audioDeviceManager
+    )
+    speechAnalyzerController = AppleSpeechAnalyzerLiveController(
       permissionsManager: permissionsManager,
       appSettings: appSettings,
       audioDeviceManager: audioDeviceManager
@@ -3946,6 +4109,25 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       try await controller.start()
       invalidateBeforeNextStart = false
     } catch {
+      if model == AppleLocalModels.speechTranscriberModelID {
+        print(
+          "[SwitchingLiveTranscriber] SpeechAnalyzer failed "
+            + "(\(error.localizedDescription)); using legacy Apple Speech")
+        nativeController.configure(
+          language: currentLanguage,
+          model: AppleLocalModels.legacySpeechModelID
+        )
+        activeController = nativeController
+        do {
+          try await nativeController.start()
+          invalidateBeforeNextStart = false
+          return
+        } catch {
+          activeController = nil
+          invalidateBeforeNextStart = true
+          throw error
+        }
+      }
       activeController = nil
       invalidateBeforeNextStart = true
       throw error
@@ -3960,6 +4142,9 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   }
 
   private func controller(for model: String) -> any LiveTranscriptionController {
+    if model == AppleLocalModels.speechTranscriberModelID {
+      return speechAnalyzerController
+    }
     if let route = controllerRoutes.first(where: { model.hasPrefix($0.prefix) }) {
       return route.controller
     }
@@ -3992,6 +4177,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private func applyDelegateAndConfiguration() {
     var controllers: [any LiveTranscriptionController] = [
       nativeController,
+      speechAnalyzerController,
       deepgramController,
       modulateController,
       assemblyAIController,
@@ -4025,6 +4211,11 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private func resetControllers() {
     activeController = nil
     nativeController = NativeOSXLiveTranscriber(
+      permissionsManager: permissionsManager,
+      appSettings: appSettings,
+      audioDeviceManager: audioDeviceManager
+    )
+    speechAnalyzerController = AppleSpeechAnalyzerLiveController(
       permissionsManager: permissionsManager,
       appSettings: appSettings,
       audioDeviceManager: audioDeviceManager

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -499,7 +499,7 @@ enum WireUp {
     // Only configure if user hasn't explicitly set a preference
     // Check if it's still the default Apple value
     let currentModel = settings.liveTranscriptionModel
-    let isDefaultApple = currentModel == "apple/local/SFSpeechRecognizer"
+    let isDefaultApple = AppleLocalModels.isAppleSpeechModel(currentModel)
 
     // If user has already changed from default, respect their choice
     guard isDefaultApple else {
@@ -516,7 +516,7 @@ enum WireUp {
         print("[WireUp] Deepgram API key found, setting as default transcription provider")
       }
     } else {
-      print("[WireUp] No Deepgram API key found, using Apple SFSpeechRecognizer as default")
+      print("[WireUp] No Deepgram API key found, using Apple on-device transcription as default")
     }
   }
 }

--- a/Sources/SpeakCore/AppleLocalModels.swift
+++ b/Sources/SpeakCore/AppleLocalModels.swift
@@ -1,0 +1,366 @@
+import AVFoundation
+import CoreMedia
+import Foundation
+import Speech
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+public enum AppleLocalModels {
+    public static let legacySpeechModelID = "apple/local/SFSpeechRecognizer"
+    public static let speechTranscriberModelID = "apple/local/SpeechTranscriber"
+    public static let foundationModelID = "apple/local/FoundationModels"
+
+    public static var supportsSpeechTranscriber: Bool {
+        if #available(macOS 26.0, iOS 26.0, *) {
+            return SpeechTranscriber.isAvailable
+        }
+        return false
+    }
+
+    public static var preferredSpeechModelID: String {
+        preferredSpeechModelID(speechTranscriberAvailable: supportsSpeechTranscriber)
+    }
+
+    public static func preferredSpeechModelID(speechTranscriberAvailable: Bool) -> String {
+        speechTranscriberAvailable ? speechTranscriberModelID : legacySpeechModelID
+    }
+
+    public static var supportsFoundationModels: Bool {
+        #if canImport(FoundationModels)
+        if #available(macOS 26.0, iOS 26.0, *) {
+            return SystemLanguageModel.default.isAvailable
+        }
+        #endif
+        return false
+    }
+
+    public static func isAppleSpeechModel(_ modelID: String) -> Bool {
+        modelID == legacySpeechModelID || modelID == speechTranscriberModelID
+    }
+}
+
+public enum AppleLocalModelError: LocalizedError {
+    case speechTranscriberUnavailable
+    case localeUnsupported(String)
+    case modelAssetsUnavailable
+    case compatibleAudioFormatUnavailable
+    case foundationModelUnavailable
+    case emptyTranscript
+
+    public var errorDescription: String? {
+        switch self {
+        case .speechTranscriberUnavailable:
+            return "Apple SpeechTranscriber isn't available on this device."
+        case .localeUnsupported(let identifier):
+            return "Apple SpeechTranscriber doesn't support the \(identifier) locale on this device."
+        case .modelAssetsUnavailable:
+            return "Apple's on-device speech model could not be installed."
+        case .compatibleAudioFormatUnavailable:
+            return "Apple SpeechTranscriber could not provide a compatible audio format."
+        case .foundationModelUnavailable:
+            return "Apple Intelligence's on-device language model isn't available on this device."
+        case .emptyTranscript:
+            return "Apple SpeechTranscriber returned an empty transcript."
+        }
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, *)
+public enum AppleSpeechAnalyzerTranscriber {
+    public static func transcribeFile(
+        at url: URL,
+        localeIdentifier: String?
+    ) async throws -> TranscriptionResult {
+        let transcriber = try await makeTranscriber(
+            localeIdentifier: localeIdentifier,
+            preset: .timeIndexedTranscriptionWithAlternatives
+        )
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        let audioFile = try AVAudioFile(forReading: url)
+        let duration = audioFile.processingFormat.sampleRate > 0
+            ? Double(audioFile.length) / audioFile.processingFormat.sampleRate
+            : 0
+
+        async let collectedSegments = collectFinalSegments(from: transcriber)
+        _ = try await analyzer.analyzeSequence(from: audioFile)
+        try await analyzer.finalizeAndFinishThroughEndOfInput()
+        let segments = try await collectedSegments
+        let text = segments.map(\.text).joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { throw AppleLocalModelError.emptyTranscript }
+
+        return TranscriptionResult(
+            text: text,
+            segments: segments,
+            confidence: averageConfidence(in: segments),
+            duration: duration,
+            modelIdentifier: AppleLocalModels.speechTranscriberModelID,
+            cost: nil,
+            rawPayload: nil,
+            debugInfo: nil
+        )
+    }
+
+    static func makeTranscriber(
+        localeIdentifier: String?,
+        preset: SpeechTranscriber.Preset
+    ) async throws -> SpeechTranscriber {
+        guard SpeechTranscriber.isAvailable else {
+            throw AppleLocalModelError.speechTranscriberUnavailable
+        }
+
+        let requestedLocale = Locale(identifier: localeIdentifier ?? Locale.current.identifier)
+        guard let supportedLocale = await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale) else {
+            throw AppleLocalModelError.localeUnsupported(requestedLocale.identifier)
+        }
+
+        let transcriber = SpeechTranscriber(locale: supportedLocale, preset: preset)
+        try await ensureAssets(for: transcriber)
+        return transcriber
+    }
+
+    private static func ensureAssets(for transcriber: SpeechTranscriber) async throws {
+        switch await AssetInventory.status(forModules: [transcriber]) {
+        case .installed:
+            return
+        case .supported, .downloading:
+            if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+                try await request.downloadAndInstall()
+            }
+            guard try await waitForInstalledAssets(for: transcriber) else {
+                throw AppleLocalModelError.modelAssetsUnavailable
+            }
+        case .unsupported:
+            throw AppleLocalModelError.modelAssetsUnavailable
+        @unknown default:
+            throw AppleLocalModelError.modelAssetsUnavailable
+        }
+    }
+
+    private static func waitForInstalledAssets(for transcriber: SpeechTranscriber) async throws -> Bool {
+        for _ in 0 ..< 120 {
+            try Task.checkCancellation()
+            switch await AssetInventory.status(forModules: [transcriber]) {
+            case .installed:
+                return true
+            case .downloading:
+                try await Task.sleep(for: .milliseconds(250))
+            case .supported, .unsupported:
+                return false
+            @unknown default:
+                return false
+            }
+        }
+        return false
+    }
+
+    private static func collectFinalSegments(
+        from transcriber: SpeechTranscriber
+    ) async throws -> [TranscriptionSegment] {
+        var segments: [TranscriptionSegment] = []
+        for try await result in transcriber.results where result.isFinal {
+            let segment = makeSegment(from: result, isFinal: true)
+            guard !segment.text.isEmpty else { continue }
+            segments.append(segment)
+        }
+        return segments.sorted { $0.startTime < $1.startTime }
+    }
+
+    static func makeSegment(
+        from result: SpeechTranscriber.Result,
+        isFinal: Bool
+    ) -> TranscriptionSegment {
+        let start = max(0, result.range.start.seconds)
+        let duration = max(0, result.range.duration.seconds)
+        return TranscriptionSegment(
+            startTime: start.isFinite ? start : 0,
+            endTime: start.isFinite && duration.isFinite ? start + duration : 0,
+            text: String(result.text.characters).trimmingCharacters(in: .whitespacesAndNewlines),
+            isFinal: isFinal,
+            confidence: nil
+        )
+    }
+
+    static func averageConfidence(in segments: [TranscriptionSegment]) -> Double? {
+        let values = segments.compactMap(\.confidence)
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Double(values.count)
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, *)
+public struct AppleSpeechAnalyzerUpdate: Sendable {
+    public let text: String
+    public let isFinal: Bool
+    public let confidence: Double?
+
+    public init(text: String, isFinal: Bool, confidence: Double?) {
+        self.text = text
+        self.isFinal = isFinal
+        self.confidence = confidence
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, *)
+public final class AppleSpeechAnalyzerLiveSession: @unchecked Sendable {
+    public let audioFormat: AVAudioFormat
+
+    private let analyzer: SpeechAnalyzer
+    private let inputContinuation: AsyncStream<AnalyzerInput>.Continuation
+    private let resultTask: Task<TranscriptionResult, Error>
+
+    public init(
+        localeIdentifier: String?,
+        onUpdate: @escaping @Sendable (AppleSpeechAnalyzerUpdate) -> Void
+    ) async throws {
+        let transcriber = try await AppleSpeechAnalyzerTranscriber.makeTranscriber(
+            localeIdentifier: localeIdentifier,
+            preset: .timeIndexedProgressiveTranscription
+        )
+        guard let format = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
+            throw AppleLocalModelError.compatibleAudioFormatUnavailable
+        }
+
+        let (inputSequence, continuation) = AsyncStream<AnalyzerInput>.makeStream()
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        self.audioFormat = format
+        self.analyzer = analyzer
+        self.inputContinuation = continuation
+        self.resultTask = Self.makeResultTask(transcriber: transcriber, onUpdate: onUpdate)
+
+        try await analyzer.start(inputSequence: inputSequence)
+    }
+
+    private static func makeResultTask(
+        transcriber: SpeechTranscriber,
+        onUpdate: @escaping @Sendable (AppleSpeechAnalyzerUpdate) -> Void
+    ) -> Task<TranscriptionResult, Error> {
+        Task {
+            var finalSegments: [TranscriptionSegment] = []
+            var volatileSegment: TranscriptionSegment?
+
+            for try await result in transcriber.results {
+                let segment = AppleSpeechAnalyzerTranscriber.makeSegment(
+                    from: result,
+                    isFinal: result.isFinal
+                )
+                guard !segment.text.isEmpty else { continue }
+
+                if result.isFinal {
+                    finalSegments.append(segment)
+                    finalSegments.sort { $0.startTime < $1.startTime }
+                    volatileSegment = nil
+                } else {
+                    volatileSegment = segment
+                }
+
+                let displayedSegments = finalSegments + [volatileSegment].compactMap { $0 }
+                let text = displayedSegments.map(\.text).joined(separator: " ")
+                onUpdate(
+                    AppleSpeechAnalyzerUpdate(
+                        text: text,
+                        isFinal: result.isFinal,
+                        confidence: AppleSpeechAnalyzerTranscriber.averageConfidence(in: displayedSegments)
+                    )
+                )
+            }
+
+            let text = finalSegments.map(\.text).joined(separator: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let duration = finalSegments.map(\.endTime).max() ?? 0
+            return TranscriptionResult(
+                text: text,
+                segments: finalSegments,
+                confidence: AppleSpeechAnalyzerTranscriber.averageConfidence(in: finalSegments),
+                duration: duration,
+                modelIdentifier: AppleLocalModels.speechTranscriberModelID,
+                cost: nil,
+                rawPayload: nil,
+                debugInfo: nil
+            )
+        }
+    }
+
+    public func send(_ buffer: AVAudioPCMBuffer) {
+        inputContinuation.yield(AnalyzerInput(buffer: buffer))
+    }
+
+    public func finish() async throws -> TranscriptionResult {
+        inputContinuation.finish()
+        try await analyzer.finalizeAndFinishThroughEndOfInput()
+        return try await resultTask.value
+    }
+
+    public func cancel() async {
+        inputContinuation.finish()
+        await analyzer.cancelAndFinishNow()
+        resultTask.cancel()
+    }
+}
+
+@available(macOS 26.0, iOS 26.0, *)
+public final class AppleSpeechAudioConverter: @unchecked Sendable {
+    private let converter: AVAudioConverter
+    private let sourceFormat: AVAudioFormat
+    private let targetFormat: AVAudioFormat
+    private let lock = NSLock()
+
+    public init(sourceFormat: AVAudioFormat, targetFormat: AVAudioFormat) throws {
+        guard let converter = AVAudioConverter(from: sourceFormat, to: targetFormat) else {
+            throw AppleLocalModelError.compatibleAudioFormatUnavailable
+        }
+        self.converter = converter
+        self.sourceFormat = sourceFormat
+        self.targetFormat = targetFormat
+    }
+
+    public func convert(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let ratio = targetFormat.sampleRate / sourceFormat.sampleRate
+        let capacity = AVAudioFrameCount(max(1, ceil(Double(buffer.frameLength) * ratio) + 32))
+        guard let output = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else {
+            return nil
+        }
+
+        var providedInput = false
+        var conversionError: NSError?
+        let status = converter.convert(to: output, error: &conversionError) { _, outStatus in
+            if providedInput {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            providedInput = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+        guard status != .error, conversionError == nil else { return nil }
+        guard output.frameLength > 0 else { return nil }
+        return output
+    }
+}
+
+public enum AppleFoundationModelPolisher {
+    public static var isAvailable: Bool {
+        AppleLocalModels.supportsFoundationModels
+    }
+
+    public static func process(text: String, systemPrompt: String) async throws -> String {
+        #if canImport(FoundationModels)
+        if #available(macOS 26.0, iOS 26.0, *) {
+            guard SystemLanguageModel.default.isAvailable else {
+                throw AppleLocalModelError.foundationModelUnavailable
+            }
+            let session = LanguageModelSession(instructions: systemPrompt)
+            let response = try await session.respond(
+                to: "Clean this raw transcript and return only the cleaned text:\n\n\(text)"
+            )
+            return response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        #endif
+        throw AppleLocalModelError.foundationModelUnavailable
+    }
+}

--- a/Sources/SpeakCore/LiveModelCapabilities.swift
+++ b/Sources/SpeakCore/LiveModelCapabilities.swift
@@ -64,6 +64,7 @@ extension ModelCatalog {
     private static let liveCapabilityRegistry: [String: LiveModelCapabilities] = [
         // Apple on-device — raw passthrough only.
         "apple/local/SFSpeechRecognizer": .default,
+        "apple/local/SpeechTranscriber": .default,
         "apple/local/Dictation": .default,
 
         // Streaming providers that emit incremental finals during the session.

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -115,11 +115,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
 
     public static let customOptionID = "__model_custom__"
 
-    public static let liveTranscription: [Option] = [
-        Option(
-            id: "apple/local/SFSpeechRecognizer", displayName: "Apple Speech (On-device)",
-            description: "Uses the built-in Speech framework for immediate on-device transcripts.",
-            estimatedLatencyMs: 50, latencyTier: .instant),
+    public static let liveTranscription: [Option] = appleLiveTranscriptionOptions + [
         Option(
             id: "apple/local/Dictation", displayName: "Apple Dictation",
             description: "Alternative on-device engine that mirrors system dictation.",
@@ -194,7 +190,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             estimatedLatencyMs: 280, latencyTier: .fast)
     ]
 
-    public static let batchTranscription: [Option] = [
+    public static let batchTranscription: [Option] = appleBatchTranscriptionOptions + [
         // Dedicated transcription providers (OpenAI, Rev.ai, etc.)
         Option(
             id: "openai/whisper-1", displayName: "Whisper (OpenAI)",
@@ -282,6 +278,39 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
 
     public static let defaultBatchTranscriptionModel = "google/gemini-2.0-flash-001"
 
+    private static let appleLiveTranscriptionOptions: [Option] = {
+        if AppleLocalModels.supportsSpeechTranscriber {
+            return [Option(
+                id: AppleLocalModels.speechTranscriberModelID,
+                displayName: "Apple SpeechTranscriber (On-device)",
+                description: "Apple's latest private on-device model for fast, accurate live transcription.",
+                estimatedLatencyMs: 50,
+                latencyTier: .instant,
+                tags: [.fast, .privacy]
+            )]
+        }
+        return [Option(
+            id: AppleLocalModels.legacySpeechModelID,
+            displayName: "Apple Speech (On-device)",
+            description: "Uses the built-in Speech framework for immediate on-device transcripts.",
+            estimatedLatencyMs: 50,
+            latencyTier: .instant,
+            tags: [.fast, .privacy]
+        )]
+    }()
+
+    private static let appleBatchTranscriptionOptions: [Option] = {
+        guard AppleLocalModels.supportsSpeechTranscriber else { return [] }
+        return [Option(
+            id: AppleLocalModels.speechTranscriberModelID,
+            displayName: "Apple SpeechTranscriber (On-device)",
+            description: "Transcribes recorded audio locally with Apple's latest long-form speech model.",
+            estimatedLatencyMs: 250,
+            latencyTier: .instant,
+            tags: [.fast, .privacy]
+        )]
+    }()
+
     private static let retiredBatchTranscriptionModels: Set<String> = [
         "openrouter/whisper-large-v3",
         "openrouter/whisper-medium",
@@ -292,6 +321,10 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
     /// Unknown identifiers remain valid because the Mac supports custom OpenRouter batch models.
     public static func normalizedBatchTranscriptionModel(_ identifier: String?) -> String {
         let trimmed = identifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed == AppleLocalModels.speechTranscriberModelID,
+           !AppleLocalModels.supportsSpeechTranscriber {
+            return defaultBatchTranscriptionModel
+        }
         guard !trimmed.isEmpty, !retiredBatchTranscriptionModels.contains(trimmed) else {
             return defaultBatchTranscriptionModel
         }
@@ -300,7 +333,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
 
     // Curated, static set for transcript cleanup (OpenRouter) with pricing + tags.
     // Pricing is based on OpenRouter's /api/v1/models at time of writing.
-    public static let postProcessing: [Option] = [
+    public static let postProcessing: [Option] = applePostProcessingOptions + [
         Option(
             id: "local/post-processing/rules",
             displayName: "Local Cleanup (Offline)",
@@ -552,7 +585,27 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
     /// Cloud cleanup choices supported on every platform. Platform-specific
     /// local cleanup engines remain in `postProcessing` for macOS.
     public static let cloudPostProcessing: [Option] = postProcessing.filter {
-        !$0.id.hasPrefix("local/post-processing/")
+        !$0.id.hasPrefix("local/post-processing/") && $0.id != AppleLocalModels.foundationModelID
+    }
+
+    private static let applePostProcessingOptions: [Option] = {
+        guard AppleLocalModels.supportsFoundationModels else { return [] }
+        return [Option(
+            id: AppleLocalModels.foundationModelID,
+            displayName: "Apple Intelligence (On-device)",
+            description: "Polishes transcripts privately with Apple's built-in on-device language model.",
+            estimatedLatencyMs: 300,
+            latencyTier: .fast,
+            tags: [.fast, .privacy]
+        )]
+    }()
+
+    public static func normalizedLiveTranscriptionModel(_ identifier: String?) -> String {
+        let trimmed = identifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if AppleLocalModels.isAppleSpeechModel(trimmed) || trimmed.isEmpty {
+            return AppleLocalModels.preferredSpeechModelID
+        }
+        return trimmed
     }
 
     public static let defaultPostProcessingModel = "openai/gpt-5-mini"

--- a/Sources/SpeakCore/StreamingTranscriptionClient.swift
+++ b/Sources/SpeakCore/StreamingTranscriptionClient.swift
@@ -164,6 +164,21 @@ public enum LiveTranscriptionRouting {
         ModelCatalog.liveTranscription.compactMap { route(for: $0.id) }
     }
 
+    /// Resolves the model that can actually start with the supplied credential.
+    /// On-device routes never need a credential. A cloud route with a missing
+    /// or blank API key falls back to the shared on-device default so every
+    /// platform applies the same safe startup behavior.
+    public static func resolvedModelID(for modelID: String, apiKey: String?) -> String {
+        guard let route = route(for: modelID) else {
+            return modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard route.apiKeyIdentifier != nil else { return route.modelID }
+        guard !(apiKey ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+        }
+        return route.modelID
+    }
+
     /// Translates a catalog id into the provider's own API model name.
     ///
     /// The general rule strips the `provider/` prefix and the `-streaming`

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -74,13 +74,12 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         sharedState.isRecording = true
         sharedState.recordingStartTime = startTime
 
-        // Fall back to Apple Speech if the selected provider needs an API key we
-        // don't have (covers every cloud provider via the shared routing).
-        if settings.transcriptionMode == .streaming,
-           let route = LiveTranscriptionRouting.route(for: currentModel),
-           route.apiKeyIdentifier != nil,
-           settings.liveAPIKey(for: route).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            currentModel = "apple/local/SFSpeechRecognizer"
+        if settings.transcriptionMode == .streaming {
+            let route = LiveTranscriptionRouting.route(for: currentModel)
+            currentModel = LiveTranscriptionRouting.resolvedModelID(
+                for: currentModel,
+                apiKey: route.map { settings.liveAPIKey(for: $0) }
+            )
         }
 
         // A Live Activity is required to record in the *background* via an
@@ -204,6 +203,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
                 try await transcriber.start()
             } else {
                 let transcriber = iOSLiveTranscriber(audioSessionManager: audioSessionManager)
+                transcriber.modelID = currentModel
 
                 transcriber.onPartialResult = { [weak self] text, _ in
                     Task { @MainActor in

--- a/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
+++ b/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
@@ -83,6 +83,16 @@ private struct IOSBatchTranscriptionClient {
     let session: URLSession
 
     func transcribeFile(at url: URL, model: String, language: String?) async throws -> TranscriptionResult {
+        if model == AppleLocalModels.speechTranscriberModelID {
+            if #available(iOS 26.0, *) {
+                return try await AppleSpeechAnalyzerTranscriber.transcribeFile(
+                    at: url,
+                    localeIdentifier: language
+                )
+            }
+            throw AppleLocalModelError.speechTranscriberUnavailable
+        }
+
         let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedKey.isEmpty else { throw IOSBatchTranscriptionError.apiKeyMissing }
 

--- a/Sources/SpeakiOS/Services/iOSLiveTranscriber.swift
+++ b/Sources/SpeakiOS/Services/iOSLiveTranscriber.swift
@@ -22,6 +22,7 @@ public final class iOSLiveTranscriber: ObservableObject {
 
     public var language: String = Locale.current.identifier
     public var preferOnDevice: Bool = true
+    public var modelID: String = AppleLocalModels.preferredSpeechModelID
 
     // MARK: - Callbacks
 
@@ -37,6 +38,9 @@ public final class iOSLiveTranscriber: ObservableObject {
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     private var latestResult: SFSpeechRecognitionResult?
+    private var speechAnalyzerSession: Any?
+    private var speechAnalyzerConverter: Any?
+    private var activeModelID = AppleLocalModels.legacySpeechModelID
     private var startTime: Date?
     private var accumulatedSegments: [TranscriptionSegment] = []
     private var segments: [TranscriptionSegment] = []
@@ -112,9 +116,29 @@ public final class iOSLiveTranscriber: ObservableObject {
             throw iOSTranscriptionError.audioSessionFailed(error)
         }
 
+        resetState()
+
+        if modelID == AppleLocalModels.speechTranscriberModelID {
+            if #available(iOS 26.0, *) {
+                do {
+                    try await startSpeechAnalyzer()
+                    activeModelID = AppleLocalModels.speechTranscriberModelID
+                    isRunning = true
+                    print("[iOSLiveTranscriber] Started with SpeechAnalyzer")
+                    return
+                } catch {
+                    SpeakLogger.logError(
+                        error,
+                        context: "SpeechAnalyzer setup; falling back to SFSpeechRecognizer",
+                        logger: SpeakLogger.transcription
+                    )
+                }
+            }
+        }
+
+        activeModelID = AppleLocalModels.legacySpeechModelID
         let (recognizer, request) = try setupRecognition()
         try startAudioEngine()
-        resetState()
 
         // Start recognition
         recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
@@ -125,6 +149,49 @@ public final class iOSLiveTranscriber: ObservableObject {
 
         isRunning = true
         print("[iOSLiveTranscriber] Started")
+    }
+
+    @available(iOS 26.0, *)
+    private func startSpeechAnalyzer() async throws {
+        let session = try await AppleSpeechAnalyzerLiveSession(
+            localeIdentifier: language
+        ) { [weak self] update in
+            Task { @MainActor [weak self] in
+                self?.handleSpeechAnalyzerUpdate(update)
+            }
+        }
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+        do {
+            let converter = try AppleSpeechAudioConverter(
+                sourceFormat: recordingFormat,
+                targetFormat: session.audioFormat
+            )
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
+                self?.audioRecorder.writeBuffer(buffer)
+                guard let converted = converter.convert(buffer) else { return }
+                session.send(converted)
+            }
+            audioEngine.prepare()
+            try audioEngine.start()
+            _ = try? audioRecorder.startRecording(format: recordingFormat)
+            speechAnalyzerSession = session
+            speechAnalyzerConverter = converter
+        } catch {
+            audioEngine.stop()
+            inputNode.removeTap(onBus: 0)
+            await session.cancel()
+            throw error
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func handleSpeechAnalyzerUpdate(_ update: AppleSpeechAnalyzerUpdate) {
+        partialText = update.text
+        isFinal = update.isFinal
+        confidence = update.confidence
+        onPartialResult?(update.text, update.isFinal)
     }
 
     private func setupRecognition() throws -> (SFSpeechRecognizer, SFSpeechAudioBufferRecognitionRequest) {
@@ -158,7 +225,7 @@ public final class iOSLiveTranscriber: ObservableObject {
         }
         audioEngine.prepare()
         try audioEngine.start()
-        try? audioRecorder.startRecording(format: recordingFormat)
+        _ = try? audioRecorder.startRecording(format: recordingFormat)
     }
 
     private func resetState() {
@@ -183,11 +250,16 @@ public final class iOSLiveTranscriber: ObservableObject {
                 segments: segments,
                 confidence: confidence,
                 duration: 0,
-                modelIdentifier: "apple/local/SFSpeechRecognizer",
+                modelIdentifier: activeModelID,
                 cost: nil,
                 rawPayload: nil,
                 debugInfo: nil
             )
+        }
+
+        if #available(iOS 26.0, *),
+           let session = speechAnalyzerSession as? AppleSpeechAnalyzerLiveSession {
+            return await stopSpeechAnalyzer(session)
         }
 
         isShuttingDownRecognitionTask = true
@@ -223,6 +295,54 @@ public final class iOSLiveTranscriber: ObservableObject {
         return result
     }
 
+    @available(iOS 26.0, *)
+    private func stopSpeechAnalyzer(_ session: AppleSpeechAnalyzerLiveSession) async -> TranscriptionResult {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        _ = audioRecorder.stopRecording()
+
+        let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
+        let result: TranscriptionResult
+        do {
+            let analyzerResult = try await session.finish()
+            result = TranscriptionResult(
+                text: analyzerResult.text,
+                segments: analyzerResult.segments,
+                confidence: analyzerResult.confidence,
+                duration: max(elapsed, analyzerResult.duration),
+                modelIdentifier: AppleLocalModels.speechTranscriberModelID,
+                cost: nil,
+                rawPayload: nil,
+                debugInfo: nil
+            )
+        } catch {
+            self.error = error
+            onError?(error)
+            result = TranscriptionResult(
+                text: partialText,
+                segments: [],
+                confidence: confidence,
+                duration: elapsed,
+                modelIdentifier: AppleLocalModels.speechTranscriberModelID,
+                cost: nil,
+                rawPayload: nil,
+                debugInfo: nil
+            )
+        }
+
+        speechAnalyzerSession = nil
+        speechAnalyzerConverter = nil
+        isRunning = false
+        audioSessionManager.deactivate()
+        SpeakLogger.logTranscription(
+            event: "stop",
+            model: "Apple SpeechTranscriber",
+            wordCount: result.text.split(separator: " ").count
+        )
+        onFinalResult?(result)
+        return result
+    }
+
     /// Cancel transcription without returning result.
     public func cancel() {
         guard isRunning else { return }
@@ -238,9 +358,16 @@ public final class iOSLiveTranscriber: ObservableObject {
         // Cancel persistent recording (keeps partial file by default)
         audioRecorder.cancelRecording()
 
+        if #available(iOS 26.0, *),
+           let session = speechAnalyzerSession as? AppleSpeechAnalyzerLiveSession {
+            Task { await session.cancel() }
+        }
+
         recognitionRequest = nil
         recognitionTask = nil
         speechRecognizer = nil
+        speechAnalyzerSession = nil
+        speechAnalyzerConverter = nil
         isRunning = false
 
         audioSessionManager.deactivate()
@@ -397,7 +524,7 @@ public final class iOSLiveTranscriber: ObservableObject {
             segments: finalSegments,
             confidence: confidence,
             duration: duration,
-            modelIdentifier: "apple/local/SFSpeechRecognizer",
+            modelIdentifier: activeModelID,
             cost: nil,
             rawPayload: nil,
             debugInfo: nil

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -11,7 +11,7 @@ final class TranscriberCoordinator: ObservableObject {
     @Published private(set) var isRunning = false
     @Published private(set) var partialText = ""
     @Published private(set) var error: Error?
-    @Published private(set) var currentModel: String = "apple/local/SFSpeechRecognizer"
+    @Published private(set) var currentModel: String = AppleLocalModels.preferredSpeechModelID
     @Published private(set) var confidence: Double?
     @Published private(set) var wordCount: Int = 0
 
@@ -63,13 +63,12 @@ final class TranscriberCoordinator: ObservableObject {
         startTime = Date()
         sharedState.clear()
 
-        // Fall back to Apple Speech if the selected provider needs an API key we
-        // don't have (covers every cloud provider via the shared routing).
-        if settings.transcriptionMode == .streaming,
-           let route = LiveTranscriptionRouting.route(for: currentModel),
-           route.apiKeyIdentifier != nil,
-           settings.liveAPIKey(for: route).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            currentModel = "apple/local/SFSpeechRecognizer"
+        if settings.transcriptionMode == .streaming {
+            let route = LiveTranscriptionRouting.route(for: currentModel)
+            currentModel = LiveTranscriptionRouting.resolvedModelID(
+                for: currentModel,
+                apiKey: route.map { settings.liveAPIKey(for: $0) }
+            )
         }
 
         // Start Live Activity (if enabled)
@@ -186,6 +185,7 @@ final class TranscriberCoordinator: ObservableObject {
         } else {
             // Use Apple Speech
             let transcriber = iOSLiveTranscriber(audioSessionManager: audioSessionManager)
+            transcriber.modelID = currentModel
 
             transcriber.onPartialResult = { [weak self] text, isFinal in
                 self?.handlePartialResult(text: self?.appleTranscriber?.partialText ?? text, isFinal: isFinal)

--- a/Sources/SpeakiOS/Views/PostProcessingView.swift
+++ b/Sources/SpeakiOS/Views/PostProcessingView.swift
@@ -28,7 +28,8 @@ public final class iOSPostProcessingManager: ObservableObject {
         apiKey: String
     ) async {
         guard !text.isEmpty else { return }
-        guard !apiKey.isEmpty else {
+        let usesAppleModel = model == AppleLocalModels.foundationModelID
+        guard usesAppleModel || !apiKey.isEmpty else {
             error = "OpenRouter API key required for post-processing"
             return
         }
@@ -44,16 +45,23 @@ public final class iOSPostProcessingManager: ObservableObject {
         streamTask = Task {
             do {
                 let effectivePrompt = prompt.isEmpty ? AppSettings.defaultPostProcessingPrompt : prompt
-                
-                // Use streaming for real-time updates
-                for try await chunk in sendChatStreaming(
-                    systemPrompt: effectivePrompt,
-                    userMessage: text,
-                    model: model,
-                    apiKey: apiKey
-                ) {
-                    if Task.isCancelled { break }
-                    streamingText += chunk
+
+                if usesAppleModel {
+                    streamingText = try await AppleFoundationModelPolisher.process(
+                        text: text,
+                        systemPrompt: effectivePrompt
+                    )
+                } else {
+                    // Use streaming for real-time updates
+                    for try await chunk in sendChatStreaming(
+                        systemPrompt: effectivePrompt,
+                        userMessage: text,
+                        model: model,
+                        apiKey: apiKey
+                    ) {
+                        if Task.isCancelled { break }
+                        streamingText += chunk
+                    }
                 }
                 
                 processedText = streamingText
@@ -85,9 +93,15 @@ public final class iOSPostProcessingManager: ObservableObject {
         apiKey: String
     ) async throws -> String {
         guard !text.isEmpty else { return text }
+        let effectivePrompt = prompt.isEmpty ? AppSettings.defaultPostProcessingPrompt : prompt
+        if model == AppleLocalModels.foundationModelID {
+            return try await AppleFoundationModelPolisher.process(
+                text: text,
+                systemPrompt: effectivePrompt
+            )
+        }
         guard !apiKey.isEmpty else { throw PostProcessingError.apiKeyMissing }
 
-        let effectivePrompt = prompt.isEmpty ? AppSettings.defaultPostProcessingPrompt : prompt
         var result = ""
         for try await chunk in sendChatStreaming(
             systemPrompt: effectivePrompt,

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -237,10 +237,13 @@ public final class AppSettings: ObservableObject {
         """
     // swiftlint:enable line_length
 
-    public static let postProcessingModels = ModelCatalog.cloudPostProcessing
+    public static let postProcessingModels = ModelCatalog.postProcessing.filter {
+        !$0.id.hasPrefix("local/post-processing/")
+    }
 
     private init() { // swiftlint:disable:this function_body_length
-        let selectedRaw = UserDefaults.standard.string(forKey: "selectedModel") ?? "apple/local/SFSpeechRecognizer"
+        let selectedRaw = UserDefaults.standard.string(forKey: "selectedModel")
+            ?? AppleLocalModels.preferredSpeechModelID
         // Normalise to canonical catalogue ids. Keep only models that this iOS
         // target can actually run; a previously stored macOS-only model falls
         // back to Apple Speech instead of leaking into the iPhone picker.
@@ -248,7 +251,9 @@ public final class AppSettings: ObservableObject {
             (ModelCatalog.onDeviceLiveTranscription + Self.supportedLiveModels).map(\.id)
         )
         let selected: String
-        if selectableLiveIDs.contains(selectedRaw) {
+        if AppleLocalModels.isAppleSpeechModel(selectedRaw) {
+            selected = ModelCatalog.normalizedLiveTranscriptionModel(selectedRaw)
+        } else if selectableLiveIDs.contains(selectedRaw) {
             selected = selectedRaw
         } else if selectedRaw.hasPrefix("apple/") {
             selected = selectedRaw
@@ -259,7 +264,7 @@ public final class AppSettings: ObservableObject {
         } else if selectedRaw.hasPrefix("openai/") {
             selected = "openai/gpt-realtime-whisper-streaming"
         } else {
-            selected = "apple/local/SFSpeechRecognizer"
+            selected = AppleLocalModels.preferredSpeechModelID
         }
         // API keys load asynchronously from the canonical secure storage (with
         // legacy migration) in the Task below.
@@ -343,7 +348,7 @@ public final class AppSettings: ObservableObject {
             if hasDeepgramKey {
                 selectedModel = "deepgram/nova-3-streaming"
             } else {
-                selectedModel = "apple/local/SFSpeechRecognizer"
+                selectedModel = AppleLocalModels.preferredSpeechModelID
             }
             UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
         }
@@ -469,6 +474,9 @@ public final class AppSettings: ObservableObject {
     }
 
     public var batchAPIKey: String {
+        if batchTranscriptionModel == AppleLocalModels.speechTranscriberModelID {
+            return ""
+        }
         if Self.openAIBatchModelIDs.contains(batchTranscriptionModel) {
             return openAIAPIKey
         }
@@ -495,7 +503,8 @@ public final class AppSettings: ObservableObject {
     /// Mac but are hidden until their upload clients are available on iPhone.
     public static let supportedBatchModels: [ModelCatalog.Option] =
         ModelCatalog.batchTranscription.filter { option in
-            openAIBatchModelIDs.contains(option.id)
+            option.id == AppleLocalModels.speechTranscriberModelID
+                || openAIBatchModelIDs.contains(option.id)
                 || option.id.hasPrefix("google/")
                 || option.id == "openai/gpt-4o-audio-preview-2024-12-17"
         }
@@ -727,6 +736,7 @@ public struct SettingsView: View {
 
                 if transcriptionLocationBinding.wrappedValue == .remote,
                    settings.transcriptionMode == .batch,
+                   settings.batchTranscriptionModel != AppleLocalModels.speechTranscriberModelID,
                    settings.batchAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Label(
                         AppSettings.openAIBatchModelIDs.contains(settings.batchTranscriptionModel)
@@ -1020,6 +1030,13 @@ public struct SettingsView: View {
             showingAPIKeys: $showingAPIKeys,
             openURL: openURL
         )
+    }
+
+    private var batchModeDescription: String {
+        if settings.batchTranscriptionModel == AppleLocalModels.speechTranscriberModelID {
+            return "Audio is recorded first, then transcribed privately on this device when you stop."
+        }
+        return "Audio is recorded first, then uploaded when you stop for a more complete transcript."
     }
 
     private var postProcessingModelName: String {

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SpeakHotKeys
+import SpeakCore
 
 @testable import SpeakApp
 
@@ -172,7 +173,7 @@ final class AppSettingsDefaultsTests: XCTestCase {
     @MainActor
     func testTranscriptionDefaults_liveTranscriptionModelIsAppleLocal() {
         let settings = AppSettings(defaults: defaults)
-        XCTAssertEqual(settings.liveTranscriptionModel, "apple/local/SFSpeechRecognizer")
+        XCTAssertEqual(settings.liveTranscriptionModel, AppleLocalModels.preferredSpeechModelID)
     }
 
     // MARK: - TTS Settings

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -51,6 +51,18 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertLessThan(testStep.lowerBound, signingStep.lowerBound)
     }
 
+    func testDirectMacRelease_retriesDelayedDMGNotarizationTickets() throws {
+        let workflow = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-mac.yml"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(workflow.contains("for ATTEMPT in {1..5}"))
+        XCTAssertTrue(workflow.contains("xcrun stapler staple \"$DMG_PATH\""))
+        XCTAssertTrue(workflow.contains("xcrun stapler validate \"$DMG_PATH\""))
+        XCTAssertTrue(workflow.contains("Notarization ticket not available yet; retrying in 15s"))
+    }
+
     func testPlatformAppTargets_doNotCompileTheOtherPlatformsUI() throws {
         let manifest = try String(
             contentsOf: repositoryRoot.appendingPathComponent("Project.swift"),

--- a/Tests/SpeakAppTests/PostProcessingManagerTests.swift
+++ b/Tests/SpeakAppTests/PostProcessingManagerTests.swift
@@ -6,6 +6,15 @@ import SpeakCore
 
 @MainActor
 final class PostProcessingManagerTests: XCTestCase {
+  func testAppleFoundationModelIsTreatedAsLocal() {
+    XCTAssertTrue(
+      PostProcessingManager.isLocalPostProcessingModel(AppleLocalModels.foundationModelID)
+    )
+    XCTAssertTrue(
+      PostProcessingManager.isAppleFoundationModel(AppleLocalModels.foundationModelID)
+    )
+  }
+
   func testLocalPostProcessingCleansTextWithoutCallingLLM() async throws {
     let client = SpyChatClient()
     let settings = makeSettings()

--- a/Tests/SpeakCoreTests/LiveTranscriptionRoutingTests.swift
+++ b/Tests/SpeakCoreTests/LiveTranscriptionRoutingTests.swift
@@ -56,6 +56,16 @@ final class LiveTranscriptionRoutingTests: XCTestCase {
         XCTAssertEqual(route?.provider, .apple)
         XCTAssertNil(route?.apiKeyIdentifier)
         XCTAssertEqual(route?.apiModelName, "apple/local/SFSpeechRecognizer")
+
+        let speechTranscriber = LiveTranscriptionRouting.route(
+            for: AppleLocalModels.speechTranscriberModelID
+        )
+        XCTAssertEqual(speechTranscriber?.provider, .apple)
+        XCTAssertNil(speechTranscriber?.apiKeyIdentifier)
+        XCTAssertEqual(
+            speechTranscriber?.apiModelName,
+            AppleLocalModels.speechTranscriberModelID
+        )
     }
 
     func testRoute_unknownOrMalformedID_returnsNil() {
@@ -72,6 +82,33 @@ final class LiveTranscriptionRoutingTests: XCTestCase {
 
         // Assert: every catalogue live model resolves to a route.
         XCTAssertEqual(routes.count, ModelCatalog.liveTranscription.count)
+    }
+
+    func testResolvedModelID_missingCloudKeyFallsBackToSharedOnDeviceDefault() {
+        XCTAssertEqual(
+            LiveTranscriptionRouting.resolvedModelID(
+                for: "deepgram/nova-3-streaming",
+                apiKey: "  "
+            ),
+            ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+        )
+    }
+
+    func testResolvedModelID_preservesUsableAndOnDeviceModels() {
+        XCTAssertEqual(
+            LiveTranscriptionRouting.resolvedModelID(
+                for: "deepgram/nova-3-streaming",
+                apiKey: "configured"
+            ),
+            "deepgram/nova-3-streaming"
+        )
+        XCTAssertEqual(
+            LiveTranscriptionRouting.resolvedModelID(
+                for: AppleLocalModels.preferredSpeechModelID,
+                apiKey: nil
+            ),
+            AppleLocalModels.preferredSpeechModelID
+        )
     }
 
     // MARK: - iOS availability

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -123,6 +123,7 @@ final class ModelCatalogTests: XCTestCase {
 
     func testModelRouting_distinguishesAppleSpeechFromDownloadedLocal() {
         XCTAssertEqual(ModelRouting.family(for: "apple/local/SFSpeechRecognizer"), .appleSpeech)
+        XCTAssertEqual(ModelRouting.family(for: "apple/local/SpeechTranscriber"), .appleSpeech)
         XCTAssertEqual(ModelRouting.family(for: "local/whisperkit/tiny"), .downloadedLocal(engine: "whisperkit"))
     }
 
@@ -130,7 +131,7 @@ final class ModelCatalogTests: XCTestCase {
         let onDeviceIDs = Set(ModelCatalog.onDeviceLiveTranscription.map(\.id))
         let remoteIDs = Set(ModelCatalog.remoteLiveTranscription.map(\.id))
 
-        XCTAssertTrue(onDeviceIDs.contains("apple/local/SFSpeechRecognizer"))
+        XCTAssertTrue(onDeviceIDs.contains(AppleLocalModels.preferredSpeechModelID))
         XCTAssertTrue(onDeviceIDs.contains("apple/local/Dictation"))
         XCTAssertTrue(onDeviceIDs.allSatisfy(ModelCatalog.isOnDeviceLiveTranscriptionModel))
         XCTAssertTrue(remoteIDs.allSatisfy { !ModelCatalog.isOnDeviceLiveTranscriptionModel($0) })
@@ -144,6 +145,48 @@ final class ModelCatalogTests: XCTestCase {
         ))
         let remoteDefault = try XCTUnwrap(ModelCatalog.defaultRemoteLiveTranscriptionModel)
         XCTAssertFalse(ModelCatalog.isOnDeviceLiveTranscriptionModel(remoteDefault))
+    }
+
+    func testAppleSpeechCatalog_usesBestRuntimeAvailableModel() {
+        let liveIDs = Set(ModelCatalog.liveTranscription.map(\.id))
+        XCTAssertTrue(liveIDs.contains(AppleLocalModels.preferredSpeechModelID))
+
+        if AppleLocalModels.supportsSpeechTranscriber {
+            XCTAssertTrue(ModelCatalog.batchTranscription.contains {
+                $0.id == AppleLocalModels.speechTranscriberModelID
+            })
+            XCTAssertFalse(liveIDs.contains(AppleLocalModels.legacySpeechModelID))
+        } else {
+            XCTAssertFalse(ModelCatalog.batchTranscription.contains {
+                $0.id == AppleLocalModels.speechTranscriberModelID
+            })
+            XCTAssertFalse(liveIDs.contains(AppleLocalModels.speechTranscriberModelID))
+        }
+    }
+
+    func testAppleSpeechModelSelection_preservesLegacyFallback() {
+        XCTAssertEqual(
+            AppleLocalModels.preferredSpeechModelID(speechTranscriberAvailable: true),
+            AppleLocalModels.speechTranscriberModelID
+        )
+        XCTAssertEqual(
+            AppleLocalModels.preferredSpeechModelID(speechTranscriberAvailable: false),
+            AppleLocalModels.legacySpeechModelID
+        )
+        XCTAssertEqual(
+            ModelCatalog.normalizedLiveTranscriptionModel(AppleLocalModels.legacySpeechModelID),
+            AppleLocalModels.preferredSpeechModelID
+        )
+    }
+
+    func testAppleFoundationModelCatalog_matchesRuntimeAvailability() {
+        let isCatalogued = ModelCatalog.postProcessing.contains {
+            $0.id == AppleLocalModels.foundationModelID
+        }
+        XCTAssertEqual(isCatalogued, AppleLocalModels.supportsFoundationModels)
+        XCTAssertFalse(ModelCatalog.cloudPostProcessing.contains {
+            $0.id == AppleLocalModels.foundationModelID
+        })
     }
 
     func testModelRouting_treatsLocalCleanupAsPostProcessing() {
@@ -204,7 +247,10 @@ final class ModelCatalogTests: XCTestCase {
     func testCloudPostProcessing_isExactNonLocalProjection() {
         XCTAssertEqual(
             ModelCatalog.cloudPostProcessing,
-            ModelCatalog.postProcessing.filter { !$0.id.hasPrefix("local/post-processing/") }
+            ModelCatalog.postProcessing.filter {
+                !$0.id.hasPrefix("local/post-processing/")
+                    && $0.id != AppleLocalModels.foundationModelID
+            }
         )
     }
 


### PR DESCRIPTION
## Motivation

GitHub issue #528 asks us to adopt Apple's newer on-device transcription stack where it is available, while retaining the existing Speech framework path for older or unsupported systems.

## What changed

- Added a shared Apple local-model layer for SpeechAnalyzer/SpeechTranscriber asset installation, locale selection, audio conversion, live updates, and recorded-file transcription.
- Made SpeechTranscriber the preferred Apple live model on supported macOS 26/iOS 26 devices and exposed it for local batch transcription.
- Kept SFSpeechRecognizer as the runtime fallback on older systems and whenever the new model cannot start.
- Added Apple Intelligence/Foundation Models as an optional fully local transcript-polishing model when the device reports it available.
- Kept macOS and iOS model catalogues, settings migration, routing, and post-processing behavior aligned.
- Added catalogue, routing, default-selection, and local-post-processing tests.

## Things learnt that changed the direction

- One SpeechAnalyzer pipeline supports both progressive live transcription and long-form file analysis, so separate platform-specific engines were unnecessary.
- SpeechTranscriber availability is device-, locale-, and asset-dependent, so runtime selection plus fallback is safer than raising deployment targets.
- Foundation Models is a useful local polish option, but only when Apple Intelligence is actually available; it stays out of cloud model lists.

## How to test

- `swift build`
- `swift test --skip-build --filter 'ModelCatalogTests|LiveTranscriptionRoutingTests|AppSettingsDefaultsTests|PostProcessingManagerTests'` — 78 tests passed
- SwiftFormat lint on all changed files — passed
- SwiftLint strict against `.swiftlint-baseline.json` on all changed files — passed
- Generated the Tuist workspace, built, installed, launched, and visually verified `SpeakiOS` on an iOS 26.2 iPhone 17 Pro Max simulator — passed
- A full local `swift test` run reaches an unrelated existing Keychain mutex hang in `OpenRouterAPIClientTests.testBlankAPIKeyOverride_UsesStoredKey`; PR CI should provide the clean full-suite signal.

## Review confidence

The catalogue, migrations, fallback behavior, formatting, targeted tests, and real iOS build/run are verified. Please review the first-use asset-download path and live audio finalization closely because those depend on runtime SpeechAnalyzer behavior.

Closes #528