### PR TITLE
docs(web): reflect App Review submissions and GPT-5.6

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -639,7 +639,7 @@
           </article>
           <article class="model-rail" style="--rail-color:var(--orange-deep)">
             <h3 class="model-rail__heading"><svg class="rail-icon" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="2.3" aria-hidden="true"><path d="m7 25 4-12L23 1l8 8-12 12-12 4Z"/><path d="m11 13 8 8M7 25l6-2-4-4-2 6Z"/></svg>Polish</h3>
-            <ul class="model-list"><li>Local Cleanup</li><li>Downloaded GGUF models</li><li>GPT-5.4 Nano</li><li>Gemini 3.1 Flash Lite</li><li>Qwen3.6 Flash</li><li>Mistral Small 4 via OpenRouter</li></ul>
+            <ul class="model-list"><li>Local Cleanup</li><li>Downloaded GGUF models</li><li>GPT-5.6 Luna, Terra + Sol</li><li>GPT-5.4 Nano</li><li>Gemini 3.1 Flash Lite</li><li>Qwen3.6 Flash</li><li>Mistral Small 4 via OpenRouter</li></ul>
           </article>
         </div>
         <a class="model-request reveal" href="https://github.com/crmitchelmore/justspeaktoit/issues/new?title=Model%20request%3A%20&amp;body=Provider%3A%20%0AModel%3A%20%0APlatform%20%28Mac%2FiOS%29%3A%20%0AWhy%20this%20model%3A%20&amp;labels=enhancement">Missing a model? Raise an issue →</a>
@@ -662,8 +662,8 @@
         <div class="app-rail reveal">
           <div class="app-rail__lead"><h2 class="section-title">Native on every Apple screen you use.</h2></div>
           <article class="app-choice" style="--link-color:var(--orange-deep)"><svg class="app-choice__icon" viewBox="0 0 52 52" fill="none" stroke="var(--orange)" stroke-width="2.5" aria-hidden="true"><rect x="8" y="7" width="36" height="27" rx="2"/><path d="M3 42h46M15 34l-4 8m26-8 4 8"/></svg><h3>Mac — Direct download</h3><p>Fast updates and full access to local model support.</p><a href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac →</a></article>
-          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>Mac — App Store</h3><p>Sandboxed store distribution for a familiar install and update path.</p><span class="app-choice__status">App Store release in progress</span></article>
-          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>iPhone &amp; iPad — App Store</h3><p>Action Button, Shortcuts, Live Activity, and iCloud history.</p><span class="app-choice__status">Preparing for App Review</span></article>
+          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>Mac — App Store</h3><p>Sandboxed store distribution for a familiar install and update path.</p><span class="app-choice__status">Submitted for App Review</span></article>
+          <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>iPhone &amp; iPad — App Store</h3><p>Action Button, Shortcuts, Live Activity, and iCloud history.</p><span class="app-choice__status">Submitted for App Review</span></article>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Motivation
Keep the public site aligned with the release state now that both Apple apps have been submitted, and expose the GPT-5.6 cleanup models already available in the shared catalogue.

## What changed
- mark Mac and iOS releases as submitted for App Review
- add GPT-5.6 Luna, Terra, and Sol to the Polish model rail

## How to test
- `cd landing-page && npm run build`
- verify the Apps and Models sections in `landing-page/index.html`

## Review confidence
High confidence: copy-only change using model names from `Sources/SpeakCore/ModelCatalog.swift`; no layout or behavior changes.