### PR TITLE
feat: show API key readiness in model selectors

### DIFF
--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -1554,7 +1554,9 @@ struct SettingsView: View {
               value: remoteTranscriptionModelBinding(
                 \AppSettings.liveTranscriptionModel,
                 options: ModelCatalog.remoteLiveTranscription
-              )
+              ),
+              credentialPurpose: .liveTranscription,
+              storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers)
             )
           }
         }
@@ -1594,7 +1596,9 @@ struct SettingsView: View {
               value: remoteTranscriptionModelBinding(
                 \AppSettings.batchTranscriptionModel,
                 options: ModelCatalog.batchTranscription
-              )
+              ),
+              credentialPurpose: .batchTranscription,
+              storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers)
             )
             if isCustomBatchTranscriptionModel {
               SettingsInlineInfo(
@@ -1641,6 +1645,8 @@ struct SettingsView: View {
                 \AppSettings.liveTranscriptionModel,
                 options: ModelCatalog.onDeviceLiveTranscription
               ),
+              credentialPurpose: .liveTranscription,
+              storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
               allowsCustom: false
             )
           }
@@ -1726,6 +1732,8 @@ struct SettingsView: View {
                   help: "Used for local-only transcription after recording stops.",
                   options: localTranscriptionOptions,
                   value: localTranscriptionModelBinding,
+                  credentialPurpose: .batchTranscription,
+                  storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
                   allowsCustom: false
                 )
               }
