### PR TITLE
fix(mac): test before installing signing keychain

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -37,6 +37,23 @@ jobs:
         run: |
           brew install tuist
 
+      - name: Generate Xcode Project
+        run: |
+          tuist generate --no-open
+
+      - name: Resolve Swift Package Dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -workspace "$WORKSPACE" \
+            -scheme "$SCHEME"
+
+      - name: Run Tests (Release Config)
+        run: |
+          echo "Running tests in release configuration as release gate..."
+          swift test -c release
+
+      # Release tests exercise real Keychain migration. Run them before replacing
+      # the runner's Keychain search list with the temporary signing Keychain.
       - name: Import Code Signing Certificate
         env:
           APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
@@ -70,21 +87,6 @@ jobs:
           mkdir -p ~/.appstoreconnect/private_keys
           echo "$APP_STORE_CONNECT_API_KEY" | base64 --decode > "$KEY_PATH"
           chmod 600 "$KEY_PATH"
-
-      - name: Generate Xcode Project
-        run: |
-          tuist generate --no-open
-
-      - name: Resolve Swift Package Dependencies
-        run: |
-          xcodebuild -resolvePackageDependencies \
-            -workspace "$WORKSPACE" \
-            -scheme "$SCHEME"
-
-      - name: Run Tests (Release Config)
-        run: |
-          echo "Running tests in release configuration as release gate..."
-          swift test -c release
 
       - name: Verify Entitlements for Developer ID
         run: |

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -39,6 +39,18 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertFalse(workflow.contains("Entitlements.application-identifier"))
     }
 
+    func testDirectMacRelease_runsKeychainTestsBeforeInstallingSigningKeychain() throws {
+        let workflow = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-mac.yml"),
+            encoding: .utf8
+        )
+
+        let testStep = try XCTUnwrap(workflow.range(of: "- name: Run Tests (Release Config)"))
+        let signingStep = try XCTUnwrap(workflow.range(of: "- name: Import Code Signing Certificate"))
+
+        XCTAssertLessThan(testStep.lowerBound, signingStep.lowerBound)
+    }
+
     func testPlatformAppTargets_doNotCompileTheOtherPlatformsUI() throws {
         let manifest = try String(
             contentsOf: repositoryRoot.appendingPathComponent("Project.swift"),


### PR DESCRIPTION
## Motivation
The mac-v2.24.1 and mac-v2.24.2 release runs failed the real-Keychain migration test only after the release job replaced the runner Keychain search list with its temporary signing Keychain. The same Debug and Release suites passed in PR CI.

## Changes
- Run the Release test gate before importing signing credentials.
- Keep certificate/API-key installation before archive/export.
- Add a regression test for workflow step ordering.

## How to test
- `swift test --filter DistributionBuildIdentityTests`
- Parse `.github/workflows/release-mac.yml` with Ruby YAML.
- Merge and verify the next `mac-v*` release clears tests, signs, notarizes, and publishes.

## Review confidence
High. This is a narrow workflow-order change with a regression test; archive signing remains unchanged.