### PR TITLE
docs(mac): add App Review proof for Send to Mac listener

### DIFF
--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -260,6 +260,11 @@ jobs:
           expect_info_value CFBundleIdentifier "$BUNDLE_ID"
           expect_info_value CFBundleExecutable "$PRODUCT_NAME"
           expect_info_value CFBundleDisplayName "Just Speak to It (App Store)"
+          expect_info_value NSBonjourServices:0 "_speaktransport._tcp"
+          expect_info_value NSLocalNetworkUsageDescription \
+            "Just Speak to It uses your local network to connect iPhone and Mac for Send to Mac transcription transfer."
+
+          echo "::notice::network.server is required by Settings > General > Send to Mac, which starts an inbound Bonjour NWListener"
 
           if [ -d "$APP_PATH/Contents/Frameworks/Sparkle.framework" ]; then
             echo "::error::Sparkle.framework must not be embedded in the App Store build"

--- a/Docs/MAC_APP_STORE_GUIDE.md
+++ b/Docs/MAC_APP_STORE_GUIDE.md
@@ -236,14 +236,36 @@ xcrun altool --upload-app \
 4. Complete all required fields
 5. Click **Submit for Review**
 
-### Review Notes (if needed)
-```
-API keys are required to use the transcription features. 
-For testing, demo keys can be provided upon request.
+### App Review Information (required)
 
-The app requires Accessibility access for global keyboard shortcuts 
-and Microphone access for recording audio.
+Keep the following text in **App Review Information** for every macOS version. The
+`com.apple.security.network.server` entitlement is intentional: the optional,
+user-enabled **Send to Mac** feature starts an inbound Bonjour listener. Removing
+the entitlement while leaving that feature enabled breaks the feature in the App
+Sandbox.
+
 ```
+Just Speak to It uses the com.apple.security.network.server entitlement only for
+the optional, user-enabled "Send to Mac" feature.
+
+To verify:
+1. Open the macOS app and go to Settings > General > Send to Mac.
+2. Enable "Send to Mac". The app starts an Apple Network.framework NWListener,
+   advertises the Bonjour service _speaktransport._tcp, and displays a pairing code.
+3. In the iOS companion app, go to Settings > Send to Mac > Configure Mac
+   Connection, select the Mac, and enter the pairing code.
+4. The iOS app then opens the inbound TCP connection and can send transcript chunks
+   to the Mac.
+
+The listener is off by default and starts only after the user enables this setting.
+It is not a general-purpose web or FTP server. The app also declares
+com.apple.security.network.client separately for outbound transcription and
+post-processing provider connections.
+```
+
+If automated review flags the entitlement, reply in the Resolution Center with
+the same explanation and verification steps. Do not remove the entitlement unless
+the Send to Mac listener is also removed or gated out of the App Store build.
 
 ## Pre-Submission Checklist
 
@@ -259,6 +281,9 @@ and Microphone access for recording audio.
 - [ ] Tested on Apple Silicon and Intel
 - [ ] No crashes or major bugs
 - [ ] Sandbox entitlements minimal and justified
+- [ ] App Review Information explains and gives test steps for the Send to Mac
+      `com.apple.security.network.server` entitlement
+- [ ] The actual App Store-signed build starts Send to Mac from Settings > General
 
 ## Common Rejection Reasons
 

--- a/Tests/SpeakAppTests/EntitlementsTests.swift
+++ b/Tests/SpeakAppTests/EntitlementsTests.swift
@@ -154,7 +154,7 @@ final class AppStoreEntitlementsTests: XCTestCase {
     func testNetworkServerEntitlement_isPresent() {
         let value = entitlements["com.apple.security.network.server"] as? Bool
         XCTAssertEqual(value, true,
-            "Inbound network is required for the Bonjour Send to Mac listener")
+            "The user-enabled Send to Mac NWListener accepts inbound Bonjour connections")
     }
 
     // MARK: - Forbidden on App Store

--- a/Tests/SpeakCoreTests/DistributionChannelTests.swift
+++ b/Tests/SpeakCoreTests/DistributionChannelTests.swift
@@ -23,6 +23,7 @@ final class DistributionChannelTests: XCTestCase {
         XCTAssertTrue(channel.supportsAutomaticAccessibilityPrompt)
         XCTAssertTrue(channel.supportsAccessibilityTextInsertion)
         XCTAssertTrue(channel.allowsCrossChannelMessaging)
+        XCTAssertTrue(channel.supportsLocalNetworkTransport)
         XCTAssertFalse(channel.isSandboxed)
     }
 
@@ -46,6 +47,8 @@ final class DistributionChannelTests: XCTestCase {
             "The App Store sandbox blocks AXUIElement access to other apps")
         XCTAssertFalse(channel.allowsCrossChannelMessaging,
             "App Store builds must not advertise other distribution channels")
+        XCTAssertTrue(channel.supportsLocalNetworkTransport,
+            "The App Store build exposes the user-enabled Bonjour Send to Mac listener")
         XCTAssertTrue(channel.isSandboxed)
     }
 
@@ -63,6 +66,8 @@ final class DistributionChannelTests: XCTestCase {
                            channel.allowsCrossChannelMessaging)
             XCTAssertEqual(channel.supports(.encryptedCloudKitKeySync),
                            channel.supportsEncryptedCloudKitKeySync)
+            XCTAssertEqual(channel.supports(.localNetworkTransport),
+                           channel.supportsLocalNetworkTransport)
         }
     }
 


### PR DESCRIPTION
## Root cause

Apple automated review blocked both recent macOS submissions because `com.apple.security.network.server` was present without an App Review explanation showing the matching inbound feature. The entitlement is not erroneous: the user-enabled **Send to Mac** control starts an Apple Network.framework `NWListener`, advertises `_speaktransport._tcp`, and accepts connections initiated by the iOS companion app.

Removing the entitlement would break that feature in the App Sandbox. Apple explicitly permits retaining it when its use is explained in App Review Information and the Resolution Center. See the [server entitlement documentation](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.network.server) and [NWListener documentation](https://developer.apple.com/documentation/network/nwlistener).

## What changed

- Replaces the generic review note with copy-ready App Review Information and reviewer test steps.
- Locks local-network transport into the distribution capability tests for both macOS channels.
- Makes archive validation require the server entitlement, Bonjour service, and local-network usage description as one contract.
- Clarifies that the entitlement backs the user-enabled inbound listener.

## Evidence

- Source path: `Sources/SpeakApp/Transport/TransportServer.swift` constructs `NWListener(service:using:)`, installs `newConnectionHandler`, and starts it.
- Bootstrap path: `Sources/SpeakApp/WireUp.swift` starts the listener when `enableSendToMac` is enabled.
- User path: signed App Store/TestFlight build `2.26.1 (12)` exposes **Settings > General > Enable Send to Mac** and defaults it off.
- Signed bundle: `com.apple.security.network.server = true`, `NSBonjourServices[0] = _speaktransport._tcp`, signature valid.
- Executable: contains the Send to Mac control and listener startup strings.

## Verification

- `swiftc -typecheck Sources/SpeakCore/DistributionChannel.swift`
- Release workflow YAML parsed successfully.
- `plutil -lint Config/AppInfo.AppStore.plist Config/SpeakMacOS.AppStore.entitlements`
- `git diff --check`
- Read-only inspection of `/Applications/JustSpeakToItAppStore.app` verified version/build, signing, entitlements, Bonjour metadata, executable strings, and visible Settings control.

A full SwiftPM/Xcode build was intentionally left to CI because only about 11 GiB was free while another Xcode dependency extraction was active.

## Remaining App Store step

Do not upload a new binary for this issue. Add the following to **App Review Information** for each active macOS app record, reply with it in the Resolution Center for the rejected submission, and then use the existing build in the review flow if App Store Connect asks for resubmission:

> Just Speak to It uses the `com.apple.security.network.server` entitlement only for the optional, user-enabled “Send to Mac” feature. To verify, open the macOS app and go to Settings > General > Send to Mac, then enable “Send to Mac.” The app starts an Apple Network.framework `NWListener`, advertises `_speaktransport._tcp`, and displays a pairing code. In the iOS companion app, go to Settings > Send to Mac > Configure Mac Connection, select the Mac, and enter the pairing code. The iOS app then opens the inbound TCP connection and can send transcript chunks to the Mac. The listener is off by default and is not a general-purpose web or FTP server. `com.apple.security.network.client` is declared separately for outbound provider connections.

No Resolution Center reply or App Review resubmission was performed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added App Store review guidance explaining the “Send to Mac” local-network permission and entitlement.
  * Added verification steps and pre-submission checklist items for the feature.

* **Tests**
  * Expanded distribution-channel coverage for local-network transport support.
  * Improved validation of required App Store networking settings and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->