### PR TITLE
fix: separate local models and distribution sync

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -345,7 +345,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   @Published var localTranscriptionMode: LocalTranscriptionMode {
     didSet {
       #if APP_STORE
-      if !DistributionChannel.current.supportsLocalModelRuntime, localTranscriptionMode == .streaming {
+      if !DistributionChannel.current.supportsExternalLocalModelRuntime, localTranscriptionMode == .streaming {
         localTranscriptionMode = .batch
         return
       }
@@ -805,7 +805,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
         ?? LocalTranscriptionMode.batch.rawValue
     ) ?? .batch
     #if APP_STORE
-    localTranscriptionMode = DistributionChannel.current.supportsLocalModelRuntime
+    localTranscriptionMode = DistributionChannel.current.supportsExternalLocalModelRuntime
       ? loadedLocalTranscriptionMode
       : .batch
     #else

--- a/Sources/SpeakApp/SecureAppStorage.swift
+++ b/Sources/SpeakApp/SecureAppStorage.swift
@@ -67,71 +67,30 @@ actor SecureAppStorage {
     init(permissionsManager: PermissionsManager, appSettings: AppSettings) {
         self.permissionsManager = permissionsManager
         self.appSettings = appSettings
-        
-        // Check if we can use iCloud Keychain sync (kSecAttrSynchronizable)
-        // Developer ID builds cannot use this - it requires keychain-access-groups entitlement
-        let canUseSync = Self.hasKeychainSyncEntitlement()
-        
-        // IMPORTANT: For Developer ID (non-App Store) builds, we MUST NOT use:
-        // - kSecAttrSynchronizable (requires keychain-access-groups entitlement) - causes -34018
-        // - kSecAttrAccessGroup (requires keychain-access-groups entitlement in some cases)
+
+        // The local Keychain is the vault for every Mac build. App Store builds
+        // opt in to the separate passphrase-encrypted CloudKit sync layer; direct
+        // builds remain local-only. Do not silently add iCloud Keychain as a third
+        // API-key sync path.
         let configuration = SecureStorageConfiguration(
             service: "com.justspeaktoit.credentials",
             masterAccount: "speak-app-secrets",
-            // Don't use access group for Developer ID - not needed and may cause issues
             accessGroup: nil,
-            // Only enable sync if we verified the entitlement exists
-            synchronizable: canUseSync
+            synchronizable: false
         )
-        
+
         print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
         print("[SecureAppStorage] Keychain Configuration:")
-        print("  canUseSync: \(canUseSync)")
         print("  accessGroup: \(configuration.accessGroup ?? "nil")")
         print("  synchronizable: \(configuration.synchronizable)")
         print("  service: \(configuration.service)")
         print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-        
+
         self.storage = SecureStorage(
             configuration: configuration,
             permissionsChecker: PermissionsManagerBridge(permissionsManager: permissionsManager),
             identifierRegistry: appSettings
         )
-    }
-    
-    /// Check if the app can use iCloud keychain sync by testing kSecAttrSynchronizable.
-    /// Developer ID (non-App Store) builds cannot use synchronizable items.
-    private static func hasKeychainSyncEntitlement() -> Bool {
-        let testService = "com.justspeaktoit.entitlement-check"
-        let testAccount = "sync-test-\(UUID().uuidString)"
-        
-        // Test with kSecAttrSynchronizable - THIS is what requires the entitlement
-        let addQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: testService,
-            kSecAttrAccount as String: testAccount,
-            kSecAttrSynchronizable as String: kCFBooleanTrue!,
-            kSecValueData as String: "test".data(using: .utf8)!
-        ]
-        
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        
-        // Clean up if we succeeded
-        if addStatus == errSecSuccess {
-            let deleteQuery: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: testService,
-                kSecAttrAccount as String: testAccount,
-                kSecAttrSynchronizable as String: kCFBooleanTrue!
-            ]
-            SecItemDelete(deleteQuery as CFDictionary)
-            print("[SecureAppStorage] iCloud Keychain sync entitlement available")
-            return true
-        }
-        
-        // errSecMissingEntitlement (-34018) means we can't use synchronizable
-        print("[SecureAppStorage] No iCloud Keychain sync entitlement (status: \(addStatus)), disabling sync")
-        return false
     }
 
     func storeSecret(_ value: String, identifier: String, label _: String? = nil) async throws {

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -145,8 +145,22 @@ struct SettingsView: View {
 
   }
 
+  private enum LocalTranscriptionSource: String, CaseIterable, Identifiable {
+    case apple
+    case downloaded
+
+    var id: String { rawValue }
+
+    var displayName: String {
+      switch self {
+      case .apple: return "Apple Speech"
+      case .downloaded: return "Downloaded Model"
+      }
+    }
+  }
+
   private let orderedLocalTranscriptionModes: [AppSettings.LocalTranscriptionMode] = {
-    DistributionChannel.current.supportsLocalModelRuntime ? [.streaming, .batch] : [.batch]
+    DistributionChannel.current.supportsExternalLocalModelRuntime ? [.streaming, .batch] : [.batch]
   }()
   private let orderedRemoteTranscriptionModes: [RemoteTranscriptionMode] = [.streaming, .batch]
 
@@ -386,15 +400,33 @@ struct SettingsView: View {
   private var transcriptionLocationBinding: Binding<TranscriptionLocation> {
     Binding(
       get: {
-        settings.transcriptionMode == .localModel ? .local : .remote
+        isLocalTranscriptionSelected ? .local : .remote
       },
       set: { location in
         switch location {
         case .remote:
-          if settings.transcriptionMode == .localModel {
-            settings.transcriptionMode = .liveNative
+          if isLocalTranscriptionSelected {
+            settings.liveTranscriptionModel = ModelCatalog.defaultRemoteLiveTranscriptionModel
+              ?? settings.liveTranscriptionModel
           }
+          settings.transcriptionMode = .liveNative
         case .local:
+          settings.liveTranscriptionModel = ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+          settings.transcriptionMode = .liveNative
+        }
+      }
+    )
+  }
+
+  private var localTranscriptionSourceBinding: Binding<LocalTranscriptionSource> {
+    Binding(
+      get: { isAppleOnDeviceTranscriptionSelected ? .apple : .downloaded },
+      set: { source in
+        switch source {
+        case .apple:
+          settings.liveTranscriptionModel = ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+          settings.transcriptionMode = .liveNative
+        case .downloaded:
           settings.transcriptionMode = .localModel
         }
       }
@@ -407,7 +439,15 @@ struct SettingsView: View {
         settings.transcriptionMode == .batchRemote ? .batch : .streaming
       },
       set: { mode in
-        settings.transcriptionMode = mode == .streaming ? .liveNative : .batchRemote
+        if mode == .streaming {
+          if ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.liveTranscriptionModel) {
+            settings.liveTranscriptionModel = ModelCatalog.defaultRemoteLiveTranscriptionModel
+              ?? settings.liveTranscriptionModel
+          }
+          settings.transcriptionMode = .liveNative
+        } else {
+          settings.transcriptionMode = .batchRemote
+        }
       }
     )
   }
@@ -421,6 +461,19 @@ struct SettingsView: View {
   private var isStreamingTranscriptionSelected: Bool {
     settings.transcriptionMode == .liveNative
       || (settings.transcriptionMode == .localModel && settings.localTranscriptionMode == .streaming)
+  }
+
+  private var isAppleOnDeviceTranscriptionSelected: Bool {
+    settings.transcriptionMode == .liveNative
+      && ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.liveTranscriptionModel)
+  }
+
+  private var isLocalTranscriptionSelected: Bool {
+    settings.transcriptionMode == .localModel || isAppleOnDeviceTranscriptionSelected
+  }
+
+  private var isRemoteStreamingTranscriptionSelected: Bool {
+    settings.transcriptionMode == .liveNative && !isAppleOnDeviceTranscriptionSelected
   }
 
   private var cloudPostProcessingModelBinding: Binding<String> {
@@ -1128,20 +1181,36 @@ struct SettingsView: View {
           .speakTooltip("Choose whether Speak transcribes locally on this Mac or remotely with a provider.")
           .accessibilityLabel("Transcription location picker")
 
-          if settings.transcriptionMode == .localModel {
-            if DistributionChannel.current.supportsLocalModelRuntime {
-              Picker("Local transcription type", selection: settingsBinding(\AppSettings.localTranscriptionMode)) {
-                ForEach(orderedLocalTranscriptionModes) { mode in
-                  Text(transcriptionModeSegmentLabel(from: mode.displayName)).tag(mode)
-                }
+          if isLocalTranscriptionSelected {
+            Picker("Local transcription source", selection: localTranscriptionSourceBinding) {
+              ForEach(LocalTranscriptionSource.allCases) { source in
+                Text(source.displayName).tag(source)
               }
-              .modifier(TranscriptionModeSegmentedPickerStyle())
-              .speakTooltip(
-                "Choose Local Batch for offline transcription after recording, or Local Streaming for live local text."
-              )
-              .accessibilityLabel("Local transcription type picker")
-            } else {
-              localRuntimeUnavailableNote
+            }
+            .modifier(TranscriptionModeSegmentedPickerStyle())
+            .speakTooltip("Choose built-in Apple Speech or a downloaded Core ML model.")
+            .accessibilityLabel("Local transcription source picker")
+
+            if settings.transcriptionMode == .localModel {
+              if DistributionChannel.current.supportsExternalLocalModelRuntime {
+                Picker(
+                  "Downloaded transcription type",
+                  selection: settingsBinding(\AppSettings.localTranscriptionMode)
+                ) {
+                  ForEach(orderedLocalTranscriptionModes) { mode in
+                    Text(transcriptionModeSegmentLabel(from: mode.displayName)).tag(mode)
+                  }
+                }
+                .modifier(TranscriptionModeSegmentedPickerStyle())
+                .speakTooltip(
+                  "Choose Batch for WhisperKit/Core ML, or Streaming for a direct-build external ASR runtime."
+                )
+                .accessibilityLabel("Downloaded transcription type picker")
+              } else {
+                Text("Downloaded WhisperKit/Core ML models run in-process as Local Batch transcription.")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
             }
           } else {
             Picker("Remote transcription type", selection: remoteTranscriptionModeBinding) {
@@ -1175,7 +1244,7 @@ struct SettingsView: View {
       }
       .speakTooltip("Choose which transcription flow Speak uses and the locale it should prefer.")
 
-      if settings.transcriptionMode == .liveNative {
+      if isRemoteStreamingTranscriptionSelected {
         SettingsCard(
           title: "Processing Speed",
           systemImage: "gauge.with.dots.needle.67percent",
@@ -1367,7 +1436,7 @@ struct SettingsView: View {
         .speakTooltip("Configure automatic recording stop based on silence detection.")
       }
 
-      if settings.transcriptionMode == .liveNative {
+      if isRemoteStreamingTranscriptionSelected {
         SettingsCard(title: "Remote Streaming model", systemImage: "mic.fill", tint: Color.brandAccentDeep) {
           VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 8) {
@@ -1391,10 +1460,10 @@ struct SettingsView: View {
             ModelPicker(
               title: "Remote Streaming Model",
               help: "Choose the remote provider model used while recording.",
-              options: ModelCatalog.liveTranscription,
+              options: ModelCatalog.remoteLiveTranscription,
               value: remoteTranscriptionModelBinding(
                 \AppSettings.liveTranscriptionModel,
-                options: ModelCatalog.liveTranscription
+                options: ModelCatalog.remoteLiveTranscription
               )
             )
           }
@@ -1464,6 +1533,31 @@ struct SettingsView: View {
         .speakTooltip("Tell Speak which cloud transcription model should polish the full recording.")
       }
 
+      if isAppleOnDeviceTranscriptionSelected {
+        SettingsCard(
+          title: "Apple on-device transcription",
+          systemImage: "apple.logo",
+          tint: Color.green
+        ) {
+          VStack(alignment: .leading, spacing: 12) {
+            Text("Uses Apple's built-in speech engine. Audio stays on this device.")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+            ModelPicker(
+              title: "Apple Model",
+              help: "Choose the Apple on-device engine used while recording.",
+              options: ModelCatalog.onDeviceLiveTranscription,
+              value: remoteTranscriptionModelBinding(
+                \AppSettings.liveTranscriptionModel,
+                options: ModelCatalog.onDeviceLiveTranscription
+              ),
+              allowsCustom: false
+            )
+          }
+        }
+        .speakTooltip("Choose an on-device Apple transcription engine.")
+      }
+
       if settings.transcriptionMode == .localModel {
         SettingsCard(
           title: "Local transcription models",
@@ -1494,14 +1588,14 @@ struct SettingsView: View {
               {
                 #if APP_STORE
                 return """
-                Local transcription is separate from Apple Speech and cloud providers. \
-                Local Batch uses downloaded WhisperKit/Core ML models and stays local-only.
+                Downloaded transcription is separate from Apple Speech and cloud providers. \
+                WhisperKit/Core ML model data runs in-process and is supported in this App Store build.
                 """
                 #else
                 return """
-                Local Batch and Local Streaming are separate from Apple Speech and cloud providers. \
-                Both stay local-only; Local Batch uses downloaded WhisperKit/Core ML models, while \
-                Local Streaming needs a dedicated streaming ASR runtime.
+                Downloaded transcription is separate from Apple Speech and cloud providers. \
+                Local Batch uses in-process WhisperKit/Core ML model data. Local Streaming installs \
+                a dedicated external ASR runtime and is available only in the direct-download build.
                 """
                 #endif
               }()
@@ -1509,7 +1603,7 @@ struct SettingsView: View {
             .font(.caption)
             .foregroundStyle(.secondary)
 
-            if !DistributionChannel.current.supportsLocalModelRuntime {
+            if !DistributionChannel.current.supportsExternalLocalModelRuntime {
               localRuntimeUnavailableNote
             }
 
@@ -3041,7 +3135,7 @@ struct SettingsView: View {
       .foregroundStyle(.secondary)
       #endif
 
-      if !DistributionChannel.current.supportsLocalModelRuntime {
+      if !DistributionChannel.current.supportsExternalLocalModelRuntime {
         localRuntimeUnavailableNote
       }
 
@@ -3406,7 +3500,11 @@ struct SettingsView: View {
   private var apiKeySettings: some View {
     ScrollViewReader { proxy in
       LazyVStack(spacing: 20) {
-        CloudKitKeySyncSettingsCard(secureStorage: environment.secureStorage)
+        if DistributionChannel.current.supportsEncryptedCloudKitKeySync {
+          CloudKitKeySyncSettingsCard(secureStorage: environment.secureStorage)
+        } else {
+          LocalKeychainStorageCard()
+        }
 
         // OpenRouter (Legacy)
         apiKeyCard(
@@ -3789,6 +3887,23 @@ struct SettingsView: View {
         let coreStorage = await secureStorage.coreStorage()
         await keySync.configure(secureStorage: coreStorage)
         _ = await keySync.isAvailable()
+      }
+    }
+  }
+
+  private struct LocalKeychainStorageCard: View {
+    var body: some View {
+      SettingsCard(title: "Local Keychain Storage", systemImage: "key.fill", tint: .brandLagoon) {
+        VStack(alignment: .leading, spacing: 8) {
+          Label("Stored locally on this Mac", systemImage: "checkmark.seal.fill")
+            .foregroundStyle(.green)
+          Text(
+            "API keys stay in the macOS Keychain for this direct-download build. "
+              + "Encrypted CloudKit API-key sync is available only in App Store builds."
+          )
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        }
       }
     }
   }

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import Foundation
+import SpeakCore
 import SpeakSync
 
 // swiftlint:disable file_length
@@ -440,15 +441,17 @@ enum WireUp {
     Task { await syncAdapter.start() }
 
     Task { await secureStorage.preloadTrackedSecrets() }
-    Task {
-      let coreStorage = await secureStorage.coreStorage()
-      let keySync = CloudKitKeySync.shared
-      await keySync.configure(secureStorage: coreStorage)
-      guard await keySync.isAvailable() else { return }
-      do {
-        try await keySync.syncNow()
-      } catch {
-        print("[WireUp] CloudKit API-key sync failed: \(error.localizedDescription)")
+    if DistributionChannel.current.supportsEncryptedCloudKitKeySync {
+      Task {
+        let coreStorage = await secureStorage.coreStorage()
+        let keySync = CloudKitKeySync.shared
+        await keySync.configure(secureStorage: coreStorage)
+        guard await keySync.isAvailable() else { return }
+        do {
+          try await keySync.syncNow()
+        } catch {
+          print("[WireUp] CloudKit API-key sync failed: \(error.localizedDescription)")
+        }
       }
     }
     Task {

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -8,9 +8,13 @@ import Foundation
 /// which wires it into the generated Xcode project (see `Project.swift`):
 ///
 /// - `.direct`   — Developer ID / direct download. Unsandboxed, self-updates via
-///                 Sparkle, can run downloaded local model runtimes.
-/// - `.appStore` — Mac App Store. Sandboxed; no Sparkle; no downloaded local model
-///                 runtimes; some permissions must be granted manually.
+///                 Sparkle, and can install external local model runtimes.
+/// - `.appStore` — Mac App Store. Sandboxed; no Sparkle or external executable
+///                 runtime installers; some permissions must be granted manually.
+///
+/// Both channels can download model *data* consumed by an in-process, bundled
+/// runtime (for example WhisperKit/Core ML). The sandbox restriction applies to
+/// installing or spawning executable runtimes such as sherpa-onnx and llama.cpp.
 ///
 /// iOS is always distributed through the App Store / TestFlight, so it always reports
 /// `.appStore` regardless of the flag.
@@ -42,6 +46,14 @@ public enum DistributionChannel: String, Sendable, CaseIterable {
     public var isSandboxed: Bool { self == .appStore }
 }
 
+/// The only API-key persistence/sync presentation exposed by a build.
+public enum APIKeyStorageMode: String, Sendable {
+    /// Secrets remain solely in the local macOS Keychain.
+    case localKeychainOnly
+    /// Secrets are local by default and may be passphrase-encrypted into private CloudKit.
+    case encryptedCloudKit
+}
+
 // MARK: - Feature availability
 
 /// A build-time capability that may be unavailable on some distribution channels.
@@ -52,9 +64,11 @@ public enum DistributionChannel: String, Sendable, CaseIterable {
 public enum ChannelFeature: String, Sendable, CaseIterable {
     /// In-app self-update (Sparkle). App Store builds update through the store instead.
     case selfUpdate
-    /// Downloaded local model runtimes (Python venv + llama.cpp / sherpa-onnx) that
-    /// spawn subprocesses and build/download executable code — impossible when sandboxed.
-    case localModelRuntime
+    /// Downloaded Core ML model data used by a runtime already bundled in the app.
+    case downloadedCoreMLModels
+    /// External runtimes (llama.cpp / sherpa-onnx) that install or spawn executable
+    /// code and therefore cannot be offered in the App Store sandbox.
+    case externalLocalModelRuntime
     /// Automatically prompting the user for Accessibility. Sandboxed builds cannot show the
     /// Accessibility prompt (`AXIsProcessTrustedWithOptions` is inert under the sandbox), so the
     /// user must add the app manually in System Settings. Input Monitoring is unaffected — it
@@ -66,20 +80,27 @@ public enum ChannelFeature: String, Sendable, CaseIterable {
     /// iCloud-backed sync features. Runtime entitlement/account probes still decide
     /// whether each iCloud service is actually available.
     case iCloudSync
+    /// Passphrase-encrypted API-key sync through the user's private CloudKit database.
+    case encryptedCloudKitKeySync
     /// Local-network Bonjour transport for cross-device fallback.
     case localNetworkTransport
 }
 
 public extension DistributionChannel {
+    var apiKeyStorageMode: APIKeyStorageMode {
+        self == .direct ? .localKeychainOnly : .encryptedCloudKit
+    }
+
     /// Whether `feature` is available in this build.
     func supports(_ feature: ChannelFeature) -> Bool {
         switch feature {
-        case .selfUpdate, .localModelRuntime, .automaticAccessibilityPrompt, .crossChannelMessaging:
+        case .selfUpdate, .externalLocalModelRuntime, .automaticAccessibilityPrompt, .crossChannelMessaging:
             return self == .direct
-        case .iCloudSync, .localNetworkTransport:
-            // Sync transports are compiled into every build; runtime entitlement,
-            // account, and local-network permission probes decide actual availability.
-            // (The macOS Developer ID build also ships CloudKit entitlements.)
+        case .iCloudSync, .encryptedCloudKitKeySync:
+            // iOS and Mac App Store builds carry the managed iCloud entitlements.
+            // Direct Mac keeps API keys solely in its local Keychain vault.
+            return self == .appStore
+        case .downloadedCoreMLModels, .localNetworkTransport:
             return true
         }
     }
@@ -87,8 +108,11 @@ public extension DistributionChannel {
     /// In-app self-update via Sparkle (direct builds only).
     var supportsSelfUpdate: Bool { supports(.selfUpdate) }
 
-    /// Downloaded local model runtimes (direct builds only).
-    var supportsLocalModelRuntime: Bool { supports(.localModelRuntime) }
+    /// Downloadable WhisperKit/Core ML model data (both channels).
+    var supportsDownloadedCoreMLModels: Bool { supports(.downloadedCoreMLModels) }
+
+    /// Installable executable local runtimes such as sherpa-onnx and llama.cpp (direct only).
+    var supportsExternalLocalModelRuntime: Bool { supports(.externalLocalModelRuntime) }
 
     /// Whether the app can auto-prompt for Accessibility.
     /// When `false` (App Store), guide the user to add the app manually instead.
@@ -101,6 +125,9 @@ public extension DistributionChannel {
     /// Whether this distribution channel is expected to support iCloud sync when
     /// the running build also has the required entitlements and account state.
     var supportsICloudSync: Bool { supports(.iCloudSync) }
+
+    /// Whether the encrypted CloudKit API-key sync feature should be initialized and shown.
+    var supportsEncryptedCloudKitKeySync: Bool { supports(.encryptedCloudKitKeySync) }
 
     /// Whether Bonjour local-network transport is part of this build.
     var supportsLocalNetworkTransport: Bool { supports(.localNetworkTransport) }

--- a/Sources/SpeakCore/TranscriptionModelPlacement.swift
+++ b/Sources/SpeakCore/TranscriptionModelPlacement.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Shared catalogue projections used by both platform settings UIs.
+///
+/// `liveTranscription` remains the complete routing catalogue. These projections
+/// decide where a model is presented, so adding another `apple/...` live model
+/// automatically places it under Local without duplicating platform-specific lists.
+public extension ModelCatalog {
+    static var onDeviceLiveTranscription: [Option] {
+        liveTranscription.filter { ModelRouting.family(for: $0.id) == .appleSpeech }
+    }
+
+    static var remoteLiveTranscription: [Option] {
+        liveTranscription.filter { ModelRouting.family(for: $0.id) != .appleSpeech }
+    }
+
+    static var defaultOnDeviceLiveTranscriptionModel: String {
+        onDeviceLiveTranscription.first?.id ?? "apple/local/SFSpeechRecognizer"
+    }
+
+    static var defaultRemoteLiveTranscriptionModel: String? {
+        remoteLiveTranscription.first?.id
+    }
+
+    static func isOnDeviceLiveTranscriptionModel(_ identifier: String) -> Bool {
+        ModelRouting.family(for: identifier) == .appleSpeech
+    }
+}

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -135,15 +135,10 @@ public final class AppSettings: ObservableObject {
 
     // MARK: - Canonical secure storage for API keys (SpeakCore)
     //
-    // Every API key is stored through SpeakCore's SecureStorage using the same
-    // service/account as the macOS app, and synced via iCloud Keychain when the
-    // build is entitled (see `SecureStorageConfiguration.iCloudSyncedIfAvailable`).
-    // A key set on one device then appears on the user's other devices.
-    //
-    // iOS <-> macOS sync additionally requires the shared keychain-access-group
-    // to be present in BOTH apps' entitlements and the macOS app to be built
-    // with the iCloud Keychain capability; a Developer-ID macOS build can't use
-    // synchronizable items and falls back to local-only storage.
+    // Every API key is stored locally through SpeakCore's SecureStorage using the
+    // same service/account as the macOS app. Cross-device transfer is handled only
+    // by the explicit passphrase-encrypted CloudKit sync feature below; the base
+    // Keychain item is deliberately not kSecAttrSynchronizable.
     static let deepgramKeyID = "deepgram.apiKey"
     static let openRouterKeyID = "openrouter.apiKey"
     static let openAIKeyID = "openai.apiKey"
@@ -154,16 +149,10 @@ public final class AppSettings: ObservableObject {
     static let assemblyAIKeyID = "assemblyai.apiKey"
     static let gladiaKeyID = "gladia.apiKey"
 
-    /// Shared keychain access group declared in `SpeakiOS.entitlements`
-    /// (`$(AppIdentifierPrefix)com.justspeaktoit.shared`). Only used when the
-    /// runtime probe confirms the entitlement is present.
-    private static let sharedAccessGroup = "8X4ZN58TYH.com.justspeaktoit.shared"
-
     private static let credentialStorage = SecureStorage(
-        configuration: .iCloudSyncedIfAvailable(
+        configuration: SecureStorageConfiguration(
             service: "com.justspeaktoit.credentials",
-            masterAccount: "speak-app-secrets",
-            accessGroup: sharedAccessGroup
+            masterAccount: "speak-app-secrets"
         )
     )
 
@@ -627,6 +616,22 @@ private struct BatchModelGroup: Identifiable {
     }
 }
 
+private enum IOSTranscriptionLocation: String, CaseIterable, Identifiable {
+    case local
+    case remote
+
+    var id: String { rawValue }
+    var displayName: String { rawValue.capitalized }
+}
+
+private enum IOSRemoteTranscriptionMode: String, CaseIterable, Identifiable {
+    case streaming
+    case batch
+
+    var id: String { rawValue }
+    var displayName: String { rawValue.capitalized }
+}
+
 // swiftlint:disable:next type_body_length
 public struct SettingsView: View {
     @StateObject private var settings = AppSettings.shared
@@ -640,44 +645,65 @@ public struct SettingsView: View {
     public var body: some View {
         Form {
             Section("Transcription") {
-                Picker("Mode", selection: $settings.transcriptionMode) {
-                    ForEach(IOSTranscriptionMode.allCases) { mode in
-                        Text(mode.displayName).tag(mode)
+                Picker("Where transcription runs", selection: transcriptionLocationBinding) {
+                    ForEach(IOSTranscriptionLocation.allCases) { location in
+                        Text(location.displayName).tag(location)
                     }
                 }
                 .pickerStyle(.segmented)
 
-                if settings.transcriptionMode == .streaming {
-                    Picker("Streaming Model", selection: selectedModelBinding) {
-                        ForEach(LiveModelGroup.grouped(ModelCatalog.liveTranscription)) { group in
-                            Section(group.title) {
-                                ForEach(group.options) { option in
-                                    LiveModelRow(option: option).tag(option.id)
-                                }
-                            }
+                if transcriptionLocationBinding.wrappedValue == .local {
+                    Picker("Apple On-Device Model", selection: selectedModelBinding) {
+                        ForEach(ModelCatalog.onDeviceLiveTranscription) { option in
+                            Text(option.displayName).tag(option.id)
                         }
                     }
                     .pickerStyle(.navigationLink)
+
+                    Text("Uses Apple's built-in speech engine. Audio stays on this device.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 } else {
-                    Picker("Batch Model", selection: $settings.batchTranscriptionModel) {
-                        ForEach(BatchModelGroup.grouped(AppSettings.supportedBatchModels)) { group in
-                            Section(group.title) {
-                                ForEach(group.options) { option in
-                                    Text(ModelCatalog.friendlyName(for: option.id)).tag(option.id)
+                    Picker("Remote Mode", selection: remoteTranscriptionModeBinding) {
+                        ForEach(IOSRemoteTranscriptionMode.allCases) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    if settings.transcriptionMode == .streaming {
+                        Picker("Remote Streaming Model", selection: selectedModelBinding) {
+                            ForEach(LiveModelGroup.grouped(ModelCatalog.remoteLiveTranscription)) { group in
+                                Section(group.title) {
+                                    ForEach(group.options) { option in
+                                        LiveModelRow(option: option).tag(option.id)
+                                    }
                                 }
                             }
                         }
+                        .pickerStyle(.navigationLink)
+                    } else {
+                        Picker("Remote Batch Model", selection: $settings.batchTranscriptionModel) {
+                            ForEach(BatchModelGroup.grouped(AppSettings.supportedBatchModels)) { group in
+                                Section(group.title) {
+                                    ForEach(group.options) { option in
+                                        Text(ModelCatalog.friendlyName(for: option.id)).tag(option.id)
+                                    }
+                                }
+                            }
+                        }
+                        .pickerStyle(.navigationLink)
                     }
-                    .pickerStyle(.navigationLink)
+
+                    Text(settings.transcriptionMode == .streaming
+                        ? "Text appears while audio is streamed to the selected provider."
+                        : "Audio is uploaded after recording for a more complete transcript.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
-                Text(settings.transcriptionMode == .streaming
-                    ? "Text appears while you speak."
-                    : "Audio is recorded first, then uploaded when you stop for a more complete transcript.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                if settings.transcriptionMode == .streaming,
+                if transcriptionLocationBinding.wrappedValue == .remote,
+                   settings.transcriptionMode == .streaming,
                    let route = LiveTranscriptionRouting.route(for: settings.selectedModel),
                    !route.isSupportedOnIOS {
                     Label(
@@ -688,7 +714,8 @@ public struct SettingsView: View {
                     .font(.caption)
                 }
 
-                if settings.transcriptionMode == .streaming,
+                if transcriptionLocationBinding.wrappedValue == .remote,
+                   settings.transcriptionMode == .streaming,
                    let route = LiveTranscriptionRouting.route(for: settings.selectedModel),
                    route.isSupportedOnIOS,
                    route.apiKeyIdentifier != nil,
@@ -701,7 +728,8 @@ public struct SettingsView: View {
                     .font(.caption)
                 }
 
-                if settings.transcriptionMode == .batch,
+                if transcriptionLocationBinding.wrappedValue == .remote,
+                   settings.transcriptionMode == .batch,
                    settings.batchAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Label(
                         AppSettings.openAIBatchModelIDs.contains(settings.batchTranscriptionModel)
@@ -1907,6 +1935,46 @@ struct CloudKitKeySyncSettingsSection: View {
 }
 
 private extension SettingsView {
+    @MainActor
+    private var transcriptionLocationBinding: Binding<IOSTranscriptionLocation> {
+        Binding(
+            get: {
+                settings.transcriptionMode == .streaming
+                    && ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.selectedModel)
+                    ? .local
+                    : .remote
+            },
+            set: { location in
+                switch location {
+                case .local:
+                    settings.selectedModel = ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+                    settings.transcriptionMode = .streaming
+                case .remote:
+                    if ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.selectedModel) {
+                        settings.selectedModel = ModelCatalog.defaultRemoteLiveTranscriptionModel
+                            ?? settings.selectedModel
+                    }
+                    settings.transcriptionMode = .streaming
+                }
+            }
+        )
+    }
+
+    @MainActor
+    private var remoteTranscriptionModeBinding: Binding<IOSRemoteTranscriptionMode> {
+        Binding(
+            get: { settings.transcriptionMode == .batch ? .batch : .streaming },
+            set: { mode in
+                if mode == .streaming,
+                   ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.selectedModel) {
+                    settings.selectedModel = ModelCatalog.defaultRemoteLiveTranscriptionModel
+                        ?? settings.selectedModel
+                }
+                settings.transcriptionMode = mode == .batch ? .batch : .streaming
+            }
+        )
+    }
+
     @MainActor
     private var selectedModelBinding: Binding<String> {
         Binding(

--- a/Tests/SpeakCoreTests/DistributionChannelTests.swift
+++ b/Tests/SpeakCoreTests/DistributionChannelTests.swift
@@ -15,7 +15,11 @@ final class DistributionChannelTests: XCTestCase {
 
         // Act & Assert
         XCTAssertTrue(channel.supportsSelfUpdate)
-        XCTAssertTrue(channel.supportsLocalModelRuntime)
+        XCTAssertTrue(channel.supportsDownloadedCoreMLModels)
+        XCTAssertTrue(channel.supportsExternalLocalModelRuntime)
+        XCTAssertFalse(channel.supportsEncryptedCloudKitKeySync)
+        XCTAssertFalse(channel.supportsICloudSync)
+        XCTAssertEqual(channel.apiKeyStorageMode, .localKeychainOnly)
         XCTAssertTrue(channel.supportsAutomaticAccessibilityPrompt)
         XCTAssertTrue(channel.allowsCrossChannelMessaging)
         XCTAssertFalse(channel.isSandboxed)
@@ -28,8 +32,13 @@ final class DistributionChannelTests: XCTestCase {
         // Act & Assert
         XCTAssertFalse(channel.supportsSelfUpdate,
             "App Store builds update through the store, not Sparkle")
-        XCTAssertFalse(channel.supportsLocalModelRuntime,
-            "Downloaded local-model runtimes cannot run in the App Store sandbox")
+        XCTAssertTrue(channel.supportsDownloadedCoreMLModels,
+            "WhisperKit/Core ML model data can run through the bundled in-process runtime")
+        XCTAssertFalse(channel.supportsExternalLocalModelRuntime,
+            "Executable local-model runtimes cannot run in the App Store sandbox")
+        XCTAssertTrue(channel.supportsEncryptedCloudKitKeySync)
+        XCTAssertTrue(channel.supportsICloudSync)
+        XCTAssertEqual(channel.apiKeyStorageMode, .encryptedCloudKit)
         XCTAssertFalse(channel.supportsAutomaticAccessibilityPrompt,
             "Sandboxed apps cannot auto-prompt for Accessibility/Input Monitoring")
         XCTAssertFalse(channel.allowsCrossChannelMessaging,
@@ -41,11 +50,14 @@ final class DistributionChannelTests: XCTestCase {
         // Arrange / Act / Assert
         for channel in DistributionChannel.allCases {
             XCTAssertEqual(channel.supports(.selfUpdate), channel.supportsSelfUpdate)
-            XCTAssertEqual(channel.supports(.localModelRuntime), channel.supportsLocalModelRuntime)
+            XCTAssertEqual(channel.supports(.downloadedCoreMLModels), channel.supportsDownloadedCoreMLModels)
+            XCTAssertEqual(channel.supports(.externalLocalModelRuntime), channel.supportsExternalLocalModelRuntime)
             XCTAssertEqual(channel.supports(.automaticAccessibilityPrompt),
                            channel.supportsAutomaticAccessibilityPrompt)
             XCTAssertEqual(channel.supports(.crossChannelMessaging),
                            channel.allowsCrossChannelMessaging)
+            XCTAssertEqual(channel.supports(.encryptedCloudKitKeySync),
+                           channel.supportsEncryptedCloudKitKeySync)
         }
     }
 

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -126,6 +126,26 @@ final class ModelCatalogTests: XCTestCase {
         XCTAssertEqual(ModelRouting.family(for: "local/whisperkit/tiny"), .downloadedLocal(engine: "whisperkit"))
     }
 
+    func testLiveTranscriptionPlacement_keepsAppleModelsOnlyOnDevice() {
+        let onDeviceIDs = Set(ModelCatalog.onDeviceLiveTranscription.map(\.id))
+        let remoteIDs = Set(ModelCatalog.remoteLiveTranscription.map(\.id))
+
+        XCTAssertTrue(onDeviceIDs.contains("apple/local/SFSpeechRecognizer"))
+        XCTAssertTrue(onDeviceIDs.contains("apple/local/Dictation"))
+        XCTAssertTrue(onDeviceIDs.allSatisfy(ModelCatalog.isOnDeviceLiveTranscriptionModel))
+        XCTAssertTrue(remoteIDs.allSatisfy { !ModelCatalog.isOnDeviceLiveTranscriptionModel($0) })
+        XCTAssertTrue(onDeviceIDs.isDisjoint(with: remoteIDs))
+        XCTAssertEqual(onDeviceIDs.union(remoteIDs), Set(ModelCatalog.liveTranscription.map(\.id)))
+    }
+
+    func testLiveTranscriptionPlacement_defaultsMatchTheirLocation() throws {
+        XCTAssertTrue(ModelCatalog.isOnDeviceLiveTranscriptionModel(
+            ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+        ))
+        let remoteDefault = try XCTUnwrap(ModelCatalog.defaultRemoteLiveTranscriptionModel)
+        XCTAssertFalse(ModelCatalog.isOnDeviceLiveTranscriptionModel(remoteDefault))
+    }
+
     func testModelRouting_treatsLocalCleanupAsPostProcessing() {
         XCTAssertEqual(
             ModelRouting.family(for: "local/post-processing/rules"),


### PR DESCRIPTION
## Motivation

Apple Speech and Apple Dictation are on-device engines, but both platform settings screens listed them alongside remote streaming providers. The API-key sync UI also exposed passphrase-encrypted CloudKit sync to the direct Mac build even though that channel should keep keys in its local Keychain vault.

## What changed

- Added shared on-device and remote live-transcription catalogue projections, automatically classifying every `apple/...` live model as local.
- Updated macOS and iOS settings to select Local vs Remote first, with Apple engines only under Local and cloud models only under Remote.
- Split downloaded Core ML model data from external executable runtimes in `DistributionChannel`: WhisperKit/Core ML weights remain available in both Mac channels, while sherpa-onnx/llama.cpp-style runtime installation remains direct-only.
- Made direct Mac API-key storage local-Keychain-only and stopped initializing or showing encrypted CloudKit API-key sync there.
- Kept passphrase-encrypted CloudKit API-key sync as the only cross-device API-key sync path for Mac App Store and iOS builds; base Keychain items are no longer synchronizable.
- Added focused catalogue placement and distribution policy tests.

## Things learnt that changed the direction

The App Sandbox does not prevent the app from downloading model weights and consuming them through an in-process bundled runtime. The unsupported part is downloaded executable/runtime code and subprocess-based Python, llama.cpp, or sherpa-onnx installation, so the former broad local-runtime gate was replaced by narrow capabilities.

PR #532 adds more Apple on-device model identifiers. This PR deliberately classifies by the existing shared `ModelRouting` family in a separate source file, so new `apple/...` models from that PR inherit Local placement without duplicating its catalogue changes.

## How to test

- `swift test --filter 'DistributionChannelTests|ModelCatalogTests'` — 28 tests passed from the settled commit.
- `swift build -Xswiftc -DAPP_STORE` — Mac App Store-flavour SwiftPM build passed.
- `xcodebuild -project SpeakiOS.xcodeproj -scheme SpeakiOSLib -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — passed.
- SwiftFormat on all changed Swift files — passed.
- SwiftLint strict with `.swiftlint-baseline.json` on all changed Swift files — 0 violations.

The full `SpeakiOS` app scheme still hits the existing generated-project widget dependency failure (`Unable to find module dependency: SpeakiOSLib` / `SpeakCore`); the affected iOS library and settings UI compile successfully through the package scheme.

## Review confidence

High for the shared placement and distribution policy. Please review the settings interaction wording and coordinate landing with PR #532 because both touch the iOS settings screen, although catalogue classification itself was isolated to minimize conflict.
