### PR TITLE
feat: ship model, input, density, and dual-distribution fixes

### DIFF
--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -22,7 +22,10 @@ on:
 
 env:
   SCHEME: SpeakApp
-  PRODUCT_NAME: JustSpeakToIt
+  # Deliberately distinct from the direct/Sparkle app so both bundles and
+  # processes can coexist on one Mac. The App Store bundle identifier remains
+  # tied to the existing App Store Connect record.
+  PRODUCT_NAME: JustSpeakToItAppStore
   WORKSPACE: "Just Speak to It.xcworkspace"
   BUNDLE_ID: com.justspeaktoit.mac
   # Matches the existing Release iOS workflow convention. This is the ASC key ID,
@@ -221,9 +224,22 @@ jobs:
             fi
           }
 
+          expect_info_value() {
+            key="$1"
+            expected="$2"
+            value=$(/usr/libexec/PlistBuddy -c "Print :$key" "$INFO_PLIST" 2>/dev/null || true)
+            if [ "$value" != "$expected" ]; then
+              echo "::error::Unexpected $key: expected '$expected', got '${value:-missing}'"
+              exit 1
+            fi
+          }
+
           expect_entitlement_true com.apple.security.app-sandbox
           expect_entitlement_true com.apple.security.network.server
           expect_entitlement_absent com.apple.security.cs.disable-library-validation
+          expect_info_value CFBundleIdentifier "$BUNDLE_ID"
+          expect_info_value CFBundleExecutable "$PRODUCT_NAME"
+          expect_info_value CFBundleDisplayName "Just Speak to It (App Store)"
 
           if [ -d "$APP_PATH/Contents/Frameworks/Sparkle.framework" ]; then
             echo "::error::Sparkle.framework must not be embedded in the App Store build"

--- a/Config/AppInfo.AppStore.plist
+++ b/Config/AppInfo.AppStore.plist
@@ -24,6 +24,8 @@
 	<string>1</string>
 	<key>GitCommitSHA</key>
 	<string></string>
+	<key>SpeakDistributionChannel</key>
+	<string>appStore</string>
 	<!-- Export compliance: the app uses only standard, published encryption
 	     (AES-GCM and PBKDF2 via CryptoKit) to protect the user's own API keys for
 	     end-to-end encrypted iCloud/CloudKit key sync, alongside OS-provided HTTPS

--- a/Config/AppInfo.AppStore.plist
+++ b/Config/AppInfo.AppStore.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Just Speak to It</string>
+	<string>Just Speak to It (App Store)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Just Speak to It</string>
+	<string>Just Speak to It App Store</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/Config/AppInfo.plist
+++ b/Config/AppInfo.plist
@@ -24,6 +24,8 @@
 	<string>1</string>
 	<key>GitCommitSHA</key>
 	<string></string>
+	<key>SpeakDistributionChannel</key>
+	<string>direct</string>
 	<!-- Export compliance: the app uses only standard, published encryption
 	     (AES-GCM and PBKDF2 via CryptoKit) to protect the user's own API keys for
 	     end-to-end encrypted iCloud/CloudKit key sync, alongside OS-provided HTTPS

--- a/Project.swift
+++ b/Project.swift
@@ -52,6 +52,12 @@ let macEntitlementsPath = isAppStoreBuild
 let macInfoPlistPath = isAppStoreBuild
     ? "Config/AppInfo.AppStore.plist"
     : "Config/AppInfo.plist"
+// Keep the existing direct-download product name stable for Sparkle updates, while
+// giving the App Store build a distinct bundle filename and process name. Both
+// channels intentionally retain the registered com.justspeaktoit.mac identifier:
+// Sparkle treats the direct bundle identifier as immutable, and App Store Connect
+// does not allow changing the identifier of the existing Mac app record.
+let macProductName = isAppStoreBuild ? "JustSpeakToItAppStore" : "JustSpeakToIt"
 var macAppSettings: [String: SettingValue] = [
     "DEVELOPMENT_TEAM": "8X4ZN58TYH",
     "CODE_SIGN_STYLE": "Automatic",
@@ -123,7 +129,7 @@ let project = Project(
             name: "SpeakApp",
             destinations: .macOS,
             product: .app,
-            productName: "JustSpeakToIt",
+            productName: macProductName,
             bundleId: "com.justspeaktoit.mac",
             deploymentTargets: .macOS("14.0"),
             infoPlist: .file(path: .relativeToRoot(macInfoPlistPath)),

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -80,6 +80,19 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     }
   }
 
+  nonisolated static func availableTextOutputMethods(
+    for channel: DistributionChannel
+  ) -> [TextOutputMethod] {
+    channel.supportsAccessibilityTextInsertion ? TextOutputMethod.allCases : [.clipboardOnly]
+  }
+
+  nonisolated static func normalizedTextOutputMethod(
+    _ method: TextOutputMethod,
+    for channel: DistributionChannel
+  ) -> TextOutputMethod {
+    availableTextOutputMethods(for: channel).contains(method) ? method : .clipboardOnly
+  }
+
   enum AccessibilityInsertionMode: String, CaseIterable, Identifiable {
     case insertAtCursor
     case replaceAll
@@ -444,7 +457,17 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   @Published var textOutputMethod: TextOutputMethod {
-    didSet { store(textOutputMethod.rawValue, key: .textOutputMethod) }
+    didSet {
+      let normalized = Self.normalizedTextOutputMethod(
+        textOutputMethod,
+        for: DistributionChannel.current
+      )
+      guard normalized == textOutputMethod else {
+        textOutputMethod = normalized
+        return
+      }
+      store(textOutputMethod.rawValue, key: .textOutputMethod)
+    }
   }
 
   @Published var accessibilityInsertionMode: AccessibilityInsertionMode {
@@ -857,10 +880,12 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       defaults.object(forKey: DefaultsKey.postProcessingIncludeContextTags.rawValue) as? Bool ?? true
     postProcessingIncludeFinalInstruction =
       defaults.object(forKey: DefaultsKey.postProcessingIncludeFinalInstruction.rawValue) as? Bool ?? true
-    textOutputMethod =
+    textOutputMethod = Self.normalizedTextOutputMethod(
       TextOutputMethod(
         rawValue: defaults.string(forKey: DefaultsKey.textOutputMethod.rawValue)
-          ?? TextOutputMethod.clipboardOnly.rawValue) ?? .clipboardOnly
+          ?? TextOutputMethod.clipboardOnly.rawValue) ?? .clipboardOnly,
+      for: DistributionChannel.current
+    )
     accessibilityInsertionMode =
       AccessibilityInsertionMode(
         rawValue: defaults.string(forKey: DefaultsKey.accessibilityInsertionMode.rawValue)
@@ -899,7 +924,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       defaults.object(forKey: DefaultsKey.doubleTapWindow.rawValue) as? Double ?? 0.4
     if let hotKeyData = defaults.data(forKey: DefaultsKey.selectedHotKey.rawValue),
       let decoded = try? JSONDecoder().decode(HotKey.self, from: hotKeyData) {
-      selectedHotKey = decoded
+      selectedHotKey = decoded.isSupportedForGlobalMonitoring ? decoded : .fnKey
     } else {
       selectedHotKey = .fnKey
     }

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -239,6 +239,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
 
   enum DefaultsKey: String {
     case appearance
+    case visualDensity
     case transcriptionMode
     case liveTranscriptionModel
     case batchTranscriptionModel
@@ -317,6 +318,10 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
 
   @Published var appearance: Appearance {
     didSet { store(appearance.rawValue, key: .appearance) }
+  }
+
+  @Published var visualDensity: AppVisualDensity {
+    didSet { store(visualDensity.rawValue, key: .visualDensity) }
   }
 
   @Published var transcriptionMode: TranscriptionMode {
@@ -792,6 +797,10 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       Appearance(
         rawValue: defaults.string(forKey: DefaultsKey.appearance.rawValue)
           ?? Appearance.system.rawValue) ?? .system
+    visualDensity =
+      AppVisualDensity(
+        rawValue: defaults.string(forKey: DefaultsKey.visualDensity.rawValue)
+          ?? AppVisualDensity.normal.rawValue) ?? .normal
     transcriptionMode =
       TranscriptionMode(
         rawValue: defaults.string(forKey: DefaultsKey.transcriptionMode.rawValue)

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -345,7 +345,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   @Published var localTranscriptionMode: LocalTranscriptionMode {
     didSet {
       #if APP_STORE
-      if !DistributionChannel.current.supportsLocalModelRuntime, localTranscriptionMode == .streaming {
+      if !DistributionChannel.current.supportsExternalLocalModelRuntime, localTranscriptionMode == .streaming {
         localTranscriptionMode = .batch
         return
       }
@@ -805,7 +805,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
         ?? LocalTranscriptionMode.batch.rawValue
     ) ?? .batch
     #if APP_STORE
-    localTranscriptionMode = DistributionChannel.current.supportsLocalModelRuntime
+    localTranscriptionMode = DistributionChannel.current.supportsExternalLocalModelRuntime
       ? loadedLocalTranscriptionMode
       : .batch
     #else

--- a/Sources/SpeakApp/DashboardView.swift
+++ b/Sources/SpeakApp/DashboardView.swift
@@ -4,15 +4,16 @@ import SwiftUI
 struct DashboardView: View {
   @EnvironmentObject private var environment: AppEnvironment
   @EnvironmentObject private var history: HistoryManager
+  @Environment(\.appVisualDensity) private var density
   @State private var requestingPermission: PermissionType?
 
   var body: some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: 24) {
+      VStack(alignment: .leading, spacing: density.sectionSpacing) {
         heroHeader
         dashboardSections
       }
-      .padding(24)
+      .padding(density.pagePadding)
       .frame(maxWidth: 1100, alignment: .center)
     }
     .background(
@@ -112,8 +113,11 @@ struct DashboardView: View {
   }
 
   private var dashboardSections: some View {
-    VStack(spacing: 24) {
-      LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 24)], spacing: 24) {
+    VStack(spacing: density.sectionSpacing) {
+      LazyVGrid(
+        columns: [GridItem(.adaptive(minimum: 340), spacing: density.sectionSpacing)],
+        spacing: density.sectionSpacing
+      ) {
         permissionsSection
         statisticsSection
         recentSection
@@ -122,13 +126,19 @@ struct DashboardView: View {
       // Usage Charts
       dailyUsageChartSection
 
-      LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 24)], spacing: 24) {
+      LazyVGrid(
+        columns: [GridItem(.adaptive(minimum: 340), spacing: density.sectionSpacing)],
+        spacing: density.sectionSpacing
+      ) {
         transcriptionModelChartSection
         postProcessingModelChartSection
       }
 
       // TTS Charts
-      LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 24)], spacing: 24) {
+      LazyVGrid(
+        columns: [GridItem(.adaptive(minimum: 340), spacing: density.sectionSpacing)],
+        spacing: density.sectionSpacing
+      ) {
         ttsUsageChartSection
         ttsProviderChartSection
       }
@@ -377,8 +387,7 @@ struct DashboardView: View {
   }
 
   private var recentSection: some View {
-    DashboardCard(title: "Recent Session", systemImage: "clock.arrow.circlepath", tint: Color.brandLagoon)
-    {
+    DashboardCard(title: "Recent Session", systemImage: "clock.arrow.circlepath", tint: Color.brandLagoon) {
       if let item = history.items.first {
         recentItemView(item)
       } else {

--- a/Sources/SpeakApp/DashboardView.swift
+++ b/Sources/SpeakApp/DashboardView.swift
@@ -264,7 +264,7 @@ struct DashboardView: View {
       LazyVGrid(
         columns: Array(repeating: GridItem(.flexible(), spacing: 16), count: 2), spacing: 16
       ) {
-        ForEach(PermissionType.allCases) { permission in
+        ForEach(PermissionType.availablePermissions(for: DistributionChannel.current)) { permission in
           permissionCard(for: permission)
         }
       }

--- a/Sources/SpeakApp/DashboardView.swift
+++ b/Sources/SpeakApp/DashboardView.swift
@@ -1,6 +1,8 @@
 import SpeakCore
 import SwiftUI
 
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
 struct DashboardView: View {
   @EnvironmentObject private var environment: AppEnvironment
   @EnvironmentObject private var history: HistoryManager

--- a/Sources/SpeakApp/HistoryView.swift
+++ b/Sources/SpeakApp/HistoryView.swift
@@ -8,6 +8,7 @@ import UniformTypeIdentifiers
 
 struct HistoryView: View { // swiftlint:disable:this type_body_length
   @EnvironmentObject private var environment: AppEnvironment
+  @Environment(\.appVisualDensity) private var density
   @State private var searchText: String = ""
   @State private var showErrorsOnly: Bool = false
   @State private var dateRangeEnabled: Bool = false
@@ -139,14 +140,14 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
   var body: some View {
     ScrollViewReader { proxy in
       ScrollView {
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: density.sectionSpacing) {
           header
           if isInitialLoad {
             skeletonLoadingView
           } else if filteredItems.isEmpty {
             emptyState
           } else {
-            LazyVStack(spacing: 20) {
+            LazyVStack(spacing: density.sectionSpacing) {
               ForEach(filteredItems) { item in
                 HistoryListRow(item: item)
                   .id(item.id)
@@ -155,7 +156,7 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
             .animation(.spring(response: 0.28, dampingFraction: 0.88), value: filteredItems)
           }
         }
-        .padding(24)
+        .padding(density.pagePadding)
         .frame(maxWidth: 1100, alignment: .center)
       }
       .onAppear {
@@ -237,7 +238,7 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
 
 
   private var header: some View {
-    return VStack(alignment: .leading, spacing: 18) {
+    VStack(alignment: .leading, spacing: 18) {
       VStack(alignment: .leading, spacing: 8) {
         Text("Session History")
           .font(.largeTitle.bold())
@@ -919,8 +920,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
 
         metaTile(icon: "clock.arrow.circlepath", title: "Timeline") {
           if let start = item.phaseTimestamps.recordingStarted,
-            let end = item.phaseTimestamps.outputDelivered
-          {
+            let end = item.phaseTimestamps.outputDelivered {
             let total = end.timeIntervalSince(start)
             Text("Total: \(formatDuration(total))")
           } else {
@@ -943,8 +943,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
       }
 
       if let summary = item.personalCorrections,
-        !(summary.applied.isEmpty && summary.suggestions.isEmpty)
-      {
+        !(summary.applied.isEmpty && summary.suggestions.isEmpty) {
         personalCorrectionsSection(summary)
       }
     }
@@ -1471,8 +1470,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
 
     if let raw = item.rawTranscription,
       raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        == processed.trimmingCharacters(in: .whitespacesAndNewlines)
-    {
+        == processed.trimmingCharacters(in: .whitespacesAndNewlines) {
       return nil
     }
 
@@ -1484,8 +1482,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
       return processed
     }
     if let raw = item.rawTranscription,
-      !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    {
+      !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
       return raw
     }
     return nil

--- a/Sources/SpeakApp/HotKeyManager.swift
+++ b/Sources/SpeakApp/HotKeyManager.swift
@@ -78,7 +78,7 @@ final class HotKeyManager: ObservableObject {
 
 		Task { [weak self] in
 			guard let self else { return }
-			for permission in [PermissionType.accessibility, .inputMonitoring] {
+			for permission in [PermissionType.inputMonitoring] {
 				let status = await MainActor.run { self.permissionsManager.status(for: permission) }
 				if !status.isGranted {
 					_ = await self.permissionsManager.request(permission)

--- a/Sources/SpeakApp/MainView.swift
+++ b/Sources/SpeakApp/MainView.swift
@@ -1,10 +1,12 @@
 import AppKit
+import SpeakCore
 import SwiftUI
 
 struct MainView: View {
   @EnvironmentObject private var environment: AppEnvironment
   @EnvironmentObject private var history: HistoryManager
   @EnvironmentObject private var personalLexicon: PersonalLexiconService
+  @EnvironmentObject private var settings: AppSettings
   @State private var selection: SidebarItem? = .dashboard
 
   var body: some View {
@@ -14,10 +16,11 @@ struct MainView: View {
     } detail: {
       detailView
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
+        .padding(settings.visualDensity == .compact ? 8 : 16)
         .background(Color(nsColor: .windowBackgroundColor))
     }
     .frame(minWidth: 960, minHeight: 640)
+    .environment(\.appVisualDensity, settings.visualDensity)
     .toolbar { toolbar }
     .onReceive(environment.$sidebarNavigationTarget) { item in
       guard let item else { return }

--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -1,6 +1,7 @@
 // swiftlint:disable file_length
 import AppKit
 import AVFoundation
+import SpeakCore
 import SpeakHotKeys
 import SwiftUI
 
@@ -125,7 +126,7 @@ final class OnboardingState: ObservableObject {
     
     func refreshPermissions() {
         permissionsGranted = []
-        for perm in [PermissionType.microphone, .accessibility, .inputMonitoring] {
+        for perm in PermissionType.availablePermissions(for: DistributionChannel.current) {
             // Force a fresh computation; cached statuses go stale when the user
             // toggles a permission in System Settings (the OS never notifies us).
             permissionsManager.refresh(perm)
@@ -137,7 +138,8 @@ final class OnboardingState: ObservableObject {
     
     var allPermissionsGranted: Bool {
         permissionsGranted.contains(.microphone) &&
-        permissionsGranted.contains(.accessibility)
+        (!DistributionChannel.current.supportsAccessibilityTextInsertion
+          || permissionsGranted.contains(.accessibility))
     }
     
     // swiftlint:disable:next cyclomatic_complexity function_body_length
@@ -543,25 +545,27 @@ struct PermissionsStepView: View {
                     }
                 )
                 
-                PermissionRow(
-                    type: .accessibility,
-                    title: "Accessibility",
-                    description: "To type text into other apps",
-                    isGranted: state.permissionsGranted.contains(.accessibility),
-                    onRequest: {
-                        accessibilityAttempted = true
-                        Task {
-                            _ = await state.permissionsManager.request(.accessibility)
-                            // Wait a moment then check if it worked
-                            try? await Task.sleep(nanoseconds: 1_000_000_000)
-                            state.refreshPermissions()
-                            // If still not granted after attempt, show helper
-                            if !state.permissionsGranted.contains(.accessibility) {
-                                showAccessibilityHelper = true
+                if DistributionChannel.current.supportsAccessibilityTextInsertion {
+                    PermissionRow(
+                        type: .accessibility,
+                        title: "Accessibility",
+                        description: "To type text into other apps",
+                        isGranted: state.permissionsGranted.contains(.accessibility),
+                        onRequest: {
+                            accessibilityAttempted = true
+                            Task {
+                                _ = await state.permissionsManager.request(.accessibility)
+                                // Wait a moment then check if it worked
+                                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                                state.refreshPermissions()
+                                // If still not granted after attempt, show helper
+                                if !state.permissionsGranted.contains(.accessibility) {
+                                    showAccessibilityHelper = true
+                                }
                             }
                         }
-                    }
-                )
+                    )
+                }
                 
                 // Show manual add helper if accessibility wasn't auto-added
                 if showAccessibilityHelper && !state.permissionsGranted.contains(.accessibility) {

--- a/Sources/SpeakApp/PermissionsManager.swift
+++ b/Sources/SpeakApp/PermissionsManager.swift
@@ -3,6 +3,7 @@ import AppKit
 import Combine
 import CoreGraphics
 import Foundation
+import SpeakCore
 import Speech
 
 // @Implement This class manages system permissions. It knows how to request the following permissions when asked and also surface the current status of permissions as per the system
@@ -14,6 +15,12 @@ enum PermissionType: CaseIterable, Identifiable {
   case inputMonitoring
 
   var id: String { displayName }
+
+  static func availablePermissions(for channel: DistributionChannel) -> [PermissionType] {
+    allCases.filter { permission in
+      permission != .accessibility || channel.supportsAccessibilityTextInsertion
+    }
+  }
 
   var displayName: String {
     switch self {
@@ -97,9 +104,24 @@ enum PermissionStatus: Equatable {
 @MainActor
 final class PermissionsManager: ObservableObject {
   @Published private(set) var statuses: [PermissionType: PermissionStatus] = [:]
+  private let statusProvider: (PermissionType) -> PermissionStatus
+  private let notificationCenter: NotificationCenter
+  private var lifecycleObservers: [NSObjectProtocol] = []
 
-  init() {
+  init(
+    statusProvider: @escaping (PermissionType) -> PermissionStatus = PermissionsManager.systemStatus,
+    notificationCenter: NotificationCenter = .default
+  ) {
+    self.statusProvider = statusProvider
+    self.notificationCenter = notificationCenter
     refreshAll()
+    registerLifecycleObservers()
+  }
+
+  deinit {
+    for observer in lifecycleObservers {
+      notificationCenter.removeObserver(observer)
+    }
   }
 
   func status(for type: PermissionType) -> PermissionStatus {
@@ -168,6 +190,10 @@ final class PermissionsManager: ObservableObject {
   }
 
   private func computeStatus(for type: PermissionType) -> PermissionStatus {
+    statusProvider(type)
+  }
+
+  private nonisolated static func systemStatus(for type: PermissionType) -> PermissionStatus {
     switch type {
     case .microphone:
       switch AVCaptureDevice.authorizationStatus(for: .audio) {
@@ -198,9 +224,25 @@ final class PermissionsManager: ObservableObject {
     case .accessibility:
       return AXIsProcessTrusted() ? .granted : .denied
     case .inputMonitoring:
-      let granted = CGPreflightListenEventAccess()
-      return granted ? .granted : .denied
+      return inputMonitoringStatus(
+        hasListenAccess: CGPreflightListenEventAccess(),
+        hasAccessibilityAccess: AXIsProcessTrusted()
+      )
     }
+  }
+
+  /// Accessibility permission is a superset of event-listening permission on macOS.
+  /// Treat either TCC grant as effective access so the app does not report Input
+  /// Monitoring as disabled while its global event tap is allowed to run.
+  nonisolated static func inputMonitoringStatus(
+    hasListenAccess: Bool,
+    hasAccessibilityAccess: Bool
+  ) -> PermissionStatus {
+    hasListenAccess || hasAccessibilityAccess ? .granted : .denied
+  }
+
+  nonisolated static func shouldPromptForAccessibility(channel: DistributionChannel) -> Bool {
+    channel.supportsAutomaticAccessibilityPrompt
   }
 
   private func requestMicrophone() async -> PermissionStatus {
@@ -230,13 +272,37 @@ final class PermissionsManager: ObservableObject {
   }
 
   private func requestAccessibility() -> PermissionStatus {
-    let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as NSString: true]
-    let trusted = AXIsProcessTrustedWithOptions(options)
+    let trusted: Bool
+    if Self.shouldPromptForAccessibility(channel: DistributionChannel.current) {
+      let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as NSString: true]
+      trusted = AXIsProcessTrustedWithOptions(options)
+    } else {
+      // The App Store sandbox cannot present the Accessibility prompt. It can
+      // only observe a grant the user made manually in System Settings.
+      trusted = AXIsProcessTrusted()
+    }
     return trusted ? .granted : .denied
   }
 
   private func requestInputMonitoring() -> PermissionStatus {
     let granted = CGRequestListenEventAccess()
-    return granted ? .granted : .denied
+    return Self.inputMonitoringStatus(
+      hasListenAccess: granted,
+      hasAccessibilityAccess: AXIsProcessTrusted()
+    )
+  }
+
+  private func registerLifecycleObservers() {
+    lifecycleObservers = [
+      notificationCenter.addObserver(
+        forName: NSApplication.didBecomeActiveNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        Task { @MainActor in
+          self?.refreshAll()
+        }
+      }
+    ]
   }
 }

--- a/Sources/SpeakApp/PermissionsManager.swift
+++ b/Sources/SpeakApp/PermissionsManager.swift
@@ -196,31 +196,9 @@ final class PermissionsManager: ObservableObject {
   private nonisolated static func systemStatus(for type: PermissionType) -> PermissionStatus {
     switch type {
     case .microphone:
-      switch AVCaptureDevice.authorizationStatus(for: .audio) {
-      case .authorized:
-        return .granted
-      case .notDetermined:
-        return .notDetermined
-      case .denied:
-        return .denied
-      case .restricted:
-        return .restricted
-      @unknown default:
-        return .restricted
-      }
+      return microphoneStatus()
     case .speechRecognition:
-      switch SFSpeechRecognizer.authorizationStatus() {
-      case .authorized:
-        return .granted
-      case .notDetermined:
-        return .notDetermined
-      case .denied:
-        return .denied
-      case .restricted:
-        return .restricted
-      @unknown default:
-        return .restricted
-      }
+      return speechRecognitionStatus()
     case .accessibility:
       return AXIsProcessTrusted() ? .granted : .denied
     case .inputMonitoring:
@@ -228,6 +206,26 @@ final class PermissionsManager: ObservableObject {
         hasListenAccess: CGPreflightListenEventAccess(),
         hasAccessibilityAccess: AXIsProcessTrusted()
       )
+    }
+  }
+
+  private nonisolated static func microphoneStatus() -> PermissionStatus {
+    switch AVCaptureDevice.authorizationStatus(for: .audio) {
+    case .authorized: return .granted
+    case .notDetermined: return .notDetermined
+    case .denied: return .denied
+    case .restricted: return .restricted
+    @unknown default: return .restricted
+    }
+  }
+
+  private nonisolated static func speechRecognitionStatus() -> PermissionStatus {
+    switch SFSpeechRecognizer.authorizationStatus() {
+    case .authorized: return .granted
+    case .notDetermined: return .notDetermined
+    case .denied: return .denied
+    case .restricted: return .restricted
+    @unknown default: return .restricted
     }
   }
 

--- a/Sources/SpeakApp/SecureAppStorage.swift
+++ b/Sources/SpeakApp/SecureAppStorage.swift
@@ -67,71 +67,30 @@ actor SecureAppStorage {
     init(permissionsManager: PermissionsManager, appSettings: AppSettings) {
         self.permissionsManager = permissionsManager
         self.appSettings = appSettings
-        
-        // Check if we can use iCloud Keychain sync (kSecAttrSynchronizable)
-        // Developer ID builds cannot use this - it requires keychain-access-groups entitlement
-        let canUseSync = Self.hasKeychainSyncEntitlement()
-        
-        // IMPORTANT: For Developer ID (non-App Store) builds, we MUST NOT use:
-        // - kSecAttrSynchronizable (requires keychain-access-groups entitlement) - causes -34018
-        // - kSecAttrAccessGroup (requires keychain-access-groups entitlement in some cases)
+
+        // The local Keychain is the vault for every Mac build. App Store builds
+        // opt in to the separate passphrase-encrypted CloudKit sync layer; direct
+        // builds remain local-only. Do not silently add iCloud Keychain as a third
+        // API-key sync path.
         let configuration = SecureStorageConfiguration(
             service: "com.justspeaktoit.credentials",
             masterAccount: "speak-app-secrets",
-            // Don't use access group for Developer ID - not needed and may cause issues
             accessGroup: nil,
-            // Only enable sync if we verified the entitlement exists
-            synchronizable: canUseSync
+            synchronizable: false
         )
-        
+
         print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
         print("[SecureAppStorage] Keychain Configuration:")
-        print("  canUseSync: \(canUseSync)")
         print("  accessGroup: \(configuration.accessGroup ?? "nil")")
         print("  synchronizable: \(configuration.synchronizable)")
         print("  service: \(configuration.service)")
         print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-        
+
         self.storage = SecureStorage(
             configuration: configuration,
             permissionsChecker: PermissionsManagerBridge(permissionsManager: permissionsManager),
             identifierRegistry: appSettings
         )
-    }
-    
-    /// Check if the app can use iCloud keychain sync by testing kSecAttrSynchronizable.
-    /// Developer ID (non-App Store) builds cannot use synchronizable items.
-    private static func hasKeychainSyncEntitlement() -> Bool {
-        let testService = "com.justspeaktoit.entitlement-check"
-        let testAccount = "sync-test-\(UUID().uuidString)"
-        
-        // Test with kSecAttrSynchronizable - THIS is what requires the entitlement
-        let addQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: testService,
-            kSecAttrAccount as String: testAccount,
-            kSecAttrSynchronizable as String: kCFBooleanTrue!,
-            kSecValueData as String: "test".data(using: .utf8)!
-        ]
-        
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        
-        // Clean up if we succeeded
-        if addStatus == errSecSuccess {
-            let deleteQuery: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: testService,
-                kSecAttrAccount as String: testAccount,
-                kSecAttrSynchronizable as String: kCFBooleanTrue!
-            ]
-            SecItemDelete(deleteQuery as CFDictionary)
-            print("[SecureAppStorage] iCloud Keychain sync entitlement available")
-            return true
-        }
-        
-        // errSecMissingEntitlement (-34018) means we can't use synchronizable
-        print("[SecureAppStorage] No iCloud Keychain sync entitlement (status: \(addStatus)), disabling sync")
-        return false
     }
 
     func storeSecret(_ value: String, identifier: String, label _: String? = nil) async throws {

--- a/Sources/SpeakApp/SecureAppStorage.swift
+++ b/Sources/SpeakApp/SecureAppStorage.swift
@@ -64,7 +64,11 @@ actor SecureAppStorage {
     private nonisolated let permissionsManager: PermissionsManager
     private nonisolated let appSettings: AppSettings
 
-    init(permissionsManager: PermissionsManager, appSettings: AppSettings) {
+    init(
+        permissionsManager: PermissionsManager,
+        appSettings: AppSettings,
+        keychainService: String = "com.justspeaktoit.credentials"
+    ) {
         self.permissionsManager = permissionsManager
         self.appSettings = appSettings
 
@@ -73,7 +77,7 @@ actor SecureAppStorage {
         // builds remain local-only. Do not silently add iCloud Keychain as a third
         // API-key sync path.
         let configuration = SecureStorageConfiguration(
-            service: "com.justspeaktoit.credentials",
+            service: keychainService,
             masterAccount: "speak-app-secrets",
             accessGroup: nil,
             synchronizable: false

--- a/Sources/SpeakApp/Services/ShortcutManager.swift
+++ b/Sources/SpeakApp/Services/ShortcutManager.swift
@@ -230,6 +230,7 @@ final class ShortcutManager: ObservableObject {
     @Published private(set) var conflicts: [ShortcutConflict] = []
     @Published private(set) var isRecordingShortcut: Bool = false
     @Published private(set) var recordingAction: ShortcutAction?
+    @Published private(set) var recordingError: String?
 
     private var carbonHotKeys: [UInt32: EventHotKeyRef] = [:]
     private var carbonHotKeyActions: [UInt32: ShortcutAction] = [:]
@@ -340,6 +341,7 @@ final class ShortcutManager: ObservableObject {
         stopRecording()
         isRecordingShortcut = true
         recordingAction = action
+        recordingError = nil
 
         recordingMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
@@ -349,9 +351,25 @@ final class ShortcutManager: ObservableObject {
                 return nil
             }
 
+            let modifiers = event.modifierFlags.intersection([.command, .shift, .option, .control])
+
+            // Escape cancels without replacing the existing shortcut.
+            if event.keyCode == 53, modifiers.isEmpty {
+                self.stopRecording()
+                return nil
+            }
+
+            guard KeyCodeMapping.isSupportedCustomHotKey(
+                keyCode: event.keyCode,
+                hasModifiers: !modifiers.isEmpty
+            ) else {
+                self.recordingError = KeyCodeMapping.unsupportedSingleKeyMessage
+                return nil
+            }
+
             let newBinding = KeyBinding(
                 keyCode: event.keyCode,
-                modifiers: event.modifierFlags.intersection([.command, .shift, .option, .control]),
+                modifiers: modifiers,
                 isGlobal: action.isGlobalByDefault,
                 isEnabled: true
             )
@@ -366,6 +384,7 @@ final class ShortcutManager: ObservableObject {
     func stopRecording() {
         isRecordingShortcut = false
         recordingAction = nil
+        recordingError = nil
         if let monitor = recordingMonitor {
             NSEvent.removeMonitor(monitor)
             recordingMonitor = nil
@@ -431,7 +450,7 @@ final class ShortcutManager: ObservableObject {
                 UInt32(binding.keyCode),
                 carbonModifiers,
                 hotKeyID,
-                GetEventDispatcherTarget(),
+                GetApplicationEventTarget(),
                 0,
                 &hotKeyRef
             )
@@ -464,7 +483,7 @@ final class ShortcutManager: ObservableObject {
         )
         let selfPtr = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
         let status = InstallEventHandler(
-            GetEventDispatcherTarget(),
+            GetApplicationEventTarget(),
             { _, event, userData -> OSStatus in
                 guard let userData, let event else { return OSStatus(eventNotHandledErr) }
                 let manager = Unmanaged<ShortcutManager>.fromOpaque(userData).takeUnretainedValue()

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -727,22 +727,34 @@ struct SettingsView: View {
 
       SettingsCard(title: "Output", systemImage: "textformat.alt", tint: Color.brandLagoon) {
         VStack(alignment: .leading, spacing: 12) {
-          Picker("Text Output", selection: settingsBinding(\AppSettings.textOutputMethod)) {
-            ForEach(AppSettings.TextOutputMethod.allCases) { method in
-              Text(method.displayName).tag(method)
+          if DistributionChannel.current.supportsAccessibilityTextInsertion {
+            Picker("Text Output", selection: settingsBinding(\AppSettings.textOutputMethod)) {
+              ForEach(AppSettings.availableTextOutputMethods(for: DistributionChannel.current)) { method in
+                Text(method.displayName).tag(method)
+              }
             }
+            .pickerStyle(.menu)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+              RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+            )
+            .speakTooltip("Decide how Speak returns transcripts—typed for you or placed on the clipboard.")
+            .accessibilityLabel("Text output method picker")
+          } else {
+            Label("Clipboard delivery", systemImage: "doc.on.clipboard")
+              .font(.subheadline.weight(.medium))
+            Text(
+              "The App Store sandbox blocks changing text in other apps. "
+                + "Transcripts stay on the clipboard, ready to paste."
+            )
+              .font(.caption)
+              .foregroundStyle(.secondary)
           }
-          .pickerStyle(.menu)
-          .padding(.horizontal, 12)
-          .padding(.vertical, 8)
-          .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-              .fill(Color(nsColor: .controlBackgroundColor))
-          )
-          .speakTooltip("Decide how Speak returns transcripts—typed for you, placed on the clipboard, or saved for later.")
-          .accessibilityLabel("Text output method picker")
 
-          if settings.textOutputMethod != .clipboardOnly {
+          if DistributionChannel.current.supportsAccessibilityTextInsertion,
+             settings.textOutputMethod != .clipboardOnly {
             Picker("Accessibility Insertion", selection: settingsBinding(\AppSettings.accessibilityInsertionMode)) {
               ForEach(AppSettings.AccessibilityInsertionMode.allCases) { mode in
                 Text(mode.displayName).tag(mode)
@@ -764,12 +776,16 @@ struct SettingsView: View {
               .foregroundStyle(.secondary)
           }
           VStack(alignment: .leading, spacing: 8) {
-            settingsToggle(
-              "Restore clipboard after paste",
-              isOn: settingsBinding(\AppSettings.restoreClipboardAfterPaste),
-              tint: .brandLagoon
-            )
-            .speakTooltip("After Speak pastes your transcript, we put your original clipboard content back automatically.")
+            if DistributionChannel.current.supportsAccessibilityTextInsertion {
+              settingsToggle(
+                "Restore clipboard after paste",
+                isOn: settingsBinding(\AppSettings.restoreClipboardAfterPaste),
+                tint: .brandLagoon
+              )
+              .speakTooltip(
+                "After Speak pastes your transcript, we put your original clipboard content back automatically."
+              )
+            }
             settingsToggle(
               "Show HUD during sessions",
               isOn: settingsBinding(\AppSettings.showHUDDuringSessions),
@@ -4344,7 +4360,7 @@ struct SettingsView: View {
     LazyVStack(spacing: 20) {
       SettingsCard(title: "System permissions", systemImage: "lock.shield", tint: Color.red) {
         VStack(alignment: .leading, spacing: 12) {
-          ForEach(PermissionType.allCases) { permission in
+          ForEach(PermissionType.availablePermissions(for: DistributionChannel.current)) { permission in
             let status = environment.permissions.status(for: permission)
             VStack(alignment: .leading, spacing: 8) {
               HStack(spacing: 12) {
@@ -4382,6 +4398,12 @@ struct SettingsView: View {
         }
       }
       .speakTooltip("Review and refresh the macOS permissions Speak depends on.")
+    }
+    .task {
+      while !Task.isCancelled {
+        environment.permissions.refreshAll()
+        try? await Task.sleep(for: .seconds(1))
+      }
     }
   }
 

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -4023,9 +4023,8 @@ struct SettingsView: View {
 
           Text(
             "Opt in to sync API keys through your private CloudKit database. Keys are encrypted with "
-              + "CryptoKit before upload. Developer-ID macOS builds need a managed provisioning profile "
-              + "with CloudKit entitlements; otherwise this stays unavailable and local Keychain storage "
-              + "works normally."
+              + "CryptoKit before upload. Sync is available when this app is signed into iCloud and "
+              + "CloudKit is available."
           )
           .font(.caption)
           .foregroundStyle(.secondary)

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -145,8 +145,22 @@ struct SettingsView: View {
 
   }
 
+  private enum LocalTranscriptionSource: String, CaseIterable, Identifiable {
+    case apple
+    case downloaded
+
+    var id: String { rawValue }
+
+    var displayName: String {
+      switch self {
+      case .apple: return "Apple Speech"
+      case .downloaded: return "Downloaded Model"
+      }
+    }
+  }
+
   private let orderedLocalTranscriptionModes: [AppSettings.LocalTranscriptionMode] = {
-    DistributionChannel.current.supportsLocalModelRuntime ? [.streaming, .batch] : [.batch]
+    DistributionChannel.current.supportsExternalLocalModelRuntime ? [.streaming, .batch] : [.batch]
   }()
   private let orderedRemoteTranscriptionModes: [RemoteTranscriptionMode] = [.streaming, .batch]
 
@@ -386,15 +400,33 @@ struct SettingsView: View {
   private var transcriptionLocationBinding: Binding<TranscriptionLocation> {
     Binding(
       get: {
-        settings.transcriptionMode == .localModel ? .local : .remote
+        isLocalTranscriptionSelected ? .local : .remote
       },
       set: { location in
         switch location {
         case .remote:
-          if settings.transcriptionMode == .localModel {
-            settings.transcriptionMode = .liveNative
+          if isLocalTranscriptionSelected {
+            settings.liveTranscriptionModel = ModelCatalog.defaultRemoteLiveTranscriptionModel
+              ?? settings.liveTranscriptionModel
           }
+          settings.transcriptionMode = .liveNative
         case .local:
+          settings.liveTranscriptionModel = ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+          settings.transcriptionMode = .liveNative
+        }
+      }
+    )
+  }
+
+  private var localTranscriptionSourceBinding: Binding<LocalTranscriptionSource> {
+    Binding(
+      get: { isAppleOnDeviceTranscriptionSelected ? .apple : .downloaded },
+      set: { source in
+        switch source {
+        case .apple:
+          settings.liveTranscriptionModel = ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+          settings.transcriptionMode = .liveNative
+        case .downloaded:
           settings.transcriptionMode = .localModel
         }
       }
@@ -407,7 +439,15 @@ struct SettingsView: View {
         settings.transcriptionMode == .batchRemote ? .batch : .streaming
       },
       set: { mode in
-        settings.transcriptionMode = mode == .streaming ? .liveNative : .batchRemote
+        if mode == .streaming {
+          if ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.liveTranscriptionModel) {
+            settings.liveTranscriptionModel = ModelCatalog.defaultRemoteLiveTranscriptionModel
+              ?? settings.liveTranscriptionModel
+          }
+          settings.transcriptionMode = .liveNative
+        } else {
+          settings.transcriptionMode = .batchRemote
+        }
       }
     )
   }
@@ -421,6 +461,19 @@ struct SettingsView: View {
   private var isStreamingTranscriptionSelected: Bool {
     settings.transcriptionMode == .liveNative
       || (settings.transcriptionMode == .localModel && settings.localTranscriptionMode == .streaming)
+  }
+
+  private var isAppleOnDeviceTranscriptionSelected: Bool {
+    settings.transcriptionMode == .liveNative
+      && ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.liveTranscriptionModel)
+  }
+
+  private var isLocalTranscriptionSelected: Bool {
+    settings.transcriptionMode == .localModel || isAppleOnDeviceTranscriptionSelected
+  }
+
+  private var isRemoteStreamingTranscriptionSelected: Bool {
+    settings.transcriptionMode == .liveNative && !isAppleOnDeviceTranscriptionSelected
   }
 
   private var cloudPostProcessingModelBinding: Binding<String> {
@@ -1128,20 +1181,36 @@ struct SettingsView: View {
           .speakTooltip("Choose whether Speak transcribes locally on this Mac or remotely with a provider.")
           .accessibilityLabel("Transcription location picker")
 
-          if settings.transcriptionMode == .localModel {
-            if DistributionChannel.current.supportsLocalModelRuntime {
-              Picker("Local transcription type", selection: settingsBinding(\AppSettings.localTranscriptionMode)) {
-                ForEach(orderedLocalTranscriptionModes) { mode in
-                  Text(transcriptionModeSegmentLabel(from: mode.displayName)).tag(mode)
-                }
+          if isLocalTranscriptionSelected {
+            Picker("Local transcription source", selection: localTranscriptionSourceBinding) {
+              ForEach(LocalTranscriptionSource.allCases) { source in
+                Text(source.displayName).tag(source)
               }
-              .modifier(TranscriptionModeSegmentedPickerStyle())
-              .speakTooltip(
-                "Choose Local Batch for offline transcription after recording, or Local Streaming for live local text."
-              )
-              .accessibilityLabel("Local transcription type picker")
-            } else {
-              localRuntimeUnavailableNote
+            }
+            .modifier(TranscriptionModeSegmentedPickerStyle())
+            .speakTooltip("Choose built-in Apple Speech or a downloaded Core ML model.")
+            .accessibilityLabel("Local transcription source picker")
+
+            if settings.transcriptionMode == .localModel {
+              if DistributionChannel.current.supportsExternalLocalModelRuntime {
+                Picker(
+                  "Downloaded transcription type",
+                  selection: settingsBinding(\AppSettings.localTranscriptionMode)
+                ) {
+                  ForEach(orderedLocalTranscriptionModes) { mode in
+                    Text(transcriptionModeSegmentLabel(from: mode.displayName)).tag(mode)
+                  }
+                }
+                .modifier(TranscriptionModeSegmentedPickerStyle())
+                .speakTooltip(
+                  "Choose Batch for WhisperKit/Core ML, or Streaming for a direct-build external ASR runtime."
+                )
+                .accessibilityLabel("Downloaded transcription type picker")
+              } else {
+                Text("Downloaded WhisperKit/Core ML models run in-process as Local Batch transcription.")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
             }
           } else {
             Picker("Remote transcription type", selection: remoteTranscriptionModeBinding) {
@@ -1175,7 +1244,7 @@ struct SettingsView: View {
       }
       .speakTooltip("Choose which transcription flow Speak uses and the locale it should prefer.")
 
-      if settings.transcriptionMode == .liveNative {
+      if isRemoteStreamingTranscriptionSelected {
         SettingsCard(
           title: "Processing Speed",
           systemImage: "gauge.with.dots.needle.67percent",
@@ -1367,7 +1436,7 @@ struct SettingsView: View {
         .speakTooltip("Configure automatic recording stop based on silence detection.")
       }
 
-      if settings.transcriptionMode == .liveNative {
+      if isRemoteStreamingTranscriptionSelected {
         SettingsCard(title: "Remote Streaming model", systemImage: "mic.fill", tint: Color.brandAccentDeep) {
           VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 8) {
@@ -1391,10 +1460,10 @@ struct SettingsView: View {
             ModelPicker(
               title: "Remote Streaming Model",
               help: "Choose the remote provider model used while recording.",
-              options: ModelCatalog.liveTranscription,
+              options: ModelCatalog.remoteLiveTranscription,
               value: remoteTranscriptionModelBinding(
                 \AppSettings.liveTranscriptionModel,
-                options: ModelCatalog.liveTranscription
+                options: ModelCatalog.remoteLiveTranscription
               )
             )
           }
@@ -1464,6 +1533,31 @@ struct SettingsView: View {
         .speakTooltip("Tell Speak which cloud transcription model should polish the full recording.")
       }
 
+      if isAppleOnDeviceTranscriptionSelected {
+        SettingsCard(
+          title: "Apple on-device transcription",
+          systemImage: "apple.logo",
+          tint: Color.green
+        ) {
+          VStack(alignment: .leading, spacing: 12) {
+            Text("Uses Apple's built-in speech engine. Audio stays on this device.")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+            ModelPicker(
+              title: "Apple Model",
+              help: "Choose the Apple on-device engine used while recording.",
+              options: ModelCatalog.onDeviceLiveTranscription,
+              value: remoteTranscriptionModelBinding(
+                \AppSettings.liveTranscriptionModel,
+                options: ModelCatalog.onDeviceLiveTranscription
+              ),
+              allowsCustom: false
+            )
+          }
+        }
+        .speakTooltip("Choose an on-device Apple transcription engine.")
+      }
+
       if settings.transcriptionMode == .localModel {
         SettingsCard(
           title: "Local transcription models",
@@ -1494,14 +1588,14 @@ struct SettingsView: View {
               {
                 #if APP_STORE
                 return """
-                Local transcription is separate from Apple Speech and cloud providers. \
-                Local Batch uses downloaded WhisperKit/Core ML models and stays local-only.
+                Downloaded transcription is separate from Apple Speech and cloud providers. \
+                WhisperKit/Core ML model data runs in-process and is supported in this App Store build.
                 """
                 #else
                 return """
-                Local Batch and Local Streaming are separate from Apple Speech and cloud providers. \
-                Both stay local-only; Local Batch uses downloaded WhisperKit/Core ML models, while \
-                Local Streaming needs a dedicated streaming ASR runtime.
+                Downloaded transcription is separate from Apple Speech and cloud providers. \
+                Local Batch uses in-process WhisperKit/Core ML model data. Local Streaming installs \
+                a dedicated external ASR runtime and is available only in the direct-download build.
                 """
                 #endif
               }()
@@ -1509,7 +1603,7 @@ struct SettingsView: View {
             .font(.caption)
             .foregroundStyle(.secondary)
 
-            if !DistributionChannel.current.supportsLocalModelRuntime {
+            if !DistributionChannel.current.supportsExternalLocalModelRuntime {
               localRuntimeUnavailableNote
             }
 
@@ -3041,7 +3135,7 @@ struct SettingsView: View {
       .foregroundStyle(.secondary)
       #endif
 
-      if !DistributionChannel.current.supportsLocalModelRuntime {
+      if !DistributionChannel.current.supportsExternalLocalModelRuntime {
         localRuntimeUnavailableNote
       }
 
@@ -3406,7 +3500,11 @@ struct SettingsView: View {
   private var apiKeySettings: some View {
     ScrollViewReader { proxy in
       LazyVStack(spacing: 20) {
-        CloudKitKeySyncSettingsCard(secureStorage: environment.secureStorage)
+        if DistributionChannel.current.supportsEncryptedCloudKitKeySync {
+          CloudKitKeySyncSettingsCard(secureStorage: environment.secureStorage)
+        } else {
+          LocalKeychainStorageCard()
+        }
 
         // OpenRouter (Legacy)
         apiKeyCard(
@@ -3789,6 +3887,23 @@ struct SettingsView: View {
         let coreStorage = await secureStorage.coreStorage()
         await keySync.configure(secureStorage: coreStorage)
         _ = await keySync.isAvailable()
+      }
+    }
+  }
+
+  private struct LocalKeychainStorageCard: View {
+    var body: some View {
+      SettingsCard(title: "Local Keychain Storage", systemImage: "key.fill", tint: .brandLagoon) {
+        VStack(alignment: .leading, spacing: 8) {
+          Label("Stored locally on this Mac", systemImage: "checkmark.seal.fill")
+            .foregroundStyle(.green)
+          Text(
+            "API keys stay in the macOS Keychain for this direct-download build. "
+              + "Encrypted CloudKit API-key sync is available only in App Store builds."
+          )
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        }
       }
     }
   }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -52,6 +52,18 @@ enum SettingsTab: String, CaseIterable, Identifiable, Hashable {
   }
 }
 
+private struct MacAPIKeyItem: Identifiable {
+  enum Source {
+    case openRouter
+    case transcription(TranscriptionProviderMetadata)
+    case textToSpeech(TTSProvider)
+  }
+
+  let entry: APIKeyListEntry
+  let source: Source
+  var id: String { entry.id }
+}
+
 struct SettingsView: View {
   @EnvironmentObject private var environment: AppEnvironment
   @EnvironmentObject private var settings: AppSettings
@@ -92,6 +104,9 @@ struct SettingsView: View {
   @State private var providerValidationStates: [String: ValidationViewState] = [:]
   @State private var ttsProviderAPIKeys: [String: String] = [:]
   @State private var ttsProviderValidationStates: [String: ValidationViewState] = [:]
+  @State private var apiKeySearchText = ""
+  @State private var apiKeyStatusFilter: APIKeyStatusFilter = .all
+  @State private var apiKeySortOrder: APIKeySortOrder = .name
   @State private var missingTranscriptionAPIKeyAlert: MissingLiveAPIKeyAlert?
   @State private var showSystemPromptPreview = false
   @State private var systemPromptPreview = ""
@@ -195,6 +210,56 @@ struct SettingsView: View {
   private var isValidatingKey: Bool {
     if case .validating = apiKeyValidationState { return true }
     return false
+  }
+
+  private var allMacAPIKeyItems: [MacAPIKeyItem] {
+    var items = [
+      MacAPIKeyItem(
+        entry: APIKeyListEntry(
+          id: "general-openrouter",
+          title: "OpenRouter",
+          category: "Post-processing",
+          isStored: isOpenRouterKeyStored
+        ),
+        source: .openRouter
+      )
+    ]
+    items += transcriptionProviders
+      .filter { $0.id != "elevenlabs" }
+      .map { provider in
+        MacAPIKeyItem(
+          entry: APIKeyListEntry(
+            id: "transcription-\(provider.id)",
+            title: provider.displayName,
+            category: "Transcription",
+            isStored: settings.trackedAPIKeyIdentifiers.contains(provider.apiKeyIdentifier)
+          ),
+          source: .transcription(provider)
+        )
+      }
+    items += [TTSProvider.elevenlabs, .openai, .azure, .deepgram].map { provider in
+      MacAPIKeyItem(
+        entry: APIKeyListEntry(
+          id: "tts-\(provider.id)",
+          title: provider == .elevenlabs ? "ElevenLabs" : provider.displayName,
+          category: provider == .elevenlabs ? "Transcription & Voice Output" : "Voice Output",
+          isStored: settings.trackedAPIKeyIdentifiers.contains(provider.apiKeyIdentifier)
+        ),
+        source: .textToSpeech(provider)
+      )
+    }
+    return items
+  }
+
+  private var visibleMacAPIKeyItems: [MacAPIKeyItem] {
+    let orderedEntries = APIKeyListQuery.apply(
+      to: allMacAPIKeyItems.map(\.entry),
+      searchText: apiKeySearchText,
+      status: apiKeyStatusFilter,
+      sortOrder: apiKeySortOrder
+    )
+    let itemsByID = Dictionary(uniqueKeysWithValues: allMacAPIKeyItems.map { ($0.id, $0) })
+    return orderedEntries.compactMap { itemsByID[$0.id] }
   }
 
   private var overviewPostProcessingValue: String {
@@ -640,12 +705,13 @@ struct SettingsView: View {
   }
 
   var body: some View {
+    let density = settings.visualDensity
     ScrollView {
-      VStack(alignment: .leading, spacing: 28) {
+      VStack(alignment: .leading, spacing: density == .compact ? 16 : 28) {
         overviewHeader
         tabContent
       }
-      .padding(24)
+      .padding(density.pagePadding)
       .frame(maxWidth: 1100, alignment: .center)
     }
     .background(
@@ -721,6 +787,21 @@ struct SettingsView: View {
           )
           .speakTooltip("Choose whether Speak follows macOS appearance or stays in light or dark mode all the time.")
           .accessibilityLabel("Appearance theme picker")
+
+          Picker("Layout Density", selection: settingsBinding(\AppSettings.visualDensity)) {
+            ForEach(AppVisualDensity.allCases) { density in
+              Text(density.displayName).tag(density)
+            }
+          }
+          .pickerStyle(.segmented)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 8)
+          .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+              .fill(Color(nsColor: .controlBackgroundColor))
+          )
+          .speakTooltip("Choose normal spacing or a higher-density layout across Speak.")
+          .accessibilityLabel("Application layout density picker")
         }
       }
       .speakTooltip("Set Speak's look to match your workspace with light, dark, or system themes.")
@@ -3515,15 +3596,85 @@ struct SettingsView: View {
 
   private var apiKeySettings: some View {
     ScrollViewReader { proxy in
-      LazyVStack(spacing: 20) {
+      LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
+        apiKeyListControls
+
         if DistributionChannel.current.supportsEncryptedCloudKitKeySync {
           CloudKitKeySyncSettingsCard(secureStorage: environment.secureStorage)
         } else {
           LocalKeychainStorageCard()
         }
 
-        // OpenRouter (Legacy)
-        apiKeyCard(
+        if visibleMacAPIKeyItems.isEmpty {
+          ContentUnavailableView(
+            "No API Keys",
+            systemImage: "key.slash",
+            description: Text("Try a different search or status filter.")
+          )
+          .padding(.vertical, 24)
+        } else {
+          ForEach(visibleMacAPIKeyItems) { item in
+            macAPIKeyView(for: item)
+              .id(item.id)
+          }
+        }
+      }
+      .onAppear {
+        if let target = environment.apiKeysScrollTarget {
+          revealAPIKeyTarget()
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            withAnimation { proxy.scrollTo(target, anchor: .top) }
+            environment.apiKeysScrollTarget = nil
+          }
+        }
+      }
+      .onChange(of: environment.apiKeysScrollTarget) { _, newValue in
+        guard let target = newValue else { return }
+        revealAPIKeyTarget()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+          withAnimation { proxy.scrollTo(target, anchor: .top) }
+          environment.apiKeysScrollTarget = nil
+        }
+      }
+    }
+  }
+
+  private var apiKeyListControls: some View {
+    SettingsCard(title: "Find API Keys", systemImage: "magnifyingglass", tint: .brandAccent) {
+      VStack(alignment: .leading, spacing: settings.visualDensity == .compact ? 8 : 12) {
+        TextField("Search provider or category", text: $apiKeySearchText)
+          .textFieldStyle(.roundedBorder)
+          .accessibilityLabel("Search API keys")
+
+        HStack(spacing: 12) {
+          Picker("Status", selection: $apiKeyStatusFilter) {
+            ForEach(APIKeyStatusFilter.allCases) { filter in
+              Text(filter.displayName).tag(filter)
+            }
+          }
+          .pickerStyle(.menu)
+
+          Picker("Sort", selection: $apiKeySortOrder) {
+            ForEach(APIKeySortOrder.allCases) { order in
+              Text(order.displayName).tag(order)
+            }
+          }
+          .pickerStyle(.menu)
+
+          Spacer()
+          Text("\(visibleMacAPIKeyItems.count) of \(allMacAPIKeyItems.count)")
+            .font(.caption.monospacedDigit())
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func macAPIKeyView(for item: MacAPIKeyItem) -> some View {
+    switch item.source {
+    case .openRouter:
+      apiKeyCard(
         title: "OpenRouter",
         systemImage: "network",
         tint: .green,
@@ -3551,35 +3702,16 @@ struct SettingsView: View {
         link: nil,
         linkLabel: nil
       )
-
-      // Transcription Providers (Dynamic) — ElevenLabs excluded; it shares the TTS card below
-      ForEach(transcriptionProviders.filter { $0.id != "elevenlabs" }) { provider in
-        providerAPIKeyCard(for: provider)
-          .id("transcription-\(provider.id)")
-      }
-
-      // TTS Providers
-      ForEach([TTSProvider.elevenlabs, .openai, .azure, .deepgram]) { provider in
-        ttsProviderAPIKeyCard(for: provider)
-          .id("tts-\(provider.id)")
-      }
+    case .transcription(let provider):
+      providerAPIKeyCard(for: provider)
+    case .textToSpeech(let provider):
+      ttsProviderAPIKeyCard(for: provider)
     }
-    .onAppear {
-        if let target = environment.apiKeysScrollTarget {
-          DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            withAnimation { proxy.scrollTo(target, anchor: .top) }
-            environment.apiKeysScrollTarget = nil
-          }
-        }
-      }
-      .onChange(of: environment.apiKeysScrollTarget) { _, newValue in
-        guard let target = newValue else { return }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-          withAnimation { proxy.scrollTo(target, anchor: .top) }
-          environment.apiKeysScrollTarget = nil
-        }
-      }
-    }
+  }
+
+  private func revealAPIKeyTarget() {
+    apiKeySearchText = ""
+    apiKeyStatusFilter = .all
   }
 
   private func providerAPIKeyCard(for provider: TranscriptionProviderMetadata) -> some View {
@@ -4961,6 +5093,7 @@ private struct SettingsInlineInfo: View {
 }
 
 private struct SettingsCard<Content: View>: View {
+  @Environment(\.appVisualDensity) private var density
   let title: String
   let systemImage: String
   let tint: Color
@@ -4974,7 +5107,7 @@ private struct SettingsCard<Content: View>: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 18) {
+    VStack(alignment: .leading, spacing: density.cardContentSpacing) {
       HStack(spacing: 14) {
         ZStack {
           RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -4993,7 +5126,7 @@ private struct SettingsCard<Content: View>: View {
 
       content
     }
-    .padding(24)
+    .padding(density.cardPadding)
     .frame(maxWidth: .infinity, alignment: .leading)
     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
     .overlay(

--- a/Sources/SpeakApp/SpeakApp.swift
+++ b/Sources/SpeakApp/SpeakApp.swift
@@ -98,9 +98,9 @@ struct SpeakApp: App {
 final class EnvironmentHolder: ObservableObject {
     @Published var environment: AppEnvironment?
 
-    func bootstrap() {
+    func bootstrap(options: WireUp.BootstrapOptions = .default) {
         guard environment == nil else { return }
-        let env = WireUp.bootstrap()
+        let env = WireUp.bootstrap(options: options)
         environment = env
         // Install the status bar access point immediately, independent of any
         // window, so the app is always reachable — even when launched straight

--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -27,6 +27,7 @@ Following this sequence allows another project to drop in the same smart Insert 
 import AppKit
 import ApplicationServices
 import Foundation
+import SpeakCore
 
 struct TextOutputResult {
   let method: HistoryTrigger.OutputMethod
@@ -68,6 +69,7 @@ struct AccessibilityTextOutput: TextOutputting {
   let appSettings: AppSettings
 
   func output(text: String) -> TextOutputResult {
+    permissionsManager.refresh(.accessibility)
     let status = permissionsManager.status(for: .accessibility)
     guard status.isGranted else {
       return TextOutputResult(
@@ -130,7 +132,8 @@ struct PasteTextOutput: TextOutputting {
 
   func output(text: String) -> TextOutputResult {
     let pasteboard = NSPasteboard.general
-    let restoreClipboard = appSettings.restoreClipboardAfterPaste
+    let canPasteIntoOtherApps = DistributionChannel.current.supportsAccessibilityTextInsertion
+    let restoreClipboard = canPasteIntoOtherApps && appSettings.restoreClipboardAfterPaste
     let previousString = restoreClipboard ? pasteboard.string(forType: .string) : nil
 
     pasteboard.clearContents()
@@ -138,7 +141,9 @@ struct PasteTextOutput: TextOutputting {
       return TextOutputResult(method: .none, error: TextOutputError.clipboardWriteFailed)
     }
 
-    simulatePasteShortcut()
+    if canPasteIntoOtherApps {
+      simulatePasteShortcut()
+    }
 
     if restoreClipboard {
       scheduleClipboardRestore(previousString, on: pasteboard)
@@ -236,6 +241,10 @@ struct SmartTextOutput: TextOutputting {
   }
 
   func output(text: String) -> TextOutputResult {
+    guard DistributionChannel.current.supportsAccessibilityTextInsertion else {
+      return clipboardOutput.output(text: text)
+    }
+
     switch appSettings.textOutputMethod {
     case .accessibilityOnly:
       return accessibilityOutput.output(text: text)
@@ -247,6 +256,10 @@ struct SmartTextOutput: TextOutputting {
         print("[SmartTextOutput] Skipping accessibility for problematic app, using clipboard")
         return clipboardOutput.output(text: text)
       }
+
+      // Permission grants can change while System Settings is frontmost. Re-read
+      // TCC before deciding whether direct insertion is available.
+      permissionsManager.refresh(.accessibility)
 
       // Only try accessibility if permission is granted AND there's a focused element
       if permissionsManager.status(for: .accessibility).isGranted,

--- a/Sources/SpeakApp/TroubleshootingAnalyser.swift
+++ b/Sources/SpeakApp/TroubleshootingAnalyser.swift
@@ -79,18 +79,12 @@ struct HotkeyInfoCheck: TroubleshootingCheck {
           actions: [.navigate(.shortcuts)]
         )
       )
-    }
-    
-    // Custom shortcut troubleshooting
-    if case .custom = hotKey {
-      let accessibilityGranted = permissions.status(for: .accessibility).isGranted
-      let inputMonitoringGranted = permissions.status(for: .inputMonitoring).isGranted
-      if !accessibilityGranted || !inputMonitoringGranted {
+      if !permissions.status(for: .inputMonitoring).isGranted {
         items.append(
           TroubleshootingItem(
-            id: "hotkey-custom-permissions",
-            title: "Custom Shortcut Needs Permissions",
-            detail: "Custom hotkey detection requires both Accessibility and Input Monitoring permissions. Grant them in System Settings → Privacy & Security.",
+            id: "hotkey-fn-permission",
+            title: "Fn Shortcut Needs Input Monitoring",
+            detail: "Grant Input Monitoring so Speak can detect the Fn key while another app is active.",
             status: .issue,
             systemImage: "lock.shield",
             actions: [.navigate(.permissions)]

--- a/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
@@ -129,6 +129,13 @@ struct ShortcutsSettingsView: View {
         }
         .padding(.vertical, 4)
         .opacity(binding.isEnabled ? 1.0 : 0.6)
+
+        if isRecording, let recordingError = shortcutManager.recordingError {
+            Label(recordingError, systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.red)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }
 

--- a/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
@@ -68,6 +68,7 @@ struct ShortcutsSettingsView: View {
     }
 
     @ViewBuilder
+    // swiftlint:disable:next function_body_length
     private func shortcutRow(for action: ShortcutAction) -> some View {
         let binding = shortcutManager.binding(for: action)
         let isRecording = shortcutManager.isRecordingShortcut && shortcutManager.recordingAction == action

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import Foundation
+import SpeakCore
 import SpeakSync
 
 // swiftlint:disable file_length
@@ -440,15 +441,17 @@ enum WireUp {
     Task { await syncAdapter.start() }
 
     Task { await secureStorage.preloadTrackedSecrets() }
-    Task {
-      let coreStorage = await secureStorage.coreStorage()
-      let keySync = CloudKitKeySync.shared
-      await keySync.configure(secureStorage: coreStorage)
-      guard await keySync.isAvailable() else { return }
-      do {
-        try await keySync.syncNow()
-      } catch {
-        print("[WireUp] CloudKit API-key sync failed: \(error.localizedDescription)")
+    if DistributionChannel.current.supportsEncryptedCloudKitKeySync {
+      Task {
+        let coreStorage = await secureStorage.coreStorage()
+        let keySync = CloudKitKeySync.shared
+        await keySync.configure(secureStorage: coreStorage)
+        guard await keySync.isAvailable() else { return }
+        do {
+          try await keySync.syncNow()
+        } catch {
+          print("[WireUp] CloudKit API-key sync failed: \(error.localizedDescription)")
+        }
       }
     }
     Task {

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -314,6 +314,7 @@ enum WireUp {
   struct BootstrapOptions {
     var settingsOverride: AppSettings?
     var permissionsOverride: PermissionsManager?
+    var keychainServiceOverride: String?
 
     static let `default` = BootstrapOptions()
   }
@@ -334,7 +335,11 @@ enum WireUp {
       permissionsManager: permissions,
       audioDeviceManager: audioDevices
     )
-    let secureStorage = SecureAppStorage(permissionsManager: permissions, appSettings: settings)
+    let secureStorage = SecureAppStorage(
+      permissionsManager: permissions,
+      appSettings: settings,
+      keychainService: options.keychainServiceOverride ?? "com.justspeaktoit.credentials"
+    )
     let openRouter = OpenRouterAPIClient(secureStorage: secureStorage)
     let transcription = TranscriptionManager(
       appSettings: settings,

--- a/Sources/SpeakCore/AppVisualDensity.swift
+++ b/Sources/SpeakCore/AppVisualDensity.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// A user-selected presentation density shared by the macOS and iOS apps.
+/// Normal intentionally preserves the existing spacing; compact reduces
+/// whitespace without shrinking interactive controls below platform norms.
+public enum AppVisualDensity: String, CaseIterable, Identifiable, Sendable {
+    case normal
+    case compact
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .normal: return "Normal"
+        case .compact: return "Compact"
+        }
+    }
+
+    public var sectionSpacing: CGFloat { self == .compact ? 12 : 20 }
+    public var pagePadding: CGFloat { self == .compact ? 14 : 24 }
+    public var cardPadding: CGFloat { self == .compact ? 15 : 24 }
+    public var cardContentSpacing: CGFloat { self == .compact ? 11 : 18 }
+    public var listRowVerticalPadding: CGFloat { self == .compact ? 1 : 4 }
+    public var minimumListRowHeight: CGFloat { self == .compact ? 38 : 44 }
+    public var listSectionSpacing: CGFloat { self == .compact ? 12 : 24 }
+}
+
+private struct AppVisualDensityKey: EnvironmentKey {
+    static let defaultValue = AppVisualDensity.normal
+}
+
+public extension EnvironmentValues {
+    var appVisualDensity: AppVisualDensity {
+        get { self[AppVisualDensityKey.self] }
+        set { self[AppVisualDensityKey.self] = newValue }
+    }
+}
+
+public enum APIKeyStatusFilter: String, CaseIterable, Identifiable, Sendable {
+    case all
+    case stored
+    case missing
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .all: return "All Keys"
+        case .stored: return "Stored"
+        case .missing: return "Missing"
+        }
+    }
+}
+
+public enum APIKeySortOrder: String, CaseIterable, Identifiable, Sendable {
+    case name
+    case category
+    case status
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .name: return "Name"
+        case .category: return "Category"
+        case .status: return "Status"
+        }
+    }
+}
+
+public struct APIKeyListEntry: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let category: String
+    public let isStored: Bool
+
+    public init(id: String, title: String, category: String, isStored: Bool) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.isStored = isStored
+    }
+}
+
+public enum APIKeyListQuery {
+    public static func apply(
+        to entries: [APIKeyListEntry],
+        searchText: String,
+        status: APIKeyStatusFilter,
+        sortOrder: APIKeySortOrder
+    ) -> [APIKeyListEntry] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filtered = entries.filter { entry in
+            let matchesStatus: Bool
+            switch status {
+            case .all: matchesStatus = true
+            case .stored: matchesStatus = entry.isStored
+            case .missing: matchesStatus = !entry.isStored
+            }
+            guard matchesStatus else { return false }
+            guard !query.isEmpty else { return true }
+            return entry.title.localizedCaseInsensitiveContains(query)
+                || entry.category.localizedCaseInsensitiveContains(query)
+        }
+
+        return filtered.sorted { lhs, rhs in
+            switch sortOrder {
+            case .name:
+                return compare(lhs.title, rhs.title, fallback: lhs.id < rhs.id)
+            case .category:
+                return compare(
+                    lhs.category,
+                    rhs.category,
+                    fallback: compare(lhs.title, rhs.title, fallback: lhs.id < rhs.id)
+                )
+            case .status:
+                if lhs.isStored != rhs.isStored { return lhs.isStored && !rhs.isStored }
+                return compare(lhs.title, rhs.title, fallback: lhs.id < rhs.id)
+            }
+        }
+    }
+
+    private static func compare(_ lhs: String, _ rhs: String, fallback: @autoclosure () -> Bool) -> Bool {
+        let result = lhs.localizedCaseInsensitiveCompare(rhs)
+        if result == .orderedSame { return fallback() }
+        return result == .orderedAscending
+    }
+}

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -8,9 +8,13 @@ import Foundation
 /// which wires it into the generated Xcode project (see `Project.swift`):
 ///
 /// - `.direct`   — Developer ID / direct download. Unsandboxed, self-updates via
-///                 Sparkle, can run downloaded local model runtimes.
-/// - `.appStore` — Mac App Store. Sandboxed; no Sparkle; no downloaded local model
-///                 runtimes; some permissions must be granted manually.
+///                 Sparkle, and can install external local model runtimes.
+/// - `.appStore` — Mac App Store. Sandboxed; no Sparkle or external executable
+///                 runtime installers; some permissions must be granted manually.
+///
+/// Both channels can download model *data* consumed by an in-process, bundled
+/// runtime (for example WhisperKit/Core ML). The sandbox restriction applies to
+/// installing or spawning executable runtimes such as sherpa-onnx and llama.cpp.
 ///
 /// iOS is always distributed through the App Store / TestFlight, so it always reports
 /// `.appStore` regardless of the flag.
@@ -42,6 +46,14 @@ public enum DistributionChannel: String, Sendable, CaseIterable {
     public var isSandboxed: Bool { self == .appStore }
 }
 
+/// The only API-key persistence/sync presentation exposed by a build.
+public enum APIKeyStorageMode: String, Sendable {
+    /// Secrets remain solely in the local macOS Keychain.
+    case localKeychainOnly
+    /// Secrets are local by default and may be passphrase-encrypted into private CloudKit.
+    case encryptedCloudKit
+}
+
 // MARK: - Feature availability
 
 /// A build-time capability that may be unavailable on some distribution channels.
@@ -52,9 +64,11 @@ public enum DistributionChannel: String, Sendable, CaseIterable {
 public enum ChannelFeature: String, Sendable, CaseIterable {
     /// In-app self-update (Sparkle). App Store builds update through the store instead.
     case selfUpdate
-    /// Downloaded local model runtimes (Python venv + llama.cpp / sherpa-onnx) that
-    /// spawn subprocesses and build/download executable code — impossible when sandboxed.
-    case localModelRuntime
+    /// Downloaded Core ML model data used by a runtime already bundled in the app.
+    case downloadedCoreMLModels
+    /// External runtimes (llama.cpp / sherpa-onnx) that install or spawn executable
+    /// code and therefore cannot be offered in the App Store sandbox.
+    case externalLocalModelRuntime
     /// Automatically prompting the user for Accessibility. Sandboxed builds cannot show the
     /// Accessibility prompt (`AXIsProcessTrustedWithOptions` is inert under the sandbox), so the
     /// user must add the app manually in System Settings. Input Monitoring is unaffected — it
@@ -66,20 +80,27 @@ public enum ChannelFeature: String, Sendable, CaseIterable {
     /// iCloud-backed sync features. Runtime entitlement/account probes still decide
     /// whether each iCloud service is actually available.
     case iCloudSync
+    /// Passphrase-encrypted API-key sync through the user's private CloudKit database.
+    case encryptedCloudKitKeySync
     /// Local-network Bonjour transport for cross-device fallback.
     case localNetworkTransport
 }
 
 public extension DistributionChannel {
+    var apiKeyStorageMode: APIKeyStorageMode {
+        self == .direct ? .localKeychainOnly : .encryptedCloudKit
+    }
+
     /// Whether `feature` is available in this build.
     func supports(_ feature: ChannelFeature) -> Bool {
         switch feature {
-        case .selfUpdate, .localModelRuntime, .automaticAccessibilityPrompt, .crossChannelMessaging:
+        case .selfUpdate, .externalLocalModelRuntime, .automaticAccessibilityPrompt, .crossChannelMessaging:
             return self == .direct
-        case .iCloudSync, .localNetworkTransport:
-            // Sync transports are compiled into every build; runtime entitlement,
-            // account, and local-network permission probes decide actual availability.
-            // (The macOS Developer ID build also ships CloudKit entitlements.)
+        case .iCloudSync, .encryptedCloudKitKeySync:
+            // iOS and Mac App Store builds carry the managed iCloud entitlements.
+            // Direct Mac keeps API keys solely in its local Keychain vault.
+            return self == .appStore
+        case .downloadedCoreMLModels, .localNetworkTransport:
             return true
         }
     }
@@ -87,8 +108,11 @@ public extension DistributionChannel {
     /// In-app self-update via Sparkle (direct builds only).
     var supportsSelfUpdate: Bool { supports(.selfUpdate) }
 
-    /// Downloaded local model runtimes (direct builds only).
-    var supportsLocalModelRuntime: Bool { supports(.localModelRuntime) }
+    /// Downloadable WhisperKit/Core ML model data (both channels).
+    var supportsDownloadedCoreMLModels: Bool { supports(.downloadedCoreMLModels) }
+
+    /// Installable executable local runtimes such as sherpa-onnx and llama.cpp (direct only).
+    var supportsExternalLocalModelRuntime: Bool { supports(.externalLocalModelRuntime) }
 
     /// Whether the app can auto-prompt for Accessibility.
     /// When `false` (App Store), guide the user to add the app manually instead.
@@ -101,6 +125,9 @@ public extension DistributionChannel {
     /// Whether this distribution channel is expected to support iCloud sync when
     /// the running build also has the required entitlements and account state.
     var supportsICloudSync: Bool { supports(.iCloudSync) }
+
+    /// Whether the encrypted CloudKit API-key sync feature should be initialized and shown.
+    var supportsEncryptedCloudKitKeySync: Bool { supports(.encryptedCloudKitKeySync) }
 
     /// Whether Bonjour local-network transport is part of this build.
     var supportsLocalNetworkTransport: Bool { supports(.localNetworkTransport) }

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -29,7 +29,12 @@ public enum DistributionChannel: String, Sendable, CaseIterable {
     /// App Store (macOS Mac App Store, or iOS App Store / TestFlight).
     case appStore
 
-    /// The channel the current build was compiled for.
+    /// The channel the current app bundle was built for.
+    ///
+    /// Xcode does not propagate an app target's active compilation conditions into
+    /// local Swift-package dependencies, so the generated macOS app records its
+    /// channel in Info.plist. The compile-time branch remains useful for SwiftPM
+    /// release/test builds that explicitly pass `-DAPP_STORE`.
     public static var current: DistributionChannel {
         #if os(iOS)
         // iOS only ever ships through the App Store / TestFlight.
@@ -37,6 +42,12 @@ public enum DistributionChannel: String, Sendable, CaseIterable {
         #elseif APP_STORE
         return .appStore
         #else
+        if let configuredChannel = Bundle.main.object(
+            forInfoDictionaryKey: "SpeakDistributionChannel"
+        ) as? String,
+            configuredChannel == DistributionChannel.appStore.rawValue {
+            return .appStore
+        }
         return .direct
         #endif
     }

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -74,6 +74,9 @@ public enum ChannelFeature: String, Sendable, CaseIterable {
     /// user must add the app manually in System Settings. Input Monitoring is unaffected — it
     /// still prompts via `CGRequestListenEventAccess` even when sandboxed.
     case automaticAccessibilityPrompt
+    /// Cross-app text insertion via AXUIElement. The App Store sandbox blocks
+    /// reading and mutating another app's accessibility hierarchy.
+    case accessibilityTextInsertion
     /// Freedom to reference other distribution channels or external purchases in UI copy.
     /// App Store review guidelines discourage this, so App Store builds must not.
     case crossChannelMessaging
@@ -94,7 +97,8 @@ public extension DistributionChannel {
     /// Whether `feature` is available in this build.
     func supports(_ feature: ChannelFeature) -> Bool {
         switch feature {
-        case .selfUpdate, .externalLocalModelRuntime, .automaticAccessibilityPrompt, .crossChannelMessaging:
+        case .selfUpdate, .externalLocalModelRuntime, .automaticAccessibilityPrompt,
+             .accessibilityTextInsertion, .crossChannelMessaging:
             return self == .direct
         case .iCloudSync, .encryptedCloudKitKeySync:
             // iOS and Mac App Store builds carry the managed iCloud entitlements.
@@ -117,6 +121,9 @@ public extension DistributionChannel {
     /// Whether the app can auto-prompt for Accessibility.
     /// When `false` (App Store), guide the user to add the app manually instead.
     var supportsAutomaticAccessibilityPrompt: Bool { supports(.automaticAccessibilityPrompt) }
+
+    /// Whether this build may insert text directly into another app via AXUIElement.
+    var supportsAccessibilityTextInsertion: Bool { supports(.accessibilityTextInsertion) }
 
     /// Whether UI copy may reference other distribution channels (e.g. the direct
     /// download). `false` for App Store builds to stay within review guidelines.

--- a/Sources/SpeakCore/TranscriptionModelPlacement.swift
+++ b/Sources/SpeakCore/TranscriptionModelPlacement.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Shared catalogue projections used by both platform settings UIs.
+///
+/// `liveTranscription` remains the complete routing catalogue. These projections
+/// decide where a model is presented, so adding another `apple/...` live model
+/// automatically places it under Local without duplicating platform-specific lists.
+public extension ModelCatalog {
+    static var onDeviceLiveTranscription: [Option] {
+        liveTranscription.filter { ModelRouting.family(for: $0.id) == .appleSpeech }
+    }
+
+    static var remoteLiveTranscription: [Option] {
+        liveTranscription.filter { ModelRouting.family(for: $0.id) != .appleSpeech }
+    }
+
+    static var defaultOnDeviceLiveTranscriptionModel: String {
+        onDeviceLiveTranscription.first?.id ?? "apple/local/SFSpeechRecognizer"
+    }
+
+    static var defaultRemoteLiveTranscriptionModel: String? {
+        remoteLiveTranscription.first?.id
+    }
+
+    static func isOnDeviceLiveTranscriptionModel(_ identifier: String) -> Bool {
+        ModelRouting.family(for: identifier) == .appleSpeech
+    }
+}

--- a/Sources/SpeakHotKeys/CarbonKeyBackend.swift
+++ b/Sources/SpeakHotKeys/CarbonKeyBackend.swift
@@ -59,7 +59,7 @@ final class CarbonKeyBackend {
     let selfPtr = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
 
     let status = InstallEventHandler(
-      GetEventDispatcherTarget(),
+      GetApplicationEventTarget(),
       { _, event, userData -> OSStatus in
         guard let userData, let event else { return OSStatus(eventNotHandledErr) }
         let backend = Unmanaged<CarbonKeyBackend>.fromOpaque(userData).takeUnretainedValue()
@@ -89,7 +89,7 @@ final class CarbonKeyBackend {
       UInt32(keyCode),
       modifiers.carbonFlags,
       hotKeyIDSpec,
-      GetEventDispatcherTarget(),
+      GetApplicationEventTarget(),
       0,
       &hotKeyRef
     )

--- a/Sources/SpeakHotKeys/HotKeyEngine.swift
+++ b/Sources/SpeakHotKeys/HotKeyEngine.swift
@@ -69,6 +69,10 @@ public final class HotKeyEngine: ObservableObject {
   /// Start monitoring for the given hotkey.
   public func start(for hotKey: HotKey) {
     stop()
+    guard hotKey.isSupportedForGlobalMonitoring else {
+      log.error("Refusing unsupported unmodified global hotkey: \(hotKey.displayString)")
+      return
+    }
     activeHotKey = hotKey
     isMonitoring = true
 

--- a/Sources/SpeakHotKeys/HotKeyRecorder.swift
+++ b/Sources/SpeakHotKeys/HotKeyRecorder.swift
@@ -11,6 +11,7 @@ public struct HotKeyRecorder: View {
   @State private var isRecording = false
   @State private var pendingModifiers: HotKey.ModifierSet = []
   @State private var eventMonitor: Any?
+  @State private var validationMessage: String?
 
   private let label: String
 
@@ -34,6 +35,13 @@ public struct HotKeyRecorder: View {
         if !hotKey.isFnKey {
           clearButton
         }
+      }
+
+      if let validationMessage {
+        Label(validationMessage, systemImage: "exclamationmark.triangle.fill")
+          .font(.caption)
+          .foregroundStyle(.red)
+          .fixedSize(horizontal: false, vertical: true)
       }
     }
     .onDisappear {
@@ -134,6 +142,7 @@ public struct HotKeyRecorder: View {
     stopRecording()
     isRecording = true
     pendingModifiers = []
+    validationMessage = nil
     NotificationCenter.default.post(name: .speakHotKeyShouldPause, object: nil)
 
     eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
@@ -172,8 +181,15 @@ public struct HotKeyRecorder: View {
     )
 
     // Allow dedicated extended keys as single-key hotkeys, but keep ordinary typing keys modifier-gated.
-    guard !modifiers.isEmpty || KeyCodeMapping.singleKeyHotKeyCodes.contains(event.keyCode) else { return true }
+    guard KeyCodeMapping.isSupportedCustomHotKey(
+      keyCode: event.keyCode,
+      hasModifiers: !modifiers.isEmpty
+    ) else {
+      validationMessage = KeyCodeMapping.unsupportedSingleKeyMessage
+      return true
+    }
 
+    validationMessage = nil
     hotKey = .custom(keyCode: event.keyCode, modifiers: modifiers)
     stopRecording()
     return true

--- a/Sources/SpeakHotKeys/HotKeyStore.swift
+++ b/Sources/SpeakHotKeys/HotKeyStore.swift
@@ -27,6 +27,10 @@ public final class HotKeyStore: ObservableObject {
     else {
       return .fnKey
     }
+    guard decoded.isSupportedForGlobalMonitoring else {
+      log.error("Discarding unsupported stored hotkey: \(decoded.displayString)")
+      return .fnKey
+    }
     log.debug("Loaded hotkey: \(decoded.displayString)")
     return decoded
   }

--- a/Sources/SpeakHotKeys/HotKeyTypes.swift
+++ b/Sources/SpeakHotKeys/HotKeyTypes.swift
@@ -69,6 +69,19 @@ public enum HotKey: Codable, Hashable, Sendable {
     if case .fnKey = self { return true }
     return false
   }
+
+  /// Whether this binding is safe and supported for system-wide monitoring.
+  public var isSupportedForGlobalMonitoring: Bool {
+    switch self {
+    case .fnKey:
+      return true
+    case .custom(let keyCode, let modifiers):
+      return KeyCodeMapping.isSupportedCustomHotKey(
+        keyCode: keyCode,
+        hasModifiers: !modifiers.isEmpty
+      )
+    }
+  }
 }
 
 /// Gesture types emitted by the hotkey engine.

--- a/Sources/SpeakHotKeys/KeyCodeMapping.swift
+++ b/Sources/SpeakHotKeys/KeyCodeMapping.swift
@@ -110,6 +110,18 @@ public enum KeyCodeMapping {
     105, 106, 107, 113,  // F13-F16
     114  // Insert/Help
   ]
+
+  /// Whether a custom hotkey can be registered safely system-wide.
+  ///
+  /// Ordinary unmodified keys are deliberately rejected because registering one
+  /// globally would steal normal typing. Dedicated extended keys remain useful
+  /// as single-key triggers and are explicitly allow-listed above.
+  public static func isSupportedCustomHotKey(keyCode: UInt16, hasModifiers: Bool) -> Bool {
+    hasModifiers || singleKeyHotKeyCodes.contains(keyCode)
+  }
+
+  public static let unsupportedSingleKeyMessage =
+    "Use Command, Option, Shift, or Control with this key. F13-F20 and Insert can be used alone."
 }
 
 #endif

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -369,7 +369,10 @@ public struct ContentView: View {
                 VStack {
                     ScrollViewReader { proxy in
                         ScrollView {
-                            VStack(alignment: .leading, spacing: 12) {
+                            VStack(
+                                alignment: .leading,
+                                spacing: settings.visualDensity == .compact ? 8 : 12
+                            ) {
                                 if currentText.isEmpty {
                                     Text(backgroundService.isRunning
                                          ? "Recording via Action Button…"
@@ -386,7 +389,7 @@ public struct ContentView: View {
                                         .textSelection(.enabled)
                                 }
                             }
-                            .padding()
+                            .padding(settings.visualDensity == .compact ? 12 : 16)
                             .id("transcript")
                         }
                         .onChange(of: coordinator.partialText) { _, _ in
@@ -504,6 +507,8 @@ public struct ContentView: View {
                 }
             }
         }
+        .environment(\.appVisualDensity, settings.visualDensity)
+        .environment(\.defaultMinListRowHeight, settings.visualDensity.minimumListRowHeight)
     }
 
     // MARK: - Floating Controls with Glass Effect

--- a/Sources/SpeakiOS/Views/ConversationListView.swift
+++ b/Sources/SpeakiOS/Views/ConversationListView.swift
@@ -6,6 +6,7 @@ import SpeakCore
 
 /// Shows a list of OpenClaw conversations with the ability to create new ones.
 public struct ConversationListView: View {
+    @Environment(\.appVisualDensity) private var density
     @ObservedObject private var store = ConversationStore.shared
     @ObservedObject private var settings = OpenClawSettings.shared
     @EnvironmentObject private var deepLinkRouter: DeepLinkRouter
@@ -25,6 +26,7 @@ public struct ConversationListView: View {
             }
         }
         .navigationTitle("OpenClaw")
+        .environment(\.defaultMinListRowHeight, density.minimumListRowHeight)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 12) {
@@ -118,12 +120,14 @@ public struct ConversationListView: View {
                 }
             }
         }
+        .listSectionSpacing(density.listSectionSpacing)
     }
 }
 
 // MARK: - Conversation Row
 
 struct ConversationRow: View {
+    @Environment(\.appVisualDensity) private var density
     let conversation: OpenClawClient.Conversation
 
     var body: some View {
@@ -153,7 +157,7 @@ struct ConversationRow: View {
                     .foregroundStyle(.tertiary)
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, density.listRowVerticalPadding)
     }
 }
 

--- a/Sources/SpeakiOS/Views/HistoryItemRow.swift
+++ b/Sources/SpeakiOS/Views/HistoryItemRow.swift
@@ -1,10 +1,12 @@
 #if os(iOS)
 import SwiftUI
+import SpeakCore
 import SpeakSync
 
 // MARK: - History Item Row
 
 struct HistoryItemRow: View {
+    @Environment(\.appVisualDensity) private var density
     let item: iOSHistoryItem
     let isSynced: Bool
     var isReprocessing: Bool = false
@@ -15,7 +17,7 @@ struct HistoryItemRow: View {
     @State private var isExpanded = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: density == .compact ? 5 : 8) {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(item.createdAt, style: .date)
@@ -116,7 +118,7 @@ struct HistoryItemRow: View {
                 }
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, density.listRowVerticalPadding)
         .contentShape(Rectangle())
         .onTapGesture {
             if max(item.transcription.count, item.postProcessedTranscription?.count ?? 0) > 150 {

--- a/Sources/SpeakiOS/Views/HistoryView.swift
+++ b/Sources/SpeakiOS/Views/HistoryView.swift
@@ -7,6 +7,7 @@ import SpeakSync
 
 // swiftlint:disable:next type_body_length
 public struct HistoryView: View {
+    @Environment(\.appVisualDensity) private var density
     @StateObject private var historyManager = iOSHistoryManager.shared
     @ObservedObject private var syncEngine = HistorySyncEngine.shared
     @State private var showingClearConfirmation = false
@@ -42,6 +43,7 @@ public struct HistoryView: View {
             }
         }
         .navigationTitle("History")
+        .environment(\.defaultMinListRowHeight, density.minimumListRowHeight)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 syncStatusIcon
@@ -200,11 +202,12 @@ public struct HistoryView: View {
                 }
             }
         }
+        .listSectionSpacing(density.listSectionSpacing)
     }
 
     private var statsHeader: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 24) {
+            HStack(spacing: density == .compact ? 14 : 24) {
                 statBadge(value: "\(statistics.totalSessions)", label: "Sessions")
                 statBadge(value: formatDuration(statistics.averageSessionLength), label: "Average")
                 statBadge(value: formatDuration(statistics.cumulativeRecordingDuration), label: "Total Time")

--- a/Sources/SpeakiOS/Views/RecordingsView.swift
+++ b/Sources/SpeakiOS/Views/RecordingsView.swift
@@ -8,6 +8,7 @@ import SpeakCore
 /// Shows all locally saved audio recordings with playback,
 /// delete, and re-transcribe support.
 public struct RecordingsView: View {
+    @Environment(\.appVisualDensity) private var density
     @State private var recordings: [RecordingInfo] = []
     @State private var playingURL: URL?
     @State private var audioPlayer: AVAudioPlayer?
@@ -54,6 +55,7 @@ public struct RecordingsView: View {
             }
         }
         .navigationTitle("Recordings")
+        .environment(\.defaultMinListRowHeight, density.minimumListRowHeight)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear { reload() }
         .onDisappear { stopPlayback() }
@@ -141,6 +143,7 @@ public struct RecordingsView: View {
 // MARK: - Recording Row
 
 struct RecordingRow: View {
+    @Environment(\.appVisualDensity) private var density
     let recording: RecordingInfo
     let isPlaying: Bool
     let onPlay: () -> Void
@@ -203,7 +206,7 @@ struct RecordingRow: View {
                 Label("Delete", systemImage: "trash")
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, density.listRowVerticalPadding)
     }
 }
 

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -135,15 +135,10 @@ public final class AppSettings: ObservableObject {
 
     // MARK: - Canonical secure storage for API keys (SpeakCore)
     //
-    // Every API key is stored through SpeakCore's SecureStorage using the same
-    // service/account as the macOS app, and synced via iCloud Keychain when the
-    // build is entitled (see `SecureStorageConfiguration.iCloudSyncedIfAvailable`).
-    // A key set on one device then appears on the user's other devices.
-    //
-    // iOS <-> macOS sync additionally requires the shared keychain-access-group
-    // to be present in BOTH apps' entitlements and the macOS app to be built
-    // with the iCloud Keychain capability; a Developer-ID macOS build can't use
-    // synchronizable items and falls back to local-only storage.
+    // Every API key is stored locally through SpeakCore's SecureStorage using the
+    // same service/account as the macOS app. Cross-device transfer is handled only
+    // by the explicit passphrase-encrypted CloudKit sync feature below; the base
+    // Keychain item is deliberately not kSecAttrSynchronizable.
     static let deepgramKeyID = "deepgram.apiKey"
     static let openRouterKeyID = "openrouter.apiKey"
     static let openAIKeyID = "openai.apiKey"
@@ -154,16 +149,10 @@ public final class AppSettings: ObservableObject {
     static let assemblyAIKeyID = "assemblyai.apiKey"
     static let gladiaKeyID = "gladia.apiKey"
 
-    /// Shared keychain access group declared in `SpeakiOS.entitlements`
-    /// (`$(AppIdentifierPrefix)com.justspeaktoit.shared`). Only used when the
-    /// runtime probe confirms the entitlement is present.
-    private static let sharedAccessGroup = "8X4ZN58TYH.com.justspeaktoit.shared"
-
     private static let credentialStorage = SecureStorage(
-        configuration: .iCloudSyncedIfAvailable(
+        configuration: SecureStorageConfiguration(
             service: "com.justspeaktoit.credentials",
-            masterAccount: "speak-app-secrets",
-            accessGroup: sharedAccessGroup
+            masterAccount: "speak-app-secrets"
         )
     )
 
@@ -627,6 +616,22 @@ private struct BatchModelGroup: Identifiable {
     }
 }
 
+private enum IOSTranscriptionLocation: String, CaseIterable, Identifiable {
+    case local
+    case remote
+
+    var id: String { rawValue }
+    var displayName: String { rawValue.capitalized }
+}
+
+private enum IOSRemoteTranscriptionMode: String, CaseIterable, Identifiable {
+    case streaming
+    case batch
+
+    var id: String { rawValue }
+    var displayName: String { rawValue.capitalized }
+}
+
 // swiftlint:disable:next type_body_length
 public struct SettingsView: View {
     @StateObject private var settings = AppSettings.shared
@@ -640,44 +645,65 @@ public struct SettingsView: View {
     public var body: some View {
         Form {
             Section("Transcription") {
-                Picker("Mode", selection: $settings.transcriptionMode) {
-                    ForEach(IOSTranscriptionMode.allCases) { mode in
-                        Text(mode.displayName).tag(mode)
+                Picker("Where transcription runs", selection: transcriptionLocationBinding) {
+                    ForEach(IOSTranscriptionLocation.allCases) { location in
+                        Text(location.displayName).tag(location)
                     }
                 }
                 .pickerStyle(.segmented)
 
-                if settings.transcriptionMode == .streaming {
-                    Picker("Streaming Model", selection: selectedModelBinding) {
-                        ForEach(LiveModelGroup.grouped(ModelCatalog.liveTranscription)) { group in
-                            Section(group.title) {
-                                ForEach(group.options) { option in
-                                    LiveModelRow(option: option).tag(option.id)
-                                }
-                            }
+                if transcriptionLocationBinding.wrappedValue == .local {
+                    Picker("Apple On-Device Model", selection: selectedModelBinding) {
+                        ForEach(ModelCatalog.onDeviceLiveTranscription) { option in
+                            Text(option.displayName).tag(option.id)
                         }
                     }
                     .pickerStyle(.navigationLink)
+
+                    Text("Uses Apple's built-in speech engine. Audio stays on this device.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 } else {
-                    Picker("Batch Model", selection: $settings.batchTranscriptionModel) {
-                        ForEach(BatchModelGroup.grouped(AppSettings.supportedBatchModels)) { group in
-                            Section(group.title) {
-                                ForEach(group.options) { option in
-                                    Text(ModelCatalog.friendlyName(for: option.id)).tag(option.id)
+                    Picker("Remote Mode", selection: remoteTranscriptionModeBinding) {
+                        ForEach(IOSRemoteTranscriptionMode.allCases) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    if settings.transcriptionMode == .streaming {
+                        Picker("Remote Streaming Model", selection: selectedModelBinding) {
+                            ForEach(LiveModelGroup.grouped(ModelCatalog.remoteLiveTranscription)) { group in
+                                Section(group.title) {
+                                    ForEach(group.options) { option in
+                                        LiveModelRow(option: option).tag(option.id)
+                                    }
                                 }
                             }
                         }
+                        .pickerStyle(.navigationLink)
+                    } else {
+                        Picker("Remote Batch Model", selection: $settings.batchTranscriptionModel) {
+                            ForEach(BatchModelGroup.grouped(AppSettings.supportedBatchModels)) { group in
+                                Section(group.title) {
+                                    ForEach(group.options) { option in
+                                        Text(ModelCatalog.friendlyName(for: option.id)).tag(option.id)
+                                    }
+                                }
+                            }
+                        }
+                        .pickerStyle(.navigationLink)
                     }
-                    .pickerStyle(.navigationLink)
+
+                    Text(settings.transcriptionMode == .streaming
+                        ? "Text appears while audio is streamed to the selected provider."
+                        : "Audio is uploaded after recording for a more complete transcript.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
-                Text(settings.transcriptionMode == .streaming
-                    ? "Text appears while you speak."
-                    : "Audio is recorded first, then uploaded when you stop for a more complete transcript.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                if settings.transcriptionMode == .streaming,
+                if transcriptionLocationBinding.wrappedValue == .remote,
+                   settings.transcriptionMode == .streaming,
                    let route = LiveTranscriptionRouting.route(for: settings.selectedModel),
                    !route.isSupportedOnIOS {
                     Label(
@@ -688,7 +714,8 @@ public struct SettingsView: View {
                     .font(.caption)
                 }
 
-                if settings.transcriptionMode == .streaming,
+                if transcriptionLocationBinding.wrappedValue == .remote,
+                   settings.transcriptionMode == .streaming,
                    let route = LiveTranscriptionRouting.route(for: settings.selectedModel),
                    route.isSupportedOnIOS,
                    route.apiKeyIdentifier != nil,
@@ -701,7 +728,8 @@ public struct SettingsView: View {
                     .font(.caption)
                 }
 
-                if settings.transcriptionMode == .batch,
+                if transcriptionLocationBinding.wrappedValue == .remote,
+                   settings.transcriptionMode == .batch,
                    settings.batchAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Label(
                         AppSettings.openAIBatchModelIDs.contains(settings.batchTranscriptionModel)
@@ -1907,6 +1935,46 @@ struct CloudKitKeySyncSettingsSection: View {
 }
 
 private extension SettingsView {
+    @MainActor
+    private var transcriptionLocationBinding: Binding<IOSTranscriptionLocation> {
+        Binding(
+            get: {
+                settings.transcriptionMode == .streaming
+                    && ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.selectedModel)
+                    ? .local
+                    : .remote
+            },
+            set: { location in
+                switch location {
+                case .local:
+                    settings.selectedModel = ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+                    settings.transcriptionMode = .streaming
+                case .remote:
+                    if ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.selectedModel) {
+                        settings.selectedModel = ModelCatalog.defaultRemoteLiveTranscriptionModel
+                            ?? settings.selectedModel
+                    }
+                    settings.transcriptionMode = .streaming
+                }
+            }
+        )
+    }
+
+    @MainActor
+    private var remoteTranscriptionModeBinding: Binding<IOSRemoteTranscriptionMode> {
+        Binding(
+            get: { settings.transcriptionMode == .batch ? .batch : .streaming },
+            set: { mode in
+                if mode == .streaming,
+                   ModelCatalog.isOnDeviceLiveTranscriptionModel(settings.selectedModel) {
+                    settings.selectedModel = ModelCatalog.defaultRemoteLiveTranscriptionModel
+                        ?? settings.selectedModel
+                }
+                settings.transcriptionMode = mode == .batch ? .batch : .streaming
+            }
+        )
+    }
+
     @MainActor
     private var selectedModelBinding: Binding<String> {
         Binding(

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -184,6 +184,10 @@ public final class AppSettings: ObservableObject {
         didSet { UserDefaults.standard.set(liveActivitiesEnabled, forKey: "liveActivitiesEnabled") }
     }
 
+    @Published public var visualDensity: AppVisualDensity {
+        didSet { UserDefaults.standard.set(visualDensity.rawValue, forKey: "visualDensity") }
+    }
+
     @Published public var autoStartRecording: Bool {
         didSet { UserDefaults.standard.set(autoStartRecording, forKey: "autoStartRecording") }
     }
@@ -260,6 +264,9 @@ public final class AppSettings: ObservableObject {
 
         // Default Live Activities to true if not set
         let liveActivities = UserDefaults.standard.object(forKey: "liveActivitiesEnabled") as? Bool ?? true
+        let density = AppVisualDensity(
+            rawValue: UserDefaults.standard.string(forKey: "visualDensity") ?? ""
+        ) ?? .normal
         let autoStart = UserDefaults.standard.bool(forKey: "autoStartRecording")
 
         // Hardware trigger destination (Action Button, Siri, Shortcuts).
@@ -296,6 +303,7 @@ public final class AppSettings: ObservableObject {
         self.assemblyAIAPIKey = ""
         self.gladiaAPIKey = ""
         self.liveActivitiesEnabled = liveActivities
+        self.visualDensity = density
         self.autoStartRecording = autoStart
         self.hardwareTriggerDestination = hardwareDest
         self.postProcessingEnabled = postEnabled
@@ -644,6 +652,19 @@ public struct SettingsView: View {
 
     public var body: some View {
         Form {
+            Section("Appearance") {
+                Picker("Layout Density", selection: $settings.visualDensity) {
+                    ForEach(AppVisualDensity.allCases) { density in
+                        Text(density.displayName).tag(density)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Text("Compact reduces whitespace across lists, forms, and cards while keeping controls easy to tap.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Transcription") {
                 Picker("Where transcription runs", selection: transcriptionLocationBinding) {
                     ForEach(IOSTranscriptionLocation.allCases) { location in
@@ -1012,6 +1033,8 @@ public struct SettingsView: View {
                 }
             }
         }
+        .environment(\.defaultMinListRowHeight, settings.visualDensity.minimumListRowHeight)
+        .listSectionSpacing(settings.visualDensity.listSectionSpacing)
         .navigationTitle("Settings")
         .navigationDestination(isPresented: $showingAPIKeys) {
             APIKeysView(settings: settings)
@@ -1251,218 +1274,96 @@ struct APIKeysView: View {
     @State private var isValidating = false
     @State private var validationMessage: String?
     @State private var showingValidation = false
+    @State private var searchText = ""
+    @State private var statusFilter: APIKeyStatusFilter = .all
+    @State private var sortOrder: APIKeySortOrder = .name
+
+    private struct KeyPresentation {
+        let title: String
+        let systemImage: String
+        let help: String
+    }
+
+    private var allEntries: [APIKeyListEntry] {
+        [
+            APIKeyListEntry(
+                id: "deepgram", title: "Deepgram", category: "Transcription", isStored: settings.hasDeepgramKey
+            ),
+            APIKeyListEntry(
+                id: "elevenlabs", title: "ElevenLabs", category: "Transcription & Voice Output",
+                isStored: settings.hasElevenLabsKey
+            ),
+            APIKeyListEntry(
+                id: "openrouter", title: "OpenRouter", category: "Post-processing", isStored: settings.hasOpenRouterKey
+            ),
+            APIKeyListEntry(
+                id: "openai", title: "OpenAI", category: "Transcription", isStored: settings.hasOpenAIKey
+            ),
+            APIKeyListEntry(
+                id: "cartesia", title: "Cartesia", category: "Transcription", isStored: settings.hasCartesiaKey
+            ),
+            APIKeyListEntry(
+                id: "soniox", title: "Soniox", category: "Transcription", isStored: settings.hasSonioxKey
+            ),
+            APIKeyListEntry(
+                id: "modulate", title: "Modulate", category: "Transcription", isStored: settings.hasModulateKey
+            ),
+            APIKeyListEntry(
+                id: "assemblyai", title: "AssemblyAI", category: "Transcription",
+                isStored: settings.hasAssemblyAIKey
+            ),
+            APIKeyListEntry(
+                id: "gladia", title: "Gladia", category: "Transcription", isStored: settings.hasGladiaKey
+            )
+        ]
+    }
+
+    private var visibleEntries: [APIKeyListEntry] {
+        APIKeyListQuery.apply(
+            to: allEntries,
+            searchText: searchText,
+            status: statusFilter,
+            sortOrder: sortOrder
+        )
+    }
 
     var body: some View {
         Form {
-            Section {
-                SecureField("API Key", text: $deepgramKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasDeepgramKey && deepgramKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.deepgramAPIKey = ""
-                    }
+            if visibleEntries.isEmpty {
+                ContentUnavailableView(
+                    "No API Keys",
+                    systemImage: "key.slash",
+                    description: Text("Try another search or status filter.")
+                )
+            } else {
+                ForEach(visibleEntries) { entry in
+                    apiKeySection(for: entry)
                 }
-            } header: {
-                Label("Deepgram", systemImage: "waveform")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from deepgram.com")
-                    if settings.hasDeepgramKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $elevenLabsKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasElevenLabsKey && elevenLabsKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.elevenLabsAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("ElevenLabs", systemImage: "mic.and.signal.meter")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from elevenlabs.io")
-                    if settings.hasElevenLabsKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $openRouterKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasOpenRouterKey && openRouterKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.openRouterAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("OpenRouter", systemImage: "network")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from openrouter.ai")
-                    if settings.hasOpenRouterKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $openAIKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasOpenAIKey && openAIKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.openAIAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("OpenAI", systemImage: "brain.head.profile")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from platform.openai.com. Used by gpt-realtime-whisper streaming.")
-                    if settings.hasOpenAIKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $cartesiaKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasCartesiaKey && cartesiaKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.cartesiaAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("Cartesia", systemImage: "waveform.circle")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from cartesia.ai. Used by Ink streaming.")
-                    if settings.hasCartesiaKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $sonioxKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasSonioxKey && sonioxKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.sonioxAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("Soniox", systemImage: "waveform.badge.mic")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from soniox.com. Used by STT real-time streaming.")
-                    if settings.hasSonioxKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $modulateKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasModulateKey && modulateKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.modulateAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("Modulate", systemImage: "waveform.badge.magnifyingglass")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from modulate.ai. Used by Velma streaming.")
-                    if settings.hasModulateKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $assemblyAIKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasAssemblyAIKey && assemblyAIKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.assemblyAIAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("AssemblyAI", systemImage: "waveform.badge.plus")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from assemblyai.com. Used by Universal-Streaming.")
-                    if settings.hasAssemblyAIKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
-            }
-
-            Section {
-                SecureField("API Key", text: $gladiaKey)
-                    .textContentType(.password)
-                    .autocorrectionDisabled()
-
-                if settings.hasGladiaKey && gladiaKey.isEmpty {
-                    Button("Clear Stored Key", role: .destructive) {
-                        settings.gladiaAPIKey = ""
-                    }
-                }
-            } header: {
-                Label("Gladia", systemImage: "waveform.badge.exclamationmark")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Get your API key from gladia.io. Used by Solaria streaming.")
-                    if settings.hasGladiaKey {
-                        Text("✓ API key is stored")
-                            .foregroundStyle(.green)
-                    }
-                }
-                .font(.caption)
             }
         }
+        .environment(\.defaultMinListRowHeight, settings.visualDensity.minimumListRowHeight)
+        .listSectionSpacing(settings.visualDensity.listSectionSpacing)
         .navigationTitle("API Keys")
+        .searchable(text: $searchText, prompt: "Provider or use")
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    Picker("Status", selection: $statusFilter) {
+                        ForEach(APIKeyStatusFilter.allCases) { filter in
+                            Text(filter.displayName).tag(filter)
+                        }
+                    }
+                    Picker("Sort", selection: $sortOrder) {
+                        ForEach(APIKeySortOrder.allCases) { order in
+                            Text(order.displayName).tag(order)
+                        }
+                    }
+                } label: {
+                    Label("Filter and Sort", systemImage: statusFilter == .all
+                        ? "line.3.horizontal.decrease.circle"
+                        : "line.3.horizontal.decrease.circle.fill")
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 if isValidating {
                     ProgressView()
@@ -1488,6 +1389,97 @@ struct APIKeysView: View {
             Button("OK") {}
         } message: {
             Text(validationMessage ?? "Keys saved")
+        }
+    }
+
+    private func apiKeySection(for entry: APIKeyListEntry) -> some View {
+        let presentation = presentation(for: entry.id)
+        return Section {
+            SecureField("API Key", text: draftBinding(for: entry.id))
+                .textContentType(.password)
+                .autocorrectionDisabled()
+
+            if entry.isStored && draftBinding(for: entry.id).wrappedValue.isEmpty {
+                Button("Clear Stored Key", role: .destructive) {
+                    clearStoredKey(for: entry.id)
+                }
+            }
+        } header: {
+            HStack {
+                Label(presentation.title, systemImage: presentation.systemImage)
+                Spacer()
+                Text(entry.isStored ? "Stored" : "Missing")
+                    .font(.caption)
+                    .foregroundStyle(entry.isStored ? .green : .secondary)
+            }
+        } footer: {
+            Text(presentation.help)
+                .font(.caption)
+        }
+    }
+
+    private func presentation(for id: String) -> KeyPresentation {
+        switch id {
+        case "deepgram":
+            return KeyPresentation(title: "Deepgram", systemImage: "waveform", help: "Get your key from deepgram.com.")
+        case "elevenlabs":
+            return KeyPresentation(
+                title: "ElevenLabs", systemImage: "mic.and.signal.meter", help: "Get your key from elevenlabs.io."
+            )
+        case "openrouter":
+            return KeyPresentation(title: "OpenRouter", systemImage: "network", help: "Get your key from openrouter.ai.")
+        case "openai":
+            return KeyPresentation(
+                title: "OpenAI", systemImage: "brain.head.profile", help: "Get your key from platform.openai.com."
+            )
+        case "cartesia":
+            return KeyPresentation(
+                title: "Cartesia", systemImage: "waveform.circle", help: "Get your key from cartesia.ai."
+            )
+        case "soniox":
+            return KeyPresentation(
+                title: "Soniox", systemImage: "waveform.badge.mic", help: "Get your key from soniox.com."
+            )
+        case "modulate":
+            return KeyPresentation(
+                title: "Modulate", systemImage: "waveform.badge.magnifyingglass", help: "Get your key from modulate.ai."
+            )
+        case "assemblyai":
+            return KeyPresentation(
+                title: "AssemblyAI", systemImage: "waveform.badge.plus", help: "Get your key from assemblyai.com."
+            )
+        default:
+            return KeyPresentation(
+                title: "Gladia", systemImage: "waveform.badge.exclamationmark", help: "Get your key from gladia.io."
+            )
+        }
+    }
+
+    private func draftBinding(for id: String) -> Binding<String> {
+        switch id {
+        case "deepgram": return $deepgramKey
+        case "elevenlabs": return $elevenLabsKey
+        case "openrouter": return $openRouterKey
+        case "openai": return $openAIKey
+        case "cartesia": return $cartesiaKey
+        case "soniox": return $sonioxKey
+        case "modulate": return $modulateKey
+        case "assemblyai": return $assemblyAIKey
+        default: return $gladiaKey
+        }
+    }
+
+    private func clearStoredKey(for id: String) {
+        switch id {
+        case "deepgram": settings.deepgramAPIKey = ""
+        case "elevenlabs": settings.elevenLabsAPIKey = ""
+        case "openrouter": settings.openRouterAPIKey = ""
+        case "openai": settings.openAIAPIKey = ""
+        case "cartesia": settings.cartesiaAPIKey = ""
+        case "soniox": settings.sonioxAPIKey = ""
+        case "modulate": settings.modulateAPIKey = ""
+        case "assemblyai": settings.assemblyAIAPIKey = ""
+        default: settings.gladiaAPIKey = ""
         }
     }
 

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -1421,13 +1421,21 @@ struct APIKeysView: View {
     private func presentation(for id: String) -> KeyPresentation {
         switch id {
         case "deepgram":
-            return KeyPresentation(title: "Deepgram", systemImage: "waveform", help: "Get your key from deepgram.com.")
+            return KeyPresentation(
+                title: "Deepgram",
+                systemImage: "waveform",
+                help: "Get your key from deepgram.com."
+            )
         case "elevenlabs":
             return KeyPresentation(
                 title: "ElevenLabs", systemImage: "mic.and.signal.meter", help: "Get your key from elevenlabs.io."
             )
         case "openrouter":
-            return KeyPresentation(title: "OpenRouter", systemImage: "network", help: "Get your key from openrouter.ai.")
+            return KeyPresentation(
+                title: "OpenRouter",
+                systemImage: "network",
+                help: "Get your key from openrouter.ai."
+            )
         case "openai":
             return KeyPresentation(
                 title: "OpenAI", systemImage: "brain.head.profile", help: "Get your key from platform.openai.com."

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -3,6 +3,7 @@ import SpeakHotKeys
 
 @testable import SpeakApp
 
+// swiftlint:disable:next type_body_length
 final class AppSettingsDefaultsTests: XCTestCase {
 
     private var suiteName: String!

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SpeakHotKeys
 
 @testable import SpeakApp
 
@@ -95,6 +96,39 @@ final class AppSettingsDefaultsTests: XCTestCase {
     func testRecordingDefaults_selectedHotKeyIsFnKey() {
         let settings = AppSettings(defaults: defaults)
         XCTAssertEqual(settings.selectedHotKey, .fnKey)
+    }
+
+    @MainActor
+    func testStoredHotKey_unsupportedOrdinarySingleKeyFallsBackToFn() throws {
+        let unsupported = HotKey.custom(keyCode: 0, modifiers: [])
+        defaults.set(try JSONEncoder().encode(unsupported), forKey: "selectedHotKey")
+
+        let settings = AppSettings(defaults: defaults)
+
+        XCTAssertEqual(settings.selectedHotKey, .fnKey)
+    }
+
+    func testTextOutputAvailability_appStoreOnlyOffersClipboard() {
+        XCTAssertEqual(AppSettings.availableTextOutputMethods(for: .appStore), [.clipboardOnly])
+        XCTAssertEqual(
+            AppSettings.normalizedTextOutputMethod(.accessibilityOnly, for: .appStore),
+            .clipboardOnly
+        )
+        XCTAssertEqual(
+            AppSettings.normalizedTextOutputMethod(.smart, for: .appStore),
+            .clipboardOnly
+        )
+    }
+
+    func testTextOutputAvailability_directKeepsAccessibilityOptions() {
+        XCTAssertEqual(
+            AppSettings.availableTextOutputMethods(for: .direct),
+            AppSettings.TextOutputMethod.allCases
+        )
+        XCTAssertEqual(
+            AppSettings.normalizedTextOutputMethod(.accessibilityOnly, for: .direct),
+            .accessibilityOnly
+        )
     }
 
     // MARK: - Speed Mode Settings

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -43,6 +43,21 @@ final class AppSettingsDefaultsTests: XCTestCase {
     }
 
     @MainActor
+    func testCoreDefaults_visualDensityIsNormal() {
+        let settings = AppSettings(defaults: defaults)
+        XCTAssertEqual(settings.visualDensity, .normal)
+    }
+
+    @MainActor
+    func testVisualDensity_compactPersists() {
+        let settings = AppSettings(defaults: defaults)
+        settings.visualDensity = .compact
+
+        XCTAssertEqual(defaults.string(forKey: "visualDensity"), "compact")
+        XCTAssertEqual(AppSettings(defaults: defaults).visualDensity, .compact)
+    }
+
+    @MainActor
     func testCoreDefaults_accessibilityInsertionModeIsInsertAtCursor() {
         let settings = AppSettings(defaults: defaults)
         XCTAssertEqual(settings.accessibilityInsertionMode, .insertAtCursor)

--- a/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
+++ b/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
@@ -44,12 +44,21 @@ final class AppStoreInfoPlistTests: XCTestCase {
         ]
         var directWithoutSparkle = directPlist!
         sparkleKeys.forEach { directWithoutSparkle.removeValue(forKey: $0) }
+        directWithoutSparkle["CFBundleDisplayName"] = "Just Speak to It (App Store)"
+        directWithoutSparkle["CFBundleName"] = "Just Speak to It App Store"
 
         XCTAssertEqual(
             appStorePlist as NSDictionary,
             directWithoutSparkle as NSDictionary,
-            "Distribution plists should differ only by the direct build's Sparkle metadata"
+            "Distribution plists should differ only by Sparkle metadata and the channel-specific app name"
         )
+    }
+
+    func testDistributionNames_allowSideBySideInstallation() {
+        XCTAssertEqual(directPlist["CFBundleDisplayName"] as? String, "Just Speak to It")
+        XCTAssertEqual(appStorePlist["CFBundleDisplayName"] as? String, "Just Speak to It (App Store)")
+        XCTAssertEqual(directPlist["CFBundleName"] as? String, "Just Speak to It")
+        XCTAssertEqual(appStorePlist["CFBundleName"] as? String, "Just Speak to It App Store")
     }
 
     private static func loadPlist(at path: String) throws -> [String: Any] {

--- a/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
+++ b/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
@@ -46,12 +46,18 @@ final class AppStoreInfoPlistTests: XCTestCase {
         sparkleKeys.forEach { directWithoutSparkle.removeValue(forKey: $0) }
         directWithoutSparkle["CFBundleDisplayName"] = "Just Speak to It (App Store)"
         directWithoutSparkle["CFBundleName"] = "Just Speak to It App Store"
+        directWithoutSparkle["SpeakDistributionChannel"] = "appStore"
 
         XCTAssertEqual(
             appStorePlist as NSDictionary,
             directWithoutSparkle as NSDictionary,
-            "Distribution plists should differ only by Sparkle metadata and the channel-specific app name"
+            "Distribution plists should differ only by Sparkle metadata and channel-specific identity"
         )
+    }
+
+    func testDistributionPlists_declareTheirRuntimeChannel() {
+        XCTAssertEqual(directPlist["SpeakDistributionChannel"] as? String, "direct")
+        XCTAssertEqual(appStorePlist["SpeakDistributionChannel"] as? String, "appStore")
     }
 
     func testDistributionNames_allowSideBySideInstallation() {

--- a/Tests/SpeakAppTests/ElevenLabsClientValidationTests.swift
+++ b/Tests/SpeakAppTests/ElevenLabsClientValidationTests.swift
@@ -50,7 +50,11 @@ final class ElevenLabsClientValidationTests: XCTestCase {
     private func makeSecureStorage() -> SecureAppStorage {
         let settings = AppSettings()
         let permissions = PermissionsManager()
-        return SecureAppStorage(permissionsManager: permissions, appSettings: settings)
+        return SecureAppStorage(
+            permissionsManager: permissions,
+            appSettings: settings,
+            keychainService: "com.justspeaktoit.tests.elevenlabs.validation.\(UUID().uuidString)"
+        )
     }
 
     // Plan requirement: TTS-only restricted key → `/user` 200, `/speech-to-text` 403 → `.invalid`

--- a/Tests/SpeakAppTests/ElevenLabsKeyRemovalTests.swift
+++ b/Tests/SpeakAppTests/ElevenLabsKeyRemovalTests.swift
@@ -13,7 +13,11 @@ final class ElevenLabsKeyRemovalTests: XCTestCase {
         let settings = AppSettings()
         let permissions = PermissionsManager()
         let audioDevices = AudioInputDeviceManager(appSettings: settings)
-        let secureStorage = SecureAppStorage(permissionsManager: permissions, appSettings: settings)
+        let secureStorage = SecureAppStorage(
+            permissionsManager: permissions,
+            appSettings: settings,
+            keychainService: "com.justspeaktoit.tests.elevenlabs.removal.\(UUID().uuidString)"
+        )
 
         let transcriber = SwitchingLiveTranscriber(
             appSettings: settings,
@@ -31,7 +35,7 @@ final class ElevenLabsKeyRemovalTests: XCTestCase {
     // to the underlying SwitchingLiveTranscriber stale flag.
     @MainActor
     func testInvalidateLiveControllerCache_isExposedOnTranscriptionManager() {
-        let env = WireUp.bootstrap()
+        let env = WireUp.bootstrap(options: makeWireUpTestOptions())
         // Should not throw or crash — the method delegates to markControllersStale()
         env.transcription.invalidateLiveControllerCache()
         // No observable assertion needed here: the call itself validates the API contract.

--- a/Tests/SpeakAppTests/HotKeyMappingTests.swift
+++ b/Tests/SpeakAppTests/HotKeyMappingTests.swift
@@ -15,4 +15,21 @@ final class HotKeyMappingTests: XCTestCase {
         XCTAssertEqual(KeyCodeMapping.string(for: 64), "F17")
         XCTAssertEqual(KeyCodeMapping.string(for: 114), "Insert")
     }
+
+    func testCustomHotKeyValidation_rejectsOrdinaryUnmodifiedKey() {
+        XCTAssertFalse(KeyCodeMapping.isSupportedCustomHotKey(keyCode: 0, hasModifiers: false))
+    }
+
+    func testCustomHotKeyValidation_acceptsOrdinaryKeyWithModifier() {
+        XCTAssertTrue(KeyCodeMapping.isSupportedCustomHotKey(keyCode: 0, hasModifiers: true))
+    }
+
+    func testCustomHotKeyValidation_acceptsDedicatedExtendedKeyWithoutModifier() {
+        XCTAssertTrue(KeyCodeMapping.isSupportedCustomHotKey(keyCode: 105, hasModifiers: false))
+    }
+
+    func testHotKeySupport_rejectsOrdinaryUnmodifiedKey() {
+        let hotKey = HotKey.custom(keyCode: 0, modifiers: [])
+        XCTAssertFalse(hotKey.isSupportedForGlobalMonitoring)
+    }
 }

--- a/Tests/SpeakAppTests/OpenRouterAPIClientTests.swift
+++ b/Tests/SpeakAppTests/OpenRouterAPIClientTests.swift
@@ -164,7 +164,11 @@ final class OpenRouterAPIClientTests: XCTestCase {
     let defaults = UserDefaults(suiteName: suiteName) ?? .standard
     let settings = AppSettings(defaults: defaults)
     let permissions = PermissionsManager()
-    return SecureAppStorage(permissionsManager: permissions, appSettings: settings)
+    return SecureAppStorage(
+      permissionsManager: permissions,
+      appSettings: settings,
+      keychainService: "com.justspeaktoit.tests.openrouter.\(UUID().uuidString)"
+    )
   }
 
   private func makeAudioFile(extension fileExtension: String, data: Data) throws -> URL {

--- a/Tests/SpeakAppTests/PermissionsManagerTests.swift
+++ b/Tests/SpeakAppTests/PermissionsManagerTests.swift
@@ -1,0 +1,70 @@
+import AppKit
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+final class PermissionsManagerTests: XCTestCase {
+    func testInputMonitoringStatus_listenGrantIsGranted() {
+        XCTAssertEqual(
+            PermissionsManager.inputMonitoringStatus(
+                hasListenAccess: true,
+                hasAccessibilityAccess: false
+            ),
+            .granted
+        )
+    }
+
+    func testInputMonitoringStatus_accessibilityGrantIsEffectiveAccess() {
+        XCTAssertEqual(
+            PermissionsManager.inputMonitoringStatus(
+                hasListenAccess: false,
+                hasAccessibilityAccess: true
+            ),
+            .granted
+        )
+    }
+
+    func testInputMonitoringStatus_noGrantIsDenied() {
+        XCTAssertEqual(
+            PermissionsManager.inputMonitoringStatus(
+                hasListenAccess: false,
+                hasAccessibilityAccess: false
+            ),
+            .denied
+        )
+    }
+
+    func testAccessibilityPromptPolicy_directPromptsAndAppStoreDoesNot() {
+        XCTAssertTrue(PermissionsManager.shouldPromptForAccessibility(channel: .direct))
+        XCTAssertFalse(PermissionsManager.shouldPromptForAccessibility(channel: .appStore))
+    }
+
+    func testAvailablePermissions_appStoreOmitsAccessibility() {
+        XCTAssertFalse(PermissionType.availablePermissions(for: .appStore).contains(.accessibility))
+        XCTAssertTrue(PermissionType.availablePermissions(for: .appStore).contains(.inputMonitoring))
+        XCTAssertTrue(PermissionType.availablePermissions(for: .direct).contains(.accessibility))
+    }
+
+    @MainActor
+    func testDidBecomeActive_refreshesPermissionStatuses() async {
+        let notificationCenter = NotificationCenter()
+        var accessibilityGranted = false
+        let manager = PermissionsManager(
+            statusProvider: { permission in
+                if permission == .accessibility, accessibilityGranted {
+                    return .granted
+                }
+                return .denied
+            },
+            notificationCenter: notificationCenter
+        )
+        XCTAssertEqual(manager.status(for: .accessibility), .denied)
+
+        accessibilityGranted = true
+        notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+        await Task.yield()
+
+        XCTAssertEqual(manager.status(for: .accessibility), .granted)
+    }
+}

--- a/Tests/SpeakAppTests/SpeakAppTests.swift
+++ b/Tests/SpeakAppTests/SpeakAppTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class SpeakAppTests: XCTestCase {
     @MainActor
     func testMainView_isComposableWithEnvironment() {
-        let environment = WireUp.bootstrap()
+        let environment = WireUp.bootstrap(options: makeWireUpTestOptions())
         let view = MainView().environmentObject(environment)
         let hostingView = NSHostingView(rootView: view)
         XCTAssertNotNil(hostingView)

--- a/Tests/SpeakAppTests/WireUpBootstrapTests.swift
+++ b/Tests/SpeakAppTests/WireUpBootstrapTests.swift
@@ -16,7 +16,7 @@ final class WireUpBootstrapTests: XCTestCase {
     @MainActor
     func testBootstrap_completesWithoutCrashing() {
         // This is the P0 test. If this fails, the app cannot launch.
-        let environment = WireUp.bootstrap()
+        let environment = WireUp.bootstrap(options: makeWireUpTestOptions())
         XCTAssertNotNil(environment, "WireUp.bootstrap() must return a valid AppEnvironment")
     }
 
@@ -24,7 +24,7 @@ final class WireUpBootstrapTests: XCTestCase {
 
     @MainActor
     func testBootstrap_allServicesAreInitialised() {
-        let env = WireUp.bootstrap()
+        let env = WireUp.bootstrap(options: makeWireUpTestOptions())
 
         // Every service in the dependency graph must be non-nil and accessible.
         // We access each property to ensure it doesn't trigger a lazy-init crash.
@@ -57,7 +57,7 @@ final class WireUpBootstrapTests: XCTestCase {
         // Verify that the environment wires a shared AppSettings instance —
         // a mutation on env.settings should be observable by any service that
         // holds the same reference. We toggle a boolean as a proxy.
-        let env = WireUp.bootstrap()
+        let env = WireUp.bootstrap(options: makeWireUpTestOptions())
         let before = env.settings.postProcessingEnabled
         env.settings.postProcessingEnabled.toggle()
         XCTAssertNotEqual(env.settings.postProcessingEnabled, before,
@@ -68,7 +68,7 @@ final class WireUpBootstrapTests: XCTestCase {
     @MainActor
     func testBootstrap_permissionsManagerAlias() {
         // AppEnvironment has a `permissionsManager` alias for `permissions`
-        let env = WireUp.bootstrap()
+        let env = WireUp.bootstrap(options: makeWireUpTestOptions())
         XCTAssertTrue(env.permissionsManager === env.permissions,
                       "permissionsManager should be an alias for permissions")
     }
@@ -79,8 +79,8 @@ final class WireUpBootstrapTests: XCTestCase {
     func testBootstrap_canBeCalledMultipleTimes() {
         // EnvironmentHolder guards against double-init, but bootstrap itself
         // should be safe to call multiple times (e.g., during testing)
-        let env1 = WireUp.bootstrap()
-        let env2 = WireUp.bootstrap()
+        let env1 = WireUp.bootstrap(options: makeWireUpTestOptions())
+        let env2 = WireUp.bootstrap(options: makeWireUpTestOptions())
         XCTAssertNotNil(env1)
         XCTAssertNotNil(env2)
         // They should be different instances (no singleton)
@@ -94,17 +94,17 @@ final class WireUpBootstrapTests: XCTestCase {
         let holder = EnvironmentHolder()
         XCTAssertNil(holder.environment, "Environment should not be created until bootstrap() is called")
 
-        holder.bootstrap()
+        holder.bootstrap(options: makeWireUpTestOptions())
         XCTAssertNotNil(holder.environment, "Environment should be created after bootstrap()")
     }
 
     @MainActor
     func testEnvironmentHolder_bootstrapIsIdempotent() {
         let holder = EnvironmentHolder()
-        holder.bootstrap()
+        holder.bootstrap(options: makeWireUpTestOptions())
         let first = holder.environment
 
-        holder.bootstrap() // second call should be a no-op
+        holder.bootstrap(options: makeWireUpTestOptions()) // second call should be a no-op
         let second = holder.environment
 
         XCTAssertTrue(first === second, "Second bootstrap() call should not create a new environment")

--- a/Tests/SpeakAppTests/WireUpDITests.swift
+++ b/Tests/SpeakAppTests/WireUpDITests.swift
@@ -10,9 +10,7 @@ final class WireUpDITests: XCTestCase {
         let customSettings = AppSettings()
         customSettings.postProcessingEnabled = false
 
-        let options = WireUp.BootstrapOptions(
-            settingsOverride: customSettings
-        )
+        let options = makeWireUpTestOptions(settingsOverride: customSettings)
         let env = WireUp.bootstrap(options: options)
 
         XCTAssertFalse(
@@ -24,16 +22,14 @@ final class WireUpDITests: XCTestCase {
     @MainActor
     func testBootstrap_defaultOptionsMatchesProduction() {
         // Ensure default bootstrap still works (no arguments)
-        let env = WireUp.bootstrap()
+        let env = WireUp.bootstrap(options: makeWireUpTestOptions())
         XCTAssertNotNil(env.main)
     }
 
     @MainActor
     func testBootstrap_acceptsCustomPermissions() {
         let customPermissions = PermissionsManager()
-        let options = WireUp.BootstrapOptions(
-            permissionsOverride: customPermissions
-        )
+        let options = makeWireUpTestOptions(permissionsOverride: customPermissions)
         let env = WireUp.bootstrap(options: options)
 
         XCTAssertTrue(
@@ -45,9 +41,7 @@ final class WireUpDITests: XCTestCase {
     @MainActor
     func testBootstrap_injectedSettingsIsSharedAcrossServices() {
         let customSettings = AppSettings()
-        let options = WireUp.BootstrapOptions(
-            settingsOverride: customSettings
-        )
+        let options = makeWireUpTestOptions(settingsOverride: customSettings)
         let env = WireUp.bootstrap(options: options)
 
         XCTAssertTrue(

--- a/Tests/SpeakAppTests/WireUpTestSupport.swift
+++ b/Tests/SpeakAppTests/WireUpTestSupport.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@testable import SpeakApp
+
+@MainActor
+func makeWireUpTestOptions(
+    settingsOverride: AppSettings? = nil,
+    permissionsOverride: PermissionsManager? = nil
+) -> WireUp.BootstrapOptions {
+    let testSettings: AppSettings
+    if let settingsOverride {
+        testSettings = settingsOverride
+    } else {
+        let suite = "WireUpTests-\(UUID().uuidString)"
+        testSettings = AppSettings(defaults: UserDefaults(suiteName: suite) ?? .standard)
+    }
+
+    return WireUp.BootstrapOptions(
+        settingsOverride: testSettings,
+        permissionsOverride: permissionsOverride,
+        keychainServiceOverride: "com.justspeaktoit.tests.wireup.\(UUID().uuidString)"
+    )
+}

--- a/Tests/SpeakCoreTests/APIKeyListQueryTests.swift
+++ b/Tests/SpeakCoreTests/APIKeyListQueryTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import SpeakCore
+
+final class APIKeyListQueryTests: XCTestCase {
+    private let entries = [
+        APIKeyListEntry(id: "deepgram", title: "Deepgram", category: "Transcription", isStored: true),
+        APIKeyListEntry(id: "openai", title: "OpenAI", category: "Voice Output", isStored: false),
+        APIKeyListEntry(id: "openrouter", title: "OpenRouter", category: "Post-processing", isStored: true)
+    ]
+
+    func testApply_searchesNameAndCategoryCaseInsensitively() {
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "VOICE", status: .all, sortOrder: .name).map(\.id),
+            ["openai"]
+        )
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "router", status: .all, sortOrder: .name).map(\.id),
+            ["openrouter"]
+        )
+    }
+
+    func testApply_filtersByStoredStatus() {
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "", status: .stored, sortOrder: .name).map(\.id),
+            ["deepgram", "openrouter"]
+        )
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "", status: .missing, sortOrder: .name).map(\.id),
+            ["openai"]
+        )
+    }
+
+    func testApply_sortsStoredFirstThenByName() {
+        XCTAssertEqual(
+            APIKeyListQuery.apply(to: entries, searchText: "", status: .all, sortOrder: .status).map(\.id),
+            ["deepgram", "openrouter", "openai"]
+        )
+    }
+
+    func testNormalDensity_preservesExistingMetrics() {
+        XCTAssertEqual(AppVisualDensity.normal.pagePadding, 24)
+        XCTAssertEqual(AppVisualDensity.normal.cardPadding, 24)
+        XCTAssertLessThan(AppVisualDensity.compact.pagePadding, AppVisualDensity.normal.pagePadding)
+        XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 38)
+    }
+}

--- a/Tests/SpeakCoreTests/DistributionChannelTests.swift
+++ b/Tests/SpeakCoreTests/DistributionChannelTests.swift
@@ -72,8 +72,8 @@ final class DistributionChannelTests: XCTestCase {
         // Arrange
         let channel = DistributionChannel.current
 
-        // Act & Assert — `current` is derived from compile-time flags, so it must be
-        // one of the two known channels and its sandbox state must agree.
+        // Act & Assert — package tests use the direct fallback unless an App Store
+        // compilation condition is explicitly supplied.
         #if os(iOS)
         XCTAssertEqual(channel, .appStore, "iOS always ships through the App Store")
         #elseif APP_STORE

--- a/Tests/SpeakCoreTests/DistributionChannelTests.swift
+++ b/Tests/SpeakCoreTests/DistributionChannelTests.swift
@@ -15,7 +15,11 @@ final class DistributionChannelTests: XCTestCase {
 
         // Act & Assert
         XCTAssertTrue(channel.supportsSelfUpdate)
-        XCTAssertTrue(channel.supportsLocalModelRuntime)
+        XCTAssertTrue(channel.supportsDownloadedCoreMLModels)
+        XCTAssertTrue(channel.supportsExternalLocalModelRuntime)
+        XCTAssertFalse(channel.supportsEncryptedCloudKitKeySync)
+        XCTAssertFalse(channel.supportsICloudSync)
+        XCTAssertEqual(channel.apiKeyStorageMode, .localKeychainOnly)
         XCTAssertTrue(channel.supportsAutomaticAccessibilityPrompt)
         XCTAssertTrue(channel.allowsCrossChannelMessaging)
         XCTAssertFalse(channel.isSandboxed)
@@ -28,8 +32,13 @@ final class DistributionChannelTests: XCTestCase {
         // Act & Assert
         XCTAssertFalse(channel.supportsSelfUpdate,
             "App Store builds update through the store, not Sparkle")
-        XCTAssertFalse(channel.supportsLocalModelRuntime,
-            "Downloaded local-model runtimes cannot run in the App Store sandbox")
+        XCTAssertTrue(channel.supportsDownloadedCoreMLModels,
+            "WhisperKit/Core ML model data can run through the bundled in-process runtime")
+        XCTAssertFalse(channel.supportsExternalLocalModelRuntime,
+            "Executable local-model runtimes cannot run in the App Store sandbox")
+        XCTAssertTrue(channel.supportsEncryptedCloudKitKeySync)
+        XCTAssertTrue(channel.supportsICloudSync)
+        XCTAssertEqual(channel.apiKeyStorageMode, .encryptedCloudKit)
         XCTAssertFalse(channel.supportsAutomaticAccessibilityPrompt,
             "Sandboxed apps cannot auto-prompt for Accessibility/Input Monitoring")
         XCTAssertFalse(channel.allowsCrossChannelMessaging,
@@ -41,11 +50,14 @@ final class DistributionChannelTests: XCTestCase {
         // Arrange / Act / Assert
         for channel in DistributionChannel.allCases {
             XCTAssertEqual(channel.supports(.selfUpdate), channel.supportsSelfUpdate)
-            XCTAssertEqual(channel.supports(.localModelRuntime), channel.supportsLocalModelRuntime)
+            XCTAssertEqual(channel.supports(.downloadedCoreMLModels), channel.supportsDownloadedCoreMLModels)
+            XCTAssertEqual(channel.supports(.externalLocalModelRuntime), channel.supportsExternalLocalModelRuntime)
             XCTAssertEqual(channel.supports(.automaticAccessibilityPrompt),
                            channel.supportsAutomaticAccessibilityPrompt)
             XCTAssertEqual(channel.supports(.crossChannelMessaging),
                            channel.allowsCrossChannelMessaging)
+            XCTAssertEqual(channel.supports(.encryptedCloudKitKeySync),
+                           channel.supportsEncryptedCloudKitKeySync)
         }
     }
 

--- a/Tests/SpeakCoreTests/DistributionChannelTests.swift
+++ b/Tests/SpeakCoreTests/DistributionChannelTests.swift
@@ -21,6 +21,7 @@ final class DistributionChannelTests: XCTestCase {
         XCTAssertFalse(channel.supportsICloudSync)
         XCTAssertEqual(channel.apiKeyStorageMode, .localKeychainOnly)
         XCTAssertTrue(channel.supportsAutomaticAccessibilityPrompt)
+        XCTAssertTrue(channel.supportsAccessibilityTextInsertion)
         XCTAssertTrue(channel.allowsCrossChannelMessaging)
         XCTAssertFalse(channel.isSandboxed)
     }
@@ -41,6 +42,8 @@ final class DistributionChannelTests: XCTestCase {
         XCTAssertEqual(channel.apiKeyStorageMode, .encryptedCloudKit)
         XCTAssertFalse(channel.supportsAutomaticAccessibilityPrompt,
             "Sandboxed apps cannot auto-prompt for Accessibility/Input Monitoring")
+        XCTAssertFalse(channel.supportsAccessibilityTextInsertion,
+            "The App Store sandbox blocks AXUIElement access to other apps")
         XCTAssertFalse(channel.allowsCrossChannelMessaging,
             "App Store builds must not advertise other distribution channels")
         XCTAssertTrue(channel.isSandboxed)
@@ -54,6 +57,8 @@ final class DistributionChannelTests: XCTestCase {
             XCTAssertEqual(channel.supports(.externalLocalModelRuntime), channel.supportsExternalLocalModelRuntime)
             XCTAssertEqual(channel.supports(.automaticAccessibilityPrompt),
                            channel.supportsAutomaticAccessibilityPrompt)
+            XCTAssertEqual(channel.supports(.accessibilityTextInsertion),
+                           channel.supportsAccessibilityTextInsertion)
             XCTAssertEqual(channel.supports(.crossChannelMessaging),
                            channel.allowsCrossChannelMessaging)
             XCTAssertEqual(channel.supports(.encryptedCloudKitKeySync),

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -126,6 +126,26 @@ final class ModelCatalogTests: XCTestCase {
         XCTAssertEqual(ModelRouting.family(for: "local/whisperkit/tiny"), .downloadedLocal(engine: "whisperkit"))
     }
 
+    func testLiveTranscriptionPlacement_keepsAppleModelsOnlyOnDevice() {
+        let onDeviceIDs = Set(ModelCatalog.onDeviceLiveTranscription.map(\.id))
+        let remoteIDs = Set(ModelCatalog.remoteLiveTranscription.map(\.id))
+
+        XCTAssertTrue(onDeviceIDs.contains("apple/local/SFSpeechRecognizer"))
+        XCTAssertTrue(onDeviceIDs.contains("apple/local/Dictation"))
+        XCTAssertTrue(onDeviceIDs.allSatisfy(ModelCatalog.isOnDeviceLiveTranscriptionModel))
+        XCTAssertTrue(remoteIDs.allSatisfy { !ModelCatalog.isOnDeviceLiveTranscriptionModel($0) })
+        XCTAssertTrue(onDeviceIDs.isDisjoint(with: remoteIDs))
+        XCTAssertEqual(onDeviceIDs.union(remoteIDs), Set(ModelCatalog.liveTranscription.map(\.id)))
+    }
+
+    func testLiveTranscriptionPlacement_defaultsMatchTheirLocation() throws {
+        XCTAssertTrue(ModelCatalog.isOnDeviceLiveTranscriptionModel(
+            ModelCatalog.defaultOnDeviceLiveTranscriptionModel
+        ))
+        let remoteDefault = try XCTUnwrap(ModelCatalog.defaultRemoteLiveTranscriptionModel)
+        XCTAssertFalse(ModelCatalog.isOnDeviceLiveTranscriptionModel(remoteDefault))
+    }
+
     func testModelRouting_treatsLocalCleanupAsPostProcessing() {
         XCTAssertEqual(
             ModelRouting.family(for: "local/post-processing/rules"),

--- a/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
+++ b/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
@@ -14,7 +14,7 @@ final class ActionButtonSettingsUITests: XCTestCase {
         app.buttons["Settings"].tap()
 
         let hardwareTriggerLink = app.buttons["hardwareTriggerSettingsLink"]
-        XCTAssertTrue(hardwareTriggerLink.waitForExistence(timeout: 5))
+        XCTAssertTrue(scrollUpUntilExists(hardwareTriggerLink))
         hardwareTriggerLink.tap()
 
         XCTAssertTrue(app.navigationBars["Action Button & Shortcuts"].waitForExistence(timeout: 5))


### PR DESCRIPTION
## Motivation

Fix the reported model-placement, macOS shortcut/permission, API-key usability, distribution sync, accessibility-output, and dual-install problems across direct macOS, Mac App Store, and iOS.

## User-visible changes

- Treat Apple Speech and Dictation as local on-device models on macOS and iOS; remote lists now contain only remote providers.
- Keep downloadable in-process WhisperKit/Core ML models in both builds, while limiting external executable runtimes to direct macOS.
- Deliver Carbon shortcuts through the application event target so they work while other apps are focused; reject ordinary unmodified single-key shortcuts and repair invalid saved bindings.
- Refresh permission state when the app becomes active and when permission views appear; report Input Monitoring from effective listen/Accessibility access.
- Add API-key search, stored/missing filters, sorting, and app-wide Normal/Compact density on macOS and iOS.
- Direct macOS now exposes local Keychain storage only. App Store/iOS expose encrypted CloudKit key sync only.
- Direct macOS keeps Accessibility insertion. Sandboxed Mac App Store builds use clipboard output because the sandbox cannot mutate other apps through AXUIElement.
- Name the Mac App Store executable and app bundle `JustSpeakToItAppStore` / `Just Speak to It (App Store)` so it can run beside the Sparkle build without changing either registered bundle identifier.

## What changed direction

A real side-by-side Release run showed that an app-target `APP_STORE` condition does not propagate into local Swift-package targets. Distribution is now an explicit Info.plist bundle contract, so shared `SpeakCore` resolves the correct channel in packaged builds.

## Verification

- `swift test` — 613 tests, 11 skipped, 0 failures
- strict SwiftLint with repository baseline — 0 violations
- SwiftPM direct and `APP_STORE` builds passed
- `SpeakiOSLib` build passed
- generated iOS app built, installed, launched, and was visually checked in Simulator
- generated direct and App Store macOS Release apps built and launched simultaneously
- verified direct: Sparkle present, local Keychain UI, Accessibility insertion available
- verified App Store: Sparkle absent, encrypted CloudKit UI, clipboard-only output, Accessibility insertion omitted
- verified Local/Remote model placement and Normal/Compact UI on both platforms

## Review confidence

High. Core policy and query behavior are unit-tested, all package tests and strict lint pass, and both packaged Mac channels plus the iOS app were exercised as running applications.