### PR TITLE
ci(mac): retry notarization ticket stapling

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -275,7 +275,7 @@ jobs:
           fi
           
           # Staple the notarization ticket
-          xcrun stapler staple "$APP_PATH"
+          bash scripts/retry-staple.sh "$APP_PATH"
 
       - name: Verify Entitlements (Post-Sign)
         run: |
@@ -307,23 +307,7 @@ jobs:
             --team-id "${{ secrets.APPLE_TEAM_ID }}" \
             --wait
           
-          # Accepted notarization tickets can take a short time to propagate to
-          # CloudKit. Retry stapling before treating the release as failed.
-          for ATTEMPT in {1..5}; do
-            if xcrun stapler staple "$DMG_PATH"; then
-              break
-            fi
-
-            if [ "$ATTEMPT" -eq 5 ]; then
-              echo "Failed to staple DMG after $ATTEMPT attempts"
-              exit 1
-            fi
-
-            echo "Notarization ticket not available yet; retrying in 15s..."
-            sleep 15
-          done
-
-          xcrun stapler validate "$DMG_PATH"
+          bash scripts/retry-staple.sh "$DMG_PATH"
           
           echo "DMG_PATH=$DMG_PATH" >> $GITHUB_ENV
 

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -51,16 +51,20 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertLessThan(testStep.lowerBound, signingStep.lowerBound)
     }
 
-    func testDirectMacRelease_retriesDelayedDMGNotarizationTickets() throws {
+    func testDirectMacRelease_retriesStaplingAcceptedNotarizationTickets() throws {
         let workflow = try String(
             contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-mac.yml"),
             encoding: .utf8
         )
+        let retryScript = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("scripts/retry-staple.sh"),
+            encoding: .utf8
+        )
 
-        XCTAssertTrue(workflow.contains("for ATTEMPT in {1..5}"))
-        XCTAssertTrue(workflow.contains("xcrun stapler staple \"$DMG_PATH\""))
-        XCTAssertTrue(workflow.contains("xcrun stapler validate \"$DMG_PATH\""))
-        XCTAssertTrue(workflow.contains("Notarization ticket not available yet; retrying in 15s"))
+        XCTAssertEqual(workflow.components(separatedBy: "bash scripts/retry-staple.sh").count - 1, 2)
+        XCTAssertTrue(retryScript.contains("stapler staple"))
+        XCTAssertTrue(retryScript.contains("stapler validate"))
+        XCTAssertTrue(retryScript.contains("STAPLE_MAX_ATTEMPTS:-6"))
     }
 
     func testPlatformAppTargets_doNotCompileTheOtherPlatformsUI() throws {

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -61,10 +61,14 @@ final class DistributionBuildIdentityTests: XCTestCase {
             encoding: .utf8
         )
 
-        XCTAssertEqual(workflow.components(separatedBy: "bash scripts/retry-staple.sh").count - 1, 2)
+        XCTAssertTrue(workflow.contains("bash scripts/retry-staple.sh \"$APP_PATH\""))
+        XCTAssertTrue(workflow.contains("bash scripts/retry-staple.sh \"$DMG_PATH\""))
         XCTAssertTrue(retryScript.contains("stapler staple"))
         XCTAssertTrue(retryScript.contains("stapler validate"))
         XCTAssertTrue(retryScript.contains("STAPLE_MAX_ATTEMPTS:-6"))
+        XCTAssertTrue(retryScript.contains("[[ ! -e \"$ARTIFACT_PATH\" ]]"))
+        XCTAssertTrue(retryScript.contains("STAPLE_MAX_ATTEMPTS must be a positive integer"))
+        XCTAssertTrue(retryScript.contains("RETRY_DELAY > 300"))
     }
 
     func testPlatformAppTargets_doNotCompileTheOtherPlatformsUI() throws {

--- a/scripts/retry-staple.sh
+++ b/scripts/retry-staple.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_PATH="${1:?Usage: retry-staple.sh <artifact-path>}"
+MAX_ATTEMPTS="${STAPLE_MAX_ATTEMPTS:-6}"
+RETRY_DELAY="${STAPLE_RETRY_DELAY_SECONDS:-10}"
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    if xcrun stapler staple "$ARTIFACT_PATH"; then
+        xcrun stapler validate "$ARTIFACT_PATH"
+        exit 0
+    fi
+
+    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+        echo "Stapling failed after $MAX_ATTEMPTS attempts" >&2
+        exit 1
+    fi
+
+    echo "Notarization ticket is not available yet; retrying in ${RETRY_DELAY}s (${attempt}/${MAX_ATTEMPTS})..."
+    sleep "$RETRY_DELAY"
+done

--- a/scripts/retry-staple.sh
+++ b/scripts/retry-staple.sh
@@ -5,6 +5,21 @@ ARTIFACT_PATH="${1:?Usage: retry-staple.sh <artifact-path>}"
 MAX_ATTEMPTS="${STAPLE_MAX_ATTEMPTS:-6}"
 RETRY_DELAY="${STAPLE_RETRY_DELAY_SECONDS:-10}"
 
+if [[ ! -e "$ARTIFACT_PATH" ]]; then
+    echo "Artifact does not exist: $ARTIFACT_PATH" >&2
+    exit 2
+fi
+
+if ! [[ "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "STAPLE_MAX_ATTEMPTS must be a positive integer" >&2
+    exit 2
+fi
+
+if ! [[ "$RETRY_DELAY" =~ ^[0-9]+$ ]] || (( RETRY_DELAY > 300 )); then
+    echo "STAPLE_RETRY_DELAY_SECONDS must be an integer between 0 and 300" >&2
+    exit 2
+fi
+
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
     if xcrun stapler staple "$ARTIFACT_PATH"; then
         xcrun stapler validate "$ARTIFACT_PATH"


### PR DESCRIPTION
## Motivation
Apple accepted the mac-v2.24.3 app and DMG notarizations, but the immediate DMG stapler lookup returned a transient CloudKit ticket-not-found response and blocked publication.

## Changes
- Retry notarization ticket stapling up to six times with a bounded delay.
- Validate the stapled artifact after success.
- Use the helper for both the app and DMG.
- Add a release-workflow regression test.

## How to test
- `swift test --filter DistributionBuildIdentityTests`
- `bash -n scripts/retry-staple.sh`
- Parse `.github/workflows/release-mac.yml` with Ruby YAML.

## Review confidence
High. Apple already accepted the artifacts; this only tolerates propagation delay before stapling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release reliability by centralizing notarization stapling into a dedicated retry helper and using it for both the app bundle and DMG.
  * Added post-stapling verification so failures are detected immediately, with clear errors if retries are exhausted.

* **Tests**
  * Updated distribution build identity tests to verify the macOS release workflow uses the retry helper for both artifact types and that retry behavior is correctly configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->