### PR TITLE
fix: harden platform-specific release behavior

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -170,7 +170,7 @@ let project = Project(
                 // export exemption, so the app uses no *non-exempt* encryption.
                 "ITSAppUsesNonExemptEncryption": false,
                 "NSSupportsLiveActivities": true,
-                "UIBackgroundModes": ["audio"],
+                "UIBackgroundModes": ["audio", "remote-notification"],
                 "UIApplicationShortcutItems": [
                     [
                         "UIApplicationShortcutItemType": "com.justspeaktoit.ios.quickaction.transcribe",

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -45,6 +45,31 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     }
   }
 
+  nonisolated static func effectiveTranscriptionModeDisplayName(
+    transcriptionMode: TranscriptionMode,
+    liveTranscriptionModel: String,
+    localTranscriptionMode: LocalTranscriptionMode
+  ) -> String {
+    switch transcriptionMode {
+    case .liveNative:
+      return ModelCatalog.isOnDeviceLiveTranscriptionModel(liveTranscriptionModel)
+        ? "Apple On-Device"
+        : "Remote Streaming"
+    case .batchRemote:
+      return "Remote Batch"
+    case .localModel:
+      return localTranscriptionMode.displayName
+    }
+  }
+
+  var effectiveTranscriptionModeDisplayName: String {
+    Self.effectiveTranscriptionModeDisplayName(
+      transcriptionMode: transcriptionMode,
+      liveTranscriptionModel: liveTranscriptionModel,
+      localTranscriptionMode: localTranscriptionMode
+    )
+  }
+
   enum LocalTranscriptionMode: String, CaseIterable, Identifiable {
     case batch
     case streaming

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -424,7 +424,7 @@ final class MainManager: ObservableObject {
       inputDeviceName: health.inputDeviceName,
       providerLabel: health.providerLabel,
       latencyTier: health.latencyTier.displayName,
-      transcriptionMode: appSettings.transcriptionMode.displayName,
+      transcriptionMode: appSettings.effectiveTranscriptionModeDisplayName,
       transcriptionModel: currentTranscriptionModelIdentifier(),
       postProcessingModel: appSettings.postProcessingModel,
       speedMode: appSettings.speedMode.displayName

--- a/Sources/SpeakApp/MainView.swift
+++ b/Sources/SpeakApp/MainView.swift
@@ -97,7 +97,7 @@ struct MainView: View {
     }
     ToolbarItem(placement: .status) {
       VStack(alignment: .trailing, spacing: 2) {
-        Text(environment.settings.transcriptionMode.displayName)
+        Text(environment.settings.effectiveTranscriptionModeDisplayName)
           .font(.caption)
           .foregroundStyle(.secondary)
         if let item = history.items.first {
@@ -116,7 +116,7 @@ struct MainView: View {
         Capsule()
           .strokeBorder(.secondary.opacity(0.3), lineWidth: 0.5)
       )
-      .accessibilityLabel("Current mode: \(environment.settings.transcriptionMode.displayName)")
+      .accessibilityLabel("Current mode: \(environment.settings.effectiveTranscriptionModeDisplayName)")
     }
   }
 

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -452,14 +452,7 @@ struct SettingsView: View {
   }
 
   private var overviewModeValue: String {
-    switch settings.transcriptionMode {
-    case .liveNative:
-      return "Remote Streaming"
-    case .batchRemote:
-      return "Remote Batch"
-    case .localModel:
-      return settings.localTranscriptionMode.displayName
-    }
+    settings.effectiveTranscriptionModeDisplayName
   }
 
   private var transcriptionLocationBinding: Binding<TranscriptionLocation> {

--- a/Sources/SpeakApp/StatusBarView.swift
+++ b/Sources/SpeakApp/StatusBarView.swift
@@ -52,6 +52,14 @@ final class StatusBarController {
       }
       .store(in: &cancellables)
 
+    appSettings.$liveTranscriptionModel
+      .combineLatest(appSettings.$localTranscriptionMode)
+      .receive(on: RunLoop.main)
+      .sink { [weak self] _ in
+        self?.refresh()
+      }
+      .store(in: &cancellables)
+
     historyManager.$statistics
       .receive(on: RunLoop.main)
       .sink { [weak self] _ in

--- a/Sources/SpeakApp/StatusBarView.swift
+++ b/Sources/SpeakApp/StatusBarView.swift
@@ -89,7 +89,7 @@ final class StatusBarController {
     menu.addItem(headline)
 
     let modelItem = NSMenuItem()
-    modelItem.title = "Mode: \(appSettings.transcriptionMode.displayName)"
+    modelItem.title = "Mode: \(appSettings.effectiveTranscriptionModeDisplayName)"
     modelItem.isEnabled = false
     menu.addItem(modelItem)
 

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -91,6 +91,16 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertFalse(iosTarget.contains("Sparkle"))
     }
 
+    func testIOSApp_declaresRequiredBackgroundModes() throws {
+        let manifest = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("Project.swift"),
+            encoding: .utf8
+        )
+        let iosTarget = try targetBlock(named: "SpeakiOS", in: manifest)
+
+        XCTAssertTrue(iosTarget.contains("\"UIBackgroundModes\": [\"audio\", \"remote-notification\"]"))
+    }
+
     private func targetBlock(named name: String, in manifest: String) throws -> Substring {
         let marker = ".target(\n            name: \"\(name)\""
         let start = try XCTUnwrap(manifest.range(of: marker)?.lowerBound)

--- a/Tests/SpeakAppTests/EffectiveTranscriptionModeTests.swift
+++ b/Tests/SpeakAppTests/EffectiveTranscriptionModeTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+@testable import SpeakApp
+
+final class EffectiveTranscriptionModeTests: XCTestCase {
+  func testAppleSpeech_isIdentifiedAsOnDevice() {
+    let label = AppSettings.effectiveTranscriptionModeDisplayName(
+      transcriptionMode: .liveNative,
+      liveTranscriptionModel: "apple/local/SFSpeechRecognizer",
+      localTranscriptionMode: .batch
+    )
+
+    XCTAssertEqual(label, "Apple On-Device")
+  }
+
+  func testRemoteLiveModel_isIdentifiedAsRemoteStreaming() {
+    let label = AppSettings.effectiveTranscriptionModeDisplayName(
+      transcriptionMode: .liveNative,
+      liveTranscriptionModel: "deepgram/nova-3-streaming",
+      localTranscriptionMode: .batch
+    )
+
+    XCTAssertEqual(label, "Remote Streaming")
+  }
+
+  func testRemoteBatch_keepsItsModeLabel() {
+    let label = AppSettings.effectiveTranscriptionModeDisplayName(
+      transcriptionMode: .batchRemote,
+      liveTranscriptionModel: "apple/local/SFSpeechRecognizer",
+      localTranscriptionMode: .streaming
+    )
+
+    XCTAssertEqual(label, "Remote Batch")
+  }
+
+  func testDownloadedLocalModels_useTheirConfiguredMode() {
+    let batchLabel = AppSettings.effectiveTranscriptionModeDisplayName(
+      transcriptionMode: .localModel,
+      liveTranscriptionModel: "deepgram/nova-3-streaming",
+      localTranscriptionMode: .batch
+    )
+    let streamingLabel = AppSettings.effectiveTranscriptionModeDisplayName(
+      transcriptionMode: .localModel,
+      liveTranscriptionModel: "deepgram/nova-3-streaming",
+      localTranscriptionMode: .streaming
+    )
+
+    XCTAssertEqual(batchLabel, "Local Batch")
+    XCTAssertEqual(streamingLabel, "Local Streaming")
+  }
+}


### PR DESCRIPTION
## Motivation

The signed distribution audit found two concrete release issues: Apple on-device transcription was labelled as remote in macOS status surfaces, and iOS registered for CloudKit remote notifications without declaring the required background mode.

## What changed

- Derive the macOS mode label from both the route and selected model, so Apple Speech is shown as Apple On-Device while remote, batch, and downloaded-local modes retain accurate labels.
- Use the effective label in the toolbar, accessibility text, menu bar, settings overview, and history diagnostics.
- Declare `remote-notification` alongside `audio` for the iOS application target.
- Add regression coverage for both fixes.

## What changed direction

The distribution boundary itself was already sound: generated iOS contains no macOS source references, the Mac App Store product contains no Sparkle linkage, and the direct Mac product retains Sparkle. The remaining blockers were runtime metadata and user-facing mode accuracy, so this PR stays focused on those observed defects.

## How to test

- `swift package --disable-dependency-cache plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json`
- `swift test --filter "EffectiveTranscriptionModeTests|DistributionBuildIdentityTests|DistributionChannelTests|PermissionsManagerTests"`
- `swift test --skip "SecureStorageConcurrencyTests|OpenRouterAPIClientTests"` (627 passed, 11 real-Keychain tests skipped because macOS Security blocked the local runner)
- Generate with `TUIST_APP_STORE=1` and build Release for macOS: universal app builds, uses `com.justspeaktoit.mac.appstore`, and has no Sparkle linkage.
- Generate direct macOS: Sparkle references remain present.
- Generate and build SpeakiOS for generic iOS Simulator: built Info.plist contains `audio` and `remote-notification`, no macOS privacy keys, and the generated target contains no `Sources/SpeakApp` references.

## Review confidence

High. The changes are narrow, covered by focused tests, the full non-Keychain suite, exact CI lint, and generated binary inspection for all three distribution variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer transcription mode labels throughout the app, including Apple On-Device, Remote Streaming, Remote Batch, and local model modes.
  - Background remote notifications are now supported alongside audio activity.

- **Bug Fixes**
  - Mode displays in the toolbar, settings overview, status bar, and diagnostics now consistently reflect the effective transcription method.

- **Tests**
  - Added coverage for transcription mode labels and required background notification support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->