@@ -2897,7 +2905,19 @@ struct SettingsView: View {
           VStack(alignment: .leading, spacing: 8) {
             Picker("Voice", selection: settingsBinding(\AppSettings.defaultTTSVoice)) {
               ForEach(VoiceCatalog.allVoices) { voice in
-                Text(voice.displayName).tag(voice.id)
+                HStack {
+                  Text(voice.displayName)
+                  Spacer()
+                  ModelCredentialStatusView(
+                    availability: ModelCredentialResolver.availability(
+                      for: voice.id,
+                      purpose: .voiceOutput,
+                      storedAPIKeyIdentifiers: settings.trackedAPIKeyIdentifiers
+                    )
+                  )
+                }
+                .accessibilityElement(children: .combine)
+                .tag(voice.id)
               }
             }
             .pickerStyle(.menu)
@@ -3127,6 +3147,8 @@ struct SettingsView: View {
         """,
         options: cloudPostProcessingOptions,
         value: cloudPostProcessingModelBinding,
+        credentialPurpose: .postProcessing,
+        storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
         usesDetailedChooser: true
       )
 
@@ -3252,6 +3274,8 @@ struct SettingsView: View {
         help: "Used for local-only cleanup after transcription. Built-in rules need no runtime.",
         options: localPostProcessingOptions,
         value: localPostProcessingModelBinding,
+        credentialPurpose: .postProcessing,
+        storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
         allowsCustom: false
       )
       #else
@@ -3263,6 +3287,8 @@ struct SettingsView: View {
         """,
         options: localPostProcessingOptions,
         value: localPostProcessingModelBinding,
+        credentialPurpose: .postProcessing,
+        storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
         allowsCustom: false
       )
       #endif
@@ -5148,6 +5174,8 @@ private struct ModelPicker: View {
   let title: String
   let help: String?
   let options: [ModelCatalog.Option]
+  let credentialPurpose: ModelCredentialPurpose
+  let storedAPIKeyIdentifiers: Set<String>
   let usesDetailedChooser: Bool
   let allowsCustom: Bool
   @Binding var value: String
@@ -5227,6 +5255,8 @@ private struct ModelPicker: View {
   private struct ModelChooserSheet: View {
     let title: String
     let options: [ModelCatalog.Option]
+    let credentialPurpose: ModelCredentialPurpose
+    let storedAPIKeyIdentifiers: Set<String>
     @Binding var selection: String
 
     @Environment(\.dismiss) private var dismiss
@@ -5271,6 +5301,13 @@ private struct ModelPicker: View {
                       .font(.caption.monospacedDigit())
                       .foregroundStyle(.secondary)
                   }
+                  ModelCredentialStatusView(
+                    availability: ModelCredentialResolver.availability(
+                      for: option.id,
+                      purpose: credentialPurpose,
+                      storedAPIKeyIdentifiers: storedAPIKeyIdentifiers
+                    )
+                  )
                   ModelTagBadges(tags: option.tags, compact: true)
                   LatencyBadgeCompact(option: option)
                 }
@@ -5292,7 +5329,17 @@ private struct ModelPicker: View {
             selection = ModelCatalog.customOptionID
             dismiss()
           } label: {
-            Text("Custom…")
+            HStack {
+              Text("Custom…")
+              Spacer()
+              ModelCredentialStatusView(
+                availability: ModelCredentialResolver.availability(
+                  for: ModelCatalog.customOptionID,
+                  purpose: credentialPurpose,
+                  storedAPIKeyIdentifiers: storedAPIKeyIdentifiers
+                )
+              )
+            }
           }
           .buttonStyle(.plain)
         }
@@ -5348,12 +5395,16 @@ private struct ModelPicker: View {
     help: String? = nil,
     options: [ModelCatalog.Option],
     value: Binding<String>,
+    credentialPurpose: ModelCredentialPurpose,
+    storedAPIKeyIdentifiers: Set<String>,
     usesDetailedChooser: Bool = false,
     allowsCustom: Bool = true
   ) {
     self.title = title
     self.help = help
     self.options = options
+    self.credentialPurpose = credentialPurpose
+    self.storedAPIKeyIdentifiers = storedAPIKeyIdentifiers
     self.usesDetailedChooser = usesDetailedChooser
     self.allowsCustom = allowsCustom
     _value = value
@@ -5392,6 +5443,7 @@ private struct ModelPicker: View {
           HStack {
             Text(selectedOption?.displayName ?? (customValue.isEmpty ? "Custom…" : customValue))
             Spacer()
+            ModelCredentialStatusView(availability: selectedCredentialAvailability)
             if let option = selectedOption {
               ModelPricingBadges(option: option, compact: true)
               ModelTagBadges(tags: option.tags, compact: true)
@@ -5411,15 +5463,35 @@ private struct ModelPicker: View {
         )
         .speakTooltip(tooltipText)
         .sheet(isPresented: $isShowingChooser) {
-          ModelChooserSheet(title: title, options: options, selection: $selection)
+          ModelChooserSheet(
+            title: title,
+            options: options,
+            credentialPurpose: credentialPurpose,
+            storedAPIKeyIdentifiers: storedAPIKeyIdentifiers,
+            selection: $selection
+          )
         }
       } else {
         Picker(title, selection: $selection) {
           ForEach(options) { option in
-            Text(option.displayName).tag(option.id)
+            HStack {
+              Text(option.displayName)
+              Spacer()
+              ModelCredentialStatusView(availability: credentialAvailability(for: option.id))
+            }
+            .accessibilityElement(children: .combine)
+            .tag(option.id)
           }
           if allowsCustom {
-            Text("Custom…").tag(ModelCatalog.customOptionID)
+            HStack {
+              Text("Custom…")
+              Spacer()
+              ModelCredentialStatusView(
+                availability: credentialAvailability(for: ModelCatalog.customOptionID)
+              )
+            }
+            .accessibilityElement(children: .combine)
+            .tag(ModelCatalog.customOptionID)
           }
         }
         .pickerStyle(.menu)
@@ -5467,6 +5539,8 @@ private struct ModelPicker: View {
           Text(ModelCatalog.friendlyName(for: value))
             .font(.caption)
             .foregroundStyle(.secondary)
+          Spacer()
+          ModelCredentialStatusView(availability: selectedCredentialAvailability, showsText: true)
         }
       }
     }
@@ -5497,6 +5571,18 @@ private struct ModelPicker: View {
     options.first { option in
       option.id.caseInsensitiveCompare(selection) == .orderedSame
     }
+  }
+
+  private var selectedCredentialAvailability: ModelCredentialAvailability {
+    credentialAvailability(for: selection == ModelCatalog.customOptionID ? customValue : selection)
+  }
+
+  private func credentialAvailability(for modelIdentifier: String) -> ModelCredentialAvailability {
+    ModelCredentialResolver.availability(
+      for: modelIdentifier.isEmpty ? ModelCatalog.customOptionID : modelIdentifier,
+      purpose: credentialPurpose,
+      storedAPIKeyIdentifiers: storedAPIKeyIdentifiers
+    )
   }
 
   private var tooltipText: String {

--- a/Sources/SpeakApp/Views/ModelCredentialStatusView.swift
+++ b/Sources/SpeakApp/Views/ModelCredentialStatusView.swift
@@ -1,0 +1,77 @@
+import SpeakCore
+import SwiftUI
+
+struct ModelCredentialStatusView: View {
+  let availability: ModelCredentialAvailability
+  var showsText = false
+
+  var body: some View {
+    Group {
+      if showsText {
+        Label(label, systemImage: systemImage)
+      } else {
+        Image(systemName: systemImage)
+      }
+    }
+      .font(.caption.weight(.semibold))
+      .foregroundStyle(tint)
+      .accessibilityLabel(accessibilityLabel)
+      .accessibilityIdentifier(accessibilityIdentifier)
+      .help(accessibilityLabel)
+  }
+
+  private var label: String {
+    switch availability {
+    case .ready:
+      return "Key ready"
+    case .missing:
+      return "Key missing"
+    case .notRequired:
+      return "No key needed"
+    }
+  }
+
+  private var accessibilityLabel: String {
+    switch availability {
+    case .ready(let providerName):
+      return "\(providerName) API key is set"
+    case .missing(let providerName):
+      return "\(providerName) API key is not set"
+    case .notRequired:
+      return "No API key required"
+    }
+  }
+
+  private var systemImage: String {
+    switch availability {
+    case .ready:
+      return "checkmark.circle.fill"
+    case .missing:
+      return "exclamationmark.triangle.fill"
+    case .notRequired:
+      return "lock.shield.fill"
+    }
+  }
+
+  private var accessibilityIdentifier: String {
+    switch availability {
+    case .ready:
+      return "modelCredentialStatus.ready"
+    case .missing:
+      return "modelCredentialStatus.missing"
+    case .notRequired:
+      return "modelCredentialStatus.notRequired"
+    }
+  }
+
+  private var tint: Color {
+    switch availability {
+    case .ready:
+      return .green
+    case .missing:
+      return .orange
+    case .notRequired:
+      return .secondary
+    }
+  }
+}

--- a/Sources/SpeakApp/VoiceOutputView.swift
+++ b/Sources/SpeakApp/VoiceOutputView.swift
@@ -1,4 +1,5 @@
 // swiftlint:disable file_length
+import SpeakCore
 import SwiftUI
 import UniformTypeIdentifiers
 

--- a/Sources/SpeakApp/VoiceOutputView.swift
+++ b/Sources/SpeakApp/VoiceOutputView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -28,7 +29,7 @@ enum TTSInputSource: String, CaseIterable, Identifiable {
   }
 }
 
-struct VoiceOutputView: View {
+struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
   @EnvironmentObject private var tts: TextToSpeechManager
   @EnvironmentObject private var settings: AppSettings
   @EnvironmentObject private var history: HistoryManager
@@ -147,7 +148,7 @@ struct VoiceOutputView: View {
       if let cost = estimatedCost, cost > 0, let formatted = costString {
         heroChip(title: "Est. Cost", value: formatted, systemImage: "dollarsign.circle")
       }
-      if let _ = tts.lastResult, let formatted = durationString {
+      if tts.lastResult != nil, let formatted = durationString {
         heroChip(title: "Last Duration", value: formatted, systemImage: "waveform")
       }
     }
@@ -246,7 +247,19 @@ struct VoiceOutputView: View {
         } else {
           Picker("Voice", selection: $selectedVoice) {
             ForEach(availableVoices) { voice in
-              Text(voice.displayName).tag(voice.id)
+              HStack {
+                Text(voice.displayName)
+                Spacer()
+                ModelCredentialStatusView(
+                  availability: ModelCredentialResolver.availability(
+                    for: voice.id,
+                    purpose: .voiceOutput,
+                    storedAPIKeyIdentifiers: settings.trackedAPIKeyIdentifiers
+                  )
+                )
+              }
+              .accessibilityElement(children: .combine)
+              .tag(voice.id)
             }
           }
           .labelsHidden()
@@ -335,7 +348,7 @@ struct VoiceOutputView: View {
             .scrollContentBackground(.hidden)
             .background(Color(nsColor: .textBackgroundColor).opacity(0.5))
             .cornerRadius(8)
-            .onChange(of: inputText) { _, newValue in
+            .onChange(of: inputText) { _, _ in
               updateEstimatedCost()
             }
         }

--- a/Sources/SpeakCore/ModelCredentialRequirement.swift
+++ b/Sources/SpeakCore/ModelCredentialRequirement.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+/// The operation a model is selected for. The same catalogue identifier can
+/// use a different credential depending on the operation (for example OpenAI
+/// models routed through OpenRouter for post-processing).
+public enum ModelCredentialPurpose: Sendable {
+    case liveTranscription
+    case batchTranscription
+    case postProcessing
+    case voiceOutput
+}
+
+/// The credential a model needs before it can run.
+public enum ModelCredentialRequirement: Equatable, Sendable {
+    case notRequired
+    case apiKey(identifier: String, providerName: String)
+}
+
+/// User-facing readiness derived from a model requirement and the identifiers
+/// currently stored in secure storage.
+public enum ModelCredentialAvailability: Equatable, Sendable {
+    case ready(providerName: String)
+    case missing(providerName: String)
+    case notRequired
+}
+
+/// Canonical model-to-credential mapping shared by the macOS and iOS pickers.
+/// Runtime clients remain authoritative for requests; this resolver keeps the
+/// selection UX in sync with those routing rules.
+public enum ModelCredentialResolver {
+    public static func requirement(
+        for modelIdentifier: String,
+        purpose: ModelCredentialPurpose
+    ) -> ModelCredentialRequirement {
+        let trimmed = modelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch purpose {
+        case .liveTranscription:
+            return liveTranscriptionRequirement(for: trimmed)
+        case .batchTranscription:
+            return batchTranscriptionRequirement(for: trimmed)
+        case .postProcessing:
+            return postProcessingRequirement(for: trimmed)
+        case .voiceOutput:
+            return voiceOutputRequirement(for: trimmed)
+        }
+    }
+
+    public static func availability(
+        for modelIdentifier: String,
+        purpose: ModelCredentialPurpose,
+        storedAPIKeyIdentifiers: some Sequence<String>
+    ) -> ModelCredentialAvailability {
+        let stored = Set(storedAPIKeyIdentifiers)
+        switch requirement(for: modelIdentifier, purpose: purpose) {
+        case .notRequired:
+            return .notRequired
+        case .apiKey(let identifier, let providerName):
+            return stored.contains(identifier)
+                ? .ready(providerName: providerName)
+                : .missing(providerName: providerName)
+        }
+    }
+
+    private static func liveTranscriptionRequirement(for modelIdentifier: String) -> ModelCredentialRequirement {
+        guard let route = LiveTranscriptionRouting.route(for: modelIdentifier) else {
+            return requirementForProviderPrefix(modelIdentifier, fallbackProvider: nil)
+        }
+        guard let identifier = route.apiKeyIdentifier else { return .notRequired }
+        return .apiKey(identifier: identifier, providerName: route.provider.displayName)
+    }
+
+    private static func batchTranscriptionRequirement(for modelIdentifier: String) -> ModelCredentialRequirement {
+        if modelIdentifier == ModelCatalog.customOptionID {
+            return openRouterRequirement
+        }
+        if isLocal(modelIdentifier) {
+            return .notRequired
+        }
+
+        // These models use OpenAI's own audio transcription endpoint. Other
+        // OpenAI-prefixed audio models in the batch catalogue are OpenRouter
+        // models, so an identifier prefix alone is not sufficient here.
+        if openAIBatchModelIdentifiers.contains(modelIdentifier) {
+            return .apiKey(identifier: "openai.apiKey", providerName: "OpenAI")
+        }
+
+        let provider = providerPrefix(in: modelIdentifier)
+        if directBatchProviderIdentifiers.contains(provider) {
+            return .apiKey(
+                identifier: "\(provider).apiKey",
+                providerName: providerDisplayName(provider)
+            )
+        }
+        return openRouterRequirement
+    }
+
+    private static func postProcessingRequirement(for modelIdentifier: String) -> ModelCredentialRequirement {
+        if isLocal(modelIdentifier) {
+            return .notRequired
+        }
+        return openRouterRequirement
+    }
+
+    private static func voiceOutputRequirement(for modelIdentifier: String) -> ModelCredentialRequirement {
+        let lowered = modelIdentifier.lowercased()
+        if isLocal(lowered) || lowered.hasPrefix("system/") || lowered == "system" {
+            return .notRequired
+        }
+        if lowered.hasPrefix("aura") || lowered.hasPrefix("deepgram/") {
+            return .apiKey(identifier: "deepgram.apiKey", providerName: "Deepgram")
+        }
+        if lowered.hasPrefix("elevenlabs/") {
+            return .apiKey(identifier: "elevenlabs.apiKey", providerName: "ElevenLabs")
+        }
+        if lowered.hasPrefix("openai/") {
+            return .apiKey(identifier: "openai.tts.apiKey", providerName: "OpenAI")
+        }
+        if lowered.hasPrefix("azure/") {
+            return .apiKey(identifier: "azure.speech.apiKey", providerName: "Azure")
+        }
+        return requirementForProviderPrefix(lowered, fallbackProvider: nil)
+    }
+
+    private static func requirementForProviderPrefix(
+        _ modelIdentifier: String,
+        fallbackProvider: String?
+    ) -> ModelCredentialRequirement {
+        let provider = providerPrefix(in: modelIdentifier)
+        guard !provider.isEmpty, provider != ModelCatalog.customOptionID else {
+            guard let fallbackProvider else { return .notRequired }
+            return .apiKey(
+                identifier: "\(fallbackProvider).apiKey",
+                providerName: providerDisplayName(fallbackProvider)
+            )
+        }
+        if provider == "apple" || provider == "local" || provider == "system" {
+            return .notRequired
+        }
+        return .apiKey(
+            identifier: "\(provider).apiKey",
+            providerName: providerDisplayName(provider)
+        )
+    }
+
+    private static func isLocal(_ modelIdentifier: String) -> Bool {
+        let lowered = modelIdentifier.lowercased()
+        return lowered.hasPrefix("apple/")
+            || lowered.hasPrefix("local/")
+            || lowered.hasPrefix("system/")
+    }
+
+    private static func providerPrefix(in modelIdentifier: String) -> String {
+        modelIdentifier
+            .split(separator: "/", maxSplits: 1)
+            .first
+            .map { String($0).lowercased() } ?? ""
+    }
+
+    private static func providerDisplayName(_ provider: String) -> String {
+        providerDisplayNames[provider] ?? provider.capitalized
+    }
+
+    private static let providerDisplayNames = [
+        "assemblyai": "AssemblyAI",
+        "deepgram": "Deepgram",
+        "elevenlabs": "ElevenLabs",
+        "gladia": "Gladia",
+        "groq": "Groq",
+        "mistral": "Mistral",
+        "modulate": "Modulate",
+        "openai": "OpenAI",
+        "openrouter": "OpenRouter",
+        "revai": "Rev.ai",
+        "soniox": "Soniox",
+        "speechmatics": "Speechmatics"
+    ]
+
+    private static let openRouterRequirement = ModelCredentialRequirement.apiKey(
+        identifier: "openrouter.apiKey",
+        providerName: "OpenRouter"
+    )
+
+    private static let openAIBatchModelIdentifiers: Set<String> = [
+        "openai/whisper-1",
+        "openai/gpt-4o-mini-transcribe",
+        "openai/gpt-4o-transcribe",
+        "openai/gpt-4o-transcribe-diarize"
+    ]
+
+    private static let directBatchProviderIdentifiers: Set<String> = [
+        "assemblyai",
+        "deepgram",
+        "elevenlabs",
+        "gladia",
+        "groq",
+        "mistral",
+        "modulate",
+        "revai",
+        "soniox",
+        "speechmatics"
+    ]
+}

--- a/Sources/SpeakiOS/Views/ModelCredentialStatusView.swift
+++ b/Sources/SpeakiOS/Views/ModelCredentialStatusView.swift
@@ -1,0 +1,78 @@
+#if os(iOS)
+import SpeakCore
+import SwiftUI
+
+struct IOSModelCredentialStatusView: View {
+    let availability: ModelCredentialAvailability
+    var showsText = false
+
+    var body: some View {
+        Group {
+            if showsText {
+                Label(label, systemImage: systemImage)
+            } else {
+                Image(systemName: systemImage)
+            }
+        }
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(tint)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private var label: String {
+        switch availability {
+        case .ready:
+            return "Key ready"
+        case .missing:
+            return "Key missing"
+        case .notRequired:
+            return "No key needed"
+        }
+    }
+
+    private var accessibilityLabel: String {
+        switch availability {
+        case .ready(let providerName):
+            return "\(providerName) API key is set"
+        case .missing(let providerName):
+            return "\(providerName) API key is not set"
+        case .notRequired:
+            return "No API key required"
+        }
+    }
+
+    private var systemImage: String {
+        switch availability {
+        case .ready:
+            return "checkmark.circle.fill"
+        case .missing:
+            return "exclamationmark.triangle.fill"
+        case .notRequired:
+            return "lock.shield.fill"
+        }
+    }
+
+    private var accessibilityIdentifier: String {
+        switch availability {
+        case .ready:
+            return "modelCredentialStatus.ready"
+        case .missing:
+            return "modelCredentialStatus.missing"
+        case .notRequired:
+            return "modelCredentialStatus.notRequired"
+        }
+    }
+
+    private var tint: Color {
+        switch availability {
+        case .ready:
+            return .green
+        case .missing:
+            return .orange
+        case .notRequired:
+            return .secondary
+        }
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
@@ -102,13 +102,37 @@ public struct OpenClawSettingsView: View {
                             OpenClawSettings.voices(for: settings.ttsModel),
                             id: \.id
                         ) { voice in
-                            Text(voice.label).tag(voice.id)
+                            HStack {
+                                Text(voice.label)
+                                Spacer()
+                                IOSModelCredentialStatusView(
+                                    availability: ModelCredentialResolver.availability(
+                                        for: "deepgram/\(voice.id)",
+                                        purpose: .voiceOutput,
+                                        storedAPIKeyIdentifiers: appSettings.storedAPIKeyIdentifiers
+                                    )
+                                )
+                            }
+                            .accessibilityElement(children: .combine)
+                            .tag(voice.id)
                         }
                     }
 
                     Picker("Model", selection: $settings.ttsModel) {
                         ForEach(OpenClawSettings.availableModels, id: \.id) { mdl in
-                            Text(mdl.label).tag(mdl.id)
+                            HStack {
+                                Text(mdl.label)
+                                Spacer()
+                                IOSModelCredentialStatusView(
+                                    availability: ModelCredentialResolver.availability(
+                                        for: mdl.id,
+                                        purpose: .voiceOutput,
+                                        storedAPIKeyIdentifiers: appSettings.storedAPIKeyIdentifiers
+                                    )
+                                )
+                            }
+                            .accessibilityElement(children: .combine)
+                            .tag(mdl.id)
                         }
                     }
                     .onChange(of: settings.ttsModel) { _ in

--- a/Sources/SpeakiOS/Views/PostProcessingView.swift
+++ b/Sources/SpeakiOS/Views/PostProcessingView.swift
@@ -429,6 +429,14 @@ public struct PostProcessingView: View {
                             }
                             
                             Spacer()
+
+                            IOSModelCredentialStatusView(
+                                availability: ModelCredentialResolver.availability(
+                                    for: model.id,
+                                    purpose: .postProcessing,
+                                    storedAPIKeyIdentifiers: settings.storedAPIKeyIdentifiers
+                                )
+                            )
                             
                             if settings.postProcessingModel == model.id {
                                 Image(systemName: "checkmark")

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -373,6 +373,23 @@ public final class AppSettings: ObservableObject {
     public var hasAssemblyAIKey: Bool { !assemblyAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     public var hasGladiaKey: Bool { !gladiaAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
 
+    /// Identifiers currently available to model pickers. Because this is
+    /// derived from the published key values, readiness badges refresh as soon
+    /// as a key is saved, synced, or removed.
+    public var storedAPIKeyIdentifiers: Set<String> {
+        var identifiers: Set<String> = []
+        if hasDeepgramKey { identifiers.insert(Self.deepgramKeyID) }
+        if hasOpenRouterKey { identifiers.insert(Self.openRouterKeyID) }
+        if hasOpenAIKey { identifiers.insert(Self.openAIKeyID) }
+        if hasElevenLabsKey { identifiers.insert(Self.elevenLabsKeyID) }
+        if hasCartesiaKey { identifiers.insert(Self.cartesiaKeyID) }
+        if hasSonioxKey { identifiers.insert(Self.sonioxKeyID) }
+        if hasModulateKey { identifiers.insert(Self.modulateKeyID) }
+        if hasAssemblyAIKey { identifiers.insert(Self.assemblyAIKeyID) }
+        if hasGladiaKey { identifiers.insert(Self.gladiaKeyID) }
+        return identifiers
+    }
+
     public func reloadSyncedAPIKeys() async {
         syncedKeyReloadDepth += 1
         defer { syncedKeyReloadDepth -= 1 }
@@ -669,14 +686,28 @@ public struct SettingsView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                .accessibilityIdentifier("transcriptionLocationPicker")
 
                 if transcriptionLocationBinding.wrappedValue == .local {
                     Picker("Apple On-Device Model", selection: selectedModelBinding) {
                         ForEach(ModelCatalog.onDeviceLiveTranscription) { option in
-                            Text(option.displayName).tag(option.id)
+                            HStack {
+                                Text(option.displayName)
+                                Spacer()
+                                IOSModelCredentialStatusView(
+                                    availability: ModelCredentialResolver.availability(
+                                        for: option.id,
+                                        purpose: .liveTranscription,
+                                        storedAPIKeyIdentifiers: settings.storedAPIKeyIdentifiers
+                                    )
+                                )
+                            }
+                            .accessibilityElement(children: .combine)
+                            .tag(option.id)
                         }
                     }
                     .pickerStyle(.navigationLink)
+                    .accessibilityIdentifier("appleOnDeviceModelPicker")
 
                     Text("Uses Apple's built-in speech engine. Audio stays on this device.")
                         .font(.caption)
@@ -688,29 +719,56 @@ public struct SettingsView: View {
                         }
                     }
                     .pickerStyle(.segmented)
+                    .accessibilityIdentifier("remoteTranscriptionModePicker")
 
                     if settings.transcriptionMode == .streaming {
                         Picker("Remote Streaming Model", selection: selectedModelBinding) {
                             ForEach(LiveModelGroup.grouped(AppSettings.supportedLiveModels)) { group in
                                 Section(group.title) {
                                     ForEach(group.options) { option in
-                                        Text(option.displayName).tag(option.id)
+                                        HStack {
+                                            Text(option.displayName)
+                                            Spacer()
+                                            IOSModelCredentialStatusView(
+                                                availability: ModelCredentialResolver.availability(
+                                                    for: option.id,
+                                                    purpose: .liveTranscription,
+                                                    storedAPIKeyIdentifiers: settings.storedAPIKeyIdentifiers
+                                                )
+                                            )
+                                        }
+                                        .accessibilityElement(children: .combine)
+                                        .tag(option.id)
                                     }
                                 }
                             }
                         }
                         .pickerStyle(.navigationLink)
+                        .accessibilityIdentifier("remoteStreamingModelPicker")
                     } else {
                         Picker("Remote Batch Model", selection: $settings.batchTranscriptionModel) {
                             ForEach(BatchModelGroup.grouped(AppSettings.supportedBatchModels)) { group in
                                 Section(group.title) {
                                     ForEach(group.options) { option in
-                                        Text(ModelCatalog.friendlyName(for: option.id)).tag(option.id)
+                                        HStack {
+                                            Text(ModelCatalog.friendlyName(for: option.id))
+                                            Spacer()
+                                            IOSModelCredentialStatusView(
+                                                availability: ModelCredentialResolver.availability(
+                                                    for: option.id,
+                                                    purpose: .batchTranscription,
+                                                    storedAPIKeyIdentifiers: settings.storedAPIKeyIdentifiers
+                                                )
+                                            )
+                                        }
+                                        .accessibilityElement(children: .combine)
+                                        .tag(option.id)
                                     }
                                 }
                             }
                         }
                         .pickerStyle(.navigationLink)
+                        .accessibilityIdentifier("remoteBatchModelPicker")
                     }
 
                     Text(settings.transcriptionMode == .streaming
@@ -1211,6 +1269,14 @@ struct PostProcessingSettingsView: View {
                             }
 
                             Spacer()
+
+                            IOSModelCredentialStatusView(
+                                availability: ModelCredentialResolver.availability(
+                                    for: model.id,
+                                    purpose: .postProcessing,
+                                    storedAPIKeyIdentifiers: settings.storedAPIKeyIdentifiers
+                                )
+                            )
 
                             if settings.postProcessingModel == model.id {
                                 Image(systemName: "checkmark")

--- a/Tests/SpeakAppTests/ModelCredentialResolverTests.swift
+++ b/Tests/SpeakAppTests/ModelCredentialResolverTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import SpeakCore
+
+final class ModelCredentialResolverTests: XCTestCase {
+    func testLiveProvider_UsesProviderCredential() {
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: "deepgram/nova-3-streaming",
+                purpose: .liveTranscription
+            ),
+            .apiKey(identifier: "deepgram.apiKey", providerName: "Deepgram")
+        )
+    }
+
+    func testAppleAndLocalModels_DoNotRequireCredential() {
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: AppleLocalModels.preferredSpeechModelID,
+                purpose: .liveTranscription
+            ),
+            .notRequired
+        )
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: "local/post-processing/rules",
+                purpose: .postProcessing
+            ),
+            .notRequired
+        )
+    }
+
+    func testBatchModels_DistinguishOpenAIFromOpenRouter() {
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: "openai/gpt-4o-transcribe",
+                purpose: .batchTranscription
+            ),
+            .apiKey(identifier: "openai.apiKey", providerName: "OpenAI")
+        )
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: "openai/gpt-4o-audio-preview-2024-12-17",
+                purpose: .batchTranscription
+            ),
+            .apiKey(identifier: "openrouter.apiKey", providerName: "OpenRouter")
+        )
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: "google/gemini-2.0-flash-001",
+                purpose: .batchTranscription
+            ),
+            .apiKey(identifier: "openrouter.apiKey", providerName: "OpenRouter")
+        )
+    }
+
+    func testPostProcessingRemoteModels_UseOpenRouterCredential() {
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: "openai/gpt-5-mini",
+                purpose: .postProcessing
+            ),
+            .apiKey(identifier: "openrouter.apiKey", providerName: "OpenRouter")
+        )
+    }
+
+    func testVoiceProviders_UsePurposeSpecificCredentials() {
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: "openai/alloy",
+                purpose: .voiceOutput
+            ),
+            .apiKey(identifier: "openai.tts.apiKey", providerName: "OpenAI")
+        )
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: "aura-2",
+                purpose: .voiceOutput
+            ),
+            .apiKey(identifier: "deepgram.apiKey", providerName: "Deepgram")
+        )
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: "system/default",
+                purpose: .voiceOutput
+            ),
+            .notRequired
+        )
+    }
+
+    func testAvailability_ReflectsStoredIdentifierChanges() {
+        XCTAssertEqual(
+            ModelCredentialResolver.availability(
+                for: "deepgram/nova-3-streaming",
+                purpose: .liveTranscription,
+                storedAPIKeyIdentifiers: []
+            ),
+            .missing(providerName: "Deepgram")
+        )
+        XCTAssertEqual(
+            ModelCredentialResolver.availability(
+                for: "deepgram/nova-3-streaming",
+                purpose: .liveTranscription,
+                storedAPIKeyIdentifiers: ["deepgram.apiKey"]
+            ),
+            .ready(providerName: "Deepgram")
+        )
+    }
+}

--- a/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
+++ b/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
@@ -33,6 +33,38 @@ final class ActionButtonSettingsUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Save to History Only"].waitForExistence(timeout: 5))
     }
 
+    func testModelPickersExposeCredentialReadiness() {
+        app.buttons["Settings"].tap()
+
+        let locationPicker = app.segmentedControls["transcriptionLocationPicker"]
+        XCTAssertTrue(scrollUpUntilExists(locationPicker))
+
+        let localModelPicker = app.descendants(matching: .any)["appleOnDeviceModelPicker"]
+        XCTAssertTrue(localModelPicker.waitForExistence(timeout: 5))
+        localModelPicker.tap()
+
+        let noKeyStatus = app.descendants(matching: .any).matching(
+            NSPredicate(format: "label CONTAINS %@", "No API key required")
+        ).firstMatch
+        XCTAssertTrue(noKeyStatus.waitForExistence(timeout: 5))
+
+        app.navigationBars.buttons.element(boundBy: 0).tap()
+        locationPicker.buttons["Remote"].tap()
+
+        let remoteModelPicker = app.descendants(matching: .any)["remoteStreamingModelPicker"]
+        XCTAssertTrue(remoteModelPicker.waitForExistence(timeout: 5))
+        remoteModelPicker.tap()
+
+        let readyOrMissingStatus = app.descendants(matching: .any).matching(
+            NSPredicate(
+                format: "label CONTAINS %@ OR label CONTAINS %@",
+                "API key is set",
+                "API key is not set"
+            )
+        ).firstMatch
+        XCTAssertTrue(readyOrMissingStatus.waitForExistence(timeout: 5))
+    }
+
     private func scrollUpUntilExists(_ element: XCUIElement, maxSwipes: Int = 6) -> Bool {
         if element.waitForExistence(timeout: 1) {
             return true


### PR DESCRIPTION
## Motivation
Model selectors did not show whether each provider was ready to use, so users could select a model and only discover a missing API key after recording.

## What changed
- add one shared model-to-credential resolver for live, batch, post-processing, and voice output
- show non-color ready, missing, or no-key-required indicators in every Mac and iOS execution model selector
- refresh readiness immediately from published stored-key state
- add VoiceOver labels and stable accessibility identifiers
- add focused resolver and iOS UI automation coverage

## Things we learnt that changed the direction
The Mac voice-output screen owns a separate voice picker from Settings, so it is covered explicitly rather than assuming the Settings picker was the only TTS surface. iOS batch routing also differs from Mac: only OpenAI transcription models use the OpenAI key there, while supported multimodal batch models use OpenRouter. The shared resolver models the purpose as well as the provider prefix to preserve those distinctions.

## How to test
- `swift test --filter ModelCredentialResolverTests` (6 tests passed)
- `xcodebuild -workspace "Just Speak to It.xcworkspace" -scheme SpeakiOS -destination "platform=iOS Simulator,id=24531C23-677C-4ED8-ABCD-5C08E61F96C4" -derivedDataPath /private/tmp/jsti-model-status-derived build`
- `xcodebuild ... test -only-testing:SpeakiOSUITests/ActionButtonSettingsUITests/testModelPickersExposeCredentialReadiness` (passed)
- SwiftLint 0.65.0 strict with `.swiftlint-baseline.json` (0 violations across 275 files)

## Review confidence
High confidence. Shared routing is covered by focused tests, the generated iOS target built successfully, and UI automation verified both no-key-required and remote ready/missing states. CI should deeply review the cross-platform compile matrix and existing provider tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added credential-readiness indicators to transcription, voice output, and post-processing model pickers.
  - Clearly identifies models that are ready, missing an API key, or require no API key.
  - Added credential status indicators to voice and model options in iOS settings.
  - Improved accessibility labels and identifiers for credential status and model pickers.

- **Tests**
  - Added coverage for credential resolution and picker readiness indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->