### PR TITLE
fix(mac): bound speech permission requests

### DIFF
--- a/Sources/SpeakApp/DashboardView.swift
+++ b/Sources/SpeakApp/DashboardView.swift
@@ -289,12 +289,21 @@ struct DashboardView: View {
         .font(.subheadline)
         .foregroundStyle(.secondary)
 
-      Button(status.isGranted ? "Check" : "Request") {
-        requestingPermission = permission
-        Task { await request(permission) }
+      if let issue = environment.permissions.requestIssue(for: permission) {
+        Text(issue.guidance(for: permission))
+          .font(.caption)
+          .foregroundStyle(.orange)
+        Link("Open Settings", destination: permission.settingsURL)
+          .buttonStyle(.bordered)
+          .controlSize(.small)
+      } else {
+        Button(status.isGranted ? "Check" : "Request") {
+          requestingPermission = permission
+          Task { await request(permission) }
+        }
+        .controlSize(.small)
+        .speakTooltip(permission.guidanceText)
       }
-      .controlSize(.small)
-      .speakTooltip(permission.guidanceText)
     }
     .padding()
     .background(

--- a/Sources/SpeakApp/PermissionsManager.swift
+++ b/Sources/SpeakApp/PermissionsManager.swift
@@ -101,18 +101,76 @@ enum PermissionStatus: Equatable {
   }
 }
 
+enum PermissionRequestIssue: Equatable {
+  case timedOut
+
+  func guidance(for permission: PermissionType) -> String {
+    switch self {
+    case .timedOut:
+      return "macOS did not finish the \(permission.displayName) request. Open System Settings, "
+        + "choose a permission state, then refresh Speak."
+    }
+  }
+}
+
+private enum SpeechAuthorizationRequestOutcome {
+  case status(PermissionStatus)
+  case timedOut
+}
+
+private final class SpeechAuthorizationRequestGate: @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuation: CheckedContinuation<SpeechAuthorizationRequestOutcome, Never>?
+  private var resolvedOutcome: SpeechAuthorizationRequestOutcome?
+
+  func install(_ continuation: CheckedContinuation<SpeechAuthorizationRequestOutcome, Never>) {
+    lock.lock()
+    if let resolvedOutcome {
+      lock.unlock()
+      continuation.resume(returning: resolvedOutcome)
+      return
+    }
+    self.continuation = continuation
+    lock.unlock()
+  }
+
+  func resolve(_ outcome: SpeechAuthorizationRequestOutcome) {
+    lock.lock()
+    guard resolvedOutcome == nil else {
+      lock.unlock()
+      return
+    }
+    resolvedOutcome = outcome
+    let pendingContinuation = continuation
+    continuation = nil
+    lock.unlock()
+    pendingContinuation?.resume(returning: outcome)
+  }
+}
+
 @MainActor
 final class PermissionsManager: ObservableObject {
+  typealias SpeechAuthorizationRequester = (@escaping (SFSpeechRecognizerAuthorizationStatus) -> Void) -> Void
+
   @Published private(set) var statuses: [PermissionType: PermissionStatus] = [:]
+  @Published private(set) var requestIssues: [PermissionType: PermissionRequestIssue] = [:]
   private let statusProvider: (PermissionType) -> PermissionStatus
+  private let speechAuthorizationRequester: SpeechAuthorizationRequester
+  private let speechAuthorizationTimeout: TimeInterval
   private let notificationCenter: NotificationCenter
   private var lifecycleObservers: [NSObjectProtocol] = []
 
   init(
     statusProvider: @escaping (PermissionType) -> PermissionStatus = PermissionsManager.systemStatus,
+    speechAuthorizationRequester: @escaping SpeechAuthorizationRequester = { callback in
+      SFSpeechRecognizer.requestAuthorization(callback)
+    },
+    speechAuthorizationTimeout: TimeInterval = 8,
     notificationCenter: NotificationCenter = .default
   ) {
     self.statusProvider = statusProvider
+    self.speechAuthorizationRequester = speechAuthorizationRequester
+    self.speechAuthorizationTimeout = speechAuthorizationTimeout
     self.notificationCenter = notificationCenter
     refreshAll()
     registerLifecycleObservers()
@@ -135,15 +193,24 @@ final class PermissionsManager: ObservableObject {
 
   func refreshAll() {
     PermissionType.allCases.forEach { type in
-      statuses[type] = computeStatus(for: type)
+      refresh(type)
     }
   }
 
   func refresh(_ type: PermissionType) {
-    statuses[type] = computeStatus(for: type)
+    let status = computeStatus(for: type)
+    statuses[type] = status
+    if status != .notDetermined {
+      requestIssues[type] = nil
+    }
+  }
+
+  func requestIssue(for type: PermissionType) -> PermissionRequestIssue? {
+    requestIssues[type]
   }
 
   func request(_ type: PermissionType) async -> PermissionStatus {
+    requestIssues[type] = nil
     let status: PermissionStatus
     switch type {
     case .microphone:
@@ -249,23 +316,42 @@ final class PermissionsManager: ObservableObject {
   }
 
   private func requestSpeechRecognition() async -> PermissionStatus {
-    await withCheckedContinuation { continuation in
-      SFSpeechRecognizer.requestAuthorization { status in
-        let mapped: PermissionStatus
-        switch status {
-        case .authorized:
-          mapped = .granted
-        case .notDetermined:
-          mapped = .notDetermined
-        case .denied:
-          mapped = .denied
-        case .restricted:
-          mapped = .restricted
-        @unknown default:
-          mapped = .restricted
-        }
-        continuation.resume(returning: mapped)
+    let gate = SpeechAuthorizationRequestGate()
+    let requester = speechAuthorizationRequester
+    let timeout = speechAuthorizationTimeout
+    let outcome = await withCheckedContinuation { continuation in
+      gate.install(continuation)
+      requester { status in
+        gate.resolve(.status(Self.mapSpeechAuthorizationStatus(status)))
       }
+      DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+        gate.resolve(.timedOut)
+      }
+    }
+
+    switch outcome {
+    case .status(let status):
+      return status
+    case .timedOut:
+      requestIssues[.speechRecognition] = .timedOut
+      return computeStatus(for: .speechRecognition)
+    }
+  }
+
+  private nonisolated static func mapSpeechAuthorizationStatus(
+    _ status: SFSpeechRecognizerAuthorizationStatus
+  ) -> PermissionStatus {
+    switch status {
+    case .authorized:
+      return .granted
+    case .notDetermined:
+      return .notDetermined
+    case .denied:
+      return .denied
+    case .restricted:
+      return .restricted
+    @unknown default:
+      return .restricted
     }
   }
 

--- a/Sources/SpeakApp/PermissionsManager.swift
+++ b/Sources/SpeakApp/PermissionsManager.swift
@@ -324,7 +324,8 @@ final class PermissionsManager: ObservableObject {
       requester { status in
         gate.resolve(.status(Self.mapSpeechAuthorizationStatus(status)))
       }
-      DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+      Task {
+        try? await Task.sleep(for: .seconds(timeout))
         gate.resolve(.timedOut)
       }
     }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -4537,6 +4537,10 @@ struct SettingsView: View {
                  let steps = permission.manualSetupSteps {
                 permissionManualSetupNote(for: permission, steps: steps)
               }
+
+              if let issue = environment.permissions.requestIssue(for: permission) {
+                channelAvailabilityNote(issue.guidance(for: permission))
+              }
             }
           }
 

--- a/Tests/SpeakAppTests/PermissionsManagerTests.swift
+++ b/Tests/SpeakAppTests/PermissionsManagerTests.swift
@@ -47,6 +47,60 @@ final class PermissionsManagerTests: XCTestCase {
     }
 
     @MainActor
+    func testSpeechRecognitionRequest_completedCallbackReturnsMappedStatus() async {
+        let manager = PermissionsManager(
+            statusProvider: { _ in .notDetermined },
+            speechAuthorizationRequester: { callback in callback(.authorized) },
+            speechAuthorizationTimeout: 0.05,
+            notificationCenter: NotificationCenter()
+        )
+
+        let result = await manager.request(.speechRecognition)
+
+        XCTAssertEqual(result, .granted)
+        XCTAssertNil(manager.requestIssue(for: .speechRecognition))
+    }
+
+    @MainActor
+    func testSpeechRecognitionRequest_missingCallbackTimesOutWithGuidance() async {
+        let manager = PermissionsManager(
+            statusProvider: { _ in .notDetermined },
+            speechAuthorizationRequester: { _ in },
+            speechAuthorizationTimeout: 0.01,
+            notificationCenter: NotificationCenter()
+        )
+
+        let result = await manager.request(.speechRecognition)
+
+        XCTAssertEqual(result, .notDetermined)
+        XCTAssertEqual(manager.requestIssue(for: .speechRecognition), .timedOut)
+        XCTAssertTrue(
+            PermissionRequestIssue.timedOut
+                .guidance(for: .speechRecognition)
+                .contains("Open System Settings")
+        )
+    }
+
+    @MainActor
+    func testRefresh_clearsTimedOutIssueAfterSystemStatusChanges() async {
+        var systemStatus = PermissionStatus.notDetermined
+        let manager = PermissionsManager(
+            statusProvider: { _ in systemStatus },
+            speechAuthorizationRequester: { _ in },
+            speechAuthorizationTimeout: 0.01,
+            notificationCenter: NotificationCenter()
+        )
+        _ = await manager.request(.speechRecognition)
+        XCTAssertEqual(manager.requestIssue(for: .speechRecognition), .timedOut)
+
+        systemStatus = .granted
+        manager.refresh(.speechRecognition)
+
+        XCTAssertEqual(manager.status(for: .speechRecognition), .granted)
+        XCTAssertNil(manager.requestIssue(for: .speechRecognition))
+    }
+
+    @MainActor
     func testDidBecomeActive_refreshesPermissionStatuses() async {
         let notificationCenter = NotificationCenter()
         var accessibilityGranted = false

--- a/Tests/SpeakAppTests/PermissionsManagerTests.swift
+++ b/Tests/SpeakAppTests/PermissionsManagerTests.swift
@@ -82,6 +82,28 @@ final class PermissionsManagerTests: XCTestCase {
     }
 
     @MainActor
+    func testSpeechRecognitionRequest_lateCallbackAfterTimeoutIsIgnored() async {
+        let manager = PermissionsManager(
+            statusProvider: { _ in .notDetermined },
+            speechAuthorizationRequester: { callback in
+                Task {
+                    try? await Task.sleep(for: .seconds(0.05))
+                    callback(.authorized)
+                }
+            },
+            speechAuthorizationTimeout: 0.01,
+            notificationCenter: NotificationCenter()
+        )
+
+        let result = await manager.request(.speechRecognition)
+
+        XCTAssertEqual(result, .notDetermined)
+        XCTAssertEqual(manager.requestIssue(for: .speechRecognition), .timedOut)
+        try? await Task.sleep(for: .seconds(0.1))
+        XCTAssertEqual(manager.requestIssue(for: .speechRecognition), .timedOut)
+    }
+
+    @MainActor
     func testRefresh_clearsTimedOutIssueAfterSystemStatusChanges() async {
         var systemStatus = PermissionStatus.notDetermined
         let manager = PermissionsManager(


### PR DESCRIPTION
## Motivation

The Mac App Store build could wait forever when macOS did not deliver the Speech Recognition authorization callback, leaving the permission UX stuck on machines with no usable audio input.

## What changed

- Bound Speech Recognition authorization to an eight-second timeout with a single-resume gate that safely ignores late callbacks.
- Surface actionable guidance and a System Settings link in both Dashboard and Settings when the request times out.
- Clear the issue automatically when the system permission later changes.
- Add regression coverage for successful callbacks, missing callbacks, and recovery after a later grant.

## What changed direction

Connecting a usable input device allowed the production-signed TestFlight build to complete Speech authorization and Deepgram transcription. That proved signing and entitlements were valid; the remaining defect was resilience when macOS never invokes the authorization callback.

## How to test

- `swift test`
- `swift test --filter PermissionsManagerTests`
- `swift test --filter DistributionChannelTests`
- CI-baseline SwiftLint on the four changed files: zero violations
- SwiftFormat lint on the four changed files: zero formatting changes

## Review confidence

High. The concurrency boundary is small, lock-protected, and covered for callback, timeout, late status refresh, and existing platform-distribution behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of speech-recognition permission requests that do not receive a response.
  - Permission requests now time out gracefully and provide guidance instead of leaving the app waiting indefinitely.
  - Permission-related issues are cleared automatically once access is granted or otherwise determined.

- **New Features**
  - Added clearer guidance and an **Open Settings** option when permissions require manual action.
  - Updated Dashboard and Settings permission displays to show relevant issue-specific instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->