### PR TITLE
fix(mac): reconcile API key state with Keychain

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -1079,13 +1079,17 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   func registerAPIKeyIdentifier(_ identifier: String) {
-    if !trackedAPIKeyIdentifiers.contains(identifier) {
-      trackedAPIKeyIdentifiers.append(identifier)
-    }
+    reconcileAPIKeyIdentifiers(trackedAPIKeyIdentifiers + [identifier])
   }
 
   func removeAPIKeyIdentifier(_ identifier: String) {
-    trackedAPIKeyIdentifiers.removeAll { $0 == identifier }
+    reconcileAPIKeyIdentifiers(trackedAPIKeyIdentifiers.filter { $0 != identifier })
+  }
+
+  func reconcileAPIKeyIdentifiers(_ identifiers: [String]) {
+    let reconciled = Array(Set(identifiers)).sorted()
+    guard trackedAPIKeyIdentifiers != reconciled else { return }
+    trackedAPIKeyIdentifiers = reconciled
   }
 
   private func store<T>(_ value: T, key: DefaultsKey) {

--- a/Sources/SpeakApp/SecureAppStorage.swift
+++ b/Sources/SpeakApp/SecureAppStorage.swift
@@ -134,7 +134,8 @@ actor SecureAppStorage {
         await storage.hasSecret(identifier: identifier)
     }
 
-    func preloadTrackedSecrets() async {
-        await storage.preload()
+    @discardableResult
+    func preloadTrackedSecrets() async -> Bool {
+        await storage.preloadAndReportSuccess()
     }
 }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -107,6 +107,7 @@ struct SettingsView: View {
   @State private var apiKeySearchText = ""
   @State private var apiKeyStatusFilter: APIKeyStatusFilter = .all
   @State private var apiKeySortOrder: APIKeySortOrder = .name
+  @State private var didResolveAPIKeyStorage = false
   @State private var missingTranscriptionAPIKeyAlert: MissingLiveAPIKeyAlert?
   @State private var showSystemPromptPreview = false
   @State private var systemPromptPreview = ""
@@ -200,7 +201,11 @@ struct SettingsView: View {
   }
 
   private var isOpenRouterKeyStored: Bool {
-    settings.trackedAPIKeyIdentifiers.contains(openRouterKeyIdentifier)
+    isAPIKeyStored(openRouterKeyIdentifier)
+  }
+
+  private func isAPIKeyStored(_ identifier: String) -> Bool {
+    didResolveAPIKeyStorage && settings.trackedAPIKeyIdentifiers.contains(identifier)
   }
 
   private var isCloudPostProcessingModelSelected: Bool {
@@ -232,7 +237,7 @@ struct SettingsView: View {
             id: "transcription-\(provider.id)",
             title: provider.displayName,
             category: "Transcription",
-            isStored: settings.trackedAPIKeyIdentifiers.contains(provider.apiKeyIdentifier)
+            isStored: isAPIKeyStored(provider.apiKeyIdentifier)
           ),
           source: .transcription(provider)
         )
@@ -243,7 +248,7 @@ struct SettingsView: View {
           id: "tts-\(provider.id)",
           title: provider == .elevenlabs ? "ElevenLabs" : provider.displayName,
           category: provider == .elevenlabs ? "Transcription & Voice Output" : "Voice Output",
-          isStored: settings.trackedAPIKeyIdentifiers.contains(provider.apiKeyIdentifier)
+          isStored: isAPIKeyStored(provider.apiKeyIdentifier)
         ),
         source: .textToSpeech(provider)
       )
@@ -711,6 +716,7 @@ struct SettingsView: View {
       LinearGradient(
         colors: [Color.brandAccentWarm.opacity(0.08), .clear], startPoint: .top, endPoint: .center))
     .task {
+      didResolveAPIKeyStorage = await environment.secureStorage.preloadTrackedSecrets()
       transcriptionProviders = await TranscriptionProviderRegistry.shared.allProviders()
       syncAssemblyAIKeytermsFromPronunciation()
     }
@@ -3732,7 +3738,7 @@ struct SettingsView: View {
   }
 
   private func providerAPIKeyCard(for provider: TranscriptionProviderMetadata) -> some View {
-    let isStored = settings.trackedAPIKeyIdentifiers.contains(provider.apiKeyIdentifier)
+    let isStored = isAPIKeyStored(provider.apiKeyIdentifier)
     let tintColor = colorFromString(provider.tintColor)
     let validationState = providerValidationStates[provider.id] ?? .idle
     let inFlight = isValidationInFlight(validationState)
@@ -3772,7 +3778,7 @@ struct SettingsView: View {
 
   // swiftlint:disable:next cyclomatic_complexity function_body_length
   private func ttsProviderAPIKeyCard(for provider: TTSProvider) -> some View {
-    let isStored = settings.trackedAPIKeyIdentifiers.contains(provider.apiKeyIdentifier)
+    let isStored = isAPIKeyStored(provider.apiKeyIdentifier)
     let validationState = ttsProviderValidationStates[provider.rawValue] ?? .idle
     let inFlight = isValidationInFlight(validationState)
     let saveDisabled = inFlight

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -208,6 +208,32 @@ struct SettingsView: View {
     didResolveAPIKeyStorage && settings.trackedAPIKeyIdentifiers.contains(identifier)
   }
 
+  private func resolveAPIKeyStorage() async {
+    let retryDelays: [Duration] = [
+      .milliseconds(250),
+      .milliseconds(500),
+      .seconds(1),
+      .seconds(2),
+      .seconds(5)
+    ]
+    var retryIndex = 0
+
+    while !Task.isCancelled {
+      if await environment.secureStorage.preloadTrackedSecrets() {
+        didResolveAPIKeyStorage = true
+        return
+      }
+
+      let retryDelay = retryDelays[min(retryIndex, retryDelays.count - 1)]
+      retryIndex = min(retryIndex + 1, retryDelays.count - 1)
+      do {
+        try await Task.sleep(for: retryDelay)
+      } catch {
+        return
+      }
+    }
+  }
+
   private var isCloudPostProcessingModelSelected: Bool {
     !PostProcessingManager.isLocalPostProcessingModel(settings.postProcessingModel)
   }
@@ -716,9 +742,9 @@ struct SettingsView: View {
       LinearGradient(
         colors: [Color.brandAccentWarm.opacity(0.08), .clear], startPoint: .top, endPoint: .center))
     .task {
-      didResolveAPIKeyStorage = await environment.secureStorage.preloadTrackedSecrets()
       transcriptionProviders = await TranscriptionProviderRegistry.shared.allProviders()
       syncAssemblyAIKeytermsFromPronunciation()
+      await resolveAPIKeyStorage()
     }
     .onChange(of: settings.liveTranscriptionModel) { _, newValue in
       let newIsAssembly = newValue.localizedCaseInsensitiveContains("assemblyai")

--- a/Sources/SpeakCore/SecureStorage.swift
+++ b/Sources/SpeakCore/SecureStorage.swift
@@ -50,7 +50,20 @@ public actor DefaultKeychainPermissions: KeychainPermissionsChecking {
 public protocol APIKeyIdentifierRegistry: AnyObject {
     func registerAPIKeyIdentifier(_ identifier: String)
     func removeAPIKeyIdentifier(_ identifier: String)
+    func reconcileAPIKeyIdentifiers(_ identifiers: [String])
     var trackedAPIKeyIdentifiers: [String] { get }
+}
+
+public extension APIKeyIdentifierRegistry {
+    func reconcileAPIKeyIdentifiers(_ identifiers: [String]) {
+        let canonicalIdentifiers = Set(identifiers)
+        trackedAPIKeyIdentifiers
+            .filter { !canonicalIdentifiers.contains($0) }
+            .forEach(removeAPIKeyIdentifier)
+        canonicalIdentifiers
+            .filter { !trackedAPIKeyIdentifiers.contains($0) }
+            .forEach(registerAPIKeyIdentifier)
+    }
 }
 
 // MARK: - Secure Storage Configuration
@@ -132,12 +145,25 @@ public actor SecureStorage {
             throw SecureStorageError.permissionDenied
         }
 
-        cache[identifier] = value
-        try writeCacheToKeychain()
+        let previousValue = cache.updateValue(value, forKey: identifier)
+        do {
+            try writeCacheToKeychain()
+        } catch {
+            if let previousValue {
+                cache[identifier] = previousValue
+            } else {
+                cache.removeValue(forKey: identifier)
+            }
+            throw error
+        }
 
         if let registry = identifierRegistry {
             await MainActor.run {
-                registry.registerAPIKeyIdentifier(identifier)
+                if value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    registry.removeAPIKeyIdentifier(identifier)
+                } else {
+                    registry.registerAPIKeyIdentifier(identifier)
+                }
             }
         }
 
@@ -157,13 +183,19 @@ public actor SecureStorage {
     public func removeSecret(identifier: String) async throws {
         try await ensureCacheLoaded()
 
-        cache.removeValue(forKey: identifier)
-
         guard await permissionsChecker.ensureKeychainAccess(forService: configuration.service) else {
             throw SecureStorageError.permissionDenied
         }
 
-        try writeCacheToKeychain()
+        let previousValue = cache.removeValue(forKey: identifier)
+        do {
+            try writeCacheToKeychain()
+        } catch {
+            if let previousValue {
+                cache[identifier] = previousValue
+            }
+            throw error
+        }
 
         if let registry = identifierRegistry {
             await MainActor.run {
@@ -176,7 +208,7 @@ public actor SecureStorage {
 
     public func knownIdentifiers() async -> [String] {
         try? await ensureCacheLoaded()
-        return cache.keys.sorted()
+        return storedIdentifiers
     }
 
     public func hasSecret(identifier: String) async -> Bool {
@@ -189,6 +221,16 @@ public actor SecureStorage {
 
     public func preload() async {
         try? await ensureCacheLoaded()
+    }
+
+    @discardableResult
+    public func preloadAndReportSuccess() async -> Bool {
+        do {
+            try await ensureCacheLoaded()
+            return true
+        } catch {
+            return false
+        }
     }
 
     // MARK: - Private Implementation
@@ -230,7 +272,7 @@ public actor SecureStorage {
 
         if status == errSecItemNotFound {
             if try migrateLegacyServicePayloadIfNeeded() {
-                await registerCachedIdentifiers()
+                await reconcileCachedIdentifiers()
                 didLoadFromKeychain = true
                 return
             }
@@ -241,6 +283,7 @@ public actor SecureStorage {
 
         if status == errSecItemNotFound {
             cache = [:]
+            await reconcileCachedIdentifiers()
             didLoadFromKeychain = true
             return
         }
@@ -252,17 +295,24 @@ public actor SecureStorage {
         }
 
         cache = parse(payload: payload)
-        await registerCachedIdentifiers()
+        await reconcileCachedIdentifiers()
         didLoadFromKeychain = true
     }
 
-    private func registerCachedIdentifiers() async {
+    private func reconcileCachedIdentifiers() async {
         if let registry = identifierRegistry {
-            let identifiers = Array(cache.keys)
+            let identifiers = storedIdentifiers
             await MainActor.run {
-                identifiers.forEach { registry.registerAPIKeyIdentifier($0) }
+                registry.reconcileAPIKeyIdentifiers(identifiers)
             }
         }
+    }
+
+    private var storedIdentifiers: [String] {
+        cache.compactMap { identifier, value in
+            value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : identifier
+        }
+        .sorted()
     }
 
     private func migrateLegacyServicePayloadIfNeeded() throws -> Bool {
@@ -414,7 +464,10 @@ public actor SecureStorage {
         Self.logger.debug("configuration.accessGroup: \(self.configuration.accessGroup ?? "nil", privacy: .private)")
 
         if payload.isEmpty {
-            SecItemDelete(query as CFDictionary)
+            let deleteStatus = SecItemDelete(query as CFDictionary)
+            guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+                throw SecureStorageError.unexpectedStatus(deleteStatus)
+            }
             return
         }
 

--- a/Sources/SpeakCore/SecureStorage.swift
+++ b/Sources/SpeakCore/SecureStorage.swift
@@ -61,6 +61,7 @@ public extension APIKeyIdentifierRegistry {
             .filter { !canonicalIdentifiers.contains($0) }
             .forEach(removeAPIKeyIdentifier)
         canonicalIdentifiers
+            .sorted()
             .filter { !trackedAPIKeyIdentifiers.contains($0) }
             .forEach(registerAPIKeyIdentifier)
     }

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -77,6 +77,25 @@ final class AppSettingsDefaultsTests: XCTestCase {
         XCTAssertTrue(settings.showSidebarShortcutHints)
     }
 
+    @MainActor
+    func testReconcileAPIKeyIdentifiers_replacesStaleMetadataAndPersistsCanonicalSet() {
+        defaults.set(
+            ["openrouter.apiKey", "deepgram.apiKey", "assemblyai.apiKey"],
+            forKey: "trackedKeyIdentifiers"
+        )
+        let settings = AppSettings(defaults: defaults)
+
+        settings.reconcileAPIKeyIdentifiers([
+            "openai.apiKey",
+            "assemblyai.apiKey",
+            "openai.apiKey"
+        ])
+
+        let expected = ["assemblyai.apiKey", "openai.apiKey"]
+        XCTAssertEqual(settings.trackedAPIKeyIdentifiers, expected)
+        XCTAssertEqual(defaults.stringArray(forKey: "trackedKeyIdentifiers"), expected)
+    }
+
     // MARK: - Recording Settings
 
     @MainActor

--- a/Tests/SpeakCoreTests/SecureStorageReconciliationTests.swift
+++ b/Tests/SpeakCoreTests/SecureStorageReconciliationTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Security
+import XCTest
+
+@testable import SpeakCore
+
+final class SecureStorageReconciliationTests: XCTestCase {
+    @MainActor
+    func testPreload_emptyKeychain_removesAllStaleTrackedProviderIdentifiers() async {
+        let service = "com.justspeaktoit.tests.reconcile.empty.\(UUID().uuidString)"
+        defer { deleteKeychainItem(service: service) }
+
+        let registry = TestAPIKeyIdentifierRegistry(
+            identifiers: [
+                "deepgram.apiKey",
+                "openrouter.apiKey",
+                "assemblyai.apiKey"
+            ]
+        )
+        let storage = SecureStorage(
+            configuration: SecureStorageConfiguration(service: service),
+            identifierRegistry: registry
+        )
+
+        let loaded = await storage.preloadAndReportSuccess()
+        let knownIdentifiers = await storage.knownIdentifiers()
+
+        XCTAssertTrue(loaded)
+        XCTAssertEqual(knownIdentifiers, [])
+        XCTAssertEqual(
+            registry.trackedAPIKeyIdentifiers,
+            [],
+            "Persisted metadata must not claim absent Keychain credentials are stored"
+        )
+    }
+
+    @MainActor
+    func testPreload_replacesStaleMetadataWithAllCanonicalKeychainIdentifiers() async throws {
+        let service = "com.justspeaktoit.tests.reconcile.subset.\(UUID().uuidString)"
+        defer { deleteKeychainItem(service: service) }
+
+        let seedStorage = SecureStorage(
+            configuration: SecureStorageConfiguration(service: service)
+        )
+        try await seedStorage.storeSecret("openai-key", identifier: "openai.apiKey")
+        try await seedStorage.storeSecret("assemblyai-key", identifier: "assemblyai.apiKey")
+
+        let registry = TestAPIKeyIdentifierRegistry(
+            identifiers: [
+                "deepgram.apiKey",
+                "openai.apiKey",
+                "openrouter.apiKey"
+            ]
+        )
+        let storage = SecureStorage(
+            configuration: SecureStorageConfiguration(service: service),
+            identifierRegistry: registry
+        )
+
+        let loaded = await storage.preloadAndReportSuccess()
+        let knownIdentifiers = await storage.knownIdentifiers()
+
+        XCTAssertTrue(loaded)
+        XCTAssertEqual(
+            registry.trackedAPIKeyIdentifiers,
+            ["assemblyai.apiKey", "openai.apiKey"]
+        )
+        XCTAssertEqual(
+            knownIdentifiers,
+            ["assemblyai.apiKey", "openai.apiKey"]
+        )
+    }
+
+    @MainActor
+    func testRemoveSecret_permissionFailure_preservesCacheAndTrackedMetadata() async throws {
+        let service = "com.justspeaktoit.tests.reconcile.failed-removal.\(UUID().uuidString)"
+        defer { deleteKeychainItem(service: service) }
+
+        let seedStorage = SecureStorage(
+            configuration: SecureStorageConfiguration(service: service)
+        )
+        try await seedStorage.storeSecret("deepgram-key", identifier: "deepgram.apiKey")
+
+        let registry = TestAPIKeyIdentifierRegistry(identifiers: [])
+        let permissions = SequencedKeychainPermissions(decisions: [true, false])
+        let storage = SecureStorage(
+            configuration: SecureStorageConfiguration(service: service),
+            permissionsChecker: permissions,
+            identifierRegistry: registry
+        )
+        let loaded = await storage.preloadAndReportSuccess()
+        XCTAssertTrue(loaded)
+
+        do {
+            try await storage.removeSecret(identifier: "deepgram.apiKey")
+            XCTFail("Removal should fail when Keychain permission is denied")
+        } catch SecureStorageError.permissionDenied {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected removal error: \(error)")
+        }
+
+        let retainedSecret = try await storage.secret(identifier: "deepgram.apiKey")
+        XCTAssertEqual(retainedSecret, "deepgram-key")
+        XCTAssertEqual(registry.trackedAPIKeyIdentifiers, ["deepgram.apiKey"])
+    }
+}
+
+@MainActor
+private final class TestAPIKeyIdentifierRegistry: APIKeyIdentifierRegistry {
+    private(set) var trackedAPIKeyIdentifiers: [String]
+
+    init(identifiers: [String]) {
+        trackedAPIKeyIdentifiers = identifiers
+    }
+
+    func registerAPIKeyIdentifier(_ identifier: String) {
+        if !trackedAPIKeyIdentifiers.contains(identifier) {
+            trackedAPIKeyIdentifiers.append(identifier)
+        }
+    }
+
+    func removeAPIKeyIdentifier(_ identifier: String) {
+        trackedAPIKeyIdentifiers.removeAll { $0 == identifier }
+    }
+
+    func reconcileAPIKeyIdentifiers(_ identifiers: [String]) {
+        trackedAPIKeyIdentifiers = identifiers
+    }
+}
+
+private actor SequencedKeychainPermissions: KeychainPermissionsChecking {
+    private var decisions: [Bool]
+
+    init(decisions: [Bool]) {
+        self.decisions = decisions
+    }
+
+    func ensureKeychainAccess(forService _: String) async -> Bool {
+        decisions.isEmpty ? false : decisions.removeFirst()
+    }
+}
+
+private func deleteKeychainItem(service: String) {
+    let query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: "speak-app-secrets"
+    ]
+    SecItemDelete(query as CFDictionary)
+}


### PR DESCRIPTION
## Motivation

The Settings UI could claim an API key was saved even when the credential was absent from Keychain. The same stale state could make Transcription and Post-processing disagree with the API Keys tab.

## User-visible changes

- Treats non-empty Keychain entries as the canonical stored-key state.
- Removes stale tracked-key metadata during preload.
- Keeps failed secure-storage writes and removals transactional.
- Waits for Keychain state to resolve across every Settings tab before showing readiness.

## Validation

- Six focused Keychain reconciliation, concurrency, and persistence tests pass.
- Scoped strict SwiftLint passed with the repository baseline.
- Full swift test was attempted during review; an existing legacy-Keychain lookup hung inside Security.framework, while the focused suite completed cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key status indicators now accurately reflect secrets stored in secure storage.
  * Stale, duplicate, or unsorted API key metadata is automatically corrected.
  * Failed secure-storage updates no longer leave behind inconsistent settings.
  * API key removal is safely prevented when storage permissions are denied.
  * Secure-storage preload operations now report whether they succeeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->