### PR TITLE
fix(mac): preserve clipboard for empty transcripts

### DIFF
--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -129,9 +129,23 @@ struct AccessibilityTextOutput: TextOutputting {
 struct PasteTextOutput: TextOutputting {
   let permissionsManager: PermissionsManager
   let appSettings: AppSettings
+  private let pasteboard: NSPasteboard
+
+  init(
+    permissionsManager: PermissionsManager,
+    appSettings: AppSettings,
+    pasteboard: NSPasteboard = .general
+  ) {
+    self.permissionsManager = permissionsManager
+    self.appSettings = appSettings
+    self.pasteboard = pasteboard
+  }
 
   func output(text: String) -> TextOutputResult {
-    let pasteboard = NSPasteboard.general
+    guard Self.hasDeliverableText(text) else {
+      return TextOutputResult(method: .none, error: nil)
+    }
+
     let canPasteIntoOtherApps = DistributionChannel.current.supportsAccessibilityTextInsertion
     let restoreClipboard = canPasteIntoOtherApps && appSettings.restoreClipboardAfterPaste
     let previousString = restoreClipboard ? pasteboard.string(forType: .string) : nil
@@ -150,6 +164,10 @@ struct PasteTextOutput: TextOutputting {
     }
 
     return TextOutputResult(method: .clipboard, error: nil)
+  }
+
+  static func hasDeliverableText(_ text: String) -> Bool {
+    !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
 
   private func simulatePasteShortcut() {
@@ -229,7 +247,7 @@ struct SmartTextOutput: TextOutputting {
     "Alacritty",
     "kitty",
     "Warp",
-    "Terminal", // Some secure input issues
+    "Terminal" // Some secure input issues
   ]
 
   private var accessibilityOutput: AccessibilityTextOutput {

--- a/Tests/SpeakAppTests/TextOutputTests.swift
+++ b/Tests/SpeakAppTests/TextOutputTests.swift
@@ -1,0 +1,42 @@
+import AppKit
+import XCTest
+
+@testable import SpeakApp
+
+final class TextOutputTests: XCTestCase {
+  @MainActor
+  func testOutput_emptyTranscript_PreservesClipboard() {
+    let suiteName = "com.speakapp.text-output-tests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    let pasteboard = NSPasteboard(name: NSPasteboard.Name(suiteName))
+    defer {
+      pasteboard.clearContents()
+      UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+    pasteboard.clearContents()
+    pasteboard.setString("existing clipboard", forType: .string)
+
+    let output = PasteTextOutput(
+      permissionsManager: PermissionsManager(statusProvider: { _ in .denied }),
+      appSettings: AppSettings(defaults: defaults),
+      pasteboard: pasteboard
+    )
+
+    let result = output.output(text: " \n\t ")
+
+    XCTAssertEqual(result.method, .none)
+    XCTAssertNil(result.error)
+    XCTAssertEqual(pasteboard.string(forType: .string), "existing clipboard")
+  }
+
+  @MainActor
+  func testHasDeliverableText_emptyAndWhitespace_ReturnsFalse() {
+    XCTAssertFalse(PasteTextOutput.hasDeliverableText(""))
+    XCTAssertFalse(PasteTextOutput.hasDeliverableText(" \n\t "))
+  }
+
+  @MainActor
+  func testHasDeliverableText_transcript_ReturnsTrue() {
+    XCTAssertTrue(PasteTextOutput.hasDeliverableText("Foreground recording works."))
+  }
+}


### PR DESCRIPTION
## Motivation

Production-signed Mac App Store TestFlight build 2.24.3 (7) preserved the existing clipboard while recording, but a silent session cleared it during final delivery. Empty recordings must not destroy clipboard contents.

## What changed

- Skip pasteboard delivery for empty or whitespace-only transcripts.
- Inject a named pasteboard in tests so clipboard behavior is verified without touching the user's real clipboard.
- Add focused coverage for empty, whitespace-only, and non-empty transcript classification plus preservation of existing clipboard contents.

## What changed the direction

Live TestFlight validation showed the original `Recording started` contamination was gone for a real transcript, but two silent recordings replaced seeded clipboard sentinels with an empty value. The failure was in final clipboard delivery, not recording startup.

## How to test

- `swift test --scratch-path /private/tmp/jsti-release-blockers/.build --filter TextOutputTests`
- SwiftLint strict with `.swiftlint-baseline.json` on the two changed files
- SwiftFormat on the two changed files

## Review confidence

High confidence in the narrow fix. The production path now exits before `clearContents()` when there is no deliverable text, and the regression test asserts the original pasteboard value remains unchanged.