### PR TITLE
fix(mac): restore global shortcuts and permission handling

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -80,6 +80,19 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     }
   }
 
+  nonisolated static func availableTextOutputMethods(
+    for channel: DistributionChannel
+  ) -> [TextOutputMethod] {
+    channel.supportsAccessibilityTextInsertion ? TextOutputMethod.allCases : [.clipboardOnly]
+  }
+
+  nonisolated static func normalizedTextOutputMethod(
+    _ method: TextOutputMethod,
+    for channel: DistributionChannel
+  ) -> TextOutputMethod {
+    availableTextOutputMethods(for: channel).contains(method) ? method : .clipboardOnly
+  }
+
   enum AccessibilityInsertionMode: String, CaseIterable, Identifiable {
     case insertAtCursor
     case replaceAll
@@ -444,7 +457,17 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   @Published var textOutputMethod: TextOutputMethod {
-    didSet { store(textOutputMethod.rawValue, key: .textOutputMethod) }
+    didSet {
+      let normalized = Self.normalizedTextOutputMethod(
+        textOutputMethod,
+        for: DistributionChannel.current
+      )
+      guard normalized == textOutputMethod else {
+        textOutputMethod = normalized
+        return
+      }
+      store(textOutputMethod.rawValue, key: .textOutputMethod)
+    }
   }
 
   @Published var accessibilityInsertionMode: AccessibilityInsertionMode {
@@ -857,10 +880,12 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       defaults.object(forKey: DefaultsKey.postProcessingIncludeContextTags.rawValue) as? Bool ?? true
     postProcessingIncludeFinalInstruction =
       defaults.object(forKey: DefaultsKey.postProcessingIncludeFinalInstruction.rawValue) as? Bool ?? true
-    textOutputMethod =
+    textOutputMethod = Self.normalizedTextOutputMethod(
       TextOutputMethod(
         rawValue: defaults.string(forKey: DefaultsKey.textOutputMethod.rawValue)
-          ?? TextOutputMethod.clipboardOnly.rawValue) ?? .clipboardOnly
+          ?? TextOutputMethod.clipboardOnly.rawValue) ?? .clipboardOnly,
+      for: DistributionChannel.current
+    )
     accessibilityInsertionMode =
       AccessibilityInsertionMode(
         rawValue: defaults.string(forKey: DefaultsKey.accessibilityInsertionMode.rawValue)
@@ -899,7 +924,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       defaults.object(forKey: DefaultsKey.doubleTapWindow.rawValue) as? Double ?? 0.4
     if let hotKeyData = defaults.data(forKey: DefaultsKey.selectedHotKey.rawValue),
       let decoded = try? JSONDecoder().decode(HotKey.self, from: hotKeyData) {
-      selectedHotKey = decoded
+      selectedHotKey = decoded.isSupportedForGlobalMonitoring ? decoded : .fnKey
     } else {
       selectedHotKey = .fnKey
     }

--- a/Sources/SpeakApp/HotKeyManager.swift
+++ b/Sources/SpeakApp/HotKeyManager.swift
@@ -78,7 +78,7 @@ final class HotKeyManager: ObservableObject {
 
 		Task { [weak self] in
 			guard let self else { return }
-			for permission in [PermissionType.accessibility, .inputMonitoring] {
+			for permission in [PermissionType.inputMonitoring] {
 				let status = await MainActor.run { self.permissionsManager.status(for: permission) }
 				if !status.isGranted {
 					_ = await self.permissionsManager.request(permission)

--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -1,6 +1,7 @@
 // swiftlint:disable file_length
 import AppKit
 import AVFoundation
+import SpeakCore
 import SpeakHotKeys
 import SwiftUI
 
@@ -125,7 +126,7 @@ final class OnboardingState: ObservableObject {
     
     func refreshPermissions() {
         permissionsGranted = []
-        for perm in [PermissionType.microphone, .accessibility, .inputMonitoring] {
+        for perm in PermissionType.availablePermissions(for: DistributionChannel.current) {
             // Force a fresh computation; cached statuses go stale when the user
             // toggles a permission in System Settings (the OS never notifies us).
             permissionsManager.refresh(perm)
@@ -137,7 +138,8 @@ final class OnboardingState: ObservableObject {
     
     var allPermissionsGranted: Bool {
         permissionsGranted.contains(.microphone) &&
-        permissionsGranted.contains(.accessibility)
+        (!DistributionChannel.current.supportsAccessibilityTextInsertion
+          || permissionsGranted.contains(.accessibility))
     }
     
     // swiftlint:disable:next cyclomatic_complexity function_body_length
@@ -543,25 +545,27 @@ struct PermissionsStepView: View {
                     }
                 )
                 
-                PermissionRow(
-                    type: .accessibility,
-                    title: "Accessibility",
-                    description: "To type text into other apps",
-                    isGranted: state.permissionsGranted.contains(.accessibility),
-                    onRequest: {
-                        accessibilityAttempted = true
-                        Task {
-                            _ = await state.permissionsManager.request(.accessibility)
-                            // Wait a moment then check if it worked
-                            try? await Task.sleep(nanoseconds: 1_000_000_000)
-                            state.refreshPermissions()
-                            // If still not granted after attempt, show helper
-                            if !state.permissionsGranted.contains(.accessibility) {
-                                showAccessibilityHelper = true
+                if DistributionChannel.current.supportsAccessibilityTextInsertion {
+                    PermissionRow(
+                        type: .accessibility,
+                        title: "Accessibility",
+                        description: "To type text into other apps",
+                        isGranted: state.permissionsGranted.contains(.accessibility),
+                        onRequest: {
+                            accessibilityAttempted = true
+                            Task {
+                                _ = await state.permissionsManager.request(.accessibility)
+                                // Wait a moment then check if it worked
+                                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                                state.refreshPermissions()
+                                // If still not granted after attempt, show helper
+                                if !state.permissionsGranted.contains(.accessibility) {
+                                    showAccessibilityHelper = true
+                                }
                             }
                         }
-                    }
-                )
+                    )
+                }
                 
                 // Show manual add helper if accessibility wasn't auto-added
                 if showAccessibilityHelper && !state.permissionsGranted.contains(.accessibility) {

--- a/Sources/SpeakApp/PermissionsManager.swift
+++ b/Sources/SpeakApp/PermissionsManager.swift
@@ -3,6 +3,7 @@ import AppKit
 import Combine
 import CoreGraphics
 import Foundation
+import SpeakCore
 import Speech
 
 // @Implement This class manages system permissions. It knows how to request the following permissions when asked and also surface the current status of permissions as per the system
@@ -14,6 +15,12 @@ enum PermissionType: CaseIterable, Identifiable {
   case inputMonitoring
 
   var id: String { displayName }
+
+  static func availablePermissions(for channel: DistributionChannel) -> [PermissionType] {
+    allCases.filter { permission in
+      permission != .accessibility || channel.supportsAccessibilityTextInsertion
+    }
+  }
 
   var displayName: String {
     switch self {
@@ -97,9 +104,24 @@ enum PermissionStatus: Equatable {
 @MainActor
 final class PermissionsManager: ObservableObject {
   @Published private(set) var statuses: [PermissionType: PermissionStatus] = [:]
+  private let statusProvider: (PermissionType) -> PermissionStatus
+  private let notificationCenter: NotificationCenter
+  private var lifecycleObservers: [NSObjectProtocol] = []
 
-  init() {
+  init(
+    statusProvider: @escaping (PermissionType) -> PermissionStatus = PermissionsManager.systemStatus,
+    notificationCenter: NotificationCenter = .default
+  ) {
+    self.statusProvider = statusProvider
+    self.notificationCenter = notificationCenter
     refreshAll()
+    registerLifecycleObservers()
+  }
+
+  deinit {
+    for observer in lifecycleObservers {
+      notificationCenter.removeObserver(observer)
+    }
   }
 
   func status(for type: PermissionType) -> PermissionStatus {
@@ -168,6 +190,10 @@ final class PermissionsManager: ObservableObject {
   }
 
   private func computeStatus(for type: PermissionType) -> PermissionStatus {
+    statusProvider(type)
+  }
+
+  private nonisolated static func systemStatus(for type: PermissionType) -> PermissionStatus {
     switch type {
     case .microphone:
       switch AVCaptureDevice.authorizationStatus(for: .audio) {
@@ -198,9 +224,25 @@ final class PermissionsManager: ObservableObject {
     case .accessibility:
       return AXIsProcessTrusted() ? .granted : .denied
     case .inputMonitoring:
-      let granted = CGPreflightListenEventAccess()
-      return granted ? .granted : .denied
+      return inputMonitoringStatus(
+        hasListenAccess: CGPreflightListenEventAccess(),
+        hasAccessibilityAccess: AXIsProcessTrusted()
+      )
     }
+  }
+
+  /// Accessibility permission is a superset of event-listening permission on macOS.
+  /// Treat either TCC grant as effective access so the app does not report Input
+  /// Monitoring as disabled while its global event tap is allowed to run.
+  nonisolated static func inputMonitoringStatus(
+    hasListenAccess: Bool,
+    hasAccessibilityAccess: Bool
+  ) -> PermissionStatus {
+    hasListenAccess || hasAccessibilityAccess ? .granted : .denied
+  }
+
+  nonisolated static func shouldPromptForAccessibility(channel: DistributionChannel) -> Bool {
+    channel.supportsAutomaticAccessibilityPrompt
   }
 
   private func requestMicrophone() async -> PermissionStatus {
@@ -230,13 +272,37 @@ final class PermissionsManager: ObservableObject {
   }
 
   private func requestAccessibility() -> PermissionStatus {
-    let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as NSString: true]
-    let trusted = AXIsProcessTrustedWithOptions(options)
+    let trusted: Bool
+    if Self.shouldPromptForAccessibility(channel: DistributionChannel.current) {
+      let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as NSString: true]
+      trusted = AXIsProcessTrustedWithOptions(options)
+    } else {
+      // The App Store sandbox cannot present the Accessibility prompt. It can
+      // only observe a grant the user made manually in System Settings.
+      trusted = AXIsProcessTrusted()
+    }
     return trusted ? .granted : .denied
   }
 
   private func requestInputMonitoring() -> PermissionStatus {
     let granted = CGRequestListenEventAccess()
-    return granted ? .granted : .denied
+    return Self.inputMonitoringStatus(
+      hasListenAccess: granted,
+      hasAccessibilityAccess: AXIsProcessTrusted()
+    )
+  }
+
+  private func registerLifecycleObservers() {
+    lifecycleObservers = [
+      notificationCenter.addObserver(
+        forName: NSApplication.didBecomeActiveNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        Task { @MainActor in
+          self?.refreshAll()
+        }
+      }
+    ]
   }
 }

--- a/Sources/SpeakApp/Services/ShortcutManager.swift
+++ b/Sources/SpeakApp/Services/ShortcutManager.swift
@@ -230,6 +230,7 @@ final class ShortcutManager: ObservableObject {
     @Published private(set) var conflicts: [ShortcutConflict] = []
     @Published private(set) var isRecordingShortcut: Bool = false
     @Published private(set) var recordingAction: ShortcutAction?
+    @Published private(set) var recordingError: String?
 
     private var carbonHotKeys: [UInt32: EventHotKeyRef] = [:]
     private var carbonHotKeyActions: [UInt32: ShortcutAction] = [:]
@@ -340,6 +341,7 @@ final class ShortcutManager: ObservableObject {
         stopRecording()
         isRecordingShortcut = true
         recordingAction = action
+        recordingError = nil
 
         recordingMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
@@ -349,9 +351,25 @@ final class ShortcutManager: ObservableObject {
                 return nil
             }
 
+            let modifiers = event.modifierFlags.intersection([.command, .shift, .option, .control])
+
+            // Escape cancels without replacing the existing shortcut.
+            if event.keyCode == 53, modifiers.isEmpty {
+                self.stopRecording()
+                return nil
+            }
+
+            guard KeyCodeMapping.isSupportedCustomHotKey(
+                keyCode: event.keyCode,
+                hasModifiers: !modifiers.isEmpty
+            ) else {
+                self.recordingError = KeyCodeMapping.unsupportedSingleKeyMessage
+                return nil
+            }
+
             let newBinding = KeyBinding(
                 keyCode: event.keyCode,
-                modifiers: event.modifierFlags.intersection([.command, .shift, .option, .control]),
+                modifiers: modifiers,
                 isGlobal: action.isGlobalByDefault,
                 isEnabled: true
             )
@@ -366,6 +384,7 @@ final class ShortcutManager: ObservableObject {
     func stopRecording() {
         isRecordingShortcut = false
         recordingAction = nil
+        recordingError = nil
         if let monitor = recordingMonitor {
             NSEvent.removeMonitor(monitor)
             recordingMonitor = nil
@@ -431,7 +450,7 @@ final class ShortcutManager: ObservableObject {
                 UInt32(binding.keyCode),
                 carbonModifiers,
                 hotKeyID,
-                GetEventDispatcherTarget(),
+                GetApplicationEventTarget(),
                 0,
                 &hotKeyRef
             )
@@ -464,7 +483,7 @@ final class ShortcutManager: ObservableObject {
         )
         let selfPtr = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
         let status = InstallEventHandler(
-            GetEventDispatcherTarget(),
+            GetApplicationEventTarget(),
             { _, event, userData -> OSStatus in
                 guard let userData, let event else { return OSStatus(eventNotHandledErr) }
                 let manager = Unmanaged<ShortcutManager>.fromOpaque(userData).takeUnretainedValue()

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -674,22 +674,34 @@ struct SettingsView: View {
 
       SettingsCard(title: "Output", systemImage: "textformat.alt", tint: Color.brandLagoon) {
         VStack(alignment: .leading, spacing: 12) {
-          Picker("Text Output", selection: settingsBinding(\AppSettings.textOutputMethod)) {
-            ForEach(AppSettings.TextOutputMethod.allCases) { method in
-              Text(method.displayName).tag(method)
+          if DistributionChannel.current.supportsAccessibilityTextInsertion {
+            Picker("Text Output", selection: settingsBinding(\AppSettings.textOutputMethod)) {
+              ForEach(AppSettings.availableTextOutputMethods(for: DistributionChannel.current)) { method in
+                Text(method.displayName).tag(method)
+              }
             }
+            .pickerStyle(.menu)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+              RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+            )
+            .speakTooltip("Decide how Speak returns transcripts—typed for you or placed on the clipboard.")
+            .accessibilityLabel("Text output method picker")
+          } else {
+            Label("Clipboard delivery", systemImage: "doc.on.clipboard")
+              .font(.subheadline.weight(.medium))
+            Text(
+              "The App Store sandbox blocks changing text in other apps. "
+                + "Transcripts stay on the clipboard, ready to paste."
+            )
+              .font(.caption)
+              .foregroundStyle(.secondary)
           }
-          .pickerStyle(.menu)
-          .padding(.horizontal, 12)
-          .padding(.vertical, 8)
-          .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-              .fill(Color(nsColor: .controlBackgroundColor))
-          )
-          .speakTooltip("Decide how Speak returns transcripts—typed for you, placed on the clipboard, or saved for later.")
-          .accessibilityLabel("Text output method picker")
 
-          if settings.textOutputMethod != .clipboardOnly {
+          if DistributionChannel.current.supportsAccessibilityTextInsertion,
+             settings.textOutputMethod != .clipboardOnly {
             Picker("Accessibility Insertion", selection: settingsBinding(\AppSettings.accessibilityInsertionMode)) {
               ForEach(AppSettings.AccessibilityInsertionMode.allCases) { mode in
                 Text(mode.displayName).tag(mode)
@@ -711,12 +723,16 @@ struct SettingsView: View {
               .foregroundStyle(.secondary)
           }
           VStack(alignment: .leading, spacing: 8) {
-            settingsToggle(
-              "Restore clipboard after paste",
-              isOn: settingsBinding(\AppSettings.restoreClipboardAfterPaste),
-              tint: .brandLagoon
-            )
-            .speakTooltip("After Speak pastes your transcript, we put your original clipboard content back automatically.")
+            if DistributionChannel.current.supportsAccessibilityTextInsertion {
+              settingsToggle(
+                "Restore clipboard after paste",
+                isOn: settingsBinding(\AppSettings.restoreClipboardAfterPaste),
+                tint: .brandLagoon
+              )
+              .speakTooltip(
+                "After Speak pastes your transcript, we put your original clipboard content back automatically."
+              )
+            }
             settingsToggle(
               "Show HUD during sessions",
               isOn: settingsBinding(\AppSettings.showHUDDuringSessions),
@@ -4229,7 +4245,7 @@ struct SettingsView: View {
     LazyVStack(spacing: 20) {
       SettingsCard(title: "System permissions", systemImage: "lock.shield", tint: Color.red) {
         VStack(alignment: .leading, spacing: 12) {
-          ForEach(PermissionType.allCases) { permission in
+          ForEach(PermissionType.availablePermissions(for: DistributionChannel.current)) { permission in
             let status = environment.permissions.status(for: permission)
             VStack(alignment: .leading, spacing: 8) {
               HStack(spacing: 12) {
@@ -4267,6 +4283,12 @@ struct SettingsView: View {
         }
       }
       .speakTooltip("Review and refresh the macOS permissions Speak depends on.")
+    }
+    .task {
+      while !Task.isCancelled {
+        environment.permissions.refreshAll()
+        try? await Task.sleep(for: .seconds(1))
+      }
     }
   }
 

--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -27,6 +27,7 @@ Following this sequence allows another project to drop in the same smart Insert 
 import AppKit
 import ApplicationServices
 import Foundation
+import SpeakCore
 
 struct TextOutputResult {
   let method: HistoryTrigger.OutputMethod
@@ -68,6 +69,7 @@ struct AccessibilityTextOutput: TextOutputting {
   let appSettings: AppSettings
 
   func output(text: String) -> TextOutputResult {
+    permissionsManager.refresh(.accessibility)
     let status = permissionsManager.status(for: .accessibility)
     guard status.isGranted else {
       return TextOutputResult(
@@ -130,7 +132,8 @@ struct PasteTextOutput: TextOutputting {
 
   func output(text: String) -> TextOutputResult {
     let pasteboard = NSPasteboard.general
-    let restoreClipboard = appSettings.restoreClipboardAfterPaste
+    let canPasteIntoOtherApps = DistributionChannel.current.supportsAccessibilityTextInsertion
+    let restoreClipboard = canPasteIntoOtherApps && appSettings.restoreClipboardAfterPaste
     let previousString = restoreClipboard ? pasteboard.string(forType: .string) : nil
 
     pasteboard.clearContents()
@@ -138,7 +141,9 @@ struct PasteTextOutput: TextOutputting {
       return TextOutputResult(method: .none, error: TextOutputError.clipboardWriteFailed)
     }
 
-    simulatePasteShortcut()
+    if canPasteIntoOtherApps {
+      simulatePasteShortcut()
+    }
 
     if restoreClipboard {
       scheduleClipboardRestore(previousString, on: pasteboard)
@@ -236,6 +241,10 @@ struct SmartTextOutput: TextOutputting {
   }
 
   func output(text: String) -> TextOutputResult {
+    guard DistributionChannel.current.supportsAccessibilityTextInsertion else {
+      return clipboardOutput.output(text: text)
+    }
+
     switch appSettings.textOutputMethod {
     case .accessibilityOnly:
       return accessibilityOutput.output(text: text)
@@ -247,6 +256,10 @@ struct SmartTextOutput: TextOutputting {
         print("[SmartTextOutput] Skipping accessibility for problematic app, using clipboard")
         return clipboardOutput.output(text: text)
       }
+
+      // Permission grants can change while System Settings is frontmost. Re-read
+      // TCC before deciding whether direct insertion is available.
+      permissionsManager.refresh(.accessibility)
 
       // Only try accessibility if permission is granted AND there's a focused element
       if permissionsManager.status(for: .accessibility).isGranted,

--- a/Sources/SpeakApp/TroubleshootingAnalyser.swift
+++ b/Sources/SpeakApp/TroubleshootingAnalyser.swift
@@ -79,18 +79,12 @@ struct HotkeyInfoCheck: TroubleshootingCheck {
           actions: [.navigate(.shortcuts)]
         )
       )
-    }
-    
-    // Custom shortcut troubleshooting
-    if case .custom = hotKey {
-      let accessibilityGranted = permissions.status(for: .accessibility).isGranted
-      let inputMonitoringGranted = permissions.status(for: .inputMonitoring).isGranted
-      if !accessibilityGranted || !inputMonitoringGranted {
+      if !permissions.status(for: .inputMonitoring).isGranted {
         items.append(
           TroubleshootingItem(
-            id: "hotkey-custom-permissions",
-            title: "Custom Shortcut Needs Permissions",
-            detail: "Custom hotkey detection requires both Accessibility and Input Monitoring permissions. Grant them in System Settings → Privacy & Security.",
+            id: "hotkey-fn-permission",
+            title: "Fn Shortcut Needs Input Monitoring",
+            detail: "Grant Input Monitoring so Speak can detect the Fn key while another app is active.",
             status: .issue,
             systemImage: "lock.shield",
             actions: [.navigate(.permissions)]

--- a/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
@@ -129,6 +129,13 @@ struct ShortcutsSettingsView: View {
         }
         .padding(.vertical, 4)
         .opacity(binding.isEnabled ? 1.0 : 0.6)
+
+        if isRecording, let recordingError = shortcutManager.recordingError {
+            Label(recordingError, systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.red)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }
 

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -60,6 +60,9 @@ public enum ChannelFeature: String, Sendable, CaseIterable {
     /// user must add the app manually in System Settings. Input Monitoring is unaffected — it
     /// still prompts via `CGRequestListenEventAccess` even when sandboxed.
     case automaticAccessibilityPrompt
+    /// Cross-app text insertion via AXUIElement. The App Store sandbox blocks
+    /// reading and mutating another app's accessibility hierarchy.
+    case accessibilityTextInsertion
     /// Freedom to reference other distribution channels or external purchases in UI copy.
     /// App Store review guidelines discourage this, so App Store builds must not.
     case crossChannelMessaging
@@ -74,7 +77,8 @@ public extension DistributionChannel {
     /// Whether `feature` is available in this build.
     func supports(_ feature: ChannelFeature) -> Bool {
         switch feature {
-        case .selfUpdate, .localModelRuntime, .automaticAccessibilityPrompt, .crossChannelMessaging:
+        case .selfUpdate, .localModelRuntime, .automaticAccessibilityPrompt,
+             .accessibilityTextInsertion, .crossChannelMessaging:
             return self == .direct
         case .iCloudSync, .localNetworkTransport:
             // Sync transports are compiled into every build; runtime entitlement,
@@ -93,6 +97,9 @@ public extension DistributionChannel {
     /// Whether the app can auto-prompt for Accessibility.
     /// When `false` (App Store), guide the user to add the app manually instead.
     var supportsAutomaticAccessibilityPrompt: Bool { supports(.automaticAccessibilityPrompt) }
+
+    /// Whether this build may insert text directly into another app via AXUIElement.
+    var supportsAccessibilityTextInsertion: Bool { supports(.accessibilityTextInsertion) }
 
     /// Whether UI copy may reference other distribution channels (e.g. the direct
     /// download). `false` for App Store builds to stay within review guidelines.

--- a/Sources/SpeakHotKeys/CarbonKeyBackend.swift
+++ b/Sources/SpeakHotKeys/CarbonKeyBackend.swift
@@ -59,7 +59,7 @@ final class CarbonKeyBackend {
     let selfPtr = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
 
     let status = InstallEventHandler(
-      GetEventDispatcherTarget(),
+      GetApplicationEventTarget(),
       { _, event, userData -> OSStatus in
         guard let userData, let event else { return OSStatus(eventNotHandledErr) }
         let backend = Unmanaged<CarbonKeyBackend>.fromOpaque(userData).takeUnretainedValue()
@@ -89,7 +89,7 @@ final class CarbonKeyBackend {
       UInt32(keyCode),
       modifiers.carbonFlags,
       hotKeyIDSpec,
-      GetEventDispatcherTarget(),
+      GetApplicationEventTarget(),
       0,
       &hotKeyRef
     )

--- a/Sources/SpeakHotKeys/HotKeyEngine.swift
+++ b/Sources/SpeakHotKeys/HotKeyEngine.swift
@@ -69,6 +69,10 @@ public final class HotKeyEngine: ObservableObject {
   /// Start monitoring for the given hotkey.
   public func start(for hotKey: HotKey) {
     stop()
+    guard hotKey.isSupportedForGlobalMonitoring else {
+      log.error("Refusing unsupported unmodified global hotkey: \(hotKey.displayString)")
+      return
+    }
     activeHotKey = hotKey
     isMonitoring = true
 

--- a/Sources/SpeakHotKeys/HotKeyRecorder.swift
+++ b/Sources/SpeakHotKeys/HotKeyRecorder.swift
@@ -11,6 +11,7 @@ public struct HotKeyRecorder: View {
   @State private var isRecording = false
   @State private var pendingModifiers: HotKey.ModifierSet = []
   @State private var eventMonitor: Any?
+  @State private var validationMessage: String?
 
   private let label: String
 
@@ -34,6 +35,13 @@ public struct HotKeyRecorder: View {
         if !hotKey.isFnKey {
           clearButton
         }
+      }
+
+      if let validationMessage {
+        Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
+          .font(.caption)
+          .foregroundStyle(.red)
+          .fixedSize(horizontal: false, vertical: true)
       }
     }
     .onDisappear {
@@ -134,6 +142,7 @@ public struct HotKeyRecorder: View {
     stopRecording()
     isRecording = true
     pendingModifiers = []
+    validationMessage = nil
     NotificationCenter.default.post(name: .speakHotKeyShouldPause, object: nil)
 
     eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
@@ -172,8 +181,15 @@ public struct HotKeyRecorder: View {
     )
 
     // Allow dedicated extended keys as single-key hotkeys, but keep ordinary typing keys modifier-gated.
-    guard !modifiers.isEmpty || KeyCodeMapping.singleKeyHotKeyCodes.contains(event.keyCode) else { return true }
+    guard KeyCodeMapping.isSupportedCustomHotKey(
+      keyCode: event.keyCode,
+      hasModifiers: !modifiers.isEmpty
+    ) else {
+      validationMessage = KeyCodeMapping.unsupportedSingleKeyMessage
+      return true
+    }
 
+    validationMessage = nil
     hotKey = .custom(keyCode: event.keyCode, modifiers: modifiers)
     stopRecording()
     return true

--- a/Sources/SpeakHotKeys/HotKeyStore.swift
+++ b/Sources/SpeakHotKeys/HotKeyStore.swift
@@ -27,6 +27,10 @@ public final class HotKeyStore: ObservableObject {
     else {
       return .fnKey
     }
+    guard decoded.isSupportedForGlobalMonitoring else {
+      log.error("Discarding unsupported stored hotkey: \(decoded.displayString)")
+      return .fnKey
+    }
     log.debug("Loaded hotkey: \(decoded.displayString)")
     return decoded
   }

--- a/Sources/SpeakHotKeys/HotKeyTypes.swift
+++ b/Sources/SpeakHotKeys/HotKeyTypes.swift
@@ -69,6 +69,19 @@ public enum HotKey: Codable, Hashable, Sendable {
     if case .fnKey = self { return true }
     return false
   }
+
+  /// Whether this binding is safe and supported for system-wide monitoring.
+  public var isSupportedForGlobalMonitoring: Bool {
+    switch self {
+    case .fnKey:
+      return true
+    case .custom(let keyCode, let modifiers):
+      return KeyCodeMapping.isSupportedCustomHotKey(
+        keyCode: keyCode,
+        hasModifiers: !modifiers.isEmpty
+      )
+    }
+  }
 }
 
 /// Gesture types emitted by the hotkey engine.

--- a/Sources/SpeakHotKeys/KeyCodeMapping.swift
+++ b/Sources/SpeakHotKeys/KeyCodeMapping.swift
@@ -110,6 +110,18 @@ public enum KeyCodeMapping {
     105, 106, 107, 113,  // F13-F16
     114  // Insert/Help
   ]
+
+  /// Whether a custom hotkey can be registered safely system-wide.
+  ///
+  /// Ordinary unmodified keys are deliberately rejected because registering one
+  /// globally would steal normal typing. Dedicated extended keys remain useful
+  /// as single-key triggers and are explicitly allow-listed above.
+  public static func isSupportedCustomHotKey(keyCode: UInt16, hasModifiers: Bool) -> Bool {
+    hasModifiers || singleKeyHotKeyCodes.contains(keyCode)
+  }
+
+  public static let unsupportedSingleKeyMessage =
+    "Use Command, Option, Shift, or Control with this key. F13-F20 and Insert can be used alone."
 }
 
 #endif

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SpeakHotKeys
 
 @testable import SpeakApp
 
@@ -95,6 +96,39 @@ final class AppSettingsDefaultsTests: XCTestCase {
     func testRecordingDefaults_selectedHotKeyIsFnKey() {
         let settings = AppSettings(defaults: defaults)
         XCTAssertEqual(settings.selectedHotKey, .fnKey)
+    }
+
+    @MainActor
+    func testStoredHotKey_unsupportedOrdinarySingleKeyFallsBackToFn() throws {
+        let unsupported = HotKey.custom(keyCode: 0, modifiers: [])
+        defaults.set(try JSONEncoder().encode(unsupported), forKey: "selectedHotKey")
+
+        let settings = AppSettings(defaults: defaults)
+
+        XCTAssertEqual(settings.selectedHotKey, .fnKey)
+    }
+
+    func testTextOutputAvailability_appStoreOnlyOffersClipboard() {
+        XCTAssertEqual(AppSettings.availableTextOutputMethods(for: .appStore), [.clipboardOnly])
+        XCTAssertEqual(
+            AppSettings.normalizedTextOutputMethod(.accessibilityOnly, for: .appStore),
+            .clipboardOnly
+        )
+        XCTAssertEqual(
+            AppSettings.normalizedTextOutputMethod(.smart, for: .appStore),
+            .clipboardOnly
+        )
+    }
+
+    func testTextOutputAvailability_directKeepsAccessibilityOptions() {
+        XCTAssertEqual(
+            AppSettings.availableTextOutputMethods(for: .direct),
+            AppSettings.TextOutputMethod.allCases
+        )
+        XCTAssertEqual(
+            AppSettings.normalizedTextOutputMethod(.accessibilityOnly, for: .direct),
+            .accessibilityOnly
+        )
     }
 
     // MARK: - Speed Mode Settings

--- a/Tests/SpeakAppTests/HotKeyMappingTests.swift
+++ b/Tests/SpeakAppTests/HotKeyMappingTests.swift
@@ -15,4 +15,21 @@ final class HotKeyMappingTests: XCTestCase {
         XCTAssertEqual(KeyCodeMapping.string(for: 64), "F17")
         XCTAssertEqual(KeyCodeMapping.string(for: 114), "Insert")
     }
+
+    func testCustomHotKeyValidation_rejectsOrdinaryUnmodifiedKey() {
+        XCTAssertFalse(KeyCodeMapping.isSupportedCustomHotKey(keyCode: 0, hasModifiers: false))
+    }
+
+    func testCustomHotKeyValidation_acceptsOrdinaryKeyWithModifier() {
+        XCTAssertTrue(KeyCodeMapping.isSupportedCustomHotKey(keyCode: 0, hasModifiers: true))
+    }
+
+    func testCustomHotKeyValidation_acceptsDedicatedExtendedKeyWithoutModifier() {
+        XCTAssertTrue(KeyCodeMapping.isSupportedCustomHotKey(keyCode: 105, hasModifiers: false))
+    }
+
+    func testHotKeySupport_rejectsOrdinaryUnmodifiedKey() {
+        let hotKey = HotKey.custom(keyCode: 0, modifiers: [])
+        XCTAssertFalse(hotKey.isSupportedForGlobalMonitoring)
+    }
 }

--- a/Tests/SpeakAppTests/PermissionsManagerTests.swift
+++ b/Tests/SpeakAppTests/PermissionsManagerTests.swift
@@ -1,0 +1,70 @@
+import AppKit
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+final class PermissionsManagerTests: XCTestCase {
+    func testInputMonitoringStatus_listenGrantIsGranted() {
+        XCTAssertEqual(
+            PermissionsManager.inputMonitoringStatus(
+                hasListenAccess: true,
+                hasAccessibilityAccess: false
+            ),
+            .granted
+        )
+    }
+
+    func testInputMonitoringStatus_accessibilityGrantIsEffectiveAccess() {
+        XCTAssertEqual(
+            PermissionsManager.inputMonitoringStatus(
+                hasListenAccess: false,
+                hasAccessibilityAccess: true
+            ),
+            .granted
+        )
+    }
+
+    func testInputMonitoringStatus_noGrantIsDenied() {
+        XCTAssertEqual(
+            PermissionsManager.inputMonitoringStatus(
+                hasListenAccess: false,
+                hasAccessibilityAccess: false
+            ),
+            .denied
+        )
+    }
+
+    func testAccessibilityPromptPolicy_directPromptsAndAppStoreDoesNot() {
+        XCTAssertTrue(PermissionsManager.shouldPromptForAccessibility(channel: .direct))
+        XCTAssertFalse(PermissionsManager.shouldPromptForAccessibility(channel: .appStore))
+    }
+
+    func testAvailablePermissions_appStoreOmitsAccessibility() {
+        XCTAssertFalse(PermissionType.availablePermissions(for: .appStore).contains(.accessibility))
+        XCTAssertTrue(PermissionType.availablePermissions(for: .appStore).contains(.inputMonitoring))
+        XCTAssertTrue(PermissionType.availablePermissions(for: .direct).contains(.accessibility))
+    }
+
+    @MainActor
+    func testDidBecomeActive_refreshesPermissionStatuses() async {
+        let notificationCenter = NotificationCenter()
+        var accessibilityGranted = false
+        let manager = PermissionsManager(
+            statusProvider: { permission in
+                if permission == .accessibility, accessibilityGranted {
+                    return .granted
+                }
+                return .denied
+            },
+            notificationCenter: notificationCenter
+        )
+        XCTAssertEqual(manager.status(for: .accessibility), .denied)
+
+        accessibilityGranted = true
+        notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+        await Task.yield()
+
+        XCTAssertEqual(manager.status(for: .accessibility), .granted)
+    }
+}

--- a/Tests/SpeakCoreTests/DistributionChannelTests.swift
+++ b/Tests/SpeakCoreTests/DistributionChannelTests.swift
@@ -17,6 +17,7 @@ final class DistributionChannelTests: XCTestCase {
         XCTAssertTrue(channel.supportsSelfUpdate)
         XCTAssertTrue(channel.supportsLocalModelRuntime)
         XCTAssertTrue(channel.supportsAutomaticAccessibilityPrompt)
+        XCTAssertTrue(channel.supportsAccessibilityTextInsertion)
         XCTAssertTrue(channel.allowsCrossChannelMessaging)
         XCTAssertFalse(channel.isSandboxed)
     }
@@ -32,6 +33,8 @@ final class DistributionChannelTests: XCTestCase {
             "Downloaded local-model runtimes cannot run in the App Store sandbox")
         XCTAssertFalse(channel.supportsAutomaticAccessibilityPrompt,
             "Sandboxed apps cannot auto-prompt for Accessibility/Input Monitoring")
+        XCTAssertFalse(channel.supportsAccessibilityTextInsertion,
+            "The App Store sandbox blocks AXUIElement access to other apps")
         XCTAssertFalse(channel.allowsCrossChannelMessaging,
             "App Store builds must not advertise other distribution channels")
         XCTAssertTrue(channel.isSandboxed)
@@ -44,6 +47,8 @@ final class DistributionChannelTests: XCTestCase {
             XCTAssertEqual(channel.supports(.localModelRuntime), channel.supportsLocalModelRuntime)
             XCTAssertEqual(channel.supports(.automaticAccessibilityPrompt),
                            channel.supportsAutomaticAccessibilityPrompt)
+            XCTAssertEqual(channel.supports(.accessibilityTextInsertion),
+                           channel.supportsAccessibilityTextInsertion)
             XCTAssertEqual(channel.supports(.crossChannelMessaging),
                            channel.allowsCrossChannelMessaging)
         }


### PR DESCRIPTION
## Motivation

The macOS global shortcut stopped reliably delivering while the app was unfocused, ordinary unmodified keys could be saved even though they were not viable global shortcuts, and permission UI/state became stale after returning from System Settings. The App Store build also advertised Accessibility insertion even though its sandbox cannot provide that capability.

## What changed

- Route Carbon hotkey registration and handling through the application event target so shortcuts reach the app while unfocused.
- Reject ordinary unmodified custom shortcuts with inline feedback while keeping supported extended single keys and modified keys.
- Refresh permission state on app activation and while permission settings are visible; treat either listen-event or Accessibility TCC grants as effective Input Monitoring access.
- Gate Accessibility insertion by distribution channel: direct builds keep Accessibility output; App Store builds expose truthful clipboard-only delivery without simulating paste.
- Add focused shortcut, permissions, settings normalization, and distribution-channel tests.

## Things learned

The Carbon registration used the dispatcher target, which is an exotic target rather than the application target intended for app-level handlers. Separately, Accessibility text mutation is not a viable App Store-sandbox feature, so the correct fix is distribution-aware behavior instead of presenting a permission workflow that cannot succeed.

## How to test

- `swift test --filter "HotKeyMappingTests|PermissionsManagerTests|AppSettingsDefaultsTests|DistributionChannelTests"` — 56 tests passed.
- `swift build --target SpeakApp -Xswiftc -DAPP_STORE` — passed.
- Direct SpeakApp compilation is covered by the focused test build — passed.

## Review confidence

High confidence in the code paths and focused coverage. The final signed direct and App Store artifacts should still receive a physical permission/hotkey smoke test because TCC behavior is bundle/signature-specific.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distribution-aware text output options, including clipboard-only delivery where accessibility insertion isn’t supported.
  * Improved permission handling and onboarding based on the current distribution.
  * Added validation and clear error messages for unsupported custom shortcuts.
  * Improved shortcut monitoring and fallback behavior for unsupported saved shortcuts.
* **Bug Fixes**
  * Refined accessibility and input monitoring status detection and refresh behavior.
  * Improved text output reliability by refreshing permissions before insertion.
* **Tests**
  * Added coverage for shortcut validation, permission handling, output availability, and distribution capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->