### PR TITLE
feat: add compact density and API key discovery

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -226,6 +226,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
 
   enum DefaultsKey: String {
     case appearance
+    case visualDensity
     case transcriptionMode
     case liveTranscriptionModel
     case batchTranscriptionModel
@@ -304,6 +305,10 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
 
   @Published var appearance: Appearance {
     didSet { store(appearance.rawValue, key: .appearance) }
+  }
+
+  @Published var visualDensity: AppVisualDensity {
+    didSet { store(visualDensity.rawValue, key: .visualDensity) }
   }
 
   @Published var transcriptionMode: TranscriptionMode {
@@ -769,6 +774,10 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       Appearance(
         rawValue: defaults.string(forKey: DefaultsKey.appearance.rawValue)
           ?? Appearance.system.rawValue) ?? .system
+    visualDensity =
+      AppVisualDensity(
+        rawValue: defaults.string(forKey: DefaultsKey.visualDensity.rawValue)
+          ?? AppVisualDensity.normal.rawValue) ?? .normal
     transcriptionMode =
       TranscriptionMode(
         rawValue: defaults.string(forKey: DefaultsKey.transcriptionMode.rawValue)

--- a/Sources/SpeakApp/DashboardView.swift
+++ b/Sources/SpeakApp/DashboardView.swift
@@ -4,15 +4,16 @@ import SwiftUI
 struct DashboardView: View {
   @EnvironmentObject private var environment: AppEnvironment
   @EnvironmentObject private var history: HistoryManager
+  @Environment(\.appVisualDensity) private var density
   @State private var requestingPermission: PermissionType?
 
   var body: some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: 24) {
+      VStack(alignment: .leading, spacing: density.sectionSpacing) {
         heroHeader
         dashboardSections
       }
-      .padding(24)
+      .padding(density.pagePadding)
       .frame(maxWidth: 1100, alignment: .center)
     }
     .background(
@@ -112,8 +113,11 @@ struct DashboardView: View {
   }
 
   private var dashboardSections: some View {
-    VStack(spacing: 24) {
-      LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 24)], spacing: 24) {
+    VStack(spacing: density.sectionSpacing) {
+      LazyVGrid(
+        columns: [GridItem(.adaptive(minimum: 340), spacing: density.sectionSpacing)],
+        spacing: density.sectionSpacing
+      ) {
         permissionsSection
         statisticsSection
         recentSection
@@ -122,13 +126,19 @@ struct DashboardView: View {
       // Usage Charts
       dailyUsageChartSection
 
-      LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 24)], spacing: 24) {
+      LazyVGrid(
+        columns: [GridItem(.adaptive(minimum: 340), spacing: density.sectionSpacing)],
+        spacing: density.sectionSpacing
+      ) {
         transcriptionModelChartSection
         postProcessingModelChartSection
       }
 
       // TTS Charts
-      LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 24)], spacing: 24) {
+      LazyVGrid(
+        columns: [GridItem(.adaptive(minimum: 340), spacing: density.sectionSpacing)],
+        spacing: density.sectionSpacing
+      ) {
         ttsUsageChartSection
         ttsProviderChartSection
       }
@@ -377,8 +387,7 @@ struct DashboardView: View {
   }
 
   private var recentSection: some View {
-    DashboardCard(title: "Recent Session", systemImage: "clock.arrow.circlepath", tint: Color.brandLagoon)
-    {
+    DashboardCard(title: "Recent Session", systemImage: "clock.arrow.circlepath", tint: Color.brandLagoon) {
       if let item = history.items.first {
         recentItemView(item)
       } else {

--- a/Sources/SpeakApp/HistoryView.swift
+++ b/Sources/SpeakApp/HistoryView.swift
@@ -8,6 +8,7 @@ import UniformTypeIdentifiers
 
 struct HistoryView: View { // swiftlint:disable:this type_body_length
   @EnvironmentObject private var environment: AppEnvironment
+  @Environment(\.appVisualDensity) private var density
   @State private var searchText: String = ""
   @State private var showErrorsOnly: Bool = false
   @State private var dateRangeEnabled: Bool = false
@@ -139,14 +140,14 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
   var body: some View {
     ScrollViewReader { proxy in
       ScrollView {
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: density.sectionSpacing) {
           header
           if isInitialLoad {
             skeletonLoadingView
           } else if filteredItems.isEmpty {
             emptyState
           } else {
-            LazyVStack(spacing: 20) {
+            LazyVStack(spacing: density.sectionSpacing) {
               ForEach(filteredItems) { item in
                 HistoryListRow(item: item)
                   .id(item.id)
@@ -155,7 +156,7 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
             .animation(.spring(response: 0.28, dampingFraction: 0.88), value: filteredItems)
           }
         }
-        .padding(24)
+        .padding(density.pagePadding)
         .frame(maxWidth: 1100, alignment: .center)
       }
       .onAppear {
@@ -237,7 +238,7 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
 
 
   private var header: some View {
-    return VStack(alignment: .leading, spacing: 18) {
+    VStack(alignment: .leading, spacing: 18) {
       VStack(alignment: .leading, spacing: 8) {
         Text("Session History")
           .font(.largeTitle.bold())
@@ -919,8 +920,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
 
         metaTile(icon: "clock.arrow.circlepath", title: "Timeline") {
           if let start = item.phaseTimestamps.recordingStarted,
-            let end = item.phaseTimestamps.outputDelivered
-          {
+            let end = item.phaseTimestamps.outputDelivered {
             let total = end.timeIntervalSince(start)
             Text("Total: \(formatDuration(total))")
           } else {
@@ -943,8 +943,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
       }
 
       if let summary = item.personalCorrections,
-        !(summary.applied.isEmpty && summary.suggestions.isEmpty)
-      {
+        !(summary.applied.isEmpty && summary.suggestions.isEmpty) {
         personalCorrectionsSection(summary)
       }
     }
@@ -1471,8 +1470,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
 
     if let raw = item.rawTranscription,
       raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        == processed.trimmingCharacters(in: .whitespacesAndNewlines)
-    {
+        == processed.trimmingCharacters(in: .whitespacesAndNewlines) {
       return nil
     }
 
@@ -1484,8 +1482,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
       return processed
     }
     if let raw = item.rawTranscription,
-      !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    {
+      !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
       return raw
     }
     return nil

--- a/Sources/SpeakApp/MainView.swift
+++ b/Sources/SpeakApp/MainView.swift
@@ -1,10 +1,12 @@
 import AppKit
+import SpeakCore
 import SwiftUI
 
 struct MainView: View {
   @EnvironmentObject private var environment: AppEnvironment
   @EnvironmentObject private var history: HistoryManager
   @EnvironmentObject private var personalLexicon: PersonalLexiconService
+  @EnvironmentObject private var settings: AppSettings
   @State private var selection: SidebarItem? = .dashboard
 
   var body: some View {
@@ -14,10 +16,11 @@ struct MainView: View {
     } detail: {
       detailView
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
+        .padding(settings.visualDensity == .compact ? 8 : 16)
         .background(Color(nsColor: .windowBackgroundColor))
     }
     .frame(minWidth: 960, minHeight: 640)
+    .environment(\.appVisualDensity, settings.visualDensity)
     .toolbar { toolbar }
     .onReceive(environment.$sidebarNavigationTarget) { item in
       guard let item else { return }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -52,6 +52,18 @@ enum SettingsTab: String, CaseIterable, Identifiable, Hashable {
   }
 }
 
+private struct MacAPIKeyItem: Identifiable {
+  enum Source {
+    case openRouter
+    case transcription(TranscriptionProviderMetadata)
+    case textToSpeech(TTSProvider)
+  }
+
+  let entry: APIKeyListEntry
+  let source: Source
+  var id: String { entry.id }
+}
+
 struct SettingsView: View {
   @EnvironmentObject private var environment: AppEnvironment
   @EnvironmentObject private var settings: AppSettings
@@ -92,6 +104,9 @@ struct SettingsView: View {
   @State private var providerValidationStates: [String: ValidationViewState] = [:]
   @State private var ttsProviderAPIKeys: [String: String] = [:]
   @State private var ttsProviderValidationStates: [String: ValidationViewState] = [:]
+  @State private var apiKeySearchText = ""
+  @State private var apiKeyStatusFilter: APIKeyStatusFilter = .all
+  @State private var apiKeySortOrder: APIKeySortOrder = .name
   @State private var missingTranscriptionAPIKeyAlert: MissingLiveAPIKeyAlert?
   @State private var showSystemPromptPreview = false
   @State private var systemPromptPreview = ""
@@ -181,6 +196,56 @@ struct SettingsView: View {
   private var isValidatingKey: Bool {
     if case .validating = apiKeyValidationState { return true }
     return false
+  }
+
+  private var allMacAPIKeyItems: [MacAPIKeyItem] {
+    var items = [
+      MacAPIKeyItem(
+        entry: APIKeyListEntry(
+          id: "general-openrouter",
+          title: "OpenRouter",
+          category: "Post-processing",
+          isStored: isOpenRouterKeyStored
+        ),
+        source: .openRouter
+      )
+    ]
+    items += transcriptionProviders
+      .filter { $0.id != "elevenlabs" }
+      .map { provider in
+        MacAPIKeyItem(
+          entry: APIKeyListEntry(
+            id: "transcription-\(provider.id)",
+            title: provider.displayName,
+            category: "Transcription",
+            isStored: settings.trackedAPIKeyIdentifiers.contains(provider.apiKeyIdentifier)
+          ),
+          source: .transcription(provider)
+        )
+      }
+    items += [TTSProvider.elevenlabs, .openai, .azure, .deepgram].map { provider in
+      MacAPIKeyItem(
+        entry: APIKeyListEntry(
+          id: "tts-\(provider.id)",
+          title: provider == .elevenlabs ? "ElevenLabs" : provider.displayName,
+          category: provider == .elevenlabs ? "Transcription & Voice Output" : "Voice Output",
+          isStored: settings.trackedAPIKeyIdentifiers.contains(provider.apiKeyIdentifier)
+        ),
+        source: .textToSpeech(provider)
+      )
+    }
+    return items
+  }
+
+  private var visibleMacAPIKeyItems: [MacAPIKeyItem] {
+    let orderedEntries = APIKeyListQuery.apply(
+      to: allMacAPIKeyItems.map(\.entry),
+      searchText: apiKeySearchText,
+      status: apiKeyStatusFilter,
+      sortOrder: apiKeySortOrder
+    )
+    let itemsByID = Dictionary(uniqueKeysWithValues: allMacAPIKeyItems.map { ($0.id, $0) })
+    return orderedEntries.compactMap { itemsByID[$0.id] }
   }
 
   private var overviewPostProcessingValue: String {
@@ -587,12 +652,13 @@ struct SettingsView: View {
   }
 
   var body: some View {
+    let density = settings.visualDensity
     ScrollView {
-      VStack(alignment: .leading, spacing: 28) {
+      VStack(alignment: .leading, spacing: density == .compact ? 16 : 28) {
         overviewHeader
         tabContent
       }
-      .padding(24)
+      .padding(density.pagePadding)
       .frame(maxWidth: 1100, alignment: .center)
     }
     .background(
@@ -668,6 +734,21 @@ struct SettingsView: View {
           )
           .speakTooltip("Choose whether Speak follows macOS appearance or stays in light or dark mode all the time.")
           .accessibilityLabel("Appearance theme picker")
+
+          Picker("Layout Density", selection: settingsBinding(\AppSettings.visualDensity)) {
+            ForEach(AppVisualDensity.allCases) { density in
+              Text(density.displayName).tag(density)
+            }
+          }
+          .pickerStyle(.segmented)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 8)
+          .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+              .fill(Color(nsColor: .controlBackgroundColor))
+          )
+          .speakTooltip("Choose normal spacing or a higher-density layout across Speak.")
+          .accessibilityLabel("Application layout density picker")
         }
       }
       .speakTooltip("Set Speak's look to match your workspace with light, dark, or system themes.")
@@ -3405,11 +3486,81 @@ struct SettingsView: View {
 
   private var apiKeySettings: some View {
     ScrollViewReader { proxy in
-      LazyVStack(spacing: 20) {
+      LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
+        apiKeyListControls
+
         CloudKitKeySyncSettingsCard(secureStorage: environment.secureStorage)
 
-        // OpenRouter (Legacy)
-        apiKeyCard(
+        if visibleMacAPIKeyItems.isEmpty {
+          ContentUnavailableView(
+            "No API Keys",
+            systemImage: "key.slash",
+            description: Text("Try a different search or status filter.")
+          )
+          .padding(.vertical, 24)
+        } else {
+          ForEach(visibleMacAPIKeyItems) { item in
+            macAPIKeyView(for: item)
+              .id(item.id)
+          }
+        }
+      }
+      .onAppear {
+        if let target = environment.apiKeysScrollTarget {
+          revealAPIKeyTarget()
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            withAnimation { proxy.scrollTo(target, anchor: .top) }
+            environment.apiKeysScrollTarget = nil
+          }
+        }
+      }
+      .onChange(of: environment.apiKeysScrollTarget) { _, newValue in
+        guard let target = newValue else { return }
+        revealAPIKeyTarget()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+          withAnimation { proxy.scrollTo(target, anchor: .top) }
+          environment.apiKeysScrollTarget = nil
+        }
+      }
+    }
+  }
+
+  private var apiKeyListControls: some View {
+    SettingsCard(title: "Find API Keys", systemImage: "magnifyingglass", tint: .brandAccent) {
+      VStack(alignment: .leading, spacing: settings.visualDensity == .compact ? 8 : 12) {
+        TextField("Search provider or category", text: $apiKeySearchText)
+          .textFieldStyle(.roundedBorder)
+          .accessibilityLabel("Search API keys")
+
+        HStack(spacing: 12) {
+          Picker("Status", selection: $apiKeyStatusFilter) {
+            ForEach(APIKeyStatusFilter.allCases) { filter in
+              Text(filter.displayName).tag(filter)
+            }
+          }
+          .pickerStyle(.menu)
+
+          Picker("Sort", selection: $apiKeySortOrder) {
+            ForEach(APIKeySortOrder.allCases) { order in
+              Text(order.displayName).tag(order)
+            }
+          }
+          .pickerStyle(.menu)
+
+          Spacer()
+          Text("\(visibleMacAPIKeyItems.count) of \(allMacAPIKeyItems.count)")
+            .font(.caption.monospacedDigit())
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func macAPIKeyView(for item: MacAPIKeyItem) -> some View {
+    switch item.source {
+    case .openRouter:
+      apiKeyCard(
         title: "OpenRouter",
         systemImage: "network",
         tint: .green,
@@ -3437,35 +3588,16 @@ struct SettingsView: View {
         link: nil,
         linkLabel: nil
       )
-
-      // Transcription Providers (Dynamic) — ElevenLabs excluded; it shares the TTS card below
-      ForEach(transcriptionProviders.filter { $0.id != "elevenlabs" }) { provider in
-        providerAPIKeyCard(for: provider)
-          .id("transcription-\(provider.id)")
-      }
-
-      // TTS Providers
-      ForEach([TTSProvider.elevenlabs, .openai, .azure, .deepgram]) { provider in
-        ttsProviderAPIKeyCard(for: provider)
-          .id("tts-\(provider.id)")
-      }
+    case .transcription(let provider):
+      providerAPIKeyCard(for: provider)
+    case .textToSpeech(let provider):
+      ttsProviderAPIKeyCard(for: provider)
     }
-    .onAppear {
-        if let target = environment.apiKeysScrollTarget {
-          DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            withAnimation { proxy.scrollTo(target, anchor: .top) }
-            environment.apiKeysScrollTarget = nil
-          }
-        }
-      }
-      .onChange(of: environment.apiKeysScrollTarget) { _, newValue in
-        guard let target = newValue else { return }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-          withAnimation { proxy.scrollTo(target, anchor: .top) }
-          environment.apiKeysScrollTarget = nil
-        }
-      }
-    }
+  }
+
+  private func revealAPIKeyTarget() {
+    apiKeySearchText = ""
+    apiKeyStatusFilter = .all
   }
 
   private func providerAPIKeyCard(for provider: TranscriptionProviderMetadata) -> some View {
@@ -4824,6 +4956,7 @@ private struct SettingsInlineInfo: View {
 }
 
 private struct SettingsCard<Content: View>: View {
+  @Environment(\.appVisualDensity) private var density
   let title: String
   let systemImage: String
   let tint: Color
@@ -4837,7 +4970,7 @@ private struct SettingsCard<Content: View>: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 18) {
+    VStack(alignment: .leading, spacing: density.cardContentSpacing) {
       HStack(spacing: 14) {
         ZStack {
           RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -4856,7 +4989,7 @@ private struct SettingsCard<Content: View>: View {
 
       content
     }
-    .padding(24)
+    .padding(density.cardPadding)
     .frame(maxWidth: .infinity, alignment: .leading)
     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
     .overlay(

--- a/Sources/SpeakCore/AppVisualDensity.swift
+++ b/Sources/SpeakCore/AppVisualDensity.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// A user-selected presentation density shared by the macOS and iOS apps.
+/// Normal intentionally preserves the existing spacing; compact reduces
+/// whitespace without shrinking interactive controls below platform norms.
+public enum AppVisualDensity: String, CaseIterable, Identifiable, Sendable {
+    case normal
+    case compact
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .normal: return "Normal"
+        case .compact: return "Compact"
+        }
+    }
+
+    public var sectionSpacing: CGFloat { self == .compact ? 12 : 20 }
+    public var pagePadding: CGFloat { self == .compact ? 14 : 24 }
+    public var cardPadding: CGFloat { self == .compact ? 15 : 24 }
+    public var cardContentSpacing: CGFloat { self == .compact ? 11 : 18 }
+    public var listRowVerticalPadding: CGFloat { self == .compact ? 1 : 4 }
+    public var minimumListRowHeight: CGFloat { self == .compact ? 38 : 44 }
+    public var listSectionSpacing: CGFloat { self == .compact ? 12 : 24 }
+}
+
+private struct AppVisualDensityKey: EnvironmentKey {
+    static let defaultValue = AppVisualDensity.normal
+}
+
+public extension EnvironmentValues {
+    var appVisualDensity: AppVisualDensity {
+        get { self[AppVisualDensityKey.self] }
+        set { self[AppVisualDensityKey.self] = newValue }
+    }
+}
+
+public enum APIKeyStatusFilter: String, CaseIterable, Identifiable, Sendable {
+    case all
+    case stored
+    case missing
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .all: return "All Keys"
+        case .stored: return "Stored"
+        case .missing: return "Missing"
+        }
+    }
+}
+
+public enum APIKeySortOrder: String, CaseIterable, Identifiable, Sendable {
+    case name
+    case category
+    case status
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .name: return "Name"
+        case .category: return "Category"
+        case .status: return "Status"
+        }
+    }
+}
+
+public struct APIKeyListEntry: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let category: String
+    public let isStored: Bool
+
+    public init(id: String, title: String, category: String, isStored: Bool) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.isStored = isStored
+    }
+}
+
+public enum APIKeyListQuery {
+    public static func apply(
+        to entries: [APIKeyListEntry],
+        searchText: String,
+        status: APIKeyStatusFilter,
+        sortOrder: APIKeySortOrder
+    ) -> [APIKeyListEntry] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filtered = entries.filter { entry in
+            let matchesStatus: Bool
+            switch status {
+            case .all: matchesStatus = true
+            case .stored: matchesStatus = entry.isStored
+            case .missing: matchesStatus = !entry.isStored
+            }
+            guard matchesStatus else { return false }
+            guard !query.isEmpty else { return true }
+            return entry.title.localizedCaseInsensitiveContains(query)
+                || entry.category.localizedCaseInsensitiveContains(query)
+        }
+
+        return filtered.sorted { lhs, rhs in
+            switch sortOrder {
+            case .name:
+                return compare(lhs.title, rhs.title, fallback: lhs.id < rhs.id)
+            case .category:
+                return compare(
+                    lhs.category,
+                    rhs.category,
+                    fallback: compare(lhs.title, rhs.title, fallback: lhs.id < rhs.id)
+                )
+            case .status:
+                if lhs.isStored != rhs.isStored { return lhs.isStored && !rhs.isStored }
+                return compare(lhs.title, rhs.title, fallback: lhs.id < rhs.id)
+            }
+        }
+    }
+
+    private static func compare(_ lhs: String, _ rhs: String, fallback: @autoclosure () -> Bool) -> Bool {
+        let result = lhs.localizedCaseInsensitiveCompare(rhs)
+        if result == .orderedSame { return fallback() }
+        return result == .orderedAscending
+    }
+}

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -369,7 +369,10 @@ public struct ContentView: View {
                 VStack {
                     ScrollViewReader { proxy in
                         ScrollView {
-                            VStack(alignment: .leading, spacing: 12) {
+                            VStack(
+                                alignment: .leading,
+                                spacing: settings.visualDensity == .compact ? 8 : 12
+                            ) {
                                 if currentText.isEmpty {
                                     Text(backgroundService.isRunning
                                          ? "Recording via Action Button…"
@@ -386,7 +389,7 @@ public struct ContentView: View {
                                         .textSelection(.enabled)
                                 }
                             }
-                            .padding()
+                            .padding(settings.visualDensity == .compact ? 12 : 16)
                             .id("transcript")
                         }
                         .onChange(of: coordinator.partialText) { _, _ in
@@ -504,6 +507,8 @@ public struct ContentView: View {
                 }
             }
         }
+        .environment(\.appVisualDensity, settings.visualDensity)
+        .environment(\.defaultMinListRowHeight, settings.visualDensity.minimumListRowHeight)
     }
 
     // MARK: - Floating Controls with Glass Effect

--- a/Sources/SpeakiOS/Views/ConversationListView.swift
+++ b/Sources/SpeakiOS/Views/ConversationListView.swift
@@ -6,6 +6,7 @@ import SpeakCore
 
 /// Shows a list of OpenClaw conversations with the ability to create new ones.
 public struct ConversationListView: View {
+    @Environment(\.appVisualDensity) private var density
     @ObservedObject private var store = ConversationStore.shared
     @ObservedObject private var settings = OpenClawSettings.shared
     @EnvironmentObject private var deepLinkRouter: DeepLinkRouter
@@ -25,6 +26,7 @@ public struct ConversationListView: View {
             }
         }
         .navigationTitle("OpenClaw")
+        .environment(\.defaultMinListRowHeight, density.minimumListRowHeight)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 12) {
@@ -118,12 +120,14 @@ public struct ConversationListView: View {
                 }
             }
         }
+        .listSectionSpacing(density.listSectionSpacing)
     }
 }
 
 // MARK: - Conversation Row
 
 struct ConversationRow: View {
+    @Environment(\.appVisualDensity) private var density
     let conversation: OpenClawClient.Conversation
 
     var body: some View {
@@ -153,7 +157,7 @@ struct ConversationRow: View {
                     .foregroundStyle(.tertiary)
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, density.listRowVerticalPadding)
     }
 }
 

--- a/Sources/SpeakiOS/Views/HistoryItemRow.swift
+++ b/Sources/SpeakiOS/Views/HistoryItemRow.swift
@@ -1,10 +1,12 @@
 #if os(iOS)
 import SwiftUI
+import SpeakCore
 import SpeakSync
 
 // MARK: - History Item Row
 
 struct HistoryItemRow: View {
+    @Environment(\.appVisualDensity) private var density
     let item: iOSHistoryItem
     let isSynced: Bool
     var isReprocessing: Bool = false
@@ -15,7 +17,7 @@ struct HistoryItemRow: View {
     @State private var isExpanded = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: density == .compact ? 5 : 8) {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(item.createdAt, style: .date)
@@ -116,7 +118,7 @@ struct HistoryItemRow: View {
                 }
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, density.listRowVerticalPadding)
         .contentShape(Rectangle())
         .onTapGesture {
             if max(item.transcription.count, item.postProcessedTranscription?.count ?? 0) > 150 {

--- a/Sources/SpeakiOS/Views/HistoryView.swift
+++ b/Sources/SpeakiOS/Views/HistoryView.swift
@@ -7,6 +7,7 @@ import SpeakSync
 
 // swiftlint:disable:next type_body_length
 public struct HistoryView: View {
+    @Environment(\.appVisualDensity) private var density
     @StateObject private var historyManager = iOSHistoryManager.shared
     @ObservedObject private var syncEngine = HistorySyncEngine.shared
     @State private var showingClearConfirmation = false
@@ -42,6 +43,7 @@ public struct HistoryView: View {
             }
         }
         .navigationTitle("History")
+        .environment(\.defaultMinListRowHeight, density.minimumListRowHeight)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 syncStatusIcon
@@ -200,11 +202,12 @@ public struct HistoryView: View {
                 }
             }
         }
+        .listSectionSpacing(density.listSectionSpacing)
     }
 
     private var statsHeader: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 24) {
+            HStack(spacing: density == .compact ? 14 : 24) {
                 statBadge(value: "\(statistics.totalSessions)", label: "Sessions")
                 statBadge(value: formatDuration(statistics.averageSessionLength), label: "Average")
                 statBadge(value: formatDuration(statistics.cumulativeRecordingDuration), label: "Total Time")

--- a/Sources/SpeakiOS/Views/RecordingsView.swift
+++ b/Sources/SpeakiOS/Views/RecordingsView.swift
@@ -8,6 +8,7 @@ import SpeakCore
 /// Shows all locally saved audio recordings with playback,
 /// delete, and re-transcribe support.
 public struct RecordingsView: View {
+    @Environment(\.appVisualDensity) private var density
     @State private var recordings: [RecordingInfo] = []
     @State private var playingURL: URL?
     @State private var audioPlayer: AVAudioPlayer?
@@ -54,6 +55,7 @@ public struct RecordingsView: View {
             }
         }
         .navigationTitle("Recordings")
+        .environment(\.defaultMinListRowHeight, density.minimumListRowHeight)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear { reload() }
         .onDisappear { stopPlayback() }
@@ -141,6 +143,7 @@ public struct RecordingsView: View {
 // MARK: - Recording Row
 
 struct RecordingRow: View {
+    @Environment(\.appVisualDensity) private var density
     let recording: RecordingInfo
     let isPlaying: Bool
     let onPlay: () -> Void
@@ -203,7 +206,7 @@ struct RecordingRow: View {
                 Label("Delete", systemImage: "trash")
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, density.listRowVerticalPadding)
     }
 }
 

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -195,6 +195,10 @@ public final class AppSettings: ObservableObject {
         didSet { UserDefaults.standard.set(liveActivitiesEnabled, forKey: "liveActivitiesEnabled") }
     }
 
+    @Published public var visualDensity: AppVisualDensity {
+        didSet { UserDefaults.standard.set(visualDensity.rawValue, forKey: "visualDensity") }
+    }
+
     @Published public var autoStartRecording: Bool {
         didSet { UserDefaults.standard.set(autoStartRecording, forKey: "autoStartRecording") }
     }
@@ -271,6 +275,9 @@ public final class AppSettings: ObservableObject {
 
         // Default Live Activities to true if not set
         let liveActivities = UserDefaults.standard.object(forKey: "liveActivitiesEnabled") as? Bool ?? true
+        let density = AppVisualDensity(
+            rawValue: UserDefaults.standard.string(forKey: "visualDensity") ?? ""
+        ) ?? .normal
         let autoStart = UserDefaults.standard.bool(forKey: "autoStartRecording")
 
         // Hardware trigger destination (Action Button, Siri, Shortcuts).
@@ -307,6 +314,7 @@ public final class AppSettings: ObservableObject {
         self.assemblyAIAPIKey = ""
         self.gladiaAPIKey = ""
         self.liveActivitiesEnabled = liveActivities
+        self.visualDensity = density
         self.autoStartRecording = autoStart
         self.hardwareTriggerDestination = hardwareDest
         self.postProcessingEnabled = postEnabled
@@ -639,6 +647,19 @@ public struct SettingsView: View {
 
     public var body: some View {
         Form {
+            Section("Appearance") {
+                Picker("Layout Density", selection: $settings.visualDensity) {
+                    ForEach(AppVisualDensity.allCases) { density in
+                        Text(density.displayName).tag(density)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Text("Compact reduces whitespace across lists, forms, and cards while keeping controls easy to tap.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Transcription") {
                 Picker("Mode", selection: $settings.transcriptionMode) {
                     ForEach(IOSTranscriptionMode.allCases) { mode in
@@ -984,6 +1005,8 @@ public struct SettingsView: View {
                 }
             }
         }
+        .environment(\.defaultMinListRowHeight, settings.visualDensity.minimumListRowHeight)
+        .listSectionSpacing(settings.visualDensity.listSectionSpacing)
         .navigationTitle("Settings")
         .navigationDestination(isPresented: $showingAPIKeys) {
             APIKeysView(settings: settings)
@@ -1223,218 +1246,96 @@ struct APIKeysView: View {
     @State private var isValidating = false
     @State private var validationMessage: String?
     @State private var showingValidation = false
+    @State private var searchText = ""
+    @State private var statusFilter: APIKeyStatusFilter = .all
+    @State private var sortOrder: APIKeySortOrder = .name
+
+    private struct KeyPresentation {
+        let title: String
+        let systemImage: String
+        let help: String
+    }
+
+    private var allEntries: [APIKeyListEntry] {
+        [
+            APIKeyListEntry(
+                id: "deepgram", title: "Deepgram", category: "Transcription", isStored: settings.hasDeepgramKey
+            ),
+            APIKeyListEntry(
+                id: "elevenlabs", title: "ElevenLabs", category: "Transcription & Voice Output",
+                isStored: settings.hasElevenLabsKey
+            ),
+            APIKeyListEntry(
+                id: "openrouter", title: "OpenRouter", category: "Post-processing", isStored: settings.hasOpenRouterKey
+            ),
+            APIKeyListEntry(
+                id: "openai", title: "OpenAI", category: "Transcription", isStored: settings.hasOpenAIKey
+            ),
+            APIKeyListEntry(
+                id: "cartesia", title: "Cartesia", category: "Transcription", isStored: settings.hasCartesiaKey
+            ),
+            APIKeyListEntry(
+                id: "soniox", title: "Soniox", category: "Transcription", isStored: settings.hasSonioxKey
+            ),
+            APIKeyListEntry(
+                id: "modulate", title: "Modulate", category: "Transcription", isStored: settings.hasModulateKey
+            ),
+            APIKeyListEntry(
+                id: "assemblyai", title: "AssemblyAI", category: "Transcription",
+                isStored: settings.hasAssemblyAIKey
+            ),
+            APIKeyListEntry(
+                id: "gladia", title: "Gladia", category: "Transcription", isStored: settings.hasGladiaKey
+            )
+        ]
+    }
+
+    private var visibleEntries: [APIKeyListEntry] {
+        APIKeyListQuery.apply(
+            to: allEntries,
+            searchText: searchText,
+            status: statusFilter,
+            sortOrder: sortOrder
+        )
+    }
 
     var body: some View {
         Form {
-            Section {
-                SecureField("API Key", text: $deepgramKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasDeepgramKey && deepgramKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.deepgramAPIKey = ""
-                    }
+            if visibleEntries.isEmpty {
+                ContentUnavailableView(
+                    "No API Keys",
+                    systemImage: "key.slash",
+                    description: Text("Try another search or status filter.")
+                )
+            } else {
+                ForEach(visibleEntries) { entry in
+                    apiKeySection(for: entry)
                 }
-            } header: {
-                Label("Deepgram", systemImage: "waveform")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from deepgram.com")
-                    if settings.hasDeepgramKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $elevenLabsKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasElevenLabsKey && elevenLabsKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.elevenLabsAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("ElevenLabs", systemImage: "mic.and.signal.meter")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from elevenlabs.io")
-                    if settings.hasElevenLabsKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $openRouterKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasOpenRouterKey && openRouterKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.openRouterAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("OpenRouter", systemImage: "network")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from openrouter.ai")
-                    if settings.hasOpenRouterKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $openAIKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasOpenAIKey && openAIKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.openAIAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("OpenAI", systemImage: "brain.head.profile")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from platform.openai.com. Used by gpt-realtime-whisper streaming.")
-                    if settings.hasOpenAIKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $cartesiaKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasCartesiaKey && cartesiaKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.cartesiaAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("Cartesia", systemImage: "waveform.circle")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from cartesia.ai. Used by Ink streaming.")
-                    if settings.hasCartesiaKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $sonioxKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasSonioxKey && sonioxKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.sonioxAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("Soniox", systemImage: "waveform.badge.mic")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from soniox.com. Used by STT real-time streaming.")
-                    if settings.hasSonioxKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $modulateKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasModulateKey && modulateKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.modulateAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("Modulate", systemImage: "waveform.badge.magnifyingglass")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from modulate.ai. Used by Velma streaming.")
-                    if settings.hasModulateKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $assemblyAIKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasAssemblyAIKey && assemblyAIKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.assemblyAIAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("AssemblyAI", systemImage: "waveform.badge.plus")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from assemblyai.com. Used by Universal-Streaming.")
-                    if settings.hasAssemblyAIKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $gladiaKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasGladiaKey && gladiaKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.gladiaAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("Gladia", systemImage: "waveform.badge.exclamationmark")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from gladia.io. Used by Solaria streaming.")
-                    if settings.hasGladiaKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
             }
         }
+        .environment(\.defaultMinListRowHeight, settings.visualDensity.minimumListRowHeight)
+        .listSectionSpacing(settings.visualDensity.listSectionSpacing)
         .navigationTitle("API Keys")
+        .searchable(text: $searchText, prompt: "Provider or use")
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    Picker("Status", selection: $statusFilter) {
+                        ForEach(APIKeyStatusFilter.allCases) { filter in
+                            Text(filter.displayName).tag(filter)
+                        }
+                    }
+                    Picker("Sort", selection: $sortOrder) {
+                        ForEach(APIKeySortOrder.allCases) { order in
+                            Text(order.displayName).tag(order)
+                        }
+                    }
+                } label: {
+                    Label("Filter and Sort", systemImage: statusFilter == .all
+                        ? "line.3.horizontal.decrease.circle"
+                        : "line.3.horizontal.decrease.circle.fill")
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 if isValidating {
                     ProgressView()
@@ -1460,6 +1361,97 @@ struct APIKeysView: View {
             Button("OK") {}
         } message: {
             Text(validationMessage ?? "Keys saved")
+        }
+    }
+
+    private func apiKeySection(for entry: APIKeyListEntry) -> some View {
+        let presentation = presentation(for: entry.id)
+        return Section {
+            SecureField("API Key", text: draftBinding(for: entry.id))
+                .textContentType(.password)
+                .autocorrectionDisabled()
+
+            if entry.isStored && draftBinding(for: entry.id).wrappedValue.isEmpty {
+                Button("Clear Stored Key", role: .destructive) {
+                    clearStoredKey(for: entry.id)
+                }
+            }
+        } header: {
+            HStack {
+                Label(presentation.title, systemImage: presentation.systemImage)
+                Spacer()
+                Text(entry.isStored ? "Stored" : "Missing")
+                    .font(.caption)
+                    .foregroundStyle(entry.isStored ? .green : .secondary)
+            }
+        } footer: {
+            Text(presentation.help)
+                .font(.caption)
+        }
+    }
+
+    private func presentation(for id: String) -> KeyPresentation {
+        switch id {
+        case "deepgram":
+            return KeyPresentation(title: "Deepgram", systemImage: "waveform", help: "Get your key from deepgram.com.")
+        case "elevenlabs":
+            return KeyPresentation(
+                title: "ElevenLabs", systemImage: "mic.and.signal.meter", help: "Get your key from elevenlabs.io."
+            )
+        case "openrouter":
+            return KeyPresentation(title: "OpenRouter", systemImage: "network", help: "Get your key from openrouter.ai.")
+        case "openai":
+            return KeyPresentation(
+                title: "OpenAI", systemImage: "brain.head.profile", help: "Get your key from platform.openai.com."
+            )
+        case "cartesia":
+            return KeyPresentation(
+                title: "Cartesia", systemImage: "waveform.circle", help: "Get your key from cartesia.ai."
+            )
+        case "soniox":
+            return KeyPresentation(
+                title: "Soniox", systemImage: "waveform.badge.mic", help: "Get your key from soniox.com."
+            )
+        case "modulate":
+            return KeyPresentation(
+                title: "Modulate", systemImage: "waveform.badge.magnifyingglass", help: "Get your key from modulate.ai."
+            )
+        case "assemblyai":
+            return KeyPresentation(
+                title: "AssemblyAI", systemImage: "waveform.badge.plus", help: "Get your key from assemblyai.com."
+            )
+        default:
+            return KeyPresentation(
+                title: "Gladia", systemImage: "waveform.badge.exclamationmark", help: "Get your key from gladia.io."
+            )
+        }
+    }
+
+    private func draftBinding(for id: String) -> Binding<String> {
+        switch id {
+        case "deepgram": return $deepgramKey
+        case "elevenlabs": return $elevenLabsKey
+        case "openrouter": return $openRouterKey
+        case "openai": return $openAIKey
+        case "cartesia": return $cartesiaKey
+        case "soniox": return $sonioxKey
+        case "modulate": return $modulateKey
+        case "assemblyai": return $assemblyAIKey
+        default: return $gladiaKey
+        }
+    }
+
+    private func clearStoredKey(for id: String) {
+        switch id {
+        case "deepgram": settings.deepgramAPIKey = ""
+        case "elevenlabs": settings.elevenLabsAPIKey = ""
+        case "openrouter": settings.openRouterAPIKey = ""
+        case "openai": settings.openAIAPIKey = ""
+        case "cartesia": settings.cartesiaAPIKey = ""
+        case "soniox": settings.sonioxAPIKey = ""
+        case "modulate": settings.modulateAPIKey = ""
+        case "assemblyai": settings.assemblyAIAPIKey = ""
+        default: settings.gladiaAPIKey = ""
         }
     }
 

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -42,6 +42,21 @@ final class AppSettingsDefaultsTests: XCTestCase {
     }
 
     @MainActor
+    func testCoreDefaults_visualDensityIsNormal() {
+        let settings = AppSettings(defaults: defaults)
+        XCTAssertEqual(settings.visualDensity, .normal)
+    }
+
+    @MainActor
+    func testVisualDensity_compactPersists() {
+        let settings = AppSettings(defaults: defaults)
+        settings.visualDensity = .compact
+
+        XCTAssertEqual(defaults.string(forKey: "visualDensity"), "compact")
+        XCTAssertEqual(AppSettings(defaults: defaults).visualDensity, .compact)
+    }
+
+    @MainActor
     func testCoreDefaults_accessibilityInsertionModeIsInsertAtCursor() {
         let settings = AppSettings(defaults: defaults)
         XCTAssertEqual(settings.accessibilityInsertionMode, .insertAtCursor)

--- a/Tests/SpeakCoreTests/APIKeyListQueryTests.swift
+++ b/Tests/SpeakCoreTests/APIKeyListQueryTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import SpeakCore
+
+final class APIKeyListQueryTests: XCTestCase {
+    private let entries = [
+        APIKeyListEntry(id: "deepgram", title: "Deepgram", category: "Transcription", isStored: true),
+        APIKeyListEntry(id: "openai", title: "OpenAI", category: "Voice Output", isStored: false),
+        APIKeyListEntry(id: "openrouter", title: "OpenRouter", category: "Post-processing", isStored: true)
+    ]
+
+    func testApply_searchesNameAndCategoryCaseInsensitively() {
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "VOICE", status: .all, sortOrder: .name).map(\.id),
+            ["openai"]
+        )
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "router", status: .all, sortOrder: .name).map(\.id),
+            ["openrouter"]
+        )
+    }
+
+    func testApply_filtersByStoredStatus() {
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "", status: .stored, sortOrder: .name).map(\.id),
+            ["deepgram", "openrouter"]
+        )
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "", status: .missing, sortOrder: .name).map(\.id),
+            ["openai"]
+        )
+    }
+
+    func testApply_sortsStoredFirstThenByName() {
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "", status: .all, sortOrder: .status).map(\.id),
+            ["deepgram", "openrouter", "openai"]
+        )
+    }
+
+    func testNormalDensity_preservesExistingMetrics() {
+        XCTAssertEqual(AppVisualDensity.normal.pagePadding, 24)
+        XCTAssertEqual(AppVisualDensity.normal.cardPadding, 24)
+        XCTAssertLessThan(AppVisualDensity.compact.pagePadding, AppVisualDensity.normal.pagePadding)
+        XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 38)
+    }
+}


### PR DESCRIPTION
## Motivation
API-key settings have grown difficult to scan, and users need an app-wide high-density option without changing the existing default presentation.

## What changed
- adds shared normal/compact density settings for macOS and iOS
- applies compact spacing across settings, dashboard/history, recordings, and conversation lists
- adds API-key search, stored/missing filters, and name/category/status sorting on both platforms
- preserves the current presentation as the default normal mode
- adds shared query and persistence tests

## What changed direction
The checked-in SpeakiOS.xcodeproj was stale and omitted widget package dependencies. Regenerating the workspace from Project.swift restored the full-app simulator build; no generated project files needed committing.

## How to test
- swift test --filter APIKeyListQueryTests
- swift test --filter AppSettingsDefaultsTests
- xcodebuild -workspace "Just Speak to It.xcworkspace" -scheme SpeakiOS -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build
- switch General > Layout Density between Normal and Compact, then inspect API Keys, Dashboard/History, Recordings, and Conversations

## Review confidence
High confidence: focused tests and macOS/iOS builds pass, and normal/compact macOS API-key layouts were captured and visually inspected.