### PR TITLE
test(mac): add transcribe.cpp assessment harness

### DIFF
--- a/Benchmarks/LocalTranscription/corpus.example.json
+++ b/Benchmarks/LocalTranscription/corpus.example.json
@@ -1,0 +1,48 @@
+{
+  "cases" : [
+    {
+      "audioPath" : "audio/clean-short.wav",
+      "id" : "clean-short-en",
+      "language" : "en",
+      "referenceTranscript" : "Replace this text with the human-verified reference transcript.",
+      "tags" : [
+        "short"
+      ]
+    },
+    {
+      "audioPath" : "audio/noisy-accent.wav",
+      "id" : "noisy-accent-en",
+      "language" : "en",
+      "referenceTranscript" : "Replace this text with the human-verified reference transcript.",
+      "tags" : [
+        "accent",
+        "noise"
+      ]
+    },
+    {
+      "audioPath" : "audio/multilingual.wav",
+      "id" : "multilingual",
+      "referenceTranscript" : "Replace this text with the human-verified reference transcript.",
+      "tags" : [
+        "multilingual"
+      ]
+    },
+    {
+      "audioPath" : "audio/long.wav",
+      "id" : "long-recording",
+      "referenceTranscript" : "Replace this text with the human-verified reference transcript.",
+      "tags" : [
+        "long"
+      ]
+    },
+    {
+      "audioPath" : "audio/silence.wav",
+      "id" : "silence",
+      "referenceTranscript" : "",
+      "tags" : [
+        "silence"
+      ]
+    }
+  ],
+  "schemaVersion" : 1
+}

--- a/Benchmarks/LocalTranscription/evidence.example.json
+++ b/Benchmarks/LocalTranscription/evidence.example.json
@@ -1,0 +1,16 @@
+{
+  "appStoreBuildPassed" : false,
+  "cancellationPassed" : false,
+  "directBuildPassed" : false,
+  "longRecordingPassed" : false,
+  "modelArtifacts" : [
+    {
+      "identifier" : "whisper-large-v3-turbo-Q8_0",
+      "license" : "Apache-2.0",
+      "sha256" : "REPLACE_WITH_64_CHARACTER_SHA256",
+      "sizeBytes" : 0,
+      "url" : "https://huggingface.co/handy-computer/whisper-large-v3-turbo-gguf/resolve/PINNED_REVISION/whisper-large-v3-turbo-Q8_0.gguf"
+    }
+  ],
+  "silencePassed" : false
+}

--- a/Benchmarks/LocalTranscription/results/m4-model-families-2026-07-27.json
+++ b/Benchmarks/LocalTranscription/results/m4-model-families-2026-07-27.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-27T00:59:00Z",
+  "host": {
+    "hardwareModel": "Mac16,10",
+    "processor": "Apple M4",
+    "operatingSystem": "Version 26.5.2 (Build 25F84)",
+    "physicalMemoryBytes": 17179869184
+  },
+  "runtime": {
+    "whisperKitCommit": "e2adabbe7d98dc4d0ab9a5b75424ecc42a9cdbef",
+    "transcribeCppVersion": "0.1.3",
+    "transcribeCppCommit": "a94e021ef658dc7c788837341a13f6acea3baf3c"
+  },
+  "corpus": {
+    "dataset": "openslr/librispeech_asr",
+    "revision": "71cacbfb7e2354c4226d01e70d77d5fca3d04ba1",
+    "cases": 21,
+    "selection": "first 10 test-clean, first 10 test-other, plus jobs-silence.wav",
+    "warmupIterations": 1,
+    "measuredIterations": 3
+  },
+  "results": [
+    {
+      "model": "WhisperKit Tiny",
+      "wordErrorRate": 0.0997624703087886,
+      "characterErrorRate": 0.05184776613348042,
+      "medianWallSeconds": 0.074615291,
+      "medianRealTimeFactor": 0.014569362389680924,
+      "peakResidentMemoryMB": 110.4375,
+      "silenceTranscriptEmpty": false
+    },
+    {
+      "model": "Parakeet TDT-CTC 110M Q4_K_M",
+      "wordErrorRate": 0.035629453681710214,
+      "characterErrorRate": 0.014892443463872035,
+      "medianWallSeconds": 0.044989875,
+      "medianRealTimeFactor": 0.009402272727272726,
+      "peakResidentMemoryMB": 324.875,
+      "silenceTranscriptEmpty": true,
+      "artifact": {
+        "revision": "9d66d34f9e1594075c5dd72c90c0f4c321b29f21",
+        "sha256": "486414fd90185a8c8a4ced7c123cfb133ff4f7958426c6b8bd9049946b56b448",
+        "sizeBytes": 89989600,
+        "license": "CC-BY-4.0"
+      }
+    },
+    {
+      "model": "Moonshine Tiny Q8_0",
+      "wordErrorRate": 0.0831353919239905,
+      "characterErrorRate": 0.04688361831218974,
+      "medianWallSeconds": 0.063576958,
+      "medianRealTimeFactor": 0.01549375513784461,
+      "peakResidentMemoryMB": 131.96875,
+      "silenceTranscriptEmpty": false
+    },
+    {
+      "model": "Canary 180M Flash Q4_K_M",
+      "wordErrorRate": 0.021377672209026127,
+      "characterErrorRate": 0.009376723662437948,
+      "medianWallSeconds": 0.099753042,
+      "medianRealTimeFactor": 0.02101704815920398,
+      "peakResidentMemoryMB": 239.796875,
+      "silenceTranscriptEmpty": false
+    }
+  ],
+  "parakeetLongRecording": {
+    "audioSeconds": 142.14,
+    "referenceWords": 420,
+    "baselineWordErrorRate": 0.0689,
+    "candidateWordErrorRate": 0.0404,
+    "baselineMedianWallSeconds": 1.941,
+    "candidateMedianWallSeconds": 1.747,
+    "candidatePeakResidentMemoryMB": 1016.9,
+    "completedWithoutFailure": true
+  },
+  "decision": {
+    "status": "insufficient-evidence",
+    "latencyImprovement": 0.3970421558766018,
+    "relativeWordErrorRegression": -0.6428571428571428,
+    "memoryImprovement": -1.9417091114883984,
+    "recommendation": "Keep WhisperKit; pursue Parakeet 110M as an opt-in English model after cancellation and distribution gates."
+  }
+}

--- a/Docs/TRANSCRIBE_CPP_ASSESSMENT.md
+++ b/Docs/TRANSCRIBE_CPP_ASSESSMENT.md
@@ -1,0 +1,140 @@
+# transcribe.cpp assessment
+
+Issue [#548](https://github.com/crmitchelmore/justspeaktoit/issues/548) asks whether the downloaded-local
+WhisperKit batch path should be replaced by
+[transcribe.cpp](https://github.com/handy-computer/transcribe.cpp). This change adds a reproducible comparison
+tool; it does **not** change the shipping app runtime, default, model catalogue, saved model identifiers, or imported
+WhisperKit models.
+
+## Current integration finding
+
+The assessment pins transcribe.cpp `v0.1.3` (tag commit
+`a94e021ef658dc7c788837341a13f6acea3baf3c`) through its published Apple XCFramework. The SwiftPM checksum is
+`b7a3442e2f3552cac1ee71b5e164934dd4db243f6b4b16b1e3e3ed5d1645eefd`; reproduce it with:
+
+```sh
+curl -L --fail \
+  -o /tmp/TranscribeCpp.xcframework.zip \
+  https://github.com/handy-computer/transcribe.cpp/releases/download/v0.1.3/TranscribeCpp.xcframework.zip
+swift package compute-checksum /tmp/TranscribeCpp.xcframework.zip
+```
+
+The release has macOS arm64/x86_64, iOS device, and iOS Simulator slices. Its official Swift README still marks the
+wrapper as `0.0.1` and in development, and says the standalone Swift package mirror is not published. Therefore this
+assessment consumes only the release's raw `CTranscribe` module in the benchmark executable. `SpeakApp` does not
+depend on `CTranscribe`, so the binary is not linked or bundled into either shipping macOS distribution.
+
+The current production baseline remains WhisperKit via `argmax-oss-swift` `0.18.0` at
+`e2adabbe7d98dc4d0ab9a5b75424ecc42a9cdbef` from `Package.resolved`.
+
+## Initial smoke evidence (not a replacement decision)
+
+On 2026-07-26, the tool ran the upstream 11-second JFK sample on an Apple M4 (`Mac16,10`, macOS 26.5.2). Both
+engines produced the human reference exactly (0 WER/CER over three measured iterations):
+
+| Engine and model | Median warm time | Real-time factor | Peak process RSS |
+| --- | ---: | ---: | ---: |
+| WhisperKit 0.18.0, Whisper Tiny | 97 ms | 0.0088 | 169 MB |
+| transcribe.cpp 0.1.3, Whisper Tiny Q8_0 | 117 ms | 0.0106 | 143 MB |
+
+The candidate was about 20% slower and used about 15% less peak RSS in this smoke run, so it did not meet the 20%
+performance gate. Cold-load values were excluded because one process downloaded a model and Metal pipeline caches
+were already warm for another. This single clean English sample lacks the required corpus, reliability, and
+distribution evidence; its correct outcome is `insufficient-evidence`, not adoption or rejection.
+
+The candidate model was pinned to Hugging Face revision `6687f30c99641ee265df421e582354adbc8848fc`, had byte size
+`45981088`, and SHA-256 `325b9c7997cd1eff81ef709d55766565e71be696130cc3a3d444713798706834`.
+
+## Corpus
+
+Copy `Benchmarks/LocalTranscription/corpus.example.json`, then add consented, human-verified 16 kHz mono 16-bit PCM
+WAV files. Do not commit private user recordings. Both engines receive the same decoded audio. The decision gate
+requires coverage tagged `accent`, `long`, `multilingual`, `noise`, and `silence`; add short clean dictation as a
+sanity case. Run on the same idle Mac, power source, macOS version, and build configuration.
+
+Compare an equivalent Whisper checkpoint first. WhisperKit Large v3 Turbo and transcribe.cpp's
+Whisper Large v3 Turbo Q8_0 isolate runtime differences better than comparing unrelated model families. Evaluate
+Parakeet or streaming models only in separately labelled reports.
+
+## Run
+
+Build the benchmark tool without building or launching the app:
+
+```sh
+swift build --product local-transcription-benchmark
+```
+
+Create the WhisperKit baseline:
+
+```sh
+swift run local-transcription-benchmark run \
+  --engine whisperkit \
+  --model openai_whisper-large-v3-v20240930_turbo_632MB \
+  --repo argmaxinc/whisperkit-coreml \
+  --model-source e2adabbe7d98dc4d0ab9a5b75424ecc42a9cdbef \
+  --manifest /path/to/corpus.json \
+  --warmups 1 \
+  --iterations 3 \
+  --output /path/to/whisperkit.json
+```
+
+Create the transcribe.cpp candidate report with a checksum-verified GGUF pinned to a Hugging Face revision:
+
+```sh
+swift run local-transcription-benchmark run \
+  --engine transcribe.cpp \
+  --model /path/to/whisper-large-v3-turbo-Q8_0.gguf \
+  --model-source https://huggingface.co/handy-computer/whisper-large-v3-turbo-gguf/resolve/PINNED_REVISION/whisper-large-v3-turbo-Q8_0.gguf \
+  --backend metal \
+  --manifest /path/to/corpus.json \
+  --warmups 1 \
+  --iterations 3 \
+  --output /path/to/transcribe-cpp.json
+```
+
+Each report records host details, cold load, per-run transcript, WER, CER, wall time, real-time factor, user/system
+CPU time, peak process RSS, failures, runtime version, and source metadata. Peak RSS is the process high-water mark;
+run each engine in a fresh process. Use Instruments Energy Log for energy comparison because a command-line process
+cannot collect reliable system energy data without privileged tooling.
+
+## Decision gate
+
+Copy `Benchmarks/LocalTranscription/evidence.example.json` and fill it from observed evidence. A model artifact entry
+is complete only when it has a pinned URL, 64-character SHA-256, byte size, and license. Then run:
+
+```sh
+swift run local-transcription-benchmark compare \
+  --baseline /path/to/whisperkit.json \
+  --candidate /path/to/transcribe-cpp.json \
+  --evidence /path/to/evidence.json \
+  --output /path/to/decision.json
+```
+
+The automated result is `proceed`, `reject`, or `insufficient-evidence`. Proceed requires all of the following:
+
+- no more than 5% relative WER regression;
+- at least 20% lower median warm latency or peak RSS, or a documented capability/compatibility gain;
+- identical baseline/candidate cases, required corpus coverage, and zero run failures;
+- explicit successful cancellation, long-recording, and silence checks;
+- successful direct and `TUIST_APP_STORE=1` macOS builds;
+- complete provenance for every proposed GGUF.
+
+Do not add a transcribe.cpp model to `ModelCatalog`, migrate saved selections, or remove WhisperKit based on a smoke
+test. If the full gate passes, follow with a separate opt-in production-adapter PR and retain the WhisperKit adapter
+through at least one observed release.
+
+## Build and linkage evidence for this assessment PR
+
+- `swift test --filter LocalTranscriptionBenchmarkTests`: 9 tests passed.
+- The selected test build also compiled the typed `SpeakCore` routing and catalogue test target.
+- `swift build --product SpeakApp -Xswiftc -DAPP_STORE`: passed, exercising the App Store compilation guards.
+- Direct `tuist generate --no-open`: passed. Its Xcode target graph listed SpeakCore, SpeakSync, SpeakHotKeys,
+  WhisperKit, Sentry, and Sparkle for `SpeakApp`, with no `CTranscribe` dependency.
+- `TUIST_APP_STORE=1 tuist generate --no-open`: passed. The generated target used bundle identifier
+  `com.justspeaktoit.mac.appstore`, product `JustSpeakToItAppStore`, the `APP_STORE` condition, and the sandbox audio
+  input entitlement. Its frameworks contained WhisperKit and Sentry, but neither Sparkle nor CTranscribe.
+
+A full direct Xcode build was stopped during package resolution when free disk reached the 5 GiB safety threshold;
+the agent-created DerivedData was removed. The already completed SwiftPM direct build and App Store guarded build
+provide compilation evidence, while the two generated Tuist graphs provide distribution/linkage evidence. No claim
+is made that an archived, signed, or notarised build was produced.

--- a/Docs/TRANSCRIBE_CPP_ASSESSMENT.md
+++ b/Docs/TRANSCRIBE_CPP_ASSESSMENT.md
@@ -45,6 +45,52 @@ distribution evidence; its correct outcome is `insufficient-evidence`, not adopt
 The candidate model was pinned to Hugging Face revision `6687f30c99641ee265df421e582354adbc8848fc`, had byte size
 `45981088`, and SHA-256 `325b9c7997cd1eff81ef709d55766565e71be696130cc3a3d444713798706834`.
 
+## Model-family follow-up
+
+The runtime claim is broader than a different Whisper implementation. The pinned release can also load Parakeet,
+Canary, Moonshine, SenseVoice, and streaming model families through the same C API. That creates useful opt-in
+possibilities, but it does not support replacing WhisperKit wholesale:
+
+- Parakeet TDT-CTC 110M is the strongest English candidate. Its 90 MB Q4 artifact is close to WhisperKit Tiny's
+  download size, emits timestamps, and is CC-BY-4.0.
+- Canary 180M Flash adds English, German, Spanish, and French transcription plus translation in a 139 MB Q4
+  artifact. It is a capability candidate, not a speed candidate.
+- Parakeet 0.6B v3 covers 25 European languages, but its smallest published artifact is 502 MB.
+- Nemotron 3.5 adds cache-aware streaming across 32 language-locales, but its smallest artifact is 473 MB and uses
+  OpenMDW-1.1.
+- SenseVoice Small covers Chinese, Cantonese, English, Japanese, and Korean, but has a 30-second input contract and
+  a non-standard model license.
+- Moonshine Tiny is compact, but the observed batch result below did not clear the gate and hallucinated on silence.
+
+### Public mini-corpus result
+
+On 2026-07-27 the harness ran the first 10 LibriSpeech `test-clean` and first 10 `test-other` cases from
+`openslr/librispeech_asr` revision `71cacbfb7e2354c4226d01e70d77d5fca3d04ba1`, plus the public
+`jobs-silence.wav` fixture. Each result used one warmup and three measured iterations in a fresh process on the
+same Apple M4 host:
+
+| Model | WER | Median warm time | Peak process RSS | Silence |
+| --- | ---: | ---: | ---: | --- |
+| WhisperKit Tiny | 9.98% | 75 ms | 110 MB | hallucinated text |
+| Parakeet TDT-CTC 110M Q4 | **3.56%** | **45 ms** | 325 MB | empty |
+| Moonshine Tiny Q8 | 8.31% | 64 ms | 132 MB | hallucinated text |
+| Canary 180M Flash Q4 | **2.14%** | 100 ms | 240 MB | hallucinated text |
+
+Against WhisperKit Tiny, Parakeet reduced relative WER by 64.3% and median latency by 39.7%, clearing the accuracy
+and latency gates. Peak RSS increased by 194%, so the improvement is not universal. A separate 142-second,
+420-word public-domain concatenation also completed without failures: Parakeet measured 4.04% WER and 1.747 seconds
+versus WhisperKit Tiny at 6.89% and 1.941 seconds, while Parakeet peaked at 1,017 MB RSS.
+
+The candidate artifact is pinned to Hugging Face revision
+`9d66d34f9e1594075c5dd72c90c0f4c321b29f21`, byte size `89989600`, SHA-256
+`486414fd90185a8c8a4ced7c123cfb133ff4f7958426c6b8bd9049946b56b448`, and CC-BY-4.0. Aggregate evidence is
+checked in at `Benchmarks/LocalTranscription/results/m4-model-families-2026-07-27.json`.
+
+**Recommendation:** retain WhisperKit as the default and multilingual fallback. Continue with a separate,
+opt-in English Parakeet adapter only after cancellation, noisy/accented speech, and both distribution builds are
+verified with the adapter linked. Do not pursue batch Moonshine Tiny. Canary remains a separate multilingual and
+translation capability experiment; its local latency and memory did not justify using it as the default.
+
 ## Corpus
 
 Copy `Benchmarks/LocalTranscription/corpus.example.json`, then add consented, human-verified 16 kHz mono 16-bit PCM

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,11 @@ let package = Package(
         .library(name: "SpeakCore", targets: ["SpeakCore"]),
         .library(name: "SpeakSync", targets: ["SpeakSync"]),
         .library(name: "SpeakiOSLib", targets: ["SpeakiOSLib"]),
-        .executable(name: "SpeakApp", targets: ["SpeakApp"])
+        .executable(name: "SpeakApp", targets: ["SpeakApp"]),
+        .executable(
+            name: "local-transcription-benchmark",
+            targets: ["LocalTranscriptionBenchmark"]
+        )
     ],
     dependencies: [
         .package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.0"),
@@ -23,6 +27,12 @@ let package = Package(
         .package(url: "https://github.com/argmaxinc/argmax-oss-swift.git", from: "0.9.0")
     ],
     targets: [
+        .binaryTarget(
+            name: "CTranscribe",
+            url: "https://github.com/handy-computer/transcribe.cpp/releases/download/v0.1.3/"
+                + "TranscribeCpp.xcframework.zip",
+            checksum: "b7a3442e2f3552cac1ee71b5e164934dd4db243f6b4b16b1e3e3ed5d1645eefd"
+        ),
         .target(
             name: "SpeakHotKeys",
             path: "Sources/SpeakHotKeys"
@@ -57,6 +67,18 @@ let package = Package(
             dependencies: ["SpeakHotKeys"],
             path: "Sources/SpeakHotKeysDemo"
         ),
+        .target(
+            name: "LocalTranscriptionBenchmarkKit",
+            dependencies: ["SpeakCore"]
+        ),
+        .executableTarget(
+            name: "LocalTranscriptionBenchmark",
+            dependencies: [
+                "LocalTranscriptionBenchmarkKit",
+                .product(name: "WhisperKit", package: "argmax-oss-swift"),
+                "CTranscribe"
+            ]
+        ),
         .testTarget(
             name: "SpeakCoreTests",
             dependencies: ["SpeakCore"]
@@ -72,6 +94,10 @@ let package = Package(
         .testTarget(
             name: "SpeakiOSTests",
             dependencies: ["SpeakiOSLib"]
+        ),
+        .testTarget(
+            name: "LocalTranscriptionBenchmarkTests",
+            dependencies: ["LocalTranscriptionBenchmarkKit", "SpeakCore"]
         )
     ]
 )

--- a/Sources/LocalTranscriptionBenchmark/Arguments.swift
+++ b/Sources/LocalTranscriptionBenchmark/Arguments.swift
@@ -31,6 +31,10 @@ enum ArgumentParser {
         let options = try parseOptions(Array(arguments.dropFirst()))
         switch command {
         case "run":
+            try validate(options: options, allowed: [
+                "engine", "model", "model-source", "repo", "backend",
+                "manifest", "output", "warmups", "iterations"
+            ])
             let engine = LocalTranscriptionEngine(identifier: try required("engine", in: options))
             guard engine == .whisperKit || engine == .transcribeCpp else {
                 throw CLIError.invalidValue("--engine must be whisperkit or transcribe.cpp")
@@ -49,6 +53,9 @@ enum ArgumentParser {
                 measuredIterations: iterations
             ))
         case "compare":
+            try validate(options: options, allowed: [
+                "baseline", "candidate", "evidence", "output"
+            ])
             return .compare(CompareArguments(
                 baselineURL: fileURL(try required("baseline", in: options)),
                 candidateURL: fileURL(try required("candidate", in: options)),
@@ -57,6 +64,12 @@ enum ArgumentParser {
             ))
         default:
             throw CLIError.invalidValue("Unknown command: \(command)")
+        }
+    }
+
+    private static func validate(options: [String: String], allowed: Set<String>) throws {
+        if let unsupported = options.keys.sorted().first(where: { !allowed.contains($0) }) {
+            throw CLIError.invalidValue("Unsupported option for this command: --\(unsupported)")
         }
     }
 

--- a/Sources/LocalTranscriptionBenchmark/Arguments.swift
+++ b/Sources/LocalTranscriptionBenchmark/Arguments.swift
@@ -1,0 +1,127 @@
+import Foundation
+import SpeakCore
+
+enum BenchmarkCommand {
+    case run(RunArguments)
+    case compare(CompareArguments)
+}
+
+struct RunArguments {
+    let engine: LocalTranscriptionEngine
+    let model: String
+    let modelSource: String?
+    let modelRepo: String?
+    let backend: String
+    let manifestURL: URL
+    let outputURL: URL
+    let warmupIterations: Int
+    let measuredIterations: Int
+}
+
+struct CompareArguments {
+    let baselineURL: URL
+    let candidateURL: URL
+    let evidenceURL: URL
+    let outputURL: URL
+}
+
+enum ArgumentParser {
+    static func parse(_ arguments: [String]) throws -> BenchmarkCommand {
+        guard let command = arguments.first else { throw CLIError.usage }
+        let options = try parseOptions(Array(arguments.dropFirst()))
+        switch command {
+        case "run":
+            let engine = LocalTranscriptionEngine(identifier: try required("engine", in: options))
+            guard engine == .whisperKit || engine == .transcribeCpp else {
+                throw CLIError.invalidValue("--engine must be whisperkit or transcribe.cpp")
+            }
+            let warmups = try positiveInteger(options["warmups"] ?? "1", name: "warmups", permitsZero: true)
+            let iterations = try positiveInteger(options["iterations"] ?? "3", name: "iterations")
+            return .run(RunArguments(
+                engine: engine,
+                model: try required("model", in: options),
+                modelSource: options["model-source"],
+                modelRepo: options["repo"],
+                backend: options["backend"] ?? "auto",
+                manifestURL: fileURL(try required("manifest", in: options)),
+                outputURL: fileURL(try required("output", in: options)),
+                warmupIterations: warmups,
+                measuredIterations: iterations
+            ))
+        case "compare":
+            return .compare(CompareArguments(
+                baselineURL: fileURL(try required("baseline", in: options)),
+                candidateURL: fileURL(try required("candidate", in: options)),
+                evidenceURL: fileURL(try required("evidence", in: options)),
+                outputURL: fileURL(try required("output", in: options))
+            ))
+        default:
+            throw CLIError.invalidValue("Unknown command: \(command)")
+        }
+    }
+
+    private static func parseOptions(_ arguments: [String]) throws -> [String: String] {
+        guard arguments.count.isMultiple(of: 2) else { throw CLIError.usage }
+        var options: [String: String] = [:]
+        var index = 0
+        while index < arguments.count {
+            let option = arguments[index]
+            guard option.hasPrefix("--"), option.count > 2 else { throw CLIError.usage }
+            let name = String(option.dropFirst(2))
+            guard options[name] == nil else { throw CLIError.invalidValue("Duplicate option: \(option)") }
+            options[name] = arguments[index + 1]
+            index += 2
+        }
+        return options
+    }
+
+    private static func required(_ name: String, in options: [String: String]) throws -> String {
+        guard let value = options[name], !value.isEmpty else {
+            throw CLIError.invalidValue("Missing --\(name)")
+        }
+        return value
+    }
+
+    private static func positiveInteger(
+        _ value: String,
+        name: String,
+        permitsZero: Bool = false
+    ) throws -> Int {
+        guard let parsed = Int(value), permitsZero ? parsed >= 0 : parsed > 0 else {
+            throw CLIError.invalidValue("--\(name) must be \(permitsZero ? "non-negative" : "positive")")
+        }
+        return parsed
+    }
+
+    private static func fileURL(_ path: String) -> URL {
+        URL(fileURLWithPath: path, relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
+            .standardizedFileURL
+    }
+}
+
+enum CLIError: Error, LocalizedError {
+    case usage
+    case invalidValue(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .usage:
+            return Self.usageText
+        case .invalidValue(let message):
+            return "\(message)\n\n\(Self.usageText)"
+        }
+    }
+
+    static let usageText = """
+    Usage:
+      local-transcription-benchmark run \\
+        --engine <whisperkit|transcribe.cpp> --model <name-or-gguf-path> \\
+        --manifest <corpus.json> --output <report.json> \\
+        [--repo <hugging-face-repo>] [--model-source <url-or-revision>] \\
+        [--backend <auto|cpu|metal>] [--warmups <count>] [--iterations <count>]
+
+      local-transcription-benchmark compare \\
+        --baseline <whisperkit-report.json> --candidate <transcribe-cpp-report.json> \\
+        --evidence <evidence.json> --output <decision.json>
+    """
+}

--- a/Sources/LocalTranscriptionBenchmark/Command.swift
+++ b/Sources/LocalTranscriptionBenchmark/Command.swift
@@ -153,6 +153,7 @@ struct LocalTranscriptionBenchmarkCommand {
             caseID: prepared.benchmarkCase.id,
             iteration: iteration,
             tags: prepared.benchmarkCase.tags,
+            language: prepared.benchmarkCase.language,
             referenceTranscript: prepared.benchmarkCase.referenceTranscript,
             transcript: transcript,
             audioSeconds: prepared.wav.durationSeconds,

--- a/Sources/LocalTranscriptionBenchmark/Command.swift
+++ b/Sources/LocalTranscriptionBenchmark/Command.swift
@@ -1,0 +1,175 @@
+import Foundation
+import LocalTranscriptionBenchmarkKit
+
+@main
+struct LocalTranscriptionBenchmarkCommand {
+    static func main() async {
+        do {
+            switch try ArgumentParser.parse(Array(CommandLine.arguments.dropFirst())) {
+            case .run(let arguments):
+                try await run(arguments)
+            case .compare(let arguments):
+                try compare(arguments)
+            }
+        } catch {
+            FileHandle.standardError.write(Data("error: \(error.localizedDescription)\n".utf8))
+            exit(1)
+        }
+    }
+
+    private static func run(_ arguments: RunArguments) async throws {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let corpus = try decoder.decode(
+            LocalTranscriptionBenchmarkCorpus.self,
+            from: Data(contentsOf: arguments.manifestURL)
+        )
+        try corpus.validate()
+
+        let loadStart = ContinuousClock.now
+        let runner: LocalBenchmarkEngineRunner
+        switch arguments.engine {
+        case .whisperKit:
+            runner = try await WhisperKitBenchmarkRunner(model: arguments.model, modelRepo: arguments.modelRepo)
+        case .transcribeCpp:
+            runner = try TranscribeCppBenchmarkRunner(modelPath: arguments.model, backend: arguments.backend)
+        case .streaming, .unknown:
+            throw CLIError.invalidValue("Unsupported benchmark engine: \(arguments.engine.identifier)")
+        }
+        let coldLoadSeconds = durationSeconds(from: loadStart, to: ContinuousClock.now)
+
+        let manifestDirectory = arguments.manifestURL.deletingLastPathComponent()
+        let preparedCases = try corpus.cases.map { benchmarkCase -> (LocalTranscriptionBenchmarkCase, URL, WAVFile) in
+            let audioURL = URL(
+                fileURLWithPath: benchmarkCase.audioPath,
+                relativeTo: manifestDirectory
+            ).standardizedFileURL
+            return (benchmarkCase, audioURL, try WAVFile(url: audioURL))
+        }
+
+        for _ in 0..<arguments.warmupIterations {
+            for (benchmarkCase, audioURL, wav) in preparedCases {
+                _ = try await runner.transcribe(audioURL: audioURL, wav: wav, language: benchmarkCase.language)
+            }
+        }
+
+        var measurements: [LocalTranscriptionBenchmarkMeasurement] = []
+        var failures: [LocalTranscriptionBenchmarkFailure] = []
+        for iteration in 1...arguments.measuredIterations {
+            for (benchmarkCase, audioURL, wav) in preparedCases {
+                let resourcesBefore = ProcessResourceSnapshot.capture()
+                let start = ContinuousClock.now
+                do {
+                    let transcript = try await runner.transcribe(
+                        audioURL: audioURL,
+                        wav: wav,
+                        language: benchmarkCase.language
+                    )
+                    let wallSeconds = durationSeconds(from: start, to: ContinuousClock.now)
+                    let resources = ProcessResourceSnapshot.capture().delta(from: resourcesBefore)
+                    measurements.append(LocalTranscriptionBenchmarkMeasurement(
+                        caseID: benchmarkCase.id,
+                        iteration: iteration,
+                        tags: benchmarkCase.tags,
+                        referenceTranscript: benchmarkCase.referenceTranscript,
+                        transcript: transcript,
+                        audioSeconds: wav.durationSeconds,
+                        wallSeconds: wallSeconds,
+                        userCPUSeconds: resources.userCPUSeconds,
+                        systemCPUSeconds: resources.systemCPUSeconds,
+                        peakResidentMemoryMB: resources.peakResidentMemoryMB
+                    ))
+                } catch {
+                    failures.append(LocalTranscriptionBenchmarkFailure(
+                        caseID: benchmarkCase.id,
+                        iteration: iteration,
+                        message: error.localizedDescription
+                    ))
+                }
+            }
+        }
+
+        let report = LocalTranscriptionBenchmarkReport(
+            engine: runner.engine,
+            runtimeVersion: runner.runtimeVersion,
+            runtimeCommit: runner.runtimeCommit,
+            model: arguments.model,
+            modelSource: arguments.modelSource,
+            host: HostProfiler.current(),
+            coldLoadSeconds: coldLoadSeconds,
+            warmupIterations: arguments.warmupIterations,
+            measuredIterations: arguments.measuredIterations,
+            measurements: measurements,
+            failures: failures
+        )
+        try writeJSON(report, to: arguments.outputURL)
+        printSummary(report.summary, label: runner.engine.identifier)
+        if !failures.isEmpty { throw BenchmarkRunError.caseFailures(failures.count) }
+    }
+
+    private static func compare(_ arguments: CompareArguments) throws {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let baseline = try decoder.decode(
+            LocalTranscriptionBenchmarkReport.self,
+            from: Data(contentsOf: arguments.baselineURL)
+        )
+        let candidate = try decoder.decode(
+            LocalTranscriptionBenchmarkReport.self,
+            from: Data(contentsOf: arguments.candidateURL)
+        )
+        let evidence = try decoder.decode(
+            LocalTranscriptionAssessmentEvidence.self,
+            from: Data(contentsOf: arguments.evidenceURL)
+        )
+        let decision = LocalTranscriptionAssessmentGate.evaluate(
+            baseline: baseline,
+            candidate: candidate,
+            evidence: evidence
+        )
+        try writeJSON(decision, to: arguments.outputURL)
+        print("decision: \(decision.status.rawValue)")
+        decision.reasons.forEach { print("- \($0)") }
+    }
+
+    private static func writeJSON<Value: Encodable>(_ value: Value, to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(value)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: .atomic)
+    }
+
+    private static func durationSeconds(
+        from start: ContinuousClock.Instant,
+        to end: ContinuousClock.Instant
+    ) -> Double {
+        let components = start.duration(to: end).components
+        return Double(components.seconds) + Double(components.attoseconds) / 1e18
+    }
+
+    private static func printSummary(_ summary: LocalTranscriptionBenchmarkSummary, label: String) {
+        print("\(label): WER \(percent(summary.wordErrorRate)), CER \(percent(summary.characterErrorRate))")
+        print(String(format: "median %.3fs, RTF %.4f, peak RSS %.1f MB", summary.medianWallSeconds,
+                     summary.medianRealTimeFactor, summary.peakResidentMemoryMB))
+        print("cases \(summary.caseCount), failures \(summary.failureCount)")
+    }
+
+    private static func percent(_ value: Double) -> String {
+        String(format: "%.2f%%", value * 100)
+    }
+}
+
+enum BenchmarkRunError: Error, LocalizedError {
+    case caseFailures(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .caseFailures(let count): return "Benchmark completed with \(count) failed case(s); report was written."
+        }
+    }
+}

--- a/Sources/LocalTranscriptionBenchmark/Command.swift
+++ b/Sources/LocalTranscriptionBenchmark/Command.swift
@@ -18,76 +18,13 @@ struct LocalTranscriptionBenchmarkCommand {
     }
 
     private static func run(_ arguments: RunArguments) async throws {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        let corpus = try decoder.decode(
-            LocalTranscriptionBenchmarkCorpus.self,
-            from: Data(contentsOf: arguments.manifestURL)
-        )
-        try corpus.validate()
-
+        let corpus = try loadCorpus(from: arguments.manifestURL)
         let loadStart = ContinuousClock.now
-        let runner: LocalBenchmarkEngineRunner
-        switch arguments.engine {
-        case .whisperKit:
-            runner = try await WhisperKitBenchmarkRunner(model: arguments.model, modelRepo: arguments.modelRepo)
-        case .transcribeCpp:
-            runner = try TranscribeCppBenchmarkRunner(modelPath: arguments.model, backend: arguments.backend)
-        case .streaming, .unknown:
-            throw CLIError.invalidValue("Unsupported benchmark engine: \(arguments.engine.identifier)")
-        }
+        let runner = try await makeRunner(for: arguments)
         let coldLoadSeconds = durationSeconds(from: loadStart, to: ContinuousClock.now)
-
-        let manifestDirectory = arguments.manifestURL.deletingLastPathComponent()
-        let preparedCases = try corpus.cases.map { benchmarkCase -> (LocalTranscriptionBenchmarkCase, URL, WAVFile) in
-            let audioURL = URL(
-                fileURLWithPath: benchmarkCase.audioPath,
-                relativeTo: manifestDirectory
-            ).standardizedFileURL
-            return (benchmarkCase, audioURL, try WAVFile(url: audioURL))
-        }
-
-        for _ in 0..<arguments.warmupIterations {
-            for (benchmarkCase, audioURL, wav) in preparedCases {
-                _ = try await runner.transcribe(audioURL: audioURL, wav: wav, language: benchmarkCase.language)
-            }
-        }
-
-        var measurements: [LocalTranscriptionBenchmarkMeasurement] = []
-        var failures: [LocalTranscriptionBenchmarkFailure] = []
-        for iteration in 1...arguments.measuredIterations {
-            for (benchmarkCase, audioURL, wav) in preparedCases {
-                let resourcesBefore = ProcessResourceSnapshot.capture()
-                let start = ContinuousClock.now
-                do {
-                    let transcript = try await runner.transcribe(
-                        audioURL: audioURL,
-                        wav: wav,
-                        language: benchmarkCase.language
-                    )
-                    let wallSeconds = durationSeconds(from: start, to: ContinuousClock.now)
-                    let resources = ProcessResourceSnapshot.capture().delta(from: resourcesBefore)
-                    measurements.append(LocalTranscriptionBenchmarkMeasurement(
-                        caseID: benchmarkCase.id,
-                        iteration: iteration,
-                        tags: benchmarkCase.tags,
-                        referenceTranscript: benchmarkCase.referenceTranscript,
-                        transcript: transcript,
-                        audioSeconds: wav.durationSeconds,
-                        wallSeconds: wallSeconds,
-                        userCPUSeconds: resources.userCPUSeconds,
-                        systemCPUSeconds: resources.systemCPUSeconds,
-                        peakResidentMemoryMB: resources.peakResidentMemoryMB
-                    ))
-                } catch {
-                    failures.append(LocalTranscriptionBenchmarkFailure(
-                        caseID: benchmarkCase.id,
-                        iteration: iteration,
-                        message: error.localizedDescription
-                    ))
-                }
-            }
-        }
+        let preparedCases = try prepareCases(corpus, relativeTo: arguments.manifestURL)
+        try await warmUp(runner, cases: preparedCases, iterations: arguments.warmupIterations)
+        let results = await measure(runner, cases: preparedCases, iterations: arguments.measuredIterations)
 
         let report = LocalTranscriptionBenchmarkReport(
             engine: runner.engine,
@@ -99,12 +36,131 @@ struct LocalTranscriptionBenchmarkCommand {
             coldLoadSeconds: coldLoadSeconds,
             warmupIterations: arguments.warmupIterations,
             measuredIterations: arguments.measuredIterations,
-            measurements: measurements,
-            failures: failures
+            measurements: results.measurements,
+            failures: results.failures
         )
         try writeJSON(report, to: arguments.outputURL)
         printSummary(report.summary, label: runner.engine.identifier)
-        if !failures.isEmpty { throw BenchmarkRunError.caseFailures(failures.count) }
+        if !results.failures.isEmpty { throw BenchmarkRunError.caseFailures(results.failures.count) }
+    }
+
+    private static func loadCorpus(from url: URL) throws -> LocalTranscriptionBenchmarkCorpus {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let corpus = try decoder.decode(LocalTranscriptionBenchmarkCorpus.self, from: Data(contentsOf: url))
+        try corpus.validate()
+        return corpus
+    }
+
+    private static func makeRunner(for arguments: RunArguments) async throws -> LocalBenchmarkEngineRunner {
+        switch arguments.engine {
+        case .whisperKit:
+            return try await WhisperKitBenchmarkRunner(model: arguments.model, modelRepo: arguments.modelRepo)
+        case .transcribeCpp:
+            return try TranscribeCppBenchmarkRunner(modelPath: arguments.model, backend: arguments.backend)
+        case .streaming, .unknown:
+            throw CLIError.invalidValue("Unsupported benchmark engine: \(arguments.engine.identifier)")
+        }
+    }
+
+    private static func prepareCases(
+        _ corpus: LocalTranscriptionBenchmarkCorpus,
+        relativeTo manifestURL: URL
+    ) throws -> [PreparedBenchmarkCase] {
+        let manifestDirectory = manifestURL.deletingLastPathComponent()
+        return try corpus.cases.map { benchmarkCase in
+            let audioURL = URL(
+                fileURLWithPath: benchmarkCase.audioPath,
+                relativeTo: manifestDirectory
+            ).standardizedFileURL
+            return PreparedBenchmarkCase(
+                benchmarkCase: benchmarkCase,
+                audioURL: audioURL,
+                wav: try WAVFile(url: audioURL)
+            )
+        }
+    }
+
+    private static func warmUp(
+        _ runner: LocalBenchmarkEngineRunner,
+        cases: [PreparedBenchmarkCase],
+        iterations: Int
+    ) async throws {
+        for _ in 0..<iterations {
+            for prepared in cases {
+                _ = try await runner.transcribe(
+                    audioURL: prepared.audioURL,
+                    wav: prepared.wav,
+                    language: prepared.benchmarkCase.language
+                )
+            }
+        }
+    }
+
+    private static func measure(
+        _ runner: LocalBenchmarkEngineRunner,
+        cases: [PreparedBenchmarkCase],
+        iterations: Int
+    ) async -> BenchmarkResults {
+        var results = BenchmarkResults()
+        for iteration in 1...iterations {
+            for prepared in cases {
+                await measure(prepared, with: runner, iteration: iteration, results: &results)
+            }
+        }
+        return results
+    }
+
+    private static func measure(
+        _ prepared: PreparedBenchmarkCase,
+        with runner: LocalBenchmarkEngineRunner,
+        iteration: Int,
+        results: inout BenchmarkResults
+    ) async {
+        let resourcesBefore = ProcessResourceSnapshot.capture()
+        let start = ContinuousClock.now
+        do {
+            let transcript = try await runner.transcribe(
+                audioURL: prepared.audioURL,
+                wav: prepared.wav,
+                language: prepared.benchmarkCase.language
+            )
+            let resources = ProcessResourceSnapshot.capture().delta(from: resourcesBefore)
+            results.measurements.append(measurement(
+                for: prepared,
+                iteration: iteration,
+                transcript: transcript,
+                wallSeconds: durationSeconds(from: start, to: ContinuousClock.now),
+                resources: resources
+            ))
+        } catch {
+            results.failures.append(LocalTranscriptionBenchmarkFailure(
+                caseID: prepared.benchmarkCase.id,
+                iteration: iteration,
+                message: error.localizedDescription
+            ))
+        }
+    }
+
+    private static func measurement(
+        for prepared: PreparedBenchmarkCase,
+        iteration: Int,
+        transcript: String,
+        wallSeconds: Double,
+        resources: ProcessResourceSnapshot
+    ) -> LocalTranscriptionBenchmarkMeasurement {
+        LocalTranscriptionBenchmarkMeasurement(
+            caseID: prepared.benchmarkCase.id,
+            iteration: iteration,
+            tags: prepared.benchmarkCase.tags,
+            referenceTranscript: prepared.benchmarkCase.referenceTranscript,
+            transcript: transcript,
+            audioSeconds: prepared.wav.durationSeconds,
+            wallSeconds: wallSeconds,
+            userCPUSeconds: resources.userCPUSeconds,
+            systemCPUSeconds: resources.systemCPUSeconds,
+            peakResidentMemoryMB: resources.peakResidentMemoryMB
+        )
     }
 
     private static func compare(_ arguments: CompareArguments) throws {
@@ -162,6 +218,17 @@ struct LocalTranscriptionBenchmarkCommand {
     private static func percent(_ value: Double) -> String {
         String(format: "%.2f%%", value * 100)
     }
+}
+
+private struct PreparedBenchmarkCase {
+    let benchmarkCase: LocalTranscriptionBenchmarkCase
+    let audioURL: URL
+    let wav: WAVFile
+}
+
+private struct BenchmarkResults {
+    var measurements: [LocalTranscriptionBenchmarkMeasurement] = []
+    var failures: [LocalTranscriptionBenchmarkFailure] = []
 }
 
 enum BenchmarkRunError: Error, LocalizedError {

--- a/Sources/LocalTranscriptionBenchmark/EngineRunners.swift
+++ b/Sources/LocalTranscriptionBenchmark/EngineRunners.swift
@@ -1,0 +1,128 @@
+import CTranscribe
+import Foundation
+import SpeakCore
+import class WhisperKit.WhisperKit
+import class WhisperKit.WhisperKitConfig
+
+protocol LocalBenchmarkEngineRunner: AnyObject {
+    var engine: LocalTranscriptionEngine { get }
+    var runtimeVersion: String { get }
+    var runtimeCommit: String? { get }
+    func transcribe(audioURL: URL, wav: WAVFile, language: String?) async throws -> String
+}
+
+final class WhisperKitBenchmarkRunner: LocalBenchmarkEngineRunner {
+    let engine = LocalTranscriptionEngine.whisperKit
+    let runtimeVersion = "argmax-oss-swift (see Package.resolved)"
+    let runtimeCommit: String? = nil
+    private let pipeline: WhisperKit
+
+    init(model: String, modelRepo: String?) async throws {
+        pipeline = try await WhisperKit(WhisperKitConfig(
+            model: model,
+            modelRepo: modelRepo,
+            verbose: false,
+            load: true
+        ))
+    }
+
+    func transcribe(audioURL: URL, wav: WAVFile, language: String?) async throws -> String {
+        let results = try await pipeline.transcribe(audioPath: audioURL.path)
+        return results.map(\.text).joined(separator: " ")
+            .replacingOccurrences(of: "[BLANK_AUDIO]", with: "", options: .caseInsensitive)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+final class TranscribeCppBenchmarkRunner: LocalBenchmarkEngineRunner {
+    let engine = LocalTranscriptionEngine.transcribeCpp
+    let runtimeVersion: String
+    let runtimeCommit: String?
+    private var model: OpaquePointer?
+    private var session: OpaquePointer?
+
+    init(modelPath: String, backend: String) throws {
+        runtimeVersion = String(cString: transcribe_version())
+        let commit = String(cString: transcribe_version_commit())
+        runtimeCommit = commit == "unknown" ? nil : commit
+
+        var modelParams = transcribe_model_load_params()
+        transcribe_model_load_params_init(&modelParams)
+        switch backend.lowercased() {
+        case "auto": modelParams.backend = TRANSCRIBE_BACKEND_AUTO
+        case "cpu": modelParams.backend = TRANSCRIBE_BACKEND_CPU
+        case "metal": modelParams.backend = TRANSCRIBE_BACKEND_METAL
+        default: throw CLIError.invalidValue("--backend must be auto, cpu, or metal")
+        }
+
+        var loadedModel: OpaquePointer?
+        let loadStatus = modelPath.withCString {
+            transcribe_model_load_file($0, &modelParams, &loadedModel)
+        }
+        try Self.check(loadStatus, context: "load model")
+        guard let loadedModel else { throw TranscribeCppError.nullHandle("model") }
+        model = loadedModel
+
+        var sessionParams = transcribe_session_params()
+        transcribe_session_params_init(&sessionParams)
+        var createdSession: OpaquePointer?
+        let sessionStatus = transcribe_session_init(loadedModel, &sessionParams, &createdSession)
+        do {
+            try Self.check(sessionStatus, context: "create session")
+            guard let createdSession else { throw TranscribeCppError.nullHandle("session") }
+            session = createdSession
+        } catch {
+            transcribe_model_free(loadedModel)
+            model = nil
+            throw error
+        }
+    }
+
+    deinit {
+        if let session { transcribe_session_free(session) }
+        if let model { transcribe_model_free(model) }
+    }
+
+    func transcribe(audioURL: URL, wav: WAVFile, language: String?) async throws -> String {
+        guard let session else { throw TranscribeCppError.nullHandle("session") }
+        var runParams = transcribe_run_params()
+        transcribe_run_params_init(&runParams)
+
+        let status: transcribe_status
+        if let language, !language.isEmpty {
+            status = language.withCString { languagePointer in
+                runParams.language = languagePointer
+                return wav.samples.withUnsafeBufferPointer {
+                    transcribe_run(session, $0.baseAddress, Int32($0.count), &runParams)
+                }
+            }
+        } else {
+            status = wav.samples.withUnsafeBufferPointer {
+                transcribe_run(session, $0.baseAddress, Int32($0.count), &runParams)
+            }
+        }
+        try Self.check(status, context: "transcribe \(audioURL.lastPathComponent)")
+        return String(cString: transcribe_full_text(session))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func check(_ status: transcribe_status, context: String) throws {
+        guard status == TRANSCRIBE_OK else {
+            let message = String(cString: transcribe_status_string(Int32(status.rawValue)))
+            throw TranscribeCppError.status("\(context): \(message) (\(status.rawValue))")
+        }
+    }
+}
+
+enum TranscribeCppError: Error, LocalizedError {
+    case nullHandle(String)
+    case status(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .nullHandle(let handle): return "transcribe.cpp returned a null \(handle) handle"
+        case .status(let message): return message
+        }
+    }
+}

--- a/Sources/LocalTranscriptionBenchmark/EngineRunners.swift
+++ b/Sources/LocalTranscriptionBenchmark/EngineRunners.swift
@@ -1,6 +1,7 @@
 import CTranscribe
 import Foundation
 import SpeakCore
+import struct WhisperKit.DecodingOptions
 import class WhisperKit.WhisperKit
 import class WhisperKit.WhisperKitConfig
 
@@ -13,8 +14,8 @@ protocol LocalBenchmarkEngineRunner: AnyObject {
 
 final class WhisperKitBenchmarkRunner: LocalBenchmarkEngineRunner {
     let engine = LocalTranscriptionEngine.whisperKit
-    let runtimeVersion = "argmax-oss-swift (see Package.resolved)"
-    let runtimeCommit: String? = nil
+    let runtimeVersion = "argmax-oss-swift 0.18.0"
+    let runtimeCommit: String? = "e2adabbe7d98dc4d0ab9a5b75424ecc42a9cdbef"
     private let pipeline: WhisperKit
 
     init(model: String, modelRepo: String?) async throws {
@@ -27,7 +28,11 @@ final class WhisperKitBenchmarkRunner: LocalBenchmarkEngineRunner {
     }
 
     func transcribe(audioURL: URL, wav: WAVFile, language: String?) async throws -> String {
-        let results = try await pipeline.transcribe(audioPath: audioURL.path)
+        let decodeOptions = language.map { DecodingOptions(language: $0) }
+        let results = try await pipeline.transcribe(
+            audioPath: audioURL.path,
+            decodeOptions: decodeOptions
+        )
         return results.map(\.text).joined(separator: " ")
             .replacingOccurrences(of: "[BLANK_AUDIO]", with: "", options: .caseInsensitive)
             .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)

--- a/Sources/LocalTranscriptionBenchmark/ResourceUsage.swift
+++ b/Sources/LocalTranscriptionBenchmark/ResourceUsage.swift
@@ -1,0 +1,59 @@
+import Darwin
+import Foundation
+import LocalTranscriptionBenchmarkKit
+
+struct ProcessResourceSnapshot {
+    let userCPUSeconds: Double
+    let systemCPUSeconds: Double
+    let peakResidentMemoryMB: Double
+
+    static func capture() -> Self {
+        var usage = rusage()
+        getrusage(RUSAGE_SELF, &usage)
+        return Self(
+            userCPUSeconds: seconds(usage.ru_utime),
+            systemCPUSeconds: seconds(usage.ru_stime),
+            peakResidentMemoryMB: Double(usage.ru_maxrss) / 1_048_576
+        )
+    }
+
+    func delta(from earlier: Self) -> Self {
+        Self(
+            userCPUSeconds: max(0, userCPUSeconds - earlier.userCPUSeconds),
+            systemCPUSeconds: max(0, systemCPUSeconds - earlier.systemCPUSeconds),
+            peakResidentMemoryMB: peakResidentMemoryMB
+        )
+    }
+
+    private static func seconds(_ value: timeval) -> Double {
+        Double(value.tv_sec) + Double(value.tv_usec) / 1_000_000
+    }
+}
+
+enum HostProfiler {
+    static func current() -> LocalTranscriptionBenchmarkHost {
+        LocalTranscriptionBenchmarkHost(
+            hardwareModel: sysctl("hw.model"),
+            processor: sysctl("machdep.cpu.brand_string"),
+            operatingSystem: ProcessInfo.processInfo.operatingSystemVersionString,
+            architecture: architecture(),
+            physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory
+        )
+    }
+
+    private static func sysctl(_ name: String) -> String {
+        var size = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else { return "unknown" }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else { return "unknown" }
+        return String(cString: buffer)
+    }
+
+    private static func architecture() -> String {
+        var info = utsname()
+        uname(&info)
+        return withUnsafePointer(to: &info.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) { String(cString: $0) }
+        }
+    }
+}

--- a/Sources/LocalTranscriptionBenchmark/WAVFile.swift
+++ b/Sources/LocalTranscriptionBenchmark/WAVFile.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+struct WAVFile {
+    let samples: [Float]
+    let durationSeconds: Double
+
+    init(url: URL) throws {
+        let data = try Data(contentsOf: url)
+        guard data.count >= 12,
+              String(bytes: data[0..<4], encoding: .ascii) == "RIFF",
+              String(bytes: data[8..<12], encoding: .ascii) == "WAVE" else {
+            throw WAVError.invalidContainer(url.path)
+        }
+
+        var offset = 12
+        var format: (audioFormat: Int, channels: Int, sampleRate: Int, bitsPerSample: Int)?
+        var sampleData: Data?
+        while offset + 8 <= data.count {
+            let identifier = String(bytes: data[offset..<(offset + 4)], encoding: .ascii) ?? ""
+            let chunkSize = Self.littleEndianUInt32(data, offset: offset + 4)
+            let chunkStart = offset + 8
+            let chunkEnd = min(chunkStart + chunkSize, data.count)
+            guard chunkStart <= chunkEnd else { break }
+            if identifier == "fmt ", chunkSize >= 16 {
+                format = (
+                    audioFormat: Self.littleEndianUInt16(data, offset: chunkStart),
+                    channels: Self.littleEndianUInt16(data, offset: chunkStart + 2),
+                    sampleRate: Self.littleEndianUInt32(data, offset: chunkStart + 4),
+                    bitsPerSample: Self.littleEndianUInt16(data, offset: chunkStart + 14)
+                )
+            } else if identifier == "data" {
+                sampleData = data.subdata(in: chunkStart..<chunkEnd)
+            }
+            offset = chunkStart + chunkSize + (chunkSize.isMultiple(of: 2) ? 0 : 1)
+        }
+
+        guard let format, let sampleData else { throw WAVError.missingChunks(url.path) }
+        guard format.audioFormat == 1,
+              format.channels == 1,
+              format.sampleRate == 16_000,
+              format.bitsPerSample == 16 else {
+            throw WAVError.unsupportedFormat(
+                "\(url.path) must be 16 kHz, mono, 16-bit PCM WAV for an engine-neutral comparison"
+            )
+        }
+
+        var decoded: [Float] = []
+        decoded.reserveCapacity(sampleData.count / 2)
+        var sampleOffset = 0
+        while sampleOffset + 1 < sampleData.count {
+            let raw = UInt16(sampleData[sampleOffset]) | UInt16(sampleData[sampleOffset + 1]) << 8
+            decoded.append(Float(Int16(bitPattern: raw)) / 32_768)
+            sampleOffset += 2
+        }
+        samples = decoded
+        durationSeconds = Double(decoded.count) / 16_000
+    }
+
+    private static func littleEndianUInt16(_ data: Data, offset: Int) -> Int {
+        guard offset + 1 < data.count else { return 0 }
+        return Int(data[offset]) | Int(data[offset + 1]) << 8
+    }
+
+    private static func littleEndianUInt32(_ data: Data, offset: Int) -> Int {
+        guard offset + 3 < data.count else { return 0 }
+        return Int(data[offset])
+            | Int(data[offset + 1]) << 8
+            | Int(data[offset + 2]) << 16
+            | Int(data[offset + 3]) << 24
+    }
+}
+
+enum WAVError: Error, LocalizedError {
+    case invalidContainer(String)
+    case missingChunks(String)
+    case unsupportedFormat(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidContainer(let path): return "Not a RIFF/WAVE file: \(path)"
+        case .missingChunks(let path): return "Missing fmt or data chunk: \(path)"
+        case .unsupportedFormat(let message): return message
+        }
+    }
+}

--- a/Sources/LocalTranscriptionBenchmark/WAVFile.swift
+++ b/Sources/LocalTranscriptionBenchmark/WAVFile.swift
@@ -13,7 +13,7 @@ struct WAVFile {
         }
 
         var offset = 12
-        var format: (audioFormat: Int, channels: Int, sampleRate: Int, bitsPerSample: Int)?
+        var format: WAVFormat?
         var sampleData: Data?
         while offset + 8 <= data.count {
             let identifier = String(bytes: data[offset..<(offset + 4)], encoding: .ascii) ?? ""
@@ -22,7 +22,7 @@ struct WAVFile {
             let chunkEnd = min(chunkStart + chunkSize, data.count)
             guard chunkStart <= chunkEnd else { break }
             if identifier == "fmt ", chunkSize >= 16 {
-                format = (
+                format = WAVFormat(
                     audioFormat: Self.littleEndianUInt16(data, offset: chunkStart),
                     channels: Self.littleEndianUInt16(data, offset: chunkStart + 2),
                     sampleRate: Self.littleEndianUInt32(data, offset: chunkStart + 4),
@@ -68,6 +68,13 @@ struct WAVFile {
             | Int(data[offset + 2]) << 16
             | Int(data[offset + 3]) << 24
     }
+}
+
+private struct WAVFormat {
+    let audioFormat: Int
+    let channels: Int
+    let sampleRate: Int
+    let bitsPerSample: Int
 }
 
 enum WAVError: Error, LocalizedError {

--- a/Sources/LocalTranscriptionBenchmark/WAVFile.swift
+++ b/Sources/LocalTranscriptionBenchmark/WAVFile.swift
@@ -19,8 +19,10 @@ struct WAVFile {
             let identifier = String(bytes: data[offset..<(offset + 4)], encoding: .ascii) ?? ""
             let chunkSize = Self.littleEndianUInt32(data, offset: offset + 4)
             let chunkStart = offset + 8
-            let chunkEnd = min(chunkStart + chunkSize, data.count)
-            guard chunkStart <= chunkEnd else { break }
+            guard chunkSize <= data.count - chunkStart else {
+                throw WAVError.invalidContainer(url.path)
+            }
+            let chunkEnd = chunkStart + chunkSize
             if identifier == "fmt ", chunkSize >= 16 {
                 format = WAVFormat(
                     audioFormat: Self.littleEndianUInt16(data, offset: chunkStart),
@@ -35,6 +37,9 @@ struct WAVFile {
         }
 
         guard let format, let sampleData else { throw WAVError.missingChunks(url.path) }
+        guard sampleData.count.isMultiple(of: 2) else {
+            throw WAVError.invalidContainer(url.path)
+        }
         guard format.audioFormat == 1,
               format.channels == 1,
               format.sampleRate == 16_000,

--- a/Sources/LocalTranscriptionBenchmark/WAVFile.swift
+++ b/Sources/LocalTranscriptionBenchmark/WAVFile.swift
@@ -4,6 +4,7 @@ struct WAVFile {
     let samples: [Float]
     let durationSeconds: Double
 
+    // swiftlint:disable:next function_body_length
     init(url: URL) throws {
         let data = try Data(contentsOf: url)
         guard data.count >= 12,

--- a/Sources/LocalTranscriptionBenchmarkKit/AssessmentGate.swift
+++ b/Sources/LocalTranscriptionBenchmarkKit/AssessmentGate.swift
@@ -108,7 +108,7 @@ public enum LocalTranscriptionAssessmentGate {
             baseline: baseline,
             candidate: candidate,
             requiredTags: policy.requiredCorpusTags
-        ) + operationalEvidenceReasons(evidence)
+        ) + operationalEvidenceReasons(evidence, candidateModel: candidate.model)
         let outcome = outcome(rejections: rejectionReasons, missingEvidence: missingEvidence)
 
         return LocalTranscriptionAssessmentDecision(
@@ -131,7 +131,10 @@ public enum LocalTranscriptionAssessmentGate {
     ) -> [String] {
         var reasons: [String] = []
         if metrics.wordErrorRegression > policy.maximumRelativeWordErrorRegression {
-            reasons.append("Candidate WER exceeds the allowed 5% relative regression.")
+            reasons.append(
+                "Candidate WER exceeds the allowed "
+                    + "\(policy.maximumRelativeWordErrorRegression * 100)% relative regression."
+            )
         }
         if baseline.failureCount > 0 || candidate.failureCount > 0 {
             reasons.append("One or more benchmark cases failed.")
@@ -139,7 +142,10 @@ public enum LocalTranscriptionAssessmentGate {
         let performanceGain = max(metrics.latencyImprovement, metrics.memoryImprovement)
         let capabilityGain = evidence.capabilityGain?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if performanceGain < policy.minimumPerformanceImprovement && capabilityGain.isEmpty {
-            reasons.append("Candidate has neither a 20% performance gain nor a documented capability gain.")
+            reasons.append(
+                "Candidate has neither a \(policy.minimumPerformanceImprovement * 100)% "
+                    + "performance gain nor a documented capability gain."
+            )
         }
         return reasons
     }
@@ -155,7 +161,7 @@ public enum LocalTranscriptionAssessmentGate {
         if !missingTags.isEmpty {
             reasons.append("Corpus is missing required tags: \(missingTags.joined(separator: ", ")).")
         }
-        if Set(baseline.measurements.map(\.caseID)) != Set(candidate.measurements.map(\.caseID)) {
+        if corpusIdentity(baseline.measurements) != corpusIdentity(candidate.measurements) {
             reasons.append("Baseline and candidate did not run the same cases.")
         }
         if baseline.engine != .whisperKit { reasons.append("Baseline report must use WhisperKit.") }
@@ -164,7 +170,8 @@ public enum LocalTranscriptionAssessmentGate {
     }
 
     private static func operationalEvidenceReasons(
-        _ evidence: LocalTranscriptionAssessmentEvidence
+        _ evidence: LocalTranscriptionAssessmentEvidence,
+        candidateModel: String
     ) -> [String] {
         var reasons: [String] = []
         if !evidence.directBuildPassed { reasons.append("Direct macOS build is not verified.") }
@@ -172,10 +179,19 @@ public enum LocalTranscriptionAssessmentGate {
         if !evidence.cancellationPassed { reasons.append("Cancellation is not verified.") }
         if !evidence.longRecordingPassed { reasons.append("Long recordings are not verified.") }
         if !evidence.silencePassed { reasons.append("Silence handling is not verified.") }
-        if evidence.modelArtifacts.isEmpty || !evidence.modelArtifacts.allSatisfy(\.isComplete) {
-            reasons.append("Every candidate model needs URL, SHA-256, size, and license evidence.")
+        let matchingArtifact = evidence.modelArtifacts.first { $0.identifier == candidateModel }
+        if matchingArtifact?.isComplete != true {
+            reasons.append("The candidate model needs matching URL, SHA-256, size, and license evidence.")
         }
         return reasons
+    }
+
+    private static func corpusIdentity(
+        _ measurements: [LocalTranscriptionBenchmarkMeasurement]
+    ) -> [CorpusMeasurementIdentity] {
+        measurements.map(CorpusMeasurementIdentity.init).sorted {
+            ($0.caseID, $0.iteration) < ($1.caseID, $1.iteration)
+        }
     }
 
     private static func outcome(
@@ -202,6 +218,24 @@ public enum LocalTranscriptionAssessmentGate {
     fileprivate static func relativeImprovement(baseline: Double, candidate: Double) -> Double {
         guard baseline > 0 else { return 0 }
         return (baseline - candidate) / baseline
+    }
+}
+
+private struct CorpusMeasurementIdentity: Equatable {
+    let caseID: String
+    let iteration: Int
+    let tags: [String]
+    let language: String?
+    let referenceTranscript: String
+    let audioSeconds: Double
+
+    init(_ measurement: LocalTranscriptionBenchmarkMeasurement) {
+        caseID = measurement.caseID
+        iteration = measurement.iteration
+        tags = measurement.tags.sorted()
+        language = measurement.language
+        referenceTranscript = measurement.referenceTranscript
+        audioSeconds = measurement.audioSeconds
     }
 }
 

--- a/Sources/LocalTranscriptionBenchmarkKit/AssessmentGate.swift
+++ b/Sources/LocalTranscriptionBenchmarkKit/AssessmentGate.swift
@@ -96,92 +96,140 @@ public enum LocalTranscriptionAssessmentGate {
     ) -> LocalTranscriptionAssessmentDecision {
         let baselineSummary = baseline.summary
         let candidateSummary = candidate.summary
-        let wordErrorRegression = relativeRegression(
-            baseline: baselineSummary.wordErrorRate,
-            candidate: candidateSummary.wordErrorRate
-        )
-        let latencyImprovement = relativeImprovement(
-            baseline: baselineSummary.medianWallSeconds,
-            candidate: candidateSummary.medianWallSeconds
-        )
-        let memoryImprovement = relativeImprovement(
-            baseline: baselineSummary.peakResidentMemoryMB,
-            candidate: candidateSummary.peakResidentMemoryMB
-        )
-
-        var rejectionReasons: [String] = []
-        var missingEvidence: [String] = []
-
-        if wordErrorRegression > policy.maximumRelativeWordErrorRegression {
-            rejectionReasons.append("Candidate WER exceeds the allowed 5% relative regression.")
-        }
-        if baselineSummary.failureCount > 0 || candidateSummary.failureCount > 0 {
-            rejectionReasons.append("One or more benchmark cases failed.")
-        }
-
-        let hasPerformanceGain = latencyImprovement >= policy.minimumPerformanceImprovement
-            || memoryImprovement >= policy.minimumPerformanceImprovement
-        let hasCapabilityGain = !(
-            evidence.capabilityGain?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
-        )
-        if !hasPerformanceGain && !hasCapabilityGain {
-            rejectionReasons.append("Candidate has neither a 20% performance gain nor a documented capability gain.")
-        }
-
-        let candidateTags = Set(candidateSummary.tagCoverage)
-        let missingTags = policy.requiredCorpusTags.filter { !candidateTags.contains($0) }
-        if !missingTags.isEmpty {
-            missingEvidence.append("Corpus is missing required tags: \(missingTags.joined(separator: ", ")).")
-        }
-        if Set(baseline.measurements.map(\.caseID)) != Set(candidate.measurements.map(\.caseID)) {
-            missingEvidence.append("Baseline and candidate did not run the same cases.")
-        }
-        if baseline.engine != .whisperKit {
-            missingEvidence.append("Baseline report must use WhisperKit.")
-        }
-        if candidate.engine != .transcribeCpp {
-            missingEvidence.append("Candidate report must use transcribe.cpp.")
-        }
-        if !evidence.directBuildPassed { missingEvidence.append("Direct macOS build is not verified.") }
-        if !evidence.appStoreBuildPassed { missingEvidence.append("Mac App Store build is not verified.") }
-        if !evidence.cancellationPassed { missingEvidence.append("Cancellation is not verified.") }
-        if !evidence.longRecordingPassed { missingEvidence.append("Long recordings are not verified.") }
-        if !evidence.silencePassed { missingEvidence.append("Silence handling is not verified.") }
-        if evidence.modelArtifacts.isEmpty || !evidence.modelArtifacts.allSatisfy(\.isComplete) {
-            missingEvidence.append("Every candidate model needs URL, SHA-256, size, and license evidence.")
-        }
-
-        let status: LocalTranscriptionAssessmentDecision.Status
-        let reasons: [String]
-        if !missingEvidence.isEmpty {
-            status = .insufficientEvidence
-            reasons = rejectionReasons + missingEvidence
-        } else if !rejectionReasons.isEmpty {
-            status = .reject
-            reasons = rejectionReasons
-        } else {
-            status = .proceed
-            reasons = ["Accuracy, performance or capability, reliability, distribution, and artifact gates passed."]
-        }
-
-        return LocalTranscriptionAssessmentDecision(
-            status: status,
+        let metrics = AssessmentMetrics(baseline: baselineSummary, candidate: candidateSummary)
+        let rejectionReasons = rejectionReasons(
             baseline: baselineSummary,
             candidate: candidateSummary,
-            relativeWordErrorRegression: wordErrorRegression,
-            latencyImprovement: latencyImprovement,
-            memoryImprovement: memoryImprovement,
-            reasons: reasons
+            evidence: evidence,
+            policy: policy,
+            metrics: metrics
+        )
+        let missingEvidence = corpusEvidenceReasons(
+            baseline: baseline,
+            candidate: candidate,
+            requiredTags: policy.requiredCorpusTags
+        ) + operationalEvidenceReasons(evidence)
+        let outcome = outcome(rejections: rejectionReasons, missingEvidence: missingEvidence)
+
+        return LocalTranscriptionAssessmentDecision(
+            status: outcome.status,
+            baseline: baselineSummary,
+            candidate: candidateSummary,
+            relativeWordErrorRegression: metrics.wordErrorRegression,
+            latencyImprovement: metrics.latencyImprovement,
+            memoryImprovement: metrics.memoryImprovement,
+            reasons: outcome.reasons
         )
     }
 
-    private static func relativeRegression(baseline: Double, candidate: Double) -> Double {
+    private static func rejectionReasons(
+        baseline: LocalTranscriptionBenchmarkSummary,
+        candidate: LocalTranscriptionBenchmarkSummary,
+        evidence: LocalTranscriptionAssessmentEvidence,
+        policy: LocalTranscriptionAssessmentPolicy,
+        metrics: AssessmentMetrics
+    ) -> [String] {
+        var reasons: [String] = []
+        if metrics.wordErrorRegression > policy.maximumRelativeWordErrorRegression {
+            reasons.append("Candidate WER exceeds the allowed 5% relative regression.")
+        }
+        if baseline.failureCount > 0 || candidate.failureCount > 0 {
+            reasons.append("One or more benchmark cases failed.")
+        }
+        let performanceGain = max(metrics.latencyImprovement, metrics.memoryImprovement)
+        let capabilityGain = evidence.capabilityGain?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if performanceGain < policy.minimumPerformanceImprovement && capabilityGain.isEmpty {
+            reasons.append("Candidate has neither a 20% performance gain nor a documented capability gain.")
+        }
+        return reasons
+    }
+
+    private static func corpusEvidenceReasons(
+        baseline: LocalTranscriptionBenchmarkReport,
+        candidate: LocalTranscriptionBenchmarkReport,
+        requiredTags: [String]
+    ) -> [String] {
+        var reasons: [String] = []
+        let candidateTags = Set(candidate.summary.tagCoverage)
+        let missingTags = requiredTags.filter { !candidateTags.contains($0) }
+        if !missingTags.isEmpty {
+            reasons.append("Corpus is missing required tags: \(missingTags.joined(separator: ", ")).")
+        }
+        if Set(baseline.measurements.map(\.caseID)) != Set(candidate.measurements.map(\.caseID)) {
+            reasons.append("Baseline and candidate did not run the same cases.")
+        }
+        if baseline.engine != .whisperKit { reasons.append("Baseline report must use WhisperKit.") }
+        if candidate.engine != .transcribeCpp { reasons.append("Candidate report must use transcribe.cpp.") }
+        return reasons
+    }
+
+    private static func operationalEvidenceReasons(
+        _ evidence: LocalTranscriptionAssessmentEvidence
+    ) -> [String] {
+        var reasons: [String] = []
+        if !evidence.directBuildPassed { reasons.append("Direct macOS build is not verified.") }
+        if !evidence.appStoreBuildPassed { reasons.append("Mac App Store build is not verified.") }
+        if !evidence.cancellationPassed { reasons.append("Cancellation is not verified.") }
+        if !evidence.longRecordingPassed { reasons.append("Long recordings are not verified.") }
+        if !evidence.silencePassed { reasons.append("Silence handling is not verified.") }
+        if evidence.modelArtifacts.isEmpty || !evidence.modelArtifacts.allSatisfy(\.isComplete) {
+            reasons.append("Every candidate model needs URL, SHA-256, size, and license evidence.")
+        }
+        return reasons
+    }
+
+    private static func outcome(
+        rejections: [String],
+        missingEvidence: [String]
+    ) -> AssessmentOutcome {
+        if !missingEvidence.isEmpty {
+            return AssessmentOutcome(status: .insufficientEvidence, reasons: rejections + missingEvidence)
+        }
+        if !rejections.isEmpty {
+            return AssessmentOutcome(status: .reject, reasons: rejections)
+        }
+        return AssessmentOutcome(
+            status: .proceed,
+            reasons: ["Accuracy, performance or capability, reliability, distribution, and artifact gates passed."]
+        )
+    }
+
+    fileprivate static func relativeRegression(baseline: Double, candidate: Double) -> Double {
         guard baseline > 0 else { return candidate > 0 ? 1 : 0 }
         return (candidate - baseline) / baseline
     }
 
-    private static func relativeImprovement(baseline: Double, candidate: Double) -> Double {
+    fileprivate static func relativeImprovement(baseline: Double, candidate: Double) -> Double {
         guard baseline > 0 else { return 0 }
         return (baseline - candidate) / baseline
     }
+}
+
+private struct AssessmentMetrics {
+    let wordErrorRegression: Double
+    let latencyImprovement: Double
+    let memoryImprovement: Double
+
+    init(
+        baseline: LocalTranscriptionBenchmarkSummary,
+        candidate: LocalTranscriptionBenchmarkSummary
+    ) {
+        wordErrorRegression = LocalTranscriptionAssessmentGate.relativeRegression(
+            baseline: baseline.wordErrorRate,
+            candidate: candidate.wordErrorRate
+        )
+        latencyImprovement = LocalTranscriptionAssessmentGate.relativeImprovement(
+            baseline: baseline.medianWallSeconds,
+            candidate: candidate.medianWallSeconds
+        )
+        memoryImprovement = LocalTranscriptionAssessmentGate.relativeImprovement(
+            baseline: baseline.peakResidentMemoryMB,
+            candidate: candidate.peakResidentMemoryMB
+        )
+    }
+}
+
+private struct AssessmentOutcome {
+    let status: LocalTranscriptionAssessmentDecision.Status
+    let reasons: [String]
 }

--- a/Sources/LocalTranscriptionBenchmarkKit/AssessmentGate.swift
+++ b/Sources/LocalTranscriptionBenchmarkKit/AssessmentGate.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+public struct LocalTranscriptionAssessmentPolicy: Codable, Equatable, Sendable {
+    public let maximumRelativeWordErrorRegression: Double
+    public let minimumPerformanceImprovement: Double
+    public let requiredCorpusTags: [String]
+
+    public init(
+        maximumRelativeWordErrorRegression: Double = 0.05,
+        minimumPerformanceImprovement: Double = 0.20,
+        requiredCorpusTags: [String] = ["accent", "long", "multilingual", "noise", "silence"]
+    ) {
+        self.maximumRelativeWordErrorRegression = maximumRelativeWordErrorRegression
+        self.minimumPerformanceImprovement = minimumPerformanceImprovement
+        self.requiredCorpusTags = requiredCorpusTags
+    }
+}
+
+public struct LocalTranscriptionAssessmentEvidence: Codable, Equatable, Sendable {
+    public let directBuildPassed: Bool
+    public let appStoreBuildPassed: Bool
+    public let cancellationPassed: Bool
+    public let longRecordingPassed: Bool
+    public let silencePassed: Bool
+    public let capabilityGain: String?
+    public let modelArtifacts: [LocalTranscriptionModelArtifactEvidence]
+
+    public init(
+        directBuildPassed: Bool,
+        appStoreBuildPassed: Bool,
+        cancellationPassed: Bool,
+        longRecordingPassed: Bool,
+        silencePassed: Bool,
+        capabilityGain: String? = nil,
+        modelArtifacts: [LocalTranscriptionModelArtifactEvidence]
+    ) {
+        self.directBuildPassed = directBuildPassed
+        self.appStoreBuildPassed = appStoreBuildPassed
+        self.cancellationPassed = cancellationPassed
+        self.longRecordingPassed = longRecordingPassed
+        self.silencePassed = silencePassed
+        self.capabilityGain = capabilityGain
+        self.modelArtifacts = modelArtifacts
+    }
+}
+
+public struct LocalTranscriptionModelArtifactEvidence: Codable, Equatable, Sendable {
+    public let identifier: String
+    public let url: String
+    public let sha256: String
+    public let sizeBytes: UInt64
+    public let license: String
+
+    public init(identifier: String, url: String, sha256: String, sizeBytes: UInt64, license: String) {
+        self.identifier = identifier
+        self.url = url
+        self.sha256 = sha256
+        self.sizeBytes = sizeBytes
+        self.license = license
+    }
+
+    public var isComplete: Bool {
+        guard let artifactURL = URL(string: url) else { return false }
+        return !identifier.isEmpty
+            && artifactURL.scheme == "https"
+            && artifactURL.host != nil
+            && sha256.count == 64
+            && sha256.allSatisfy(\.isHexDigit)
+            && sizeBytes > 0
+            && !license.isEmpty
+    }
+}
+
+public struct LocalTranscriptionAssessmentDecision: Codable, Equatable, Sendable {
+    public enum Status: String, Codable, Equatable, Sendable {
+        case proceed
+        case reject
+        case insufficientEvidence = "insufficient-evidence"
+    }
+
+    public let status: Status
+    public let baseline: LocalTranscriptionBenchmarkSummary
+    public let candidate: LocalTranscriptionBenchmarkSummary
+    public let relativeWordErrorRegression: Double
+    public let latencyImprovement: Double
+    public let memoryImprovement: Double
+    public let reasons: [String]
+}
+
+public enum LocalTranscriptionAssessmentGate {
+    public static func evaluate(
+        baseline: LocalTranscriptionBenchmarkReport,
+        candidate: LocalTranscriptionBenchmarkReport,
+        evidence: LocalTranscriptionAssessmentEvidence,
+        policy: LocalTranscriptionAssessmentPolicy = .init()
+    ) -> LocalTranscriptionAssessmentDecision {
+        let baselineSummary = baseline.summary
+        let candidateSummary = candidate.summary
+        let wordErrorRegression = relativeRegression(
+            baseline: baselineSummary.wordErrorRate,
+            candidate: candidateSummary.wordErrorRate
+        )
+        let latencyImprovement = relativeImprovement(
+            baseline: baselineSummary.medianWallSeconds,
+            candidate: candidateSummary.medianWallSeconds
+        )
+        let memoryImprovement = relativeImprovement(
+            baseline: baselineSummary.peakResidentMemoryMB,
+            candidate: candidateSummary.peakResidentMemoryMB
+        )
+
+        var rejectionReasons: [String] = []
+        var missingEvidence: [String] = []
+
+        if wordErrorRegression > policy.maximumRelativeWordErrorRegression {
+            rejectionReasons.append("Candidate WER exceeds the allowed 5% relative regression.")
+        }
+        if baselineSummary.failureCount > 0 || candidateSummary.failureCount > 0 {
+            rejectionReasons.append("One or more benchmark cases failed.")
+        }
+
+        let hasPerformanceGain = latencyImprovement >= policy.minimumPerformanceImprovement
+            || memoryImprovement >= policy.minimumPerformanceImprovement
+        let hasCapabilityGain = !(
+            evidence.capabilityGain?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
+        )
+        if !hasPerformanceGain && !hasCapabilityGain {
+            rejectionReasons.append("Candidate has neither a 20% performance gain nor a documented capability gain.")
+        }
+
+        let candidateTags = Set(candidateSummary.tagCoverage)
+        let missingTags = policy.requiredCorpusTags.filter { !candidateTags.contains($0) }
+        if !missingTags.isEmpty {
+            missingEvidence.append("Corpus is missing required tags: \(missingTags.joined(separator: ", ")).")
+        }
+        if Set(baseline.measurements.map(\.caseID)) != Set(candidate.measurements.map(\.caseID)) {
+            missingEvidence.append("Baseline and candidate did not run the same cases.")
+        }
+        if baseline.engine != .whisperKit {
+            missingEvidence.append("Baseline report must use WhisperKit.")
+        }
+        if candidate.engine != .transcribeCpp {
+            missingEvidence.append("Candidate report must use transcribe.cpp.")
+        }
+        if !evidence.directBuildPassed { missingEvidence.append("Direct macOS build is not verified.") }
+        if !evidence.appStoreBuildPassed { missingEvidence.append("Mac App Store build is not verified.") }
+        if !evidence.cancellationPassed { missingEvidence.append("Cancellation is not verified.") }
+        if !evidence.longRecordingPassed { missingEvidence.append("Long recordings are not verified.") }
+        if !evidence.silencePassed { missingEvidence.append("Silence handling is not verified.") }
+        if evidence.modelArtifacts.isEmpty || !evidence.modelArtifacts.allSatisfy(\.isComplete) {
+            missingEvidence.append("Every candidate model needs URL, SHA-256, size, and license evidence.")
+        }
+
+        let status: LocalTranscriptionAssessmentDecision.Status
+        let reasons: [String]
+        if !missingEvidence.isEmpty {
+            status = .insufficientEvidence
+            reasons = rejectionReasons + missingEvidence
+        } else if !rejectionReasons.isEmpty {
+            status = .reject
+            reasons = rejectionReasons
+        } else {
+            status = .proceed
+            reasons = ["Accuracy, performance or capability, reliability, distribution, and artifact gates passed."]
+        }
+
+        return LocalTranscriptionAssessmentDecision(
+            status: status,
+            baseline: baselineSummary,
+            candidate: candidateSummary,
+            relativeWordErrorRegression: wordErrorRegression,
+            latencyImprovement: latencyImprovement,
+            memoryImprovement: memoryImprovement,
+            reasons: reasons
+        )
+    }
+
+    private static func relativeRegression(baseline: Double, candidate: Double) -> Double {
+        guard baseline > 0 else { return candidate > 0 ? 1 : 0 }
+        return (candidate - baseline) / baseline
+    }
+
+    private static func relativeImprovement(baseline: Double, candidate: Double) -> Double {
+        guard baseline > 0 else { return 0 }
+        return (baseline - candidate) / baseline
+    }
+}

--- a/Sources/LocalTranscriptionBenchmarkKit/BenchmarkModels.swift
+++ b/Sources/LocalTranscriptionBenchmarkKit/BenchmarkModels.swift
@@ -132,6 +132,7 @@ public struct LocalTranscriptionBenchmarkMeasurement: Codable, Equatable, Sendab
     public let caseID: String
     public let iteration: Int
     public let tags: [String]
+    public let language: String?
     public let referenceTranscript: String
     public let transcript: String
     public let audioSeconds: Double
@@ -144,6 +145,7 @@ public struct LocalTranscriptionBenchmarkMeasurement: Codable, Equatable, Sendab
         caseID: String,
         iteration: Int,
         tags: [String],
+        language: String? = nil,
         referenceTranscript: String,
         transcript: String,
         audioSeconds: Double,
@@ -155,6 +157,7 @@ public struct LocalTranscriptionBenchmarkMeasurement: Codable, Equatable, Sendab
         self.caseID = caseID
         self.iteration = iteration
         self.tags = tags
+        self.language = language
         self.referenceTranscript = referenceTranscript
         self.transcript = transcript
         self.audioSeconds = audioSeconds
@@ -170,7 +173,11 @@ public struct LocalTranscriptionBenchmarkMeasurement: Codable, Equatable, Sendab
     }
 
     public var wordErrorRate: Double {
-        TranscriptErrorRate.wordErrorRate(reference: referenceTranscript, hypothesis: transcript)
+        TranscriptErrorRate.wordErrorRate(
+            reference: referenceTranscript,
+            hypothesis: transcript,
+            language: language
+        )
     }
 
     public var characterErrorRate: Double {

--- a/Sources/LocalTranscriptionBenchmarkKit/BenchmarkModels.swift
+++ b/Sources/LocalTranscriptionBenchmarkKit/BenchmarkModels.swift
@@ -1,0 +1,242 @@
+import Foundation
+import SpeakCore
+
+public struct LocalTranscriptionBenchmarkCorpus: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let cases: [LocalTranscriptionBenchmarkCase]
+
+    public init(
+        schemaVersion: Int = currentSchemaVersion,
+        cases: [LocalTranscriptionBenchmarkCase]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.cases = cases
+    }
+
+    public func validate() throws {
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw LocalTranscriptionBenchmarkError.unsupportedSchemaVersion(schemaVersion)
+        }
+        guard !cases.isEmpty else {
+            throw LocalTranscriptionBenchmarkError.emptyCorpus
+        }
+        let identifiers = cases.map(\.id)
+        guard Set(identifiers).count == identifiers.count else {
+            throw LocalTranscriptionBenchmarkError.duplicateCaseIdentifiers
+        }
+        guard cases.allSatisfy({ !$0.id.isEmpty && !$0.audioPath.isEmpty }) else {
+            throw LocalTranscriptionBenchmarkError.invalidCase
+        }
+    }
+}
+
+public struct LocalTranscriptionBenchmarkCase: Codable, Equatable, Sendable {
+    public let id: String
+    public let audioPath: String
+    public let referenceTranscript: String
+    public let language: String?
+    public let tags: [String]
+
+    public init(
+        id: String,
+        audioPath: String,
+        referenceTranscript: String,
+        language: String? = nil,
+        tags: [String] = []
+    ) {
+        self.id = id
+        self.audioPath = audioPath
+        self.referenceTranscript = referenceTranscript
+        self.language = language
+        self.tags = tags
+    }
+}
+
+public struct LocalTranscriptionBenchmarkReport: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let engine: LocalTranscriptionEngine
+    public let runtimeVersion: String
+    public let runtimeCommit: String?
+    public let model: String
+    public let modelSource: String?
+    public let generatedAt: Date
+    public let host: LocalTranscriptionBenchmarkHost
+    public let coldLoadSeconds: Double
+    public let warmupIterations: Int
+    public let measuredIterations: Int
+    public let measurements: [LocalTranscriptionBenchmarkMeasurement]
+    public let failures: [LocalTranscriptionBenchmarkFailure]
+
+    public init(
+        schemaVersion: Int = currentSchemaVersion,
+        engine: LocalTranscriptionEngine,
+        runtimeVersion: String,
+        runtimeCommit: String? = nil,
+        model: String,
+        modelSource: String? = nil,
+        generatedAt: Date = Date(),
+        host: LocalTranscriptionBenchmarkHost,
+        coldLoadSeconds: Double,
+        warmupIterations: Int,
+        measuredIterations: Int,
+        measurements: [LocalTranscriptionBenchmarkMeasurement],
+        failures: [LocalTranscriptionBenchmarkFailure]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.engine = engine
+        self.runtimeVersion = runtimeVersion
+        self.runtimeCommit = runtimeCommit
+        self.model = model
+        self.modelSource = modelSource
+        self.generatedAt = generatedAt
+        self.host = host
+        self.coldLoadSeconds = coldLoadSeconds
+        self.warmupIterations = warmupIterations
+        self.measuredIterations = measuredIterations
+        self.measurements = measurements
+        self.failures = failures
+    }
+
+    public var summary: LocalTranscriptionBenchmarkSummary {
+        LocalTranscriptionBenchmarkSummary(report: self)
+    }
+}
+
+public struct LocalTranscriptionBenchmarkHost: Codable, Equatable, Sendable {
+    public let hardwareModel: String
+    public let processor: String
+    public let operatingSystem: String
+    public let architecture: String
+    public let physicalMemoryBytes: UInt64
+
+    public init(
+        hardwareModel: String,
+        processor: String,
+        operatingSystem: String,
+        architecture: String,
+        physicalMemoryBytes: UInt64
+    ) {
+        self.hardwareModel = hardwareModel
+        self.processor = processor
+        self.operatingSystem = operatingSystem
+        self.architecture = architecture
+        self.physicalMemoryBytes = physicalMemoryBytes
+    }
+}
+
+public struct LocalTranscriptionBenchmarkMeasurement: Codable, Equatable, Sendable {
+    public let caseID: String
+    public let iteration: Int
+    public let tags: [String]
+    public let referenceTranscript: String
+    public let transcript: String
+    public let audioSeconds: Double
+    public let wallSeconds: Double
+    public let userCPUSeconds: Double
+    public let systemCPUSeconds: Double
+    public let peakResidentMemoryMB: Double
+
+    public init(
+        caseID: String,
+        iteration: Int,
+        tags: [String],
+        referenceTranscript: String,
+        transcript: String,
+        audioSeconds: Double,
+        wallSeconds: Double,
+        userCPUSeconds: Double,
+        systemCPUSeconds: Double,
+        peakResidentMemoryMB: Double
+    ) {
+        self.caseID = caseID
+        self.iteration = iteration
+        self.tags = tags
+        self.referenceTranscript = referenceTranscript
+        self.transcript = transcript
+        self.audioSeconds = audioSeconds
+        self.wallSeconds = wallSeconds
+        self.userCPUSeconds = userCPUSeconds
+        self.systemCPUSeconds = systemCPUSeconds
+        self.peakResidentMemoryMB = peakResidentMemoryMB
+    }
+
+    public var realTimeFactor: Double {
+        guard audioSeconds > 0 else { return 0 }
+        return wallSeconds / audioSeconds
+    }
+
+    public var wordErrorRate: Double {
+        TranscriptErrorRate.wordErrorRate(reference: referenceTranscript, hypothesis: transcript)
+    }
+
+    public var characterErrorRate: Double {
+        TranscriptErrorRate.characterErrorRate(reference: referenceTranscript, hypothesis: transcript)
+    }
+}
+
+public struct LocalTranscriptionBenchmarkFailure: Codable, Equatable, Sendable {
+    public let caseID: String
+    public let iteration: Int
+    public let message: String
+
+    public init(caseID: String, iteration: Int, message: String) {
+        self.caseID = caseID
+        self.iteration = iteration
+        self.message = message
+    }
+}
+
+public struct LocalTranscriptionBenchmarkSummary: Codable, Equatable, Sendable {
+    public let wordErrorRate: Double
+    public let characterErrorRate: Double
+    public let medianWallSeconds: Double
+    public let medianRealTimeFactor: Double
+    public let peakResidentMemoryMB: Double
+    public let failureCount: Int
+    public let caseCount: Int
+    public let tagCoverage: [String]
+
+    public init(report: LocalTranscriptionBenchmarkReport) {
+        wordErrorRate = TranscriptErrorRate.aggregateWordErrorRate(report.measurements)
+        characterErrorRate = TranscriptErrorRate.aggregateCharacterErrorRate(report.measurements)
+        medianWallSeconds = Self.median(report.measurements.map(\.wallSeconds))
+        medianRealTimeFactor = Self.median(report.measurements.map(\.realTimeFactor))
+        peakResidentMemoryMB = report.measurements.map(\.peakResidentMemoryMB).max() ?? 0
+        failureCount = report.failures.count
+        caseCount = Set(report.measurements.map(\.caseID)).count
+        tagCoverage = Array(Set(report.measurements.flatMap(\.tags))).sorted()
+    }
+
+    private static func median(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[(sorted.count / 2) - 1] + sorted[sorted.count / 2]) / 2
+        }
+        return sorted[sorted.count / 2]
+    }
+}
+
+public enum LocalTranscriptionBenchmarkError: Error, Equatable, LocalizedError {
+    case unsupportedSchemaVersion(Int)
+    case emptyCorpus
+    case duplicateCaseIdentifiers
+    case invalidCase
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedSchemaVersion(let version):
+            return "Unsupported benchmark schema version: \(version)"
+        case .emptyCorpus:
+            return "The benchmark corpus has no cases."
+        case .duplicateCaseIdentifiers:
+            return "Benchmark case identifiers must be unique."
+        case .invalidCase:
+            return "Every benchmark case needs a non-empty id and audioPath."
+        }
+    }
+}

--- a/Sources/LocalTranscriptionBenchmarkKit/TranscriptErrorRate.swift
+++ b/Sources/LocalTranscriptionBenchmarkKit/TranscriptErrorRate.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+public enum TranscriptErrorRate {
+    public static func wordErrorRate(reference: String, hypothesis: String) -> Double {
+        let referenceWords = normalizedWords(reference)
+        let hypothesisWords = normalizedWords(hypothesis)
+        return rate(reference: referenceWords, hypothesis: hypothesisWords)
+    }
+
+    public static func characterErrorRate(reference: String, hypothesis: String) -> Double {
+        let referenceCharacters = normalizedCharacters(reference)
+        let hypothesisCharacters = normalizedCharacters(hypothesis)
+        return rate(reference: referenceCharacters, hypothesis: hypothesisCharacters)
+    }
+
+    public static func aggregateWordErrorRate(
+        _ measurements: [LocalTranscriptionBenchmarkMeasurement]
+    ) -> Double {
+        aggregateRate(measurements, units: normalizedWords)
+    }
+
+    public static func aggregateCharacterErrorRate(
+        _ measurements: [LocalTranscriptionBenchmarkMeasurement]
+    ) -> Double {
+        aggregateRate(measurements, units: normalizedCharacters)
+    }
+
+    public static func normalizedWords(_ text: String) -> [String] {
+        normalizedText(text).split(separator: " ").map(String.init)
+    }
+
+    public static func normalizedCharacters(_ text: String) -> [Character] {
+        Array(normalizedText(text).filter { !$0.isWhitespace })
+    }
+
+    private static func normalizedText(_ text: String) -> String {
+        let folded = text.folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+        let scalars = folded.unicodeScalars.map { scalar -> Character in
+            if CharacterSet.letters.contains(scalar) || CharacterSet.decimalDigits.contains(scalar) {
+                return Character(String(scalar))
+            }
+            return " "
+        }
+        return String(scalars)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    private static func aggregateRate<Unit: Equatable>(
+        _ measurements: [LocalTranscriptionBenchmarkMeasurement],
+        units: (String) -> [Unit]
+    ) -> Double {
+        var edits = 0
+        var referenceCount = 0
+        for measurement in measurements {
+            let reference = units(measurement.referenceTranscript)
+            edits += editDistance(reference, units(measurement.transcript))
+            referenceCount += reference.count
+        }
+        guard referenceCount > 0 else {
+            return measurements.allSatisfy { units($0.transcript).isEmpty } ? 0 : 1
+        }
+        return Double(edits) / Double(referenceCount)
+    }
+
+    private static func rate<Unit: Equatable>(reference: [Unit], hypothesis: [Unit]) -> Double {
+        guard !reference.isEmpty else { return hypothesis.isEmpty ? 0 : 1 }
+        return Double(editDistance(reference, hypothesis)) / Double(reference.count)
+    }
+
+    private static func editDistance<Unit: Equatable>(_ lhs: [Unit], _ rhs: [Unit]) -> Int {
+        guard !lhs.isEmpty else { return rhs.count }
+        guard !rhs.isEmpty else { return lhs.count }
+
+        var previous = Array(0...rhs.count)
+        for (leftIndex, left) in lhs.enumerated() {
+            var current = [leftIndex + 1]
+            current.reserveCapacity(rhs.count + 1)
+            for (rightIndex, right) in rhs.enumerated() {
+                let substitution = previous[rightIndex] + (left == right ? 0 : 1)
+                let insertion = current[rightIndex] + 1
+                let deletion = previous[rightIndex + 1] + 1
+                current.append(min(substitution, insertion, deletion))
+            }
+            previous = current
+        }
+        return previous[rhs.count]
+    }
+}

--- a/Sources/LocalTranscriptionBenchmarkKit/TranscriptErrorRate.swift
+++ b/Sources/LocalTranscriptionBenchmarkKit/TranscriptErrorRate.swift
@@ -2,8 +2,16 @@ import Foundation
 
 public enum TranscriptErrorRate {
     public static func wordErrorRate(reference: String, hypothesis: String) -> Double {
-        let referenceWords = normalizedWords(reference)
-        let hypothesisWords = normalizedWords(hypothesis)
+        wordErrorRate(reference: reference, hypothesis: hypothesis, language: nil)
+    }
+
+    public static func wordErrorRate(
+        reference: String,
+        hypothesis: String,
+        language: String?
+    ) -> Double {
+        let referenceWords = wordUnits(reference, language: language)
+        let hypothesisWords = wordUnits(hypothesis, language: language)
         return rate(reference: referenceWords, hypothesis: hypothesisWords)
     }
 
@@ -16,7 +24,25 @@ public enum TranscriptErrorRate {
     public static func aggregateWordErrorRate(
         _ measurements: [LocalTranscriptionBenchmarkMeasurement]
     ) -> Double {
-        aggregateRate(measurements, units: normalizedWords)
+        var edits = 0
+        var referenceCount = 0
+        for measurement in measurements {
+            let reference = wordUnits(
+                measurement.referenceTranscript,
+                language: measurement.language
+            )
+            edits += editDistance(
+                reference,
+                wordUnits(measurement.transcript, language: measurement.language)
+            )
+            referenceCount += reference.count
+        }
+        guard referenceCount > 0 else {
+            return measurements.allSatisfy {
+                wordUnits($0.transcript, language: $0.language).isEmpty
+            } ? 0 : 1
+        }
+        return Double(edits) / Double(referenceCount)
     }
 
     public static func aggregateCharacterErrorRate(
@@ -31,6 +57,17 @@ public enum TranscriptErrorRate {
 
     public static func normalizedCharacters(_ text: String) -> [Character] {
         Array(normalizedText(text).filter { !$0.isWhitespace })
+    }
+
+    private static func wordUnits(_ text: String, language: String?) -> [String] {
+        let code = language?
+            .split(whereSeparator: { $0 == "-" || $0 == "_" })
+            .first?
+            .lowercased()
+        if let code, ["zh", "ja", "ko", "th"].contains(code) {
+            return normalizedCharacters(text).map(String.init)
+        }
+        return normalizedWords(text)
     }
 
     private static func normalizedText(_ text: String) -> String {

--- a/Sources/SpeakApp/LocalModelManager.swift
+++ b/Sources/SpeakApp/LocalModelManager.swift
@@ -191,7 +191,7 @@ final class LocalModelManager: ObservableObject {
       id: Self.huggingFaceModelID(repoID: repoID, modelName: resolvedModel.modelName),
       displayName: "\(resolvedModel.displayName) from \(repoID)",
       modelName: resolvedModel.modelName,
-      engine: "whisperkit",
+      engine: .whisperKit,
       modelRepo: repoID,
       approximateSizeMB: resolvedModel.approximateSizeMB,
       description: """
@@ -674,7 +674,7 @@ private struct ImportedModelRecord: Codable {
     id = model.id
     displayName = model.displayName
     modelName = model.modelName
-    engine = model.engine
+    engine = model.engine.identifier
     modelRepo = model.modelRepo
     approximateSizeMB = model.approximateSizeMB
     description = model.description
@@ -686,7 +686,7 @@ private struct ImportedModelRecord: Codable {
       id: id,
       displayName: displayName,
       modelName: modelName,
-      engine: engine,
+      engine: LocalTranscriptionEngine(identifier: engine),
       modelRepo: modelRepo,
       approximateSizeMB: approximateSizeMB,
       description: description,

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -2632,9 +2632,9 @@ struct SettingsView: View {
 
   private func localModelSizeLabel(for model: LocalTranscriptionModel) -> String {
     guard model.approximateSizeMB > 0 else {
-      return "\(model.engine.capitalized) · size confirmed during download"
+      return "\(model.engine.displayName) · size confirmed during download"
     }
-    return "\(model.engine.capitalized) · ~\(model.approximateSizeMB) MB"
+    return "\(model.engine.displayName) · ~\(model.approximateSizeMB) MB"
   }
 
   private func selectedLocalModelStatusIcon(for state: LocalModelManager.InstallState) -> String {

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -544,7 +544,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             id: "local/whisperkit/tiny",
             displayName: "WhisperKit Tiny",
             modelName: "tiny",
-            engine: "whisperkit",
+            engine: .whisperKit,
             approximateSizeMB: 75,
             description: "Small downloadable Core ML Whisper model for fast offline transcription testing.",
             tags: [.fast, .cheap]
@@ -553,7 +553,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             id: "local/whisperkit/base",
             displayName: "WhisperKit Base",
             modelName: "base",
-            engine: "whisperkit",
+            engine: .whisperKit,
             approximateSizeMB: 145,
             description: "Balanced downloaded Whisper model for private offline transcription.",
             tags: [.fast]
@@ -562,7 +562,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             id: "local/whisperkit/small",
             displayName: "WhisperKit Small",
             modelName: "small",
-            engine: "whisperkit",
+            engine: .whisperKit,
             approximateSizeMB: 465,
             description: "Higher quality local Whisper model for longer recordings on Apple silicon.",
             tags: [.quality]
@@ -571,7 +571,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             id: "local/whisperkit/large-v3-turbo",
             displayName: "WhisperKit Large v3 Turbo",
             modelName: "openai_whisper-large-v3-v20240930_turbo_632MB",
-            engine: "whisperkit",
+            engine: .whisperKit,
             approximateSizeMB: 632,
             description: "Whisper Large v3 Turbo — near-Large quality with ≈4× real-time speed on "
                 + "Apple silicon. Recommended for high-accuracy offline transcription.",
@@ -581,7 +581,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             id: "local/whisperkit/distil-large-v3",
             displayName: "WhisperKit Distil-Large v3",
             modelName: "distil-whisper_distil-large-v3_594MB",
-            engine: "whisperkit",
+            engine: .whisperKit,
             approximateSizeMB: 594,
             description: "Distilled Whisper Large v3 — English-optimised, faster and lighter than "
                 + "the full Large model with minimal accuracy loss.",
@@ -591,7 +591,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             id: "local/whisperkit/distil-large-v3-turbo",
             displayName: "WhisperKit Distil-Large v3 Turbo",
             modelName: "distil-whisper_distil-large-v3_turbo_600MB",
-            engine: "whisperkit",
+            engine: .whisperKit,
             approximateSizeMB: 600,
             description: "Distilled, turbo-optimised Whisper Large v3 — fastest high-quality "
                 + "English-only offline option on Apple silicon.",

--- a/Sources/SpeakCore/ModelRouting.swift
+++ b/Sources/SpeakCore/ModelRouting.swift
@@ -1,8 +1,53 @@
 import Foundation
 
+public enum LocalTranscriptionEngine: Hashable, Sendable {
+    case whisperKit
+    case transcribeCpp
+    case streaming
+    case unknown(String)
+
+    public init(identifier: String) {
+        switch identifier.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "whisperkit": self = .whisperKit
+        case "transcribe.cpp", "transcribe-cpp": self = .transcribeCpp
+        case "streaming": self = .streaming
+        case let identifier: self = .unknown(identifier)
+        }
+    }
+
+    public var identifier: String {
+        switch self {
+        case .whisperKit: return "whisperkit"
+        case .transcribeCpp: return "transcribe.cpp"
+        case .streaming: return "streaming"
+        case .unknown(let identifier): return identifier
+        }
+    }
+
+    public var displayName: String {
+        switch self {
+        case .whisperKit: return "WhisperKit"
+        case .transcribeCpp: return "transcribe.cpp"
+        case .streaming: return "Streaming"
+        case .unknown(let identifier): return identifier.capitalized
+        }
+    }
+}
+
+extension LocalTranscriptionEngine: Codable {
+    public init(from decoder: Decoder) throws {
+        self.init(identifier: try decoder.singleValueContainer().decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(identifier)
+    }
+}
+
 public enum TranscriptionModelFamily: Equatable, Sendable {
     case appleSpeech
-    case downloadedLocal(engine: String)
+    case downloadedLocal(engine: LocalTranscriptionEngine)
     case cloudStreaming(provider: String)
     case cloudBatch(provider: String)
     case postProcessing(provider: String)
@@ -17,8 +62,9 @@ public enum TranscriptionModelFamily: Equatable, Sendable {
         switch self {
         case .appleSpeech:
             return "apple"
-        case .downloadedLocal(let engine),
-             .cloudStreaming(let engine),
+        case .downloadedLocal(let engine):
+            return engine.identifier
+        case .cloudStreaming(let engine),
              .cloudBatch(let engine),
              .postProcessing(let engine):
             return engine
@@ -44,7 +90,11 @@ public enum ModelRouting {
             return .postProcessing(provider: provider)
         }
         if provider == "local" {
-            return .downloadedLocal(engine: components.dropFirst().first?.lowercased() ?? "unknown")
+            return .downloadedLocal(
+                engine: LocalTranscriptionEngine(
+                    identifier: components.dropFirst().first ?? "unknown"
+                )
+            )
         }
         if ModelCatalog.liveTranscription.contains(where: { $0.id == trimmed }) {
             return .cloudStreaming(provider: provider)
@@ -66,7 +116,7 @@ public struct LocalTranscriptionModel: Identifiable, Hashable, Sendable {
     public let id: String
     public let displayName: String
     public let modelName: String
-    public let engine: String
+    public let engine: LocalTranscriptionEngine
     public let modelRepo: String?
     public let approximateSizeMB: Int
     public let description: String
@@ -77,7 +127,7 @@ public struct LocalTranscriptionModel: Identifiable, Hashable, Sendable {
         id: String,
         displayName: String,
         modelName: String,
-        engine: String,
+        engine: LocalTranscriptionEngine,
         modelRepo: String? = nil,
         approximateSizeMB: Int,
         description: String,

--- a/Tests/LocalTranscriptionBenchmarkTests/AssessmentGateTests.swift
+++ b/Tests/LocalTranscriptionBenchmarkTests/AssessmentGateTests.swift
@@ -85,11 +85,34 @@ final class AssessmentGateTests: XCTestCase {
         XCTAssertTrue(decision.reasons.contains { $0.contains("Long recordings") })
     }
 
+    func testGate_rejectsEvidenceForDifferentCandidateModel() {
+        let decision = LocalTranscriptionAssessmentGate.evaluate(
+            baseline: report(engine: .whisperKit),
+            candidate: report(engine: .transcribeCpp),
+            evidence: completeEvidence(artifactIdentifier: "different-model")
+        )
+
+        XCTAssertEqual(decision.status, .insufficientEvidence)
+        XCTAssertTrue(decision.reasons.contains { $0.contains("candidate model") })
+    }
+
+    func testGate_rejectsChangedCorpusContentWithSameCaseID() {
+        let decision = LocalTranscriptionAssessmentGate.evaluate(
+            baseline: report(engine: .whisperKit, referenceTranscript: "original words"),
+            candidate: report(engine: .transcribeCpp, referenceTranscript: "changed words"),
+            evidence: completeEvidence()
+        )
+
+        XCTAssertEqual(decision.status, .insufficientEvidence)
+        XCTAssertTrue(decision.reasons.contains { $0.contains("same cases") })
+    }
+
     private func report(
         engine: LocalTranscriptionEngine,
         transcript: String = "one two three four",
         wallSeconds: Double = 1,
         memoryMB: Double = 100,
+        referenceTranscript: String = "one two three four",
         tags: [String] = ["accent", "long", "multilingual", "noise", "silence"]
     ) -> LocalTranscriptionBenchmarkReport {
         LocalTranscriptionBenchmarkReport(
@@ -110,7 +133,7 @@ final class AssessmentGateTests: XCTestCase {
                 caseID: "case",
                 iteration: 1,
                 tags: tags,
-                referenceTranscript: "one two three four",
+                referenceTranscript: referenceTranscript,
                 transcript: transcript,
                 audioSeconds: 10,
                 wallSeconds: wallSeconds,
@@ -122,7 +145,9 @@ final class AssessmentGateTests: XCTestCase {
         )
     }
 
-    private func completeEvidence() -> LocalTranscriptionAssessmentEvidence {
+    private func completeEvidence(
+        artifactIdentifier: String = "test-model"
+    ) -> LocalTranscriptionAssessmentEvidence {
         LocalTranscriptionAssessmentEvidence(
             directBuildPassed: true,
             appStoreBuildPassed: true,
@@ -130,7 +155,7 @@ final class AssessmentGateTests: XCTestCase {
             longRecordingPassed: true,
             silencePassed: true,
             modelArtifacts: [LocalTranscriptionModelArtifactEvidence(
-                identifier: "candidate",
+                identifier: artifactIdentifier,
                 url: "https://example.com/model.gguf",
                 sha256: String(repeating: "a", count: 64),
                 sizeBytes: 1,

--- a/Tests/LocalTranscriptionBenchmarkTests/AssessmentGateTests.swift
+++ b/Tests/LocalTranscriptionBenchmarkTests/AssessmentGateTests.swift
@@ -1,0 +1,102 @@
+import LocalTranscriptionBenchmarkKit
+import SpeakCore
+import XCTest
+
+final class AssessmentGateTests: XCTestCase {
+    func testGate_proceedsWhenAllMeasuredAndOperationalGatesPass() {
+        let decision = LocalTranscriptionAssessmentGate.evaluate(
+            baseline: report(engine: .whisperKit, wallSeconds: 1, memoryMB: 100),
+            candidate: report(engine: .transcribeCpp, wallSeconds: 0.9, memoryMB: 75),
+            evidence: completeEvidence()
+        )
+
+        XCTAssertEqual(decision.status, .proceed)
+        XCTAssertEqual(decision.memoryImprovement, 0.25, accuracy: 0.000_1)
+    }
+
+    func testGate_rejectsAccuracyRegressionEvenWhenPerformanceImproves() {
+        let decision = LocalTranscriptionAssessmentGate.evaluate(
+            baseline: report(engine: .whisperKit, transcript: "one two three four"),
+            candidate: report(engine: .transcribeCpp, transcript: "one wrong three four", wallSeconds: 0.5),
+            evidence: completeEvidence()
+        )
+
+        XCTAssertEqual(decision.status, .reject)
+        XCTAssertTrue(decision.reasons.contains { $0.contains("WER") })
+    }
+
+    func testGate_reportsInsufficientEvidenceForSmokeCorpusAndUnverifiedDistribution() {
+        let incompleteEvidence = LocalTranscriptionAssessmentEvidence(
+            directBuildPassed: true,
+            appStoreBuildPassed: false,
+            cancellationPassed: false,
+            longRecordingPassed: false,
+            silencePassed: false,
+            capabilityGain: nil,
+            modelArtifacts: []
+        )
+        let decision = LocalTranscriptionAssessmentGate.evaluate(
+            baseline: report(engine: .whisperKit, tags: ["short"]),
+            candidate: report(engine: .transcribeCpp, tags: ["short"]),
+            evidence: incompleteEvidence
+        )
+
+        XCTAssertEqual(decision.status, .insufficientEvidence)
+        XCTAssertTrue(decision.reasons.contains { $0.contains("required tags") })
+        XCTAssertTrue(decision.reasons.contains { $0.contains("App Store") })
+    }
+
+    private func report(
+        engine: LocalTranscriptionEngine,
+        transcript: String = "one two three four",
+        wallSeconds: Double = 1,
+        memoryMB: Double = 100,
+        tags: [String] = ["accent", "long", "multilingual", "noise", "silence"]
+    ) -> LocalTranscriptionBenchmarkReport {
+        LocalTranscriptionBenchmarkReport(
+            engine: engine,
+            runtimeVersion: "test",
+            model: "test-model",
+            host: LocalTranscriptionBenchmarkHost(
+                hardwareModel: "test",
+                processor: "test",
+                operatingSystem: "test",
+                architecture: "arm64",
+                physicalMemoryBytes: 1
+            ),
+            coldLoadSeconds: 0.1,
+            warmupIterations: 1,
+            measuredIterations: 1,
+            measurements: [LocalTranscriptionBenchmarkMeasurement(
+                caseID: "case",
+                iteration: 1,
+                tags: tags,
+                referenceTranscript: "one two three four",
+                transcript: transcript,
+                audioSeconds: 10,
+                wallSeconds: wallSeconds,
+                userCPUSeconds: wallSeconds,
+                systemCPUSeconds: 0,
+                peakResidentMemoryMB: memoryMB
+            )],
+            failures: []
+        )
+    }
+
+    private func completeEvidence() -> LocalTranscriptionAssessmentEvidence {
+        LocalTranscriptionAssessmentEvidence(
+            directBuildPassed: true,
+            appStoreBuildPassed: true,
+            cancellationPassed: true,
+            longRecordingPassed: true,
+            silencePassed: true,
+            modelArtifacts: [LocalTranscriptionModelArtifactEvidence(
+                identifier: "candidate",
+                url: "https://example.com/model.gguf",
+                sha256: String(repeating: "a", count: 64),
+                sizeBytes: 1,
+                license: "Apache-2.0"
+            )]
+        )
+    }
+}

--- a/Tests/LocalTranscriptionBenchmarkTests/AssessmentGateTests.swift
+++ b/Tests/LocalTranscriptionBenchmarkTests/AssessmentGateTests.swift
@@ -46,6 +46,45 @@ final class AssessmentGateTests: XCTestCase {
         XCTAssertTrue(decision.reasons.contains { $0.contains("App Store") })
     }
 
+    func testGate_acceptsLatencyAndAccuracyGainDespiteMemoryTradeoff() {
+        let incompleteEvidence = LocalTranscriptionAssessmentEvidence(
+            directBuildPassed: true,
+            appStoreBuildPassed: true,
+            cancellationPassed: false,
+            longRecordingPassed: false,
+            silencePassed: true,
+            modelArtifacts: [LocalTranscriptionModelArtifactEvidence(
+                identifier: "parakeet-tdt-ctc-110m-q4",
+                url: "https://example.com/parakeet.gguf",
+                sha256: String(repeating: "a", count: 64),
+                sizeBytes: 89_989_600,
+                license: "CC-BY-4.0"
+            )]
+        )
+        let decision = LocalTranscriptionAssessmentGate.evaluate(
+            baseline: report(
+                engine: .whisperKit,
+                transcript: "one wrong three four",
+                wallSeconds: 0.074_615_291,
+                memoryMB: 110.4375
+            ),
+            candidate: report(
+                engine: .transcribeCpp,
+                wallSeconds: 0.044_989_875,
+                memoryMB: 324.875
+            ),
+            evidence: incompleteEvidence
+        )
+
+        XCTAssertEqual(decision.status, .insufficientEvidence)
+        XCTAssertEqual(decision.latencyImprovement, 0.397_042, accuracy: 0.000_001)
+        XCTAssertLessThan(decision.memoryImprovement, 0)
+        XCTAssertFalse(decision.reasons.contains { $0.contains("WER") })
+        XCTAssertFalse(decision.reasons.contains { $0.contains("performance gain") })
+        XCTAssertTrue(decision.reasons.contains { $0.contains("Cancellation") })
+        XCTAssertTrue(decision.reasons.contains { $0.contains("Long recordings") })
+    }
+
     private func report(
         engine: LocalTranscriptionEngine,
         transcript: String = "one two three four",

--- a/Tests/LocalTranscriptionBenchmarkTests/BenchmarkCorpusTests.swift
+++ b/Tests/LocalTranscriptionBenchmarkTests/BenchmarkCorpusTests.swift
@@ -1,0 +1,29 @@
+import LocalTranscriptionBenchmarkKit
+import XCTest
+
+final class BenchmarkCorpusTests: XCTestCase {
+    func testCorpusValidation_acceptsUniqueNonEmptyCases() throws {
+        let corpus = LocalTranscriptionBenchmarkCorpus(cases: [
+            LocalTranscriptionBenchmarkCase(
+                id: "clean-short",
+                audioPath: "audio/clean-short.wav",
+                referenceTranscript: "hello world"
+            )
+        ])
+
+        XCTAssertNoThrow(try corpus.validate())
+    }
+
+    func testCorpusValidation_rejectsDuplicateIdentifiers() {
+        let benchmarkCase = LocalTranscriptionBenchmarkCase(
+            id: "duplicate",
+            audioPath: "audio.wav",
+            referenceTranscript: "hello"
+        )
+        let corpus = LocalTranscriptionBenchmarkCorpus(cases: [benchmarkCase, benchmarkCase])
+
+        XCTAssertThrowsError(try corpus.validate()) { error in
+            XCTAssertEqual(error as? LocalTranscriptionBenchmarkError, .duplicateCaseIdentifiers)
+        }
+    }
+}

--- a/Tests/LocalTranscriptionBenchmarkTests/TranscriptErrorRateTests.swift
+++ b/Tests/LocalTranscriptionBenchmarkTests/TranscriptErrorRateTests.swift
@@ -39,6 +39,17 @@ final class TranscriptErrorRateTests: XCTestCase {
         XCTAssertEqual(TranscriptErrorRate.aggregateWordErrorRate(measurements), 0.25)
     }
 
+    func testWordErrorRate_usesCharactersForLanguagesWithoutWordBoundaries() {
+        XCTAssertEqual(
+            TranscriptErrorRate.wordErrorRate(
+                reference: "你好世界",
+                hypothesis: "你好世",
+                language: "zh-CN"
+            ),
+            0.25
+        )
+    }
+
     private func measurement(
         reference: String,
         transcript: String

--- a/Tests/LocalTranscriptionBenchmarkTests/TranscriptErrorRateTests.swift
+++ b/Tests/LocalTranscriptionBenchmarkTests/TranscriptErrorRateTests.swift
@@ -1,0 +1,59 @@
+import LocalTranscriptionBenchmarkKit
+import SpeakCore
+import XCTest
+
+final class TranscriptErrorRateTests: XCTestCase {
+    func testWordErrorRate_normalizesCasePunctuationAndDiacritics() {
+        XCTAssertEqual(
+            TranscriptErrorRate.wordErrorRate(
+                reference: "Café, HELLO!",
+                hypothesis: "cafe hello"
+            ),
+            0
+        )
+    }
+
+    func testWordErrorRate_countsSubstitutionInsertionAndDeletion() {
+        XCTAssertEqual(
+            TranscriptErrorRate.wordErrorRate(
+                reference: "one two three four",
+                hypothesis: "one too extra"
+            ),
+            0.75
+        )
+    }
+
+    func testCharacterErrorRate_ignoresSpacesAndPunctuation() {
+        XCTAssertEqual(
+            TranscriptErrorRate.characterErrorRate(reference: "A B-C", hypothesis: "abc"),
+            0
+        )
+    }
+
+    func testAggregateRate_weightsByReferenceLength() {
+        let measurements = [
+            measurement(reference: "one", transcript: "wrong"),
+            measurement(reference: "one two three", transcript: "one two three")
+        ]
+
+        XCTAssertEqual(TranscriptErrorRate.aggregateWordErrorRate(measurements), 0.25)
+    }
+
+    private func measurement(
+        reference: String,
+        transcript: String
+    ) -> LocalTranscriptionBenchmarkMeasurement {
+        LocalTranscriptionBenchmarkMeasurement(
+            caseID: reference,
+            iteration: 1,
+            tags: [],
+            referenceTranscript: reference,
+            transcript: transcript,
+            audioSeconds: 1,
+            wallSeconds: 1,
+            userCPUSeconds: 0,
+            systemCPUSeconds: 0,
+            peakResidentMemoryMB: 100
+        )
+    }
+}

--- a/Tests/SpeakAppTests/LocalModelManagerTests.swift
+++ b/Tests/SpeakAppTests/LocalModelManagerTests.swift
@@ -56,7 +56,7 @@ final class LocalModelManagerTests: XCTestCase {
             id: "local/whisperkit/huggingface/argmaxinc/whisperkit-coreml/openai-whisper-large-v3-turbo",
             displayName: "Whisper Large v3 Turbo from argmaxinc/whisperkit-coreml",
             modelName: "openai_whisper-large-v3_turbo_954MB",
-            engine: "whisperkit",
+            engine: .whisperKit,
             modelRepo: "argmaxinc/whisperkit-coreml",
             approximateSizeMB: 954,
             description: "Imported from Hugging Face.",

--- a/Tests/SpeakCoreTests/LocalTranscriptionRoutingInvariantTests.swift
+++ b/Tests/SpeakCoreTests/LocalTranscriptionRoutingInvariantTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import SpeakCore
+
+final class LocalTranscriptionRoutingInvariantTests: XCTestCase {
+    func testCatalogEnginesMatchRouting() {
+        for model in ModelCatalog.localTranscription {
+            XCTAssertEqual(
+                ModelRouting.family(for: model.id),
+                .downloadedLocal(engine: model.engine),
+                "\(model.id) must route through its declared engine"
+            )
+        }
+    }
+}

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -124,7 +124,26 @@ final class ModelCatalogTests: XCTestCase {
     func testModelRouting_distinguishesAppleSpeechFromDownloadedLocal() {
         XCTAssertEqual(ModelRouting.family(for: "apple/local/SFSpeechRecognizer"), .appleSpeech)
         XCTAssertEqual(ModelRouting.family(for: "apple/local/SpeechTranscriber"), .appleSpeech)
-        XCTAssertEqual(ModelRouting.family(for: "local/whisperkit/tiny"), .downloadedLocal(engine: "whisperkit"))
+        XCTAssertEqual(ModelRouting.family(for: "local/whisperkit/tiny"), .downloadedLocal(engine: .whisperKit))
+        XCTAssertEqual(
+            ModelRouting.family(for: "local/transcribe.cpp/whisper-large-v3-turbo"),
+            .downloadedLocal(engine: .transcribeCpp)
+        )
+    }
+
+    func testLocalTranscriptionEngine_preservesUnknownBoundaryValues() throws {
+        let engine = LocalTranscriptionEngine(identifier: "Future-Runtime")
+
+        XCTAssertEqual(engine, .unknown("future-runtime"))
+        XCTAssertEqual(engine.identifier, "future-runtime")
+        XCTAssertEqual(
+            try JSONDecoder().decode(
+                LocalTranscriptionEngine.self,
+                from: Data(#""transcribe-cpp""#.utf8)
+            ),
+            .transcribeCpp
+        )
+        XCTAssertEqual(String(data: try JSONEncoder().encode(engine), encoding: .utf8), #""future-runtime""#)
     }
 
     func testLiveTranscriptionPlacement_keepsAppleModelsOnlyOnDevice() {


### PR DESCRIPTION
## Summary

- pins `transcribe.cpp` v0.1.3 as a benchmark-only dependency through its raw C XCFramework API
- adds typed local-engine identifiers, reproducible corpus/runner tooling, WER/CER/latency/memory reporting, artifact provenance, and explicit adoption gates
- records an Apple M4 comparison across WhisperKit Tiny, Parakeet TDT-CTC 110M Q4, Moonshine Tiny Q8, and Canary 180M Flash Q4
- adds a regression test for the observed Parakeet tradeoff: accuracy and latency improve while memory regresses, so missing operational evidence still prevents adoption

This draft does not change the production transcription engine. WhisperKit remains the default and fallback.

## Evidence

- `swift test --filter LocalTranscriptionBenchmarkTests`: 10 passed, 0 failed
- public 21-case mini-corpus, one warmup and three measured iterations per case on Apple M4:
  - WhisperKit Tiny: 9.98% WER, 75 ms median, 110 MB peak RSS
  - Parakeet 110M Q4: 3.56% WER, 45 ms median, 325 MB peak RSS, empty silence transcript
  - Moonshine Tiny Q8: 8.31% WER, 64 ms median, 132 MB peak RSS, hallucinated on silence
  - Canary 180M Flash Q4: 2.14% WER, 100 ms median, 240 MB peak RSS, hallucinated on silence
- public 142-second/420-word concatenation:
  - WhisperKit Tiny: 6.89% WER, 1.941 s median
  - Parakeet 110M Q4: 4.04% WER, 1.747 s median, 1,017 MB peak RSS

The corpus revision, model revision, artifact size, license, and SHA-256 are checked into the aggregate result file.

## Decision

The broad replacement claim is not supported. Parakeet 110M does show a provable English accuracy and latency improvement, so issue #548 should remain open while this stays a draft. The next implementation step is a separate opt-in English adapter, gated on cancellation, noisy/accented speech, and adapter-linked direct and App Store builds. Canary is worth a separate multilingual/translation experiment; Moonshine Tiny is not worth pursuing for the current batch use case.

Refs #548


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local transcription benchmarking tool supporting WhisperKit and transcribe.cpp.
  * Added benchmark reporting for accuracy, latency, memory usage, and runtime details.
  * Added benchmark comparison and assessment checks for accuracy, performance, operational validation, and model evidence.
  * Added typed local transcription engine support, including improved display names and persistence.
  * Added example benchmark corpora, evidence, and results.

* **Documentation**
  * Added reproducible guidance for evaluating local transcription engines.

* **Tests**
  * Added coverage for benchmark validation, error-rate calculations, assessment decisions, and engine routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->