### PR TITLE
feat: [mac][ios] overhaul compact UI density

### DIFF
--- a/Sources/SpeakApp/DashboardView.swift
+++ b/Sources/SpeakApp/DashboardView.swift
@@ -367,7 +367,7 @@ struct DashboardView: View {
   private func permissionCard(for permission: PermissionType) -> some View {
     let status = environment.permissions.status(for: permission)
     return Group {
-      if density.isCompact {
+      if density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) {
         compactPermissionCard(for: permission, status: status)
       } else {
         regularPermissionCard(for: permission, status: status)
@@ -744,7 +744,6 @@ private func formattedModels(_ identifiers: [String]) -> String {
 }
 
 private struct DashboardCard<Content: View>: View {
-  @Environment(\.appVisualDensity) private var density
   let title: String
   let systemImage: String
   let tint: Color
@@ -758,46 +757,9 @@ private struct DashboardCard<Content: View>: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: density.cardContentSpacing) {
-      HStack(spacing: density.isCompact ? density.inlineSpacing : 14) {
-        if density.isCompact {
-          Image(systemName: systemImage)
-            .foregroundStyle(tint)
-            .font(.caption.weight(.semibold))
-            .frame(width: 16)
-        } else {
-          ZStack {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-              .fill(tint.opacity(0.15))
-              .frame(width: 44, height: 44)
-            Image(systemName: systemImage)
-              .foregroundStyle(tint)
-              .font(.system(size: 20, weight: .semibold))
-          }
-        }
-        Text(title)
-          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
-        Spacer(minLength: 0)
-      }
-
+    SpeakDensityCard(title: title, systemImage: systemImage, tint: tint) {
       content
     }
-    .padding(density.cardPadding)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .background(
-      .ultraThinMaterial,
-      in: RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-        .stroke(tint.opacity(0.12), lineWidth: 1)
-    )
-    .shadow(
-      color: tint.opacity(density.isCompact ? 0 : 0.08),
-      radius: density.isCompact ? 0 : 18,
-      x: 0,
-      y: density.isCompact ? 0 : 12
-    )
   }
 }
 

--- a/Sources/SpeakApp/DashboardView.swift
+++ b/Sources/SpeakApp/DashboardView.swift
@@ -7,6 +7,7 @@ struct DashboardView: View {
   @EnvironmentObject private var environment: AppEnvironment
   @EnvironmentObject private var history: HistoryManager
   @Environment(\.appVisualDensity) private var density
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
   @State private var requestingPermission: PermissionType?
 
   var body: some View {
@@ -28,7 +29,72 @@ struct DashboardView: View {
     )
   }
 
+  @ViewBuilder
   private var heroHeader: some View {
+    if density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) {
+      compactHeroHeader
+    } else {
+      normalHeroHeader
+    }
+  }
+
+  private var compactHeroHeader: some View {
+    let stats = history.statistics
+    return VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: density.inlineSpacing) {
+        Label("Dashboard", systemImage: "sparkles.rectangle.stack")
+          .font(.subheadline.bold())
+          .lineLimit(1)
+
+        Spacer(minLength: 4)
+
+        compactHeroMetric(
+          value: "\(stats.totalSessions)",
+          systemImage: "record.circle",
+          accessibilityLabel: "Sessions"
+        )
+        compactHeroMetric(
+          value: formattedDuration(stats.cumulativeRecordingDuration),
+          systemImage: "timer",
+          accessibilityLabel: "Recording time"
+        )
+        compactHeroMetric(
+          value: formattedCurrency(stats.totalSpend),
+          systemImage: "creditcard",
+          accessibilityLabel: "Spend"
+        )
+
+        Button(action: environment.main.toggleRecordingFromUI) {
+          compactRecordButtonLabel
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .tint(environment.main.state == .recording ? .red : .accentColor)
+        .disabled(isBusy)
+        .keyboardShortcut(.space, modifiers: [.command])
+        .accessibilityLabel(buttonTitle)
+      }
+
+      if let preview = livePreviewText, !preview.isEmpty {
+        Label(preview, systemImage: "waveform")
+          .font(.caption.monospaced())
+          .lineLimit(1)
+          .foregroundStyle(.secondary)
+      }
+    }
+    .padding(density.cardPadding)
+    .foregroundStyle(.white)
+    .background(
+      LinearGradient(
+        colors: [Color.brandAccentDeep, Color.brandAccentWarm.opacity(0.9)],
+        startPoint: .leading,
+        endPoint: .trailing
+      ),
+      in: RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+    )
+  }
+
+  private var normalHeroHeader: some View {
     let stats = history.statistics
     return VStack(alignment: .leading, spacing: 18) {
       HStack(alignment: .top, spacing: 20) {
@@ -114,10 +180,32 @@ struct DashboardView: View {
     .shadow(color: Color.brandAccent.opacity(0.35), radius: 24, x: 0, y: 16)
   }
 
+  private func compactHeroMetric(
+    value: String,
+    systemImage: String,
+    accessibilityLabel: String
+  ) -> some View {
+    Label(value, systemImage: systemImage)
+      .font(.caption2.weight(.semibold))
+      .lineLimit(1)
+      .accessibilityLabel("\(accessibilityLabel): \(value)")
+  }
+
+  @ViewBuilder
+  private var compactRecordButtonLabel: some View {
+    switch environment.main.state {
+    case .processing, .delivering:
+      ProgressView()
+        .controlSize(.mini)
+    default:
+      Image(systemName: buttonIcon)
+    }
+  }
+
   private var dashboardSections: some View {
     VStack(spacing: density.sectionSpacing) {
       LazyVGrid(
-        columns: [GridItem(.adaptive(minimum: 340), spacing: density.sectionSpacing)],
+        columns: [GridItem(.adaptive(minimum: density.gridMinimumWidth), spacing: density.sectionSpacing)],
         spacing: density.sectionSpacing
       ) {
         permissionsSection
@@ -129,7 +217,7 @@ struct DashboardView: View {
       dailyUsageChartSection
 
       LazyVGrid(
-        columns: [GridItem(.adaptive(minimum: 340), spacing: density.sectionSpacing)],
+        columns: [GridItem(.adaptive(minimum: density.gridMinimumWidth), spacing: density.sectionSpacing)],
         spacing: density.sectionSpacing
       ) {
         transcriptionModelChartSection
@@ -138,7 +226,7 @@ struct DashboardView: View {
 
       // TTS Charts
       LazyVGrid(
-        columns: [GridItem(.adaptive(minimum: 340), spacing: density.sectionSpacing)],
+        columns: [GridItem(.adaptive(minimum: density.gridMinimumWidth), spacing: density.sectionSpacing)],
         spacing: density.sectionSpacing
       ) {
         ttsUsageChartSection
@@ -262,7 +350,11 @@ struct DashboardView: View {
   private var permissionsSection: some View {
     DashboardCard(title: "Permissions", systemImage: "lock.shield", tint: Color.brandAccentWarm) {
       LazyVGrid(
-        columns: Array(repeating: GridItem(.flexible(), spacing: 16), count: 2), spacing: 16
+        columns: Array(
+          repeating: GridItem(.flexible(), spacing: density.groupSpacing),
+          count: 2
+        ),
+        spacing: density.groupSpacing
       ) {
         ForEach(PermissionType.availablePermissions(for: DistributionChannel.current)) { permission in
           permissionCard(for: permission)
@@ -274,7 +366,79 @@ struct DashboardView: View {
 
   private func permissionCard(for permission: PermissionType) -> some View {
     let status = environment.permissions.status(for: permission)
-    return VStack(alignment: .leading, spacing: 8) {
+    return Group {
+      if density.isCompact {
+        compactPermissionCard(for: permission, status: status)
+      } else {
+        regularPermissionCard(for: permission, status: status)
+      }
+    }
+    .speakTooltip(permission.guidanceText)
+  }
+
+  private func compactPermissionCard(
+    for permission: PermissionType,
+    status: PermissionStatus
+  ) -> some View {
+    HStack(spacing: density.inlineSpacing) {
+      Image(systemName: permission.systemIconName)
+        .frame(width: 16)
+      VStack(alignment: .leading, spacing: 0) {
+        Text(permission.displayName)
+          .font(.caption.weight(.semibold))
+          .lineLimit(1)
+        Text(statusDescription(status))
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+      }
+      Spacer(minLength: 2)
+      Circle()
+        .fill(statusColor(status))
+        .frame(width: 7, height: 7)
+      compactPermissionAction(for: permission, status: status)
+    }
+    .padding(6)
+    .background(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .fill(.ultraThinMaterial)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .stroke(statusColor(status).opacity(0.35), lineWidth: 1)
+    )
+  }
+
+  @ViewBuilder
+  private func compactPermissionAction(
+    for permission: PermissionType,
+    status: PermissionStatus
+  ) -> some View {
+    if environment.permissions.requestIssue(for: permission) != nil {
+      Link(destination: permission.settingsURL) {
+        Label("Open Settings", systemImage: "gear")
+          .labelStyle(.iconOnly)
+      }
+      .buttonStyle(.borderless)
+    } else {
+      Button {
+        requestingPermission = permission
+        Task { await request(permission) }
+      } label: {
+        Label(
+          status.isGranted ? "Check" : "Request",
+          systemImage: status.isGranted ? "arrow.clockwise" : "plus.circle"
+        )
+        .labelStyle(.iconOnly)
+      }
+      .buttonStyle(.borderless)
+    }
+  }
+
+  private func regularPermissionCard(
+    for permission: PermissionType,
+    status: PermissionStatus
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
       HStack {
         Image(systemName: permission.systemIconName)
           .imageScale(.large)
@@ -314,7 +478,6 @@ struct DashboardView: View {
       RoundedRectangle(cornerRadius: 18, style: .continuous)
         .stroke(statusColor(status).opacity(0.4), lineWidth: 1)
     )
-    .speakTooltip(permission.guidanceText)
   }
 
   private func request(_ permission: PermissionType) async {
@@ -353,7 +516,15 @@ struct DashboardView: View {
   private var statisticsSection: some View {
     let stats = history.statistics
     return DashboardCard(title: "Insights", systemImage: "chart.xyaxis.line", tint: Color.brandAccentDeep) {
-      LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 16)], spacing: 16) {
+      LazyVGrid(
+        columns: [
+          GridItem(
+            .adaptive(minimum: density.isCompact ? 92 : 160),
+            spacing: density.groupSpacing
+          )
+        ],
+        spacing: density.groupSpacing
+      ) {
         statCard(title: "Sessions", value: "\(stats.totalSessions)")
         statCard(
           title: "Recording Time",
@@ -367,17 +538,19 @@ struct DashboardView: View {
   }
 
   private func statCard(title: String, value: String) -> some View {
-    VStack(alignment: .leading, spacing: 6) {
+    VStack(alignment: .leading, spacing: density.isCompact ? 1 : 6) {
       Text(title)
-        .font(.caption)
+        .font(density.isCompact ? .caption2 : .caption)
         .foregroundStyle(.secondary)
+        .lineLimit(1)
       Text(value)
-        .font(.title3.bold())
+        .font(density.isCompact ? .caption.bold() : .title3.bold())
+        .lineLimit(1)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(16)
+    .padding(density.isCompact ? 5 : 16)
     .background(
-      RoundedRectangle(cornerRadius: 20, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 7 : 20, style: .continuous)
         .fill(Color.accentColor.opacity(0.08))
     )
   }
@@ -411,7 +584,7 @@ struct DashboardView: View {
   }
 
   private func recentItemView(_ item: HistoryItem) -> some View {
-    VStack(alignment: .leading, spacing: 8) {
+    VStack(alignment: .leading, spacing: density.isCompact ? 3 : 8) {
       HStack {
         Text(item.createdAt, style: .date)
         Text(item.createdAt, style: .time)
@@ -419,12 +592,12 @@ struct DashboardView: View {
         Spacer()
         Text(formattedDuration(item.recordingDuration))
       }
-      .font(.headline)
+      .font(density.isCompact ? .caption.weight(.semibold) : .headline)
 
       if let postProcessed = item.postProcessedTranscription ?? item.rawTranscription {
         Text(postProcessed)
-          .lineLimit(4)
-          .font(.body)
+          .lineLimit(density.isCompact ? 2 : 4)
+          .font(density.isCompact ? .caption : .body)
       }
 
       HStack {
@@ -435,12 +608,12 @@ struct DashboardView: View {
             .font(.subheadline)
         }
       }
-      .font(.subheadline)
+      .font(density.isCompact ? .caption2 : .subheadline)
       .foregroundStyle(.secondary)
     }
-    .padding()
+    .padding(density.isCompact ? 5 : 16)
     .background(
-      RoundedRectangle(cornerRadius: 20, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 7 : 20, style: .continuous)
         .fill(.thinMaterial)
     )
   }
@@ -476,37 +649,37 @@ struct DashboardView: View {
 
   private var ttsUsageChartSection: some View {
     DashboardCard(title: "Voice Output Usage", systemImage: "speaker.wave.3", tint: Color.brandLagoonDeep) {
-      VStack(alignment: .leading, spacing: 12) {
+      VStack(alignment: .leading, spacing: density.inlineSpacing) {
         let totalCharacters = environment.tts.totalCharactersThisMonth()
         let totalCost = environment.tts.totalCostThisMonth()
 
         HStack {
           VStack(alignment: .leading, spacing: 4) {
             Text("Characters This Month")
-              .font(.caption)
+              .font(density.isCompact ? .caption2 : .caption)
               .foregroundStyle(.secondary)
             Text("\(totalCharacters)")
-              .font(.title2.bold())
+              .font(density.isCompact ? .caption.bold() : .title2.bold())
               .foregroundStyle(Color.brandLagoonDeep)
           }
           Spacer()
           VStack(alignment: .trailing, spacing: 4) {
             Text("Total Cost")
-              .font(.caption)
+              .font(density.isCompact ? .caption2 : .caption)
               .foregroundStyle(.secondary)
             Text("$\(totalCost, format: .number.precision(.fractionLength(2)))")
-              .font(.title2.bold())
+              .font(density.isCompact ? .caption.bold() : .title2.bold())
               .foregroundStyle(Color.brandLagoonDeep)
           }
         }
 
-        if totalCharacters > 0 {
+        if totalCharacters > 0, !density.isCompact {
           Text(
             "\(totalCharacters) characters synthesized this month"
           )
           .font(.caption)
           .foregroundStyle(.secondary)
-        } else {
+        } else if !density.isCompact {
           Text("No voice output generated yet this month")
             .font(.caption)
             .foregroundStyle(.secondary)
@@ -523,27 +696,27 @@ struct DashboardView: View {
       let usage = environment.tts.usageByProvider(since: monthAgo)
 
       if usage.isEmpty {
-        VStack(spacing: 8) {
+        VStack(spacing: density.inlineSpacing) {
           Image(systemName: "speaker.wave.2.circle")
-            .font(.largeTitle)
+            .font(density.isCompact ? .title3 : .largeTitle)
             .foregroundStyle(.secondary)
           Text("No TTS usage yet")
-            .font(.subheadline)
+            .font(density.isCompact ? .caption : .subheadline)
             .foregroundStyle(.secondary)
         }
-        .frame(maxWidth: .infinity, minHeight: 120)
+        .frame(maxWidth: .infinity, minHeight: density.isCompact ? 44 : 120)
       } else {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: density.inlineSpacing) {
           ForEach(usage.sorted(by: { $0.value > $1.value }), id: \.key) { provider, count in
             HStack {
               Circle()
                 .fill(providerColor(provider))
-                .frame(width: 12, height: 12)
+                .frame(width: density.isCompact ? 7 : 12, height: density.isCompact ? 7 : 12)
               Text(provider.displayName)
-                .font(.subheadline)
+                .font(density.isCompact ? .caption : .subheadline)
               Spacer()
               Text("\(count) chars")
-                .font(.subheadline.monospacedDigit())
+                .font(density.isCompact ? .caption2.monospacedDigit() : .subheadline.monospacedDigit())
                 .foregroundStyle(.secondary)
             }
           }
@@ -571,6 +744,7 @@ private func formattedModels(_ identifiers: [String]) -> String {
 }
 
 private struct DashboardCard<Content: View>: View {
+  @Environment(\.appVisualDensity) private var density
   let title: String
   let systemImage: String
   let tint: Color
@@ -584,31 +758,46 @@ private struct DashboardCard<Content: View>: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 18) {
-      HStack(spacing: 14) {
-        ZStack {
-          RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(tint.opacity(0.15))
-            .frame(width: 44, height: 44)
+    VStack(alignment: .leading, spacing: density.cardContentSpacing) {
+      HStack(spacing: density.isCompact ? density.inlineSpacing : 14) {
+        if density.isCompact {
           Image(systemName: systemImage)
             .foregroundStyle(tint)
-            .font(.system(size: 20, weight: .semibold))
+            .font(.caption.weight(.semibold))
+            .frame(width: 16)
+        } else {
+          ZStack {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+              .fill(tint.opacity(0.15))
+              .frame(width: 44, height: 44)
+            Image(systemName: systemImage)
+              .foregroundStyle(tint)
+              .font(.system(size: 20, weight: .semibold))
+          }
         }
         Text(title)
-          .font(.headline)
+          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
         Spacer(minLength: 0)
       }
 
       content
     }
-    .padding(24)
+    .padding(density.cardPadding)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+    .background(
+      .ultraThinMaterial,
+      in: RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+    )
     .overlay(
-      RoundedRectangle(cornerRadius: 28, style: .continuous)
+      RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
         .stroke(tint.opacity(0.12), lineWidth: 1)
     )
-    .shadow(color: tint.opacity(0.08), radius: 18, x: 0, y: 12)
+    .shadow(
+      color: tint.opacity(density.isCompact ? 0 : 0.08),
+      radius: density.isCompact ? 0 : 18,
+      x: 0,
+      y: density.isCompact ? 0 : 12
+    )
   }
 }
 

--- a/Sources/SpeakApp/HistoryView.swift
+++ b/Sources/SpeakApp/HistoryView.swift
@@ -9,6 +9,7 @@ import UniformTypeIdentifiers
 struct HistoryView: View { // swiftlint:disable:this type_body_length
   @EnvironmentObject private var environment: AppEnvironment
   @Environment(\.appVisualDensity) private var density
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
   @State private var searchText: String = ""
   @State private var showErrorsOnly: Bool = false
   @State private var dateRangeEnabled: Bool = false
@@ -237,7 +238,149 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
   }
 
 
+  @ViewBuilder
   private var header: some View {
+    if density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) {
+      compactHeader
+    } else {
+      normalHeader
+    }
+  }
+
+  private var compactHeader: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: density.inlineSpacing) {
+        Label("History", systemImage: "clock.arrow.circlepath")
+          .font(.subheadline.bold())
+
+        HStack(spacing: 4) {
+          Image(systemName: "magnifyingglass")
+            .foregroundStyle(.secondary)
+          TextField("Search", text: $searchText)
+            .textFieldStyle(.plain)
+            .frame(minWidth: 120, idealWidth: 180, maxWidth: 240)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+
+        Toggle(isOn: $showErrorsOnly) {
+          Label("Errors only", systemImage: showErrorsOnly
+            ? "exclamationmark.triangle.fill"
+            : "exclamationmark.triangle")
+            .labelStyle(.iconOnly)
+        }
+        .toggleStyle(.button)
+        .controlSize(.small)
+        .speakTooltip("Show sessions with errors")
+
+        Toggle(isOn: $dateRangeEnabled) {
+          Label("Date range", systemImage: dateRangeEnabled ? "calendar.badge.checkmark" : "calendar")
+            .labelStyle(.iconOnly)
+        }
+        .toggleStyle(.button)
+        .controlSize(.small)
+        .speakTooltip("Filter by date range")
+
+        if dateRangeEnabled {
+          DatePicker("From", selection: $startDate, displayedComponents: .date)
+            .labelsHidden()
+            .datePickerStyle(.compact)
+          DatePicker("To", selection: $endDate, in: startDate..., displayedComponents: .date)
+            .labelsHidden()
+            .datePickerStyle(.compact)
+        }
+
+        if !availableModels.isEmpty {
+          Picker("Model", selection: $selectedModelFilter) {
+            Text("All Models").tag(String?.none)
+            Divider()
+            ForEach(availableModels, id: \.self) { model in
+              Text(ModelCatalog.friendlyName(for: model)).tag(String?.some(model))
+            }
+          }
+          .labelsHidden()
+          .pickerStyle(.menu)
+          .controlSize(.small)
+          .speakTooltip("Filter by model")
+        }
+
+        Spacer(minLength: 2)
+
+        if isImportingFiles {
+          ProgressView()
+            .controlSize(.mini)
+        }
+
+        Button {
+          showImportFiles = true
+        } label: {
+          Label("Import", systemImage: "square.and.arrow.down")
+            .labelStyle(.iconOnly)
+        }
+        .buttonStyle(.borderless)
+        .disabled(isClearingAll || isImportingFiles || environment.main.isBusy)
+        .speakTooltip("Import audio")
+
+        Button {
+          showClearAllConfirmation = true
+        } label: {
+          Label("Clear All", systemImage: "trash")
+            .labelStyle(.iconOnly)
+            .foregroundStyle(.red)
+        }
+        .buttonStyle(.borderless)
+        .disabled(historyItems.isEmpty || isClearingAll || isImportingFiles)
+        .speakTooltip("Clear all history")
+      }
+
+      HStack(spacing: density.groupSpacing) {
+        compactHistoryMetric(
+          title: "Sessions",
+          value: "\(historyStats.totalSessions)",
+          systemImage: "record.circle"
+        )
+        compactHistoryMetric(
+          title: "Errors",
+          value: "\(historyStats.sessionsWithErrors)",
+          systemImage: "exclamationmark.triangle"
+        )
+        compactHistoryMetric(
+          title: "Average",
+          value: formattedDuration(historyStats.averageSessionLength),
+          systemImage: "timer"
+        )
+        compactHistoryMetric(
+          title: "Spend",
+          value: formattedCurrency(historyStats.totalSpend),
+          systemImage: "creditcard"
+        )
+      }
+    }
+    .padding(density.cardPadding)
+    .foregroundStyle(.white)
+    .background(
+      LinearGradient(
+        colors: [Color.brandAccentDeep, Color.brandAccentWarm.opacity(0.9)],
+        startPoint: .leading,
+        endPoint: .trailing
+      ),
+      in: RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+    )
+  }
+
+  private func compactHistoryMetric(
+    title: String,
+    value: String,
+    systemImage: String
+  ) -> some View {
+    Label(value, systemImage: systemImage)
+      .font(.caption2.weight(.semibold))
+      .lineLimit(1)
+      .accessibilityLabel("\(title): \(value)")
+  }
+
+  private var normalHeader: some View {
     VStack(alignment: .leading, spacing: 18) {
       VStack(alignment: .leading, spacing: 8) {
         Text("Session History")
@@ -357,49 +500,56 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
   }
 
   private var emptyState: some View {
-    VStack(spacing: 18) {
+    VStack(spacing: density.isCompact ? 6 : 18) {
       Image(systemName: "waveform")
-        .font(.system(size: 44, weight: .medium))
+        .font(.system(size: density.isCompact ? 22 : 44, weight: .medium))
         .foregroundStyle(Color.brandAccent)
       Text("No history yet")
-        .font(.title2.bold())
-      Text("Record a session to see transcripts, costs, and network activity appear here.")
-        .font(.callout)
-        .foregroundStyle(.secondary)
+        .font(density.isCompact ? .subheadline.bold() : .title2.bold())
+      if !density.isCompact {
+        Text("Record a session to see transcripts, costs, and network activity appear here.")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+      }
       Button(action: environment.main.toggleRecordingFromUI) {
-        Label("Start a recording", systemImage: "mic.fill")
+        if density.isCompact {
+          Label("Start a recording", systemImage: "mic.fill")
+            .labelStyle(.iconOnly)
+        } else {
+          Label("Start a recording", systemImage: "mic.fill")
+        }
       }
       .buttonStyle(.borderedProminent)
       .disabled(environment.main.isBusy)
     }
     .frame(maxWidth: .infinity)
-    .padding(40)
+    .padding(density.isCompact ? 12 : 40)
     .background(
-      RoundedRectangle(cornerRadius: 28, style: .continuous)
+      RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
         .fill(.ultraThinMaterial)
     )
     .overlay(
-      RoundedRectangle(cornerRadius: 28, style: .continuous)
+      RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
         .stroke(Color.brandAccent.opacity(0.15), lineWidth: 1)
     )
   }
 
   private var skeletonLoadingView: some View {
-    VStack(spacing: 20) {
+    VStack(spacing: density.sectionSpacing) {
       // Stats header skeleton
       HistoryStatsSkeleton()
-        .padding(.bottom, 8)
+        .padding(.bottom, density.isCompact ? 0 : 8)
       
       // History items skeleton
       ForEach(0..<3, id: \.self) { _ in
         HistoryItemSkeleton()
-          .padding(16)
+          .padding(density.isCompact ? 6 : 16)
           .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
+            RoundedRectangle(cornerRadius: density.isCompact ? 8 : 20, style: .continuous)
               .fill(.ultraThinMaterial)
           )
           .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
+            RoundedRectangle(cornerRadius: density.isCompact ? 8 : 20, style: .continuous)
               .stroke(Color.brandAccent.opacity(0.1), lineWidth: 1)
           )
       }
@@ -451,6 +601,7 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
 
 private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
   @EnvironmentObject private var environment: AppEnvironment
+  @Environment(\.appVisualDensity) private var density
   let item: HistoryItem
   @State private var isExpanded: Bool = false
   @State private var showNetworkDetails: Bool = false
@@ -505,19 +656,19 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
   }
 
   private var rowContent: some View {
-    VStack(alignment: .leading, spacing: 20) {
+    VStack(alignment: .leading, spacing: density.isCompact ? 6 : 20) {
       Button {
         withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
           isExpanded.toggle()
         }
       } label: {
-        VStack(alignment: .leading, spacing: 12) {
-          HStack(alignment: .top, spacing: 16) {
+        VStack(alignment: .leading, spacing: density.isCompact ? 4 : 12) {
+          HStack(alignment: .top, spacing: density.groupSpacing) {
             ViewThatFits(in: .horizontal) {
-              HStack(spacing: 8) {
+              HStack(spacing: density.isCompact ? density.inlineSpacing : 8) {
                 badgeViews
               }
-              VStack(alignment: .leading, spacing: 8) {
+              VStack(alignment: .leading, spacing: density.isCompact ? density.inlineSpacing : 8) {
                 badgeViews
               }
             }
@@ -532,17 +683,20 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
             .buttonStyle(.borderless)
             .speakTooltip("Delete this history item")
             Image(systemName: isExpanded ? "chevron.up.circle.fill" : "chevron.down.circle")
-              .imageScale(.large)
+              .imageScale(density.isCompact ? .medium : .large)
               .symbolRenderingMode(.palette)
               .foregroundStyle(Color.brandAccent, Color.brandAccentWarm.opacity(0.35))
           }
 
           if let transcript = bestTranscript {
-            HStack(alignment: .firstTextBaseline, spacing: 12) {
+            HStack(
+              alignment: .firstTextBaseline,
+              spacing: density.isCompact ? density.inlineSpacing : 10
+            ) {
               Text(previewText)
-                .font(.subheadline)
+                .font(density.isCompact ? .caption : .subheadline)
                 .foregroundStyle(.secondary)
-                .lineLimit(2)
+                .lineLimit(density.isCompact ? 1 : 2)
 
               Button {
                 copyToPasteboard(transcript)
@@ -555,15 +709,16 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
             }
           } else {
             Text(previewText)
-              .font(.subheadline)
+              .font(density.isCompact ? .caption : .subheadline)
               .foregroundStyle(.secondary)
-              .lineLimit(2)
+              .lineLimit(density.isCompact ? 1 : 2)
           }
 
           if let models = modelsSummaryByPhase {
             Label(models, systemImage: "brain.head.profile")
-              .font(.caption)
+              .font(density.isCompact ? .caption2 : .caption)
               .foregroundStyle(.secondary)
+              .lineLimit(1)
           }
         }
         .contentShape(Rectangle())
@@ -575,26 +730,31 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
         expandedContent
       }
     }
-    .padding(24)
+    .padding(density.cardPadding)
     .background(
-      RoundedRectangle(cornerRadius: 32, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 10 : 32, style: .continuous)
         .fill(.ultraThinMaterial)
     )
     .overlay(
-      RoundedRectangle(cornerRadius: 32, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 10 : 32, style: .continuous)
         .stroke(borderColor, lineWidth: 1)
     )
-    .shadow(color: borderColor.opacity(0.3), radius: 18, x: 0, y: 12)
+    .shadow(
+      color: borderColor.opacity(density.isCompact ? 0 : 0.3),
+      radius: density.isCompact ? 0 : 18,
+      x: 0,
+      y: density.isCompact ? 0 : 12
+    )
   }
 
   @ViewBuilder
   private var expandedContent: some View {
     Divider()
-      .padding(.vertical, 4)
+      .padding(.vertical, density.isCompact ? 0 : 4)
 
     ViewThatFits(in: .horizontal) {
-      HStack(alignment: .top, spacing: 28) {
-        VStack(alignment: .leading, spacing: 20) {
+      HStack(alignment: .top, spacing: density.isCompact ? 10 : 28) {
+        VStack(alignment: .leading, spacing: density.isCompact ? 8 : 20) {
           if !item.networkExchanges.isEmpty {
             networkSummaryButton
             if showNetworkDetails {
@@ -612,7 +772,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
         }
         .frame(maxWidth: .infinity, alignment: .leading)
 
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: density.isCompact ? 8 : 20) {
           transcriptSection
 
           if !item.errors.isEmpty {
@@ -625,7 +785,7 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
       }
       .frame(maxWidth: .infinity, alignment: .leading)
 
-      VStack(alignment: .leading, spacing: 20) {
+      VStack(alignment: .leading, spacing: density.isCompact ? 8 : 20) {
         if !item.networkExchanges.isEmpty {
           networkSummaryButton
           if showNetworkDetails {
@@ -739,7 +899,12 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
   private var metaColumns: [GridItem] {
     [
       GridItem(
-        .adaptive(minimum: 160, maximum: 340), spacing: 10, alignment: .topLeading
+        .adaptive(
+          minimum: density.isCompact ? 120 : 160,
+          maximum: density.isCompact ? 240 : 340
+        ),
+        spacing: density.isCompact ? density.inlineSpacing : 10,
+        alignment: .topLeading
       )
     ]
   }
@@ -807,31 +972,49 @@ private struct HistoryListRow: View { // swiftlint:disable:this type_body_length
     value: String,
     tint: Color = .accentColor
   ) -> some View {
-    VStack(alignment: .leading, spacing: 6) {
-      HStack(spacing: 6) {
-        Image(systemName: icon)
-          .imageScale(.medium)
-        Text(title.uppercased())
-          .font(.caption2.weight(.semibold))
-      }
-      .foregroundStyle(tint)
+    Group {
+      if density.isCompact {
+        HStack(spacing: 3) {
+          Image(systemName: icon)
+            .imageScale(.small)
+          Text(value)
+            .font(.caption2.weight(.medium))
+            .lineLimit(1)
+        }
+        .foregroundStyle(tint)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(tint.opacity(0.12), in: Capsule())
+      } else {
+        VStack(alignment: .leading, spacing: 6) {
+          HStack(spacing: 6) {
+            Image(systemName: icon)
+              .imageScale(.medium)
+            Text(title.uppercased())
+              .font(.caption2.weight(.semibold))
+          }
+          .foregroundStyle(tint)
 
-      Text(value)
-        .font(.footnote.weight(.medium))
-        .foregroundStyle(.primary)
-        .lineLimit(1)
-        .truncationMode(.tail)
+          Text(value)
+            .font(.footnote.weight(.medium))
+            .foregroundStyle(.primary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+          RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(tint.opacity(0.12))
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .stroke(tint.opacity(0.2), lineWidth: 1)
+        )
+      }
     }
-    .padding(.horizontal, 12)
-    .padding(.vertical, 8)
-    .background(
-      RoundedRectangle(cornerRadius: 12, style: .continuous)
-        .fill(tint.opacity(0.12))
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: 12, style: .continuous)
-        .stroke(tint.opacity(0.2), lineWidth: 1)
-    )
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel("\(title): \(value)")
   }
   private var promptDuration: TimeInterval? {
     let start =

--- a/Sources/SpeakApp/MainView.swift
+++ b/Sources/SpeakApp/MainView.swift
@@ -12,11 +12,16 @@ struct MainView: View {
   var body: some View {
     NavigationSplitView {
       SideBarView(selection: $selection)
-        .navigationSplitViewColumnWidth(min: 220, ideal: 240, max: 320)
+        .navigationSplitViewColumnWidth(
+          min: settings.visualDensity.isCompact ? 170 : 220,
+          ideal: settings.visualDensity.isCompact ? 188 : 240,
+          max: settings.visualDensity.isCompact ? 240 : 320
+        )
     } detail: {
       detailView
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(settings.visualDensity == .compact ? 8 : 16)
+        .padding(settings.visualDensity.isCompact ? 0 : 16)
+        .controlSize(settings.visualDensity.isCompact ? .small : .regular)
         .background(Color(nsColor: .windowBackgroundColor))
     }
     .frame(minWidth: 960, minHeight: 640)
@@ -79,44 +84,68 @@ struct MainView: View {
   private var toolbar: some ToolbarContent {
     ToolbarItem(placement: .primaryAction) {
       Button(action: environment.main.toggleRecordingFromUI) {
-        switch environment.main.state {
-        case .idle, .completed, .failed:
-          Label("Record", systemImage: "mic")
-        case .recording:
-          Label("Stop", systemImage: "stop.fill")
-            .foregroundStyle(.red)
-        case .processing:
-          ProgressView()
-        case .delivering:
-          ProgressView()
-        }
+        toolbarRecordLabel
       }
       .keyboardShortcut(.space, modifiers: [.command, .shift])
       .speakTooltip("Start or stop a recording from anywhere in Speak. We'll let you know when we're listening.")
       .accessibilityLabel(accessibilityLabelForRecordButton)
     }
     ToolbarItem(placement: .status) {
-      VStack(alignment: .trailing, spacing: 2) {
-        Text(environment.settings.effectiveTranscriptionModeDisplayName)
+      if settings.visualDensity.isCompact {
+        Image(systemName: "waveform.badge.magnifyingglass")
           .font(.caption)
           .foregroundStyle(.secondary)
-        if let item = history.items.first {
-          Text("Last: \(item.createdAt.formatted())")
-            .font(.caption2)
-            .foregroundStyle(.tertiary)
+          .accessibilityLabel(
+            "Current mode: \(environment.settings.effectiveTranscriptionModeDisplayName)"
+          )
+          .speakTooltip(environment.settings.effectiveTranscriptionModeDisplayName)
+      } else {
+        VStack(alignment: .trailing, spacing: 2) {
+          Text(environment.settings.effectiveTranscriptionModeDisplayName)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+          if let item = history.items.first {
+            Text("Last: \(item.createdAt.formatted())")
+              .font(.caption2)
+              .foregroundStyle(.tertiary)
+          }
         }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+          Capsule()
+            .fill(.ultraThinMaterial)
+        )
+        .overlay(
+          Capsule()
+            .strokeBorder(.secondary.opacity(0.3), lineWidth: 0.5)
+        )
+        .accessibilityLabel("Current mode: \(environment.settings.effectiveTranscriptionModeDisplayName)")
       }
-      .padding(.horizontal, 12)
-      .padding(.vertical, 6)
-      .background(
-        Capsule()
-          .fill(.ultraThinMaterial)
-      )
-      .overlay(
-        Capsule()
-          .strokeBorder(.secondary.opacity(0.3), lineWidth: 0.5)
-      )
-      .accessibilityLabel("Current mode: \(environment.settings.effectiveTranscriptionModeDisplayName)")
+    }
+  }
+
+  @ViewBuilder
+  private var toolbarRecordLabel: some View {
+    switch environment.main.state {
+    case .idle, .completed, .failed:
+      if settings.visualDensity.isCompact {
+        Label("Record", systemImage: "mic")
+          .labelStyle(.iconOnly)
+      } else {
+        Label("Record", systemImage: "mic")
+      }
+    case .recording:
+      if settings.visualDensity.isCompact {
+        Label("Stop", systemImage: "stop.fill")
+          .labelStyle(.iconOnly)
+          .foregroundStyle(.red)
+      } else {
+        Label("Stop", systemImage: "stop.fill")
+          .foregroundStyle(.red)
+      }
+    case .processing, .delivering:
+      ProgressView()
     }
   }
 

--- a/Sources/SpeakApp/PersonalCorrectionsView.swift
+++ b/Sources/SpeakApp/PersonalCorrectionsView.swift
@@ -58,9 +58,11 @@ struct PersonalCorrectionsView: View {
         Label("Automatic when context matches", systemImage: "checkmark.seal.fill")
           .labelStyle(.iconOnly)
           .foregroundStyle(.green)
+          .speakTooltip("Automatic when context matches")
         Label("Manual rules stay as suggestions", systemImage: "hand.raised")
           .labelStyle(.iconOnly)
           .foregroundStyle(.orange)
+          .speakTooltip("Manual rules stay as suggestions")
       }
       .padding(density.cardPadding)
       .foregroundStyle(.white)

--- a/Sources/SpeakApp/PersonalCorrectionsView.swift
+++ b/Sources/SpeakApp/PersonalCorrectionsView.swift
@@ -1,9 +1,14 @@
+import SpeakCore
 import SwiftUI
 
+// The correction editor intentionally keeps its tightly coupled form sections
+// together so draft focus, validation, and preview state stay local.
+// swiftlint:disable file_length type_body_length
 struct PersonalCorrectionsView: View {
   @EnvironmentObject private var lexicon: PersonalLexiconService
   @EnvironmentObject private var autoCorrectionTracker: AutoCorrectionTracker
   @EnvironmentObject private var settings: AppSettings
+  @Environment(\.appVisualDensity) private var density
   @State private var draft = RuleDraft()
   @State private var alertMessage: String?
   @State private var showAdvancedOptions: Bool = false
@@ -19,7 +24,7 @@ struct PersonalCorrectionsView: View {
 
   var body: some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: 28) {
+      VStack(alignment: .leading, spacing: density.isCompact ? density.sectionSpacing : 28) {
         hero
         autoCorrectionsSection
         postProcessingInfoBanner
@@ -27,7 +32,7 @@ struct PersonalCorrectionsView: View {
         existingRulesSection
         previewSection
       }
-      .padding(24)
+      .padding(density.pagePadding)
       .frame(maxWidth: 1100, alignment: .center)
     }
     .background(
@@ -43,77 +48,115 @@ struct PersonalCorrectionsView: View {
     }
   }
 
+  @ViewBuilder
   private var hero: some View {
-    VStack(alignment: .leading, spacing: 16) {
-      Text("Corrections")
-        .font(.largeTitle.bold())
-      Text(
-        "Teach Speak how your world sounds. Define preferred spellings and let the app correct transcripts when the context fits without leaking private names."
-      )
-      .font(.title3)
-      .foregroundStyle(.secondary)
-      HStack(spacing: 20) {
+    if density.isCompact {
+      HStack(spacing: density.groupSpacing) {
+        Label("Corrections", systemImage: "text.badge.checkmark")
+          .font(.subheadline.bold())
+        Spacer(minLength: 4)
         Label("Automatic when context matches", systemImage: "checkmark.seal.fill")
-          .labelStyle(.titleAndIcon)
+          .labelStyle(.iconOnly)
           .foregroundStyle(.green)
         Label("Manual rules stay as suggestions", systemImage: "hand.raised")
-          .labelStyle(.titleAndIcon)
+          .labelStyle(.iconOnly)
           .foregroundStyle(.orange)
       }
-      .font(.callout)
-    }
-    .padding(32)
-    .background(
-      LinearGradient(
-        colors: [Color.brandAccentWarm, Color.brandAccent.opacity(0.85)],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
+      .padding(density.cardPadding)
+      .foregroundStyle(.white)
+      .background(
+        LinearGradient(
+          colors: [Color.brandAccentWarm, Color.brandAccent.opacity(0.85)],
+          startPoint: .leading,
+          endPoint: .trailing
+        ),
+        in: RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
       )
-      .cornerRadius(32)
-      .shadow(color: Color.brandAccentWarm.opacity(0.28), radius: 24, x: 0, y: 12)
-    )
+    } else {
+      VStack(alignment: .leading, spacing: 16) {
+        Text("Corrections")
+          .font(.largeTitle.bold())
+        Text(
+          "Teach Speak how your world sounds. Define preferred spellings and let the app "
+            + "correct transcripts when the context fits without leaking private names."
+        )
+        .font(.title3)
+        .foregroundStyle(.secondary)
+        HStack(spacing: 20) {
+          Label("Automatic when context matches", systemImage: "checkmark.seal.fill")
+            .labelStyle(.titleAndIcon)
+            .foregroundStyle(.green)
+          Label("Manual rules stay as suggestions", systemImage: "hand.raised")
+            .labelStyle(.titleAndIcon)
+            .foregroundStyle(.orange)
+        }
+        .font(.callout)
+      }
+      .padding(32)
+      .background(
+        LinearGradient(
+          colors: [Color.brandAccentWarm, Color.brandAccent.opacity(0.85)],
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        )
+        .cornerRadius(32)
+        .shadow(color: Color.brandAccentWarm.opacity(0.28), radius: 24, x: 0, y: 12)
+      )
+    }
   }
 
   private var postProcessingInfoBanner: some View {
-    HStack(alignment: .top, spacing: 16) {
+    HStack(alignment: .top, spacing: density.groupSpacing) {
       Image(systemName: "info.circle.fill")
-        .font(.title2)
+        .font(density.isCompact ? .caption : .title2)
         .foregroundStyle(Color.brandLagoon)
-      VStack(alignment: .leading, spacing: 8) {
+      VStack(alignment: .leading, spacing: density.isCompact ? 1 : 8) {
         Text("How corrections work")
-          .font(.headline)
-        VStack(alignment: .leading, spacing: 6) {
-          HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "checkmark.circle.fill")
-              .foregroundStyle(.green)
-              .imageScale(.small)
-            Text("Corrections are always applied directly to transcripts based on your rules")
+          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
+        if !density.isCompact {
+          VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top, spacing: 8) {
+              Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .imageScale(.small)
+              Text("Corrections are always applied directly to transcripts based on your rules")
+                .font(.callout)
+            }
+            HStack(alignment: .top, spacing: 8) {
+              Image(systemName: "sparkles")
+                .foregroundStyle(Color.brandAccent)
+                .imageScale(.small)
+              Text(
+                "When post-processing is enabled, your correction rules are also shared "
+                  + "with the LLM for enhanced context"
+              )
               .font(.callout)
-          }
-          HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "sparkles")
-              .foregroundStyle(Color.brandAccent)
-              .imageScale(.small)
-            Text("When post-processing is enabled, your correction rules are also shared with the LLM for enhanced context")
+            }
+            HStack(alignment: .top, spacing: 8) {
+              Image(systemName: "doc.plaintext")
+                .foregroundStyle(.orange)
+                .imageScale(.small)
+              Text(
+                "When post-processing is disabled, corrections still apply "
+                  + "but without LLM context enhancement"
+              )
               .font(.callout)
+            }
           }
-          HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "doc.plaintext")
-              .foregroundStyle(.orange)
-              .imageScale(.small)
-            Text("When post-processing is disabled, corrections still apply but without LLM context enhancement")
-              .font(.callout)
-          }
+        } else {
+          Text("Rules apply locally and can also guide post-processing.")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
         }
       }
     }
-    .padding(20)
+    .padding(density.isCompact ? density.cardPadding : 20)
     .background(
-      RoundedRectangle(cornerRadius: 16, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 8 : 16, style: .continuous)
         .fill(Color.brandLagoon.opacity(0.08))
     )
     .overlay(
-      RoundedRectangle(cornerRadius: 16, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 8 : 16, style: .continuous)
         .stroke(Color.brandLagoon.opacity(0.2), lineWidth: 1)
     )
   }
@@ -121,7 +164,7 @@ struct PersonalCorrectionsView: View {
   // MARK: - Auto-Corrections Section
 
   private var autoCorrectionsSection: some View {
-    VStack(alignment: .leading, spacing: 16) {
+    VStack(alignment: .leading, spacing: density.groupSpacing) {
       HStack {
         VStack(alignment: .leading, spacing: 4) {
           HStack(spacing: 8) {
@@ -140,7 +183,7 @@ struct PersonalCorrectionsView: View {
       }
 
       if settings.autoCorrectionsEnabled {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: density.inlineSpacing) {
           HStack {
             Text("Promotion threshold:")
               .font(.callout)
@@ -155,7 +198,7 @@ struct PersonalCorrectionsView: View {
           if !autoCorrectionTracker.candidates.isEmpty {
             Divider()
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: density.inlineSpacing) {
               HStack {
                 Text("Candidate Corrections")
                   .font(.subheadline.bold())
@@ -194,13 +237,13 @@ struct PersonalCorrectionsView: View {
         }
       }
     }
-    .padding(20)
+    .padding(density.isCompact ? density.cardPadding : 20)
     .background(
-      RoundedRectangle(cornerRadius: 16, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 8 : 16, style: .continuous)
         .fill(Color.brandAccent.opacity(0.06))
     )
     .overlay(
-      RoundedRectangle(cornerRadius: 16, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 8 : 16, style: .continuous)
         .stroke(Color.brandAccent.opacity(0.15), lineWidth: 1)
     )
   }
@@ -264,10 +307,10 @@ struct PersonalCorrectionsView: View {
   }
 
   private var editorCard: some View {
-    VStack(alignment: .leading, spacing: 20) {
+    VStack(alignment: .leading, spacing: density.sectionSpacing) {
       headerRow
 
-      VStack(alignment: .leading, spacing: 12) {
+      VStack(alignment: .leading, spacing: density.inlineSpacing) {
         LabeledContent("Correct spelling") {
           TextField("e.g. Susy", text: $draft.canonical)
             .textFieldStyle(.roundedBorder)
@@ -307,7 +350,7 @@ struct PersonalCorrectionsView: View {
         }
       }
 
-      HStack(spacing: 12) {
+      HStack(spacing: density.inlineSpacing) {
         Button(draft.isEditing ? "Update Rule" : "Add Rule", action: saveDraft)
           .buttonStyle(.borderedProminent)
           .disabled(!draft.isSavable)
@@ -321,42 +364,51 @@ struct PersonalCorrectionsView: View {
         Spacer()
       }
     }
-    .padding(28)
+    .padding(density.isCompact ? density.cardPadding : 28)
     .background(
-      RoundedRectangle(cornerRadius: 26, style: .continuous)
+      RoundedRectangle(
+        cornerRadius: density.isCompact ? density.cardCornerRadius : 26,
+        style: .continuous
+      )
         .fill(.ultraThinMaterial)
     )
     .overlay(
-      RoundedRectangle(cornerRadius: 26, style: .continuous)
+      RoundedRectangle(
+        cornerRadius: density.isCompact ? density.cardCornerRadius : 26,
+        style: .continuous
+      )
         .stroke(Color.brandAccentWarm.opacity(0.15), lineWidth: 1)
     )
   }
 
   private var headerRow: some View {
     HStack(alignment: .top) {
-      VStack(alignment: .leading, spacing: 6) {
+      VStack(alignment: .leading, spacing: density.isCompact ? 1 : 6) {
         Text(draft.isEditing ? "Edit correction" : "New correction")
-          .font(.title3.bold())
-        Text(
-          "Aliases support full words only. Automatic rules run when tags match; manual rules stay as review-only suggestions."
-        )
-        .foregroundStyle(.secondary)
-        .font(.footnote)
+          .font(density.isCompact ? .caption.weight(.semibold) : .title3.bold())
+        if !density.isCompact {
+          Text(
+            "Aliases support full words only. Automatic rules run when tags match; "
+              + "manual rules stay as review-only suggestions."
+          )
+          .foregroundStyle(.secondary)
+          .font(.footnote)
+        }
       }
       Spacer()
     }
   }
 
   private var existingRulesSection: some View {
-    VStack(alignment: .leading, spacing: 16) {
+    VStack(alignment: .leading, spacing: density.groupSpacing) {
       Text("Saved rules")
-        .font(.title3.bold())
+        .font(density.isCompact ? .caption.weight(.semibold) : .title3.bold())
       if lexicon.rules.isEmpty {
         Text("No corrections yet. Add your preferred spellings above.")
           .foregroundStyle(.secondary)
           .italic()
       } else {
-        LazyVStack(spacing: 16) {
+        LazyVStack(spacing: density.isCompact ? density.sectionSpacing : 16) {
           ForEach(lexicon.rules) { rule in
             ruleRow(rule)
           }
@@ -366,7 +418,7 @@ struct PersonalCorrectionsView: View {
   }
 
   private func ruleRow(_ rule: PersonalLexiconRule) -> some View {
-    VStack(alignment: .leading, spacing: 10) {
+    VStack(alignment: .leading, spacing: density.isCompact ? 4 : 10) {
       HStack(alignment: .top) {
         VStack(alignment: .leading, spacing: 4) {
           HStack(spacing: 6) {
@@ -427,9 +479,9 @@ struct PersonalCorrectionsView: View {
           .foregroundStyle(.tertiary)
       }
     }
-    .padding(20)
+    .padding(density.isCompact ? density.cardPadding : 20)
     .background(
-      RoundedRectangle(cornerRadius: 22, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 8 : 22, style: .continuous)
         .fill(Color(nsColor: .controlBackgroundColor))
     )
   }
@@ -438,21 +490,21 @@ struct PersonalCorrectionsView: View {
     let context = PersonalLexiconContext(tags: draft.previewTags, destinationApplication: "Preview", recentTranscriptWindow: previewText)
     let preview = lexicon.apply(to: previewText, context: context)
 
-    return VStack(alignment: .leading, spacing: 16) {
+    return VStack(alignment: .leading, spacing: density.groupSpacing) {
       Text("Preview")
-        .font(.title3.bold())
+        .font(density.isCompact ? .caption.weight(.semibold) : .title3.bold())
       TextEditor(text: $previewText)
-        .frame(minHeight: 120)
-        .padding(12)
+        .frame(minHeight: density.isCompact ? 64 : 120)
+        .padding(density.isCompact ? 5 : 12)
         .background(
           RoundedRectangle(cornerRadius: 18, style: .continuous)
             .fill(Color(nsColor: .textBackgroundColor))
         )
-      VStack(alignment: .leading, spacing: 8) {
+      VStack(alignment: .leading, spacing: density.inlineSpacing) {
         Text("Transformed")
           .font(.caption.bold())
         Text(preview.transformedText)
-          .padding(12)
+          .padding(density.isCompact ? 5 : 12)
           .frame(maxWidth: .infinity, alignment: .leading)
           .background(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -480,9 +532,12 @@ struct PersonalCorrectionsView: View {
         }
       }
     }
-    .padding(24)
+    .padding(density.cardPadding)
     .background(
-      RoundedRectangle(cornerRadius: 24, style: .continuous)
+      RoundedRectangle(
+        cornerRadius: density.isCompact ? density.cardCornerRadius : 24,
+        style: .continuous
+      )
         .fill(.ultraThinMaterial)
     )
   }
@@ -597,7 +652,6 @@ private struct RuleDraft {
 
   var isEditing: Bool { id != nil }
 
-
   var canonicalDisplay: String {
     let trimmed = canonical.trimmingCharacters(in: .whitespacesAndNewlines)
     return trimmed.isEmpty ? "New correction" : trimmed
@@ -655,3 +709,4 @@ private func tokenize(_ text: String) -> [String] {
     .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
     .filter { !$0.isEmpty }
 }
+// swiftlint:enable file_length type_body_length

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -334,7 +334,71 @@ struct SettingsView: View {
     return "Control which system-generated instructions are added to the downloaded local model prompt."
   }
 
+  @ViewBuilder
   private var overviewHeader: some View {
+    if settings.visualDensity.isCompact {
+      compactOverviewHeader
+    } else {
+      normalOverviewHeader
+    }
+  }
+
+  private var compactOverviewHeader: some View {
+    HStack(spacing: settings.visualDensity.groupSpacing) {
+      Label("Settings", systemImage: "slider.horizontal.3")
+        .font(.subheadline.bold())
+        .lineLimit(1)
+
+      Spacer(minLength: 4)
+
+      compactOverviewMetric(
+        title: "Mode",
+        value: overviewModeValue,
+        systemImage: "waveform"
+      )
+      compactOverviewMetric(
+        title: settings.isActiveAssemblyAILiveModel ? "Pre-processing" : "Post-processing",
+        value: overviewPostProcessingValue,
+        systemImage: "wand.and.stars"
+      )
+      compactOverviewMetric(
+        title: "Output",
+        value: settings.textOutputMethod.displayName,
+        systemImage: "text.alignleft"
+      )
+      compactOverviewMetric(
+        title: "OpenRouter Key",
+        value: isOpenRouterKeyStored ? "Stored" : "Missing",
+        systemImage: isOpenRouterKeyStored ? "checkmark.seal.fill" : "key.fill"
+      )
+    }
+    .padding(settings.visualDensity.cardPadding)
+    .foregroundStyle(.white)
+    .background(
+      LinearGradient(
+        colors: [Color.orange, Color.orange.opacity(0.72)],
+        startPoint: .leading,
+        endPoint: .trailing
+      ),
+      in: RoundedRectangle(
+        cornerRadius: settings.visualDensity.cardCornerRadius,
+        style: .continuous
+      )
+    )
+  }
+
+  private func compactOverviewMetric(
+    title: String,
+    value: String,
+    systemImage: String
+  ) -> some View {
+    Label(value, systemImage: systemImage)
+      .font(.caption2.weight(.semibold))
+      .lineLimit(1)
+      .accessibilityLabel("\(title): \(value)")
+  }
+
+  private var normalOverviewHeader: some View {
     VStack(alignment: .leading, spacing: 16) {
       HStack(alignment: .center) {
         Image(systemName: "sparkles.rectangle.stack")
@@ -731,13 +795,14 @@ struct SettingsView: View {
   var body: some View {
     let density = settings.visualDensity
     ScrollView {
-      VStack(alignment: .leading, spacing: density == .compact ? 16 : 28) {
+      VStack(alignment: .leading, spacing: density.isCompact ? density.sectionSpacing : 28) {
         overviewHeader
         tabContent
       }
       .padding(density.pagePadding)
       .frame(maxWidth: 1100, alignment: .center)
     }
+    .controlSize(density.isCompact ? .small : .regular)
     .background(
       LinearGradient(
         colors: [Color.brandAccentWarm.opacity(0.08), .clear], startPoint: .top, endPoint: .center))
@@ -792,7 +857,7 @@ struct SettingsView: View {
   }
 
   private var generalSettings: some View {
-    LazyVStack(spacing: 20) {
+    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
       SettingsCard(title: "Appearance", systemImage: "paintpalette", tint: Color.brandAccent) {
         VStack(alignment: .leading, spacing: 12) {
           Text("Choose how Speak looks across light, dark, or system themes.")
@@ -1285,7 +1350,7 @@ struct SettingsView: View {
   }
 
   private var transcriptionSettings: some View {
-    LazyVStack(spacing: 20) {
+    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
       SettingsCard(title: "Transcription mode", systemImage: "waveform", tint: Color.teal) {
         VStack(alignment: .leading, spacing: 12) {
           Picker("Where transcription runs", selection: transcriptionLocationBinding) {
@@ -2650,7 +2715,7 @@ struct SettingsView: View {
   }
 
   private var postProcessingSettings: some View {
-    LazyVStack(spacing: 20) {
+    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
       if settings.isActiveAssemblyAILiveModel {
         preprocessingSettings
       } else {
@@ -2929,7 +2994,7 @@ struct SettingsView: View {
   }
 
   private var voiceOutputSettings: some View {
-    LazyVStack(spacing: 20) {
+    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
       SettingsCard(title: "Default Voice", systemImage: "speaker.wave.3", tint: Color.brandLagoonDeep) {
         VStack(alignment: .leading, spacing: 12) {
           VStack(alignment: .leading, spacing: 8) {
@@ -4445,14 +4510,14 @@ struct SettingsView: View {
   }
 
   private var keyboardSettings: some View {
-    VStack(spacing: 20) {
+    VStack(spacing: settings.visualDensity.sectionSpacing) {
       hotKeySettings
       ShortcutsSettingsView(shortcutManager: environment.shortcuts)
     }
   }
 
   private var hotKeySettings: some View {
-    LazyVStack(spacing: 20) {
+    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
       SettingsCard(title: "Trigger Key", systemImage: "keyboard", tint: Color.blue) {
         VStack(alignment: .leading, spacing: 12) {
           Text("Choose which key triggers recording.")
@@ -4537,7 +4602,7 @@ struct SettingsView: View {
   }
 
   private var permissionsSettings: some View {
-    LazyVStack(spacing: 20) {
+    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
       SettingsCard(title: "System permissions", systemImage: "lock.shield", tint: Color.red) {
         VStack(alignment: .leading, spacing: 12) {
           ForEach(PermissionType.availablePermissions(for: DistributionChannel.current)) { permission in
@@ -4640,7 +4705,7 @@ struct SettingsView: View {
   }
 
   private var aboutSettings: some View {
-    LazyVStack(spacing: 20) {
+    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
       SettingsCard(title: "Just Speak to It", systemImage: "info.circle", tint: Color.blue) {
         VStack(alignment: .leading, spacing: 16) {
           HStack(alignment: .top, spacing: 16) {
@@ -5119,28 +5184,31 @@ private struct LocaleOption: Identifiable, Equatable {
 }
 
 private struct SettingsInlineInfo: View {
+  @Environment(\.appVisualDensity) private var density
   let title: String
   let message: String
   let systemImage: String
 
   var body: some View {
-    HStack(alignment: .top, spacing: 10) {
+    HStack(alignment: .top, spacing: density.isCompact ? density.inlineSpacing : 10) {
       Image(systemName: systemImage)
         .foregroundStyle(Color.brandLagoon)
-        .frame(width: 20)
-      VStack(alignment: .leading, spacing: 3) {
+        .frame(width: density.isCompact ? 14 : 20)
+      VStack(alignment: .leading, spacing: density.isCompact ? 1 : 3) {
         Text(title)
           .font(.caption.weight(.semibold))
         Text(message)
-          .font(.caption)
+          .font(density.isCompact ? .caption2 : .caption)
           .foregroundStyle(.secondary)
+          .lineLimit(density.isCompact ? 1 : nil)
       }
     }
-    .padding(12)
+    .padding(density.isCompact ? 6 : 12)
     .background(
-      RoundedRectangle(cornerRadius: 12, style: .continuous)
+      RoundedRectangle(cornerRadius: density.isCompact ? 7 : 12, style: .continuous)
         .fill(Color.brandLagoon.opacity(0.08))
     )
+    .speakTooltip(message)
   }
 }
 
@@ -5160,18 +5228,25 @@ private struct SettingsCard<Content: View>: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: density.cardContentSpacing) {
-      HStack(spacing: 14) {
-        ZStack {
-          RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(tint.opacity(0.15))
-            .frame(width: 44, height: 44)
+      HStack(spacing: density.isCompact ? density.inlineSpacing : 14) {
+        if density.isCompact {
           Image(systemName: systemImage)
             .foregroundStyle(tint)
-            .font(.system(size: 20, weight: .semibold))
+            .font(.caption.weight(.semibold))
+            .frame(width: 16)
+        } else {
+          ZStack {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+              .fill(tint.opacity(0.15))
+              .frame(width: 44, height: 44)
+            Image(systemName: systemImage)
+              .foregroundStyle(tint)
+              .font(.system(size: 20, weight: .semibold))
+          }
         }
 
         Text(title)
-          .font(.headline)
+          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
           .foregroundStyle(.primary)
         Spacer()
       }
@@ -5180,13 +5255,27 @@ private struct SettingsCard<Content: View>: View {
     }
     .padding(density.cardPadding)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+    .background(
+      .ultraThinMaterial,
+      in: RoundedRectangle(
+        cornerRadius: density.isCompact ? density.cardCornerRadius : 26,
+        style: .continuous
+      )
+    )
     .overlay(
-      RoundedRectangle(cornerRadius: 26, style: .continuous)
+      RoundedRectangle(
+        cornerRadius: density.isCompact ? density.cardCornerRadius : 26,
+        style: .continuous
+      )
         .stroke(tint.opacity(0.12), lineWidth: 1)
         .allowsHitTesting(false)
     )
-    .shadow(color: tint.opacity(0.08), radius: 18, x: 0, y: 12)
+    .shadow(
+      color: tint.opacity(density.isCompact ? 0 : 0.08),
+      radius: density.isCompact ? 0 : 18,
+      x: 0,
+      y: density.isCompact ? 0 : 12
+    )
   }
 }
 

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -802,7 +802,6 @@ struct SettingsView: View {
       .padding(density.pagePadding)
       .frame(maxWidth: 1100, alignment: .center)
     }
-    .controlSize(density.isCompact ? .small : .regular)
     .background(
       LinearGradient(
         colors: [Color.brandAccentWarm.opacity(0.08), .clear], startPoint: .top, endPoint: .center))
@@ -5213,7 +5212,6 @@ private struct SettingsInlineInfo: View {
 }
 
 private struct SettingsCard<Content: View>: View {
-  @Environment(\.appVisualDensity) private var density
   let title: String
   let systemImage: String
   let tint: Color
@@ -5227,55 +5225,15 @@ private struct SettingsCard<Content: View>: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: density.cardContentSpacing) {
-      HStack(spacing: density.isCompact ? density.inlineSpacing : 14) {
-        if density.isCompact {
-          Image(systemName: systemImage)
-            .foregroundStyle(tint)
-            .font(.caption.weight(.semibold))
-            .frame(width: 16)
-        } else {
-          ZStack {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-              .fill(tint.opacity(0.15))
-              .frame(width: 44, height: 44)
-            Image(systemName: systemImage)
-              .foregroundStyle(tint)
-              .font(.system(size: 20, weight: .semibold))
-          }
-        }
-
-        Text(title)
-          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
-          .foregroundStyle(.primary)
-        Spacer()
-      }
-
+    SpeakDensityCard(
+      title: title,
+      systemImage: systemImage,
+      tint: tint,
+      regularCornerRadius: 26,
+      regularSpacerMinLength: 8
+    ) {
       content
     }
-    .padding(density.cardPadding)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .background(
-      .ultraThinMaterial,
-      in: RoundedRectangle(
-        cornerRadius: density.isCompact ? density.cardCornerRadius : 26,
-        style: .continuous
-      )
-    )
-    .overlay(
-      RoundedRectangle(
-        cornerRadius: density.isCompact ? density.cardCornerRadius : 26,
-        style: .continuous
-      )
-        .stroke(tint.opacity(0.12), lineWidth: 1)
-        .allowsHitTesting(false)
-    )
-    .shadow(
-      color: tint.opacity(density.isCompact ? 0 : 0.08),
-      radius: density.isCompact ? 0 : 18,
-      x: 0,
-      y: density.isCompact ? 0 : 12
-    )
   }
 }
 

--- a/Sources/SpeakApp/SideBarView.swift
+++ b/Sources/SpeakApp/SideBarView.swift
@@ -107,16 +107,16 @@ struct SideBarView: View {
 
   var body: some View {
     List {
-      Section("Speak") {
+      Section {
         ForEach([SidebarItem.dashboard, .history, .voiceOutput, .corrections, .troubleshooting]) { item in
           Button {
             selection = item
           } label: {
-            HStack(spacing: 12) {
+            HStack(spacing: settings.visualDensity.inlineSpacing) {
               Image(systemName: item.systemImage)
                 .foregroundStyle(item.color)
-                .imageScale(.medium)
-                .frame(width: 20)
+                .imageScale(settings.visualDensity.isCompact ? .small : .medium)
+                .frame(width: settings.visualDensity.isCompact ? 16 : 20)
               sidebarTitle(
                 item.title(isAssemblyAI: settings.isActiveAssemblyAILiveModel),
                 isSelected: selection == item
@@ -131,33 +131,35 @@ struct SideBarView: View {
           .buttonStyle(.plain)
           .focusable(true)
           .focusEffectDisabled()
-          .padding(.horizontal, 12)
-          .padding(.vertical, 8)
+          .padding(.horizontal, settings.visualDensity.isCompact ? 4 : 12)
+          .padding(.vertical, settings.visualDensity.isCompact ? 2 : 8)
           .background(
             selection == item
               ? RoundedRectangle(cornerRadius: 8)
                 .fill(item.color.opacity(0.15))
               : nil
           )
-          .listRowInsets(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8))
+          .listRowInsets(sidebarInsets)
           .listRowBackground(Color.clear)
           .speakTooltip(item.helpMessage)
           .accessibilityLabel(item.title(isAssemblyAI: settings.isActiveAssemblyAILiveModel))
           .accessibilityHint(accessibilityHint(for: item))
         }
+      } header: {
+        sidebarSectionHeader("Speak")
       }
 
-      Section("Settings") {
+      Section {
         ForEach(SettingsTab.allCases) { tab in
           let item = SidebarItem.settings(tab)
           Button {
             selection = item
           } label: {
-            HStack(spacing: 12) {
+            HStack(spacing: settings.visualDensity.inlineSpacing) {
               Image(systemName: tab.systemImage)
                 .foregroundStyle(Color.brandAccentWarm)
-                .imageScale(.medium)
-                .frame(width: 20)
+                .imageScale(settings.visualDensity.isCompact ? .small : .medium)
+                .frame(width: settings.visualDensity.isCompact ? 16 : 20)
               sidebarTitle(tab.title(isAssemblyAI: settings.isActiveAssemblyAILiveModel), isSelected: selection == item)
               ViewThatFits(in: .horizontal) {
                 shortcutHint(for: item)
@@ -165,25 +167,27 @@ struct SideBarView: View {
               }
             }
             .contentShape(Rectangle())
-            .padding(.leading, 10)
+            .padding(.leading, settings.visualDensity.isCompact ? 0 : 10)
           }
           .buttonStyle(.plain)
           .focusable(true)
           .focusEffectDisabled()
-          .padding(.horizontal, 12)
-          .padding(.vertical, 8)
+          .padding(.horizontal, settings.visualDensity.isCompact ? 4 : 12)
+          .padding(.vertical, settings.visualDensity.isCompact ? 2 : 8)
           .background(
             selection == item
               ? RoundedRectangle(cornerRadius: 8)
                 .fill(Color.brandAccentWarm.opacity(0.15))
               : nil
           )
-          .listRowInsets(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8))
+          .listRowInsets(sidebarInsets)
           .listRowBackground(Color.clear)
           .speakTooltip(item.helpMessage)
           .accessibilityLabel(item.title(isAssemblyAI: settings.isActiveAssemblyAILiveModel))
           .accessibilityHint(accessibilityHint(for: item))
         }
+      } header: {
+        sidebarSectionHeader("Settings")
       }
     }
     .listStyle(.sidebar)
@@ -192,9 +196,10 @@ struct SideBarView: View {
 
   private func sidebarTitle(_ title: String, isSelected: Bool) -> some View {
     Text(title)
+      .font(settings.visualDensity.isCompact ? .caption : .body)
       .fontWeight(isSelected ? .semibold : .regular)
       .foregroundStyle(.primary)
-      .lineLimit(nil)
+      .lineLimit(settings.visualDensity.isCompact ? 1 : nil)
       .multilineTextAlignment(.leading)
       .fixedSize(horizontal: false, vertical: true)
       .layoutPriority(3)
@@ -204,7 +209,9 @@ struct SideBarView: View {
   @ViewBuilder
   private func shortcutHint(for item: SidebarItem) -> some View {
     let binding = shortcutManager.binding(for: item.shortcutAction)
-    if settings.showSidebarShortcutHints && binding.isEnabled {
+    if !settings.visualDensity.isCompact,
+       settings.showSidebarShortcutHints,
+       binding.isEnabled {
       Text(binding.displayString)
         .font(.caption2.monospaced())
         .foregroundStyle(.secondary)
@@ -214,6 +221,29 @@ struct SideBarView: View {
         .minimumScaleFactor(0.8)
         .layoutPriority(-1)
         .accessibilityHidden(true)
+    }
+  }
+
+  private var sidebarInsets: EdgeInsets {
+    let inset: CGFloat = settings.visualDensity.isCompact ? 2 : 8
+    let verticalInset: CGFloat = settings.visualDensity.isCompact ? 1 : 2
+    return EdgeInsets(
+      top: verticalInset,
+      leading: inset,
+      bottom: verticalInset,
+      trailing: inset
+    )
+  }
+
+  @ViewBuilder
+  private func sidebarSectionHeader(_ title: String) -> some View {
+    if settings.visualDensity.isCompact {
+      Text(title)
+        .font(.caption2)
+        .fontWeight(.semibold)
+        .textCase(nil)
+    } else {
+      Text(title)
     }
   }
 

--- a/Sources/SpeakApp/SpeakDensityCard.swift
+++ b/Sources/SpeakApp/SpeakDensityCard.swift
@@ -1,0 +1,82 @@
+import SpeakCore
+import SwiftUI
+
+struct SpeakDensityCard<Content: View>: View {
+  @Environment(\.appVisualDensity) private var density
+  let title: String
+  let systemImage: String
+  let tint: Color
+  let regularCornerRadius: CGFloat
+  let regularSpacerMinLength: CGFloat
+  @ViewBuilder let content: Content
+
+  init(
+    title: String,
+    systemImage: String,
+    tint: Color,
+    regularCornerRadius: CGFloat = 28,
+    regularSpacerMinLength: CGFloat = 0,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.title = title
+    self.systemImage = systemImage
+    self.tint = tint
+    self.regularCornerRadius = regularCornerRadius
+    self.regularSpacerMinLength = regularSpacerMinLength
+    self.content = content()
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: density.cardContentSpacing) {
+      HStack(spacing: density.isCompact ? density.inlineSpacing : 14) {
+        cardIcon
+        Text(title)
+          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
+          .foregroundStyle(.primary)
+        Spacer(minLength: density.isCompact ? 0 : regularSpacerMinLength)
+      }
+
+      content
+    }
+    .padding(density.cardPadding)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      .ultraThinMaterial,
+      in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        .stroke(tint.opacity(0.12), lineWidth: 1)
+        .allowsHitTesting(false)
+    )
+    .shadow(
+      color: tint.opacity(density.isCompact ? 0 : 0.08),
+      radius: density.isCompact ? 0 : 18,
+      x: 0,
+      y: density.isCompact ? 0 : 12
+    )
+  }
+
+  @ViewBuilder
+  private var cardIcon: some View {
+    if density.isCompact {
+      Image(systemName: systemImage)
+        .foregroundStyle(tint)
+        .font(.caption.weight(.semibold))
+        .frame(width: 16)
+    } else {
+      ZStack {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+          .fill(tint.opacity(0.15))
+          .frame(width: 44, height: 44)
+        Image(systemName: systemImage)
+          .foregroundStyle(tint)
+          .font(.system(size: 20, weight: .semibold))
+      }
+    }
+  }
+
+  private var cornerRadius: CGFloat {
+    density.isCompact ? density.cardCornerRadius : regularCornerRadius
+  }
+}

--- a/Sources/SpeakApp/TroubleshootingView.swift
+++ b/Sources/SpeakApp/TroubleshootingView.swift
@@ -105,6 +105,7 @@ private struct TroubleshootingItemRow: View {
           .foregroundStyle(.secondary)
           .lineLimit(density.isCompact ? 1 : nil)
           .fixedSize(horizontal: false, vertical: !density.isCompact)
+          .speakTooltip(item.detail)
         actionButtons
       }
       Spacer()

--- a/Sources/SpeakApp/TroubleshootingView.swift
+++ b/Sources/SpeakApp/TroubleshootingView.swift
@@ -1,13 +1,15 @@
+import SpeakCore
 import SwiftUI
 
 struct TroubleshootingView: View {
   @EnvironmentObject private var environment: AppEnvironment
+  @Environment(\.appVisualDensity) private var density
   @StateObject private var analyser = TroubleshootingAnalyser()
   @Binding var sidebarSelection: SidebarItem?
 
   var body: some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: 24) {
+      VStack(alignment: .leading, spacing: density.isCompact ? density.sectionSpacing : 24) {
         header
         if analyser.items.isEmpty {
           allClearBanner
@@ -15,7 +17,7 @@ struct TroubleshootingView: View {
           itemsList
         }
       }
-      .padding(24)
+      .padding(density.pagePadding)
     }
     .onAppear { runAnalysis() }
     .onChange(of: environment.settings.restoreClipboardAfterPaste) { runAnalysis() }
@@ -36,39 +38,46 @@ struct TroubleshootingView: View {
   // MARK: - Header
 
   private var header: some View {
-    VStack(alignment: .leading, spacing: 8) {
+    VStack(alignment: .leading, spacing: density.isCompact ? 1 : 8) {
       Label("Troubleshooting", systemImage: "stethoscope")
-        .font(.title.bold())
-      Text("Common issues and quick fixes to get you up and running.")
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
+        .font(density.isCompact ? .subheadline.bold() : .title.bold())
+      if !density.isCompact {
+        Text("Common issues and quick fixes to get you up and running.")
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+      }
     }
   }
 
   // MARK: - All Clear
 
   private var allClearBanner: some View {
-    HStack(spacing: 12) {
+    HStack(spacing: density.isCompact ? density.inlineSpacing : 12) {
       Image(systemName: "checkmark.seal.fill")
-        .font(.title2)
+        .font(density.isCompact ? .caption : .title2)
         .foregroundStyle(.green)
-      VStack(alignment: .leading, spacing: 2) {
+      VStack(alignment: .leading, spacing: density.isCompact ? 0 : 2) {
         Text("Everything looks good")
-          .font(.headline)
-        Text("No issues detected with your current configuration.")
-          .font(.subheadline)
-          .foregroundStyle(.secondary)
+          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
+        if !density.isCompact {
+          Text("No issues detected with your current configuration.")
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
       }
       Spacer()
     }
-    .padding()
-    .background(RoundedRectangle(cornerRadius: 12).fill(.green.opacity(0.08)))
+    .padding(density.isCompact ? density.cardPadding : 16)
+    .background(
+      RoundedRectangle(cornerRadius: density.isCompact ? 8 : 12)
+        .fill(.green.opacity(0.08))
+    )
   }
 
   // MARK: - Items
 
   private var itemsList: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: density.isCompact ? density.sectionSpacing : 12) {
       ForEach(analyser.items) { item in
         TroubleshootingItemRow(item: item) { tab in
           sidebarSelection = .settings(tab)
@@ -81,39 +90,41 @@ struct TroubleshootingView: View {
 // MARK: - Item Row
 
 private struct TroubleshootingItemRow: View {
+  @Environment(\.appVisualDensity) private var density
   let item: TroubleshootingItem
   let navigateToTab: (SettingsTab) -> Void
 
   var body: some View {
-    HStack(alignment: .top, spacing: 14) {
+    HStack(alignment: .top, spacing: density.isCompact ? density.inlineSpacing : 14) {
       statusIcon
-      VStack(alignment: .leading, spacing: 6) {
+      VStack(alignment: .leading, spacing: density.isCompact ? 2 : 6) {
         Text(item.title)
-          .font(.headline)
+          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
         Text(item.detail)
-          .font(.subheadline)
+          .font(density.isCompact ? .caption2 : .subheadline)
           .foregroundStyle(.secondary)
-          .fixedSize(horizontal: false, vertical: true)
+          .lineLimit(density.isCompact ? 1 : nil)
+          .fixedSize(horizontal: false, vertical: !density.isCompact)
         actionButtons
       }
       Spacer()
     }
-    .padding()
+    .padding(density.isCompact ? density.cardPadding : 16)
     .background(
-      RoundedRectangle(cornerRadius: 12)
+      RoundedRectangle(cornerRadius: density.isCompact ? 8 : 12)
         .fill(backgroundColour.opacity(0.08))
     )
     .overlay(
-      RoundedRectangle(cornerRadius: 12)
+      RoundedRectangle(cornerRadius: density.isCompact ? 8 : 12)
         .strokeBorder(backgroundColour.opacity(0.2), lineWidth: 1)
     )
   }
 
   private var statusIcon: some View {
     Image(systemName: statusSystemImage)
-      .font(.title2)
+      .font(density.isCompact ? .caption : .title2)
       .foregroundStyle(backgroundColour)
-      .frame(width: 28)
+      .frame(width: density.isCompact ? 14 : 28)
   }
 
   private var statusSystemImage: String {

--- a/Sources/SpeakApp/UsageCharts.swift
+++ b/Sources/SpeakApp/UsageCharts.swift
@@ -134,25 +134,36 @@ extension HistoryItem {
 // MARK: - Chart Views
 
 struct DailyRecordingsChart: View {
+  @Environment(\.appVisualDensity) private var density
   let data: [DailyUsageData]
   @State private var showDuration = false
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: density.inlineSpacing) {
       HStack {
-        Text(showDuration ? "Recording Time per Day" : "Recordings per Day")
-          .font(.headline)
+        if !density.isCompact {
+          Text(showDuration ? "Recording Time per Day" : "Recordings per Day")
+            .font(.headline)
+        }
         Spacer()
-        Toggle(showDuration ? "Duration" : "Count", isOn: $showDuration)
-          .toggleStyle(.switch)
-          .controlSize(.small)
+        if density.isCompact {
+          Toggle(showDuration ? "Duration" : "Count", isOn: $showDuration)
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .labelsHidden()
+            .accessibilityLabel(showDuration ? "Show recording duration" : "Show recording count")
+        } else {
+          Toggle(showDuration ? "Duration" : "Count", isOn: $showDuration)
+            .toggleStyle(.switch)
+            .controlSize(.small)
+        }
       }
 
       if data.isEmpty {
         Text("No data for the last 30 days")
           .font(.callout)
           .foregroundStyle(.secondary)
-          .frame(height: 200)
+          .frame(height: density.chartHeight)
           .frame(maxWidth: .infinity)
       } else {
         Chart(data) { item in
@@ -175,10 +186,10 @@ struct DailyRecordingsChart: View {
             }
           }
         }
-        .frame(height: 200)
+        .frame(height: density.chartHeight)
       }
 
-      if !data.isEmpty {
+      if !data.isEmpty, !density.isCompact {
         Text(showDuration ? "Minutes per day" : "Number of recordings per day")
           .font(.caption)
           .foregroundStyle(.secondary)
@@ -188,27 +199,38 @@ struct DailyRecordingsChart: View {
 }
 
 struct ModelUsageChart: View {
+  @Environment(\.appVisualDensity) private var density
   let title: String
   let data: [ModelUsageData]
   let color: Color
   @State private var showSpend = false
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: density.inlineSpacing) {
       HStack {
-        Text(title)
-          .font(.headline)
+        if !density.isCompact {
+          Text(title)
+            .font(.headline)
+        }
         Spacer()
-        Toggle(showSpend ? "Spend" : "Count", isOn: $showSpend)
-          .toggleStyle(.switch)
-          .controlSize(.small)
+        if density.isCompact {
+          Toggle(showSpend ? "Spend" : "Count", isOn: $showSpend)
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .labelsHidden()
+            .accessibilityLabel(showSpend ? "Show model spend" : "Show model usage count")
+        } else {
+          Toggle(showSpend ? "Spend" : "Count", isOn: $showSpend)
+            .toggleStyle(.switch)
+            .controlSize(.small)
+        }
       }
 
       if data.isEmpty {
         Text("No usage data available")
           .font(.callout)
           .foregroundStyle(.secondary)
-          .frame(height: 200)
+          .frame(height: density.chartHeight)
           .frame(maxWidth: .infinity)
       } else {
         Chart(data) { item in
@@ -221,10 +243,15 @@ struct ModelUsageChart: View {
         .chartXAxis {
           AxisMarks(position: .bottom)
         }
-        .frame(height: max(200, CGFloat(data.count * 40)))
+        .frame(
+          height: max(
+            density.chartHeight,
+            CGFloat(data.count * (density.isCompact ? 22 : 40))
+          )
+        )
       }
 
-      if !data.isEmpty {
+      if !data.isEmpty, !density.isCompact {
         Text(showSpend ? "Total spend by model (USD)" : "Number of uses per model")
           .font(.caption)
           .foregroundStyle(.secondary)

--- a/Sources/SpeakApp/UsageCharts.swift
+++ b/Sources/SpeakApp/UsageCharts.swift
@@ -146,17 +146,17 @@ struct DailyRecordingsChart: View {
             .font(.headline)
         }
         Spacer()
-        if density.isCompact {
-          Toggle(showDuration ? "Duration" : "Count", isOn: $showDuration)
-            .toggleStyle(.switch)
-            .controlSize(.small)
-            .labelsHidden()
-            .accessibilityLabel(showDuration ? "Show recording duration" : "Show recording count")
-        } else {
-          Toggle(showDuration ? "Duration" : "Count", isOn: $showDuration)
-            .toggleStyle(.switch)
-            .controlSize(.small)
-        }
+        Toggle(showDuration ? "Duration" : "Count", isOn: $showDuration)
+          .toggleStyle(.switch)
+          .controlSize(.small)
+          .modifier(
+            CompactChartToggleModifier(
+              isCompact: density.isCompact,
+              accessibilityLabel: showDuration
+                ? "Show recording duration"
+                : "Show recording count"
+            )
+          )
       }
 
       if data.isEmpty {
@@ -213,17 +213,17 @@ struct ModelUsageChart: View {
             .font(.headline)
         }
         Spacer()
-        if density.isCompact {
-          Toggle(showSpend ? "Spend" : "Count", isOn: $showSpend)
-            .toggleStyle(.switch)
-            .controlSize(.small)
-            .labelsHidden()
-            .accessibilityLabel(showSpend ? "Show model spend" : "Show model usage count")
-        } else {
-          Toggle(showSpend ? "Spend" : "Count", isOn: $showSpend)
-            .toggleStyle(.switch)
-            .controlSize(.small)
-        }
+        Toggle(showSpend ? "Spend" : "Count", isOn: $showSpend)
+          .toggleStyle(.switch)
+          .controlSize(.small)
+          .modifier(
+            CompactChartToggleModifier(
+              isCompact: density.isCompact,
+              accessibilityLabel: showSpend
+                ? "Show model spend"
+                : "Show model usage count"
+            )
+          )
       }
 
       if data.isEmpty {
@@ -256,6 +256,22 @@ struct ModelUsageChart: View {
           .font(.caption)
           .foregroundStyle(.secondary)
       }
+    }
+  }
+}
+
+private struct CompactChartToggleModifier: ViewModifier {
+  let isCompact: Bool
+  let accessibilityLabel: String
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if isCompact {
+      content
+        .labelsHidden()
+        .accessibilityLabel(accessibilityLabel)
+    } else {
+      content
     }
   }
 }

--- a/Sources/SpeakApp/VoiceOutputView.swift
+++ b/Sources/SpeakApp/VoiceOutputView.swift
@@ -34,6 +34,7 @@ struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
   @EnvironmentObject private var tts: TextToSpeechManager
   @EnvironmentObject private var settings: AppSettings
   @EnvironmentObject private var history: HistoryManager
+  @Environment(\.appVisualDensity) private var density
 
   @State private var inputSource: TTSInputSource = .manual
   @State private var inputText: String = ""
@@ -46,11 +47,11 @@ struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
 
   var body: some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: 24) {
+      VStack(alignment: .leading, spacing: density.isCompact ? density.sectionSpacing : 24) {
         heroHeader
         contentSections
       }
-      .padding(24)
+      .padding(density.pagePadding)
       .frame(maxWidth: 1100, alignment: .center)
     }
     .background(
@@ -77,7 +78,82 @@ struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
     }
   }
 
+  @ViewBuilder
   private var heroHeader: some View {
+    if density.isCompact {
+      compactHeroHeader
+    } else {
+      normalHeroHeader
+    }
+  }
+
+  private var compactHeroHeader: some View {
+    HStack(spacing: density.groupSpacing) {
+      Label("Voice", systemImage: "speaker.wave.3")
+        .font(.subheadline.bold())
+      Spacer(minLength: 4)
+      compactVoiceMetric(
+        title: "Characters",
+        value: "\(inputText.count)",
+        systemImage: "textformat.abc"
+      )
+      if let estimatedCost, estimatedCost > 0 {
+        compactVoiceMetric(
+          title: "Estimated cost",
+          value: String(format: "$%.4f", NSDecimalNumber(decimal: estimatedCost).doubleValue),
+          systemImage: "dollarsign.circle"
+        )
+      }
+      if let result = tts.lastResult {
+        compactVoiceMetric(
+          title: "Last duration",
+          value: String(format: "%.1fs", result.duration),
+          systemImage: "waveform"
+        )
+      }
+      compactHeroAction
+    }
+    .padding(density.cardPadding)
+    .foregroundStyle(.white)
+    .background(
+      LinearGradient(
+        colors: [Color.green, Color.mint.opacity(0.8)],
+        startPoint: .leading,
+        endPoint: .trailing
+      ),
+      in: RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+    )
+  }
+
+  private func compactVoiceMetric(
+    title: String,
+    value: String,
+    systemImage: String
+  ) -> some View {
+    Label(value, systemImage: systemImage)
+      .font(.caption2.weight(.semibold))
+      .lineLimit(1)
+      .accessibilityLabel("\(title): \(value)")
+  }
+
+  @ViewBuilder
+  private var compactHeroAction: some View {
+    if tts.isSynthesizing {
+      ProgressView()
+        .controlSize(.mini)
+    } else if tts.isPlaying {
+      Button {
+        tts.stop()
+      } label: {
+        Label("Stop", systemImage: "stop.fill")
+          .labelStyle(.iconOnly)
+      }
+      .buttonStyle(.borderless)
+      .accessibilityLabel("Stop voice output")
+    }
+  }
+
+  private var normalHeroHeader: some View {
     VStack(alignment: .leading, spacing: 18) {
       heroTitleRow
       heroStatsRow
@@ -178,8 +254,16 @@ struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
   }
 
   private var contentSections: some View {
-    LazyVStack(spacing: 24) {
-      LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 24)], spacing: 24) {
+    LazyVStack(spacing: density.isCompact ? density.sectionSpacing : 24) {
+      LazyVGrid(
+        columns: [
+          GridItem(
+            .adaptive(minimum: density.gridMinimumWidth),
+            spacing: density.isCompact ? density.sectionSpacing : 24
+          )
+        ],
+        spacing: density.isCompact ? density.sectionSpacing : 24
+      ) {
         inputSourceCard
         voiceSelectionCard
       }
@@ -660,35 +744,51 @@ struct SSMLHelperView: View {
 // MARK: - Settings Card (reused from SettingsView pattern)
 
 private struct SettingsCard<Content: View>: View {
+  @Environment(\.appVisualDensity) private var density
   let title: String
   let systemImage: String
   let tint: Color
   @ViewBuilder let content: Content
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 18) {
-      HStack(spacing: 14) {
-        ZStack {
-          RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(tint.opacity(0.15))
-            .frame(width: 44, height: 44)
+    VStack(alignment: .leading, spacing: density.cardContentSpacing) {
+      HStack(spacing: density.isCompact ? density.inlineSpacing : 14) {
+        if density.isCompact {
           Image(systemName: systemImage)
             .foregroundStyle(tint)
-            .font(.system(size: 20, weight: .semibold))
+            .font(.caption.weight(.semibold))
+            .frame(width: 16)
+        } else {
+          ZStack {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+              .fill(tint.opacity(0.15))
+              .frame(width: 44, height: 44)
+            Image(systemName: systemImage)
+              .foregroundStyle(tint)
+              .font(.system(size: 20, weight: .semibold))
+          }
         }
         Text(title)
-          .font(.headline)
+          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
         Spacer(minLength: 0)
       }
       content
     }
-    .padding(24)
+    .padding(density.cardPadding)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+    .background(
+      .ultraThinMaterial,
+      in: RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
+    )
     .overlay(
-      RoundedRectangle(cornerRadius: 28, style: .continuous)
+      RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
         .stroke(tint.opacity(0.12), lineWidth: 1)
     )
-    .shadow(color: tint.opacity(0.08), radius: 18, x: 0, y: 12)
+    .shadow(
+      color: tint.opacity(density.isCompact ? 0 : 0.08),
+      radius: density.isCompact ? 0 : 18,
+      x: 0,
+      y: density.isCompact ? 0 : 12
+    )
   }
 }

--- a/Sources/SpeakApp/VoiceOutputView.swift
+++ b/Sources/SpeakApp/VoiceOutputView.swift
@@ -278,7 +278,7 @@ struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
   }
 
   private var inputSourceCard: some View {
-    SettingsCard(title: "Input Source", systemImage: "arrow.down.doc", tint: .brandLagoon) {
+    SpeakDensityCard(title: "Input Source", systemImage: "arrow.down.doc", tint: .brandLagoon) {
       VStack(alignment: .leading, spacing: 12) {
         ViewThatFits(in: .horizontal) {
           Picker("Source", selection: $inputSource) {
@@ -319,7 +319,7 @@ struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
   }
 
   private var voiceSelectionCard: some View {
-    SettingsCard(title: "Voice", systemImage: "person.wave.2", tint: .brandAccent) {
+    SpeakDensityCard(title: "Voice", systemImage: "person.wave.2", tint: .brandAccent) {
       VStack(alignment: .leading, spacing: 12) {
         if availableVoices.isEmpty {
           HStack {
@@ -376,7 +376,7 @@ struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
   }
 
   private var synthesisControlsCard: some View {
-    SettingsCard(title: "Controls", systemImage: "slider.horizontal.3", tint: .green) {
+    SpeakDensityCard(title: "Controls", systemImage: "slider.horizontal.3", tint: .green) {
       VStack(alignment: .leading, spacing: 16) {
         VStack(alignment: .leading, spacing: 8) {
           HStack {
@@ -422,7 +422,7 @@ struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
   }
 
   private var textWorkspaceCard: some View {
-    SettingsCard(title: "Text", systemImage: "text.alignleft", tint: .orange) {
+    SpeakDensityCard(title: "Text", systemImage: "text.alignleft", tint: .orange) {
       VStack(alignment: .leading, spacing: 12) {
         if inputSource == .history {
           historyItemPicker
@@ -513,7 +513,7 @@ struct VoiceOutputView: View { // swiftlint:disable:this type_body_length
   }
 
   private var resultCard: some View {
-    SettingsCard(title: "Result", systemImage: "checkmark.circle", tint: .green) {
+    SpeakDensityCard(title: "Result", systemImage: "checkmark.circle", tint: .green) {
       VStack(alignment: .leading, spacing: 12) {
         if let error = tts.lastError {
           HStack(alignment: .top, spacing: 12) {
@@ -738,57 +738,5 @@ struct SSMLHelperView: View {
       .buttonStyle(.borderless)
       .controlSize(.mini)
     }
-  }
-}
-
-// MARK: - Settings Card (reused from SettingsView pattern)
-
-private struct SettingsCard<Content: View>: View {
-  @Environment(\.appVisualDensity) private var density
-  let title: String
-  let systemImage: String
-  let tint: Color
-  @ViewBuilder let content: Content
-
-  var body: some View {
-    VStack(alignment: .leading, spacing: density.cardContentSpacing) {
-      HStack(spacing: density.isCompact ? density.inlineSpacing : 14) {
-        if density.isCompact {
-          Image(systemName: systemImage)
-            .foregroundStyle(tint)
-            .font(.caption.weight(.semibold))
-            .frame(width: 16)
-        } else {
-          ZStack {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-              .fill(tint.opacity(0.15))
-              .frame(width: 44, height: 44)
-            Image(systemName: systemImage)
-              .foregroundStyle(tint)
-              .font(.system(size: 20, weight: .semibold))
-          }
-        }
-        Text(title)
-          .font(density.isCompact ? .caption.weight(.semibold) : .headline)
-        Spacer(minLength: 0)
-      }
-      content
-    }
-    .padding(density.cardPadding)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .background(
-      .ultraThinMaterial,
-      in: RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: density.cardCornerRadius, style: .continuous)
-        .stroke(tint.opacity(0.12), lineWidth: 1)
-    )
-    .shadow(
-      color: tint.opacity(density.isCompact ? 0 : 0.08),
-      radius: density.isCompact ? 0 : 18,
-      x: 0,
-      y: density.isCompact ? 0 : 12
-    )
   }
 }

--- a/Sources/SpeakCore/AppVisualDensity.swift
+++ b/Sources/SpeakCore/AppVisualDensity.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 /// A user-selected presentation density shared by the macOS and iOS apps.
-/// Normal intentionally preserves the existing spacing; compact reduces
-/// whitespace without shrinking interactive controls below platform norms.
+/// Normal intentionally preserves the existing spacing. Compact is a distinct
+/// information-dense layout that removes decorative whitespace, favours inline
+/// presentation, and keeps touch targets at platform minimums.
 public enum AppVisualDensity: String, CaseIterable, Identifiable, Sendable {
     case normal
     case compact
@@ -16,13 +17,33 @@ public enum AppVisualDensity: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    public var sectionSpacing: CGFloat { self == .compact ? 12 : 20 }
-    public var pagePadding: CGFloat { self == .compact ? 14 : 24 }
-    public var cardPadding: CGFloat { self == .compact ? 15 : 24 }
-    public var cardContentSpacing: CGFloat { self == .compact ? 11 : 18 }
-    public var listRowVerticalPadding: CGFloat { self == .compact ? 1 : 4 }
-    public var minimumListRowHeight: CGFloat { self == .compact ? 38 : 44 }
-    public var listSectionSpacing: CGFloat { self == .compact ? 12 : 24 }
+    public var isCompact: Bool { self == .compact }
+
+    public var sectionSpacing: CGFloat { isCompact ? 6 : 20 }
+    public var pagePadding: CGFloat { isCompact ? 8 : 24 }
+    public var cardPadding: CGFloat { isCompact ? 8 : 24 }
+    public var cardContentSpacing: CGFloat { isCompact ? 6 : 18 }
+    public var inlineSpacing: CGFloat { isCompact ? 6 : 12 }
+    public var groupSpacing: CGFloat { isCompact ? 8 : 16 }
+    public var listRowVerticalPadding: CGFloat { isCompact ? 0 : 4 }
+    public var listSectionSpacing: CGFloat { isCompact ? 4 : 24 }
+    public var cardCornerRadius: CGFloat { isCompact ? 12 : 28 }
+    public var gridMinimumWidth: CGFloat { isCompact ? 240 : 340 }
+    public var chartHeight: CGFloat { isCompact ? 132 : 200 }
+
+    public var minimumListRowHeight: CGFloat {
+        #if os(iOS)
+        // Compact iOS rows remove internal whitespace but retain Apple's
+        // minimum comfortable touch target.
+        return 44
+        #else
+        return isCompact ? 30 : 44
+        #endif
+    }
+
+    public func prefersInlineLayout(dynamicTypeSize: DynamicTypeSize) -> Bool {
+        isCompact && !dynamicTypeSize.isAccessibilitySize
+    }
 }
 
 private struct AppVisualDensityKey: EnvironmentKey {

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -355,6 +355,7 @@ public struct ContentView: View {
     /// badge History when a recording landed while the app was away.
     @ObservedObject private var backgroundService = TranscriptionRecordingService.shared
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var showHistoryBadge = false
     /// Completion time of the background transcript we last surfaced, so we only
     /// surface a given session once and never clobber the user's in-app edits.
@@ -371,25 +372,25 @@ public struct ContentView: View {
                         ScrollView {
                             VStack(
                                 alignment: .leading,
-                                spacing: settings.visualDensity == .compact ? 8 : 12
+                                spacing: density.isCompact ? density.cardContentSpacing : 12
                             ) {
                                 if currentText.isEmpty {
                                     Text(backgroundService.isRunning
                                          ? "Recording via Action Button…"
                                          : "Tap the microphone to start transcription")
-                                        .font(.title3)
+                                        .font(density.isCompact ? .subheadline : .title3)
                                         .foregroundStyle(.secondary)
                                         .frame(maxWidth: .infinity, alignment: .center)
-                                        .padding(.top, 100)
+                                        .padding(.top, density.isCompact ? 24 : 100)
                                 } else {
                                     Text(currentText)
-                                        .font(.title3)
+                                        .font(density.isCompact ? .body : .title3)
                                         .foregroundStyle(.primary)
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                         .textSelection(.enabled)
                                 }
                             }
-                            .padding(settings.visualDensity == .compact ? 12 : 16)
+                            .padding(density.isCompact ? density.pagePadding : 16)
                             .id("transcript")
                         }
                         .onChange(of: coordinator.partialText) { _, _ in
@@ -408,7 +409,7 @@ public struct ContentView: View {
                         }
                     }
 
-                    Spacer(minLength: 120) // Space for floating controls
+                    Spacer(minLength: density.isCompact ? 72 : 120)
                 }
 
                 // Controls layer - floating glass controls
@@ -417,11 +418,12 @@ public struct ContentView: View {
 
                     // Floating control cluster with Liquid Glass
                     floatingControls
-                        .padding(.horizontal, 20)
-                        .padding(.bottom, 30)
+                        .padding(.horizontal, density.isCompact ? 8 : 20)
+                        .padding(.bottom, density.isCompact ? 8 : 30)
                 }
             }
             .navigationTitle("Just Speak to It")
+            .navigationBarTitleDisplayMode(usesInlineDensityLayout ? .inline : .automatic)
             .toolbar {
                 // Status indicator in toolbar (system handles glass)
                 if coordinator.isRunning || backgroundService.isRunning {
@@ -444,7 +446,7 @@ public struct ContentView: View {
                 }
 
                 ToolbarItem(placement: .topBarTrailing) {
-                    HStack(spacing: 16) {
+                    HStack(spacing: density.isCompact ? 8 : 16) {
                         NavigationLink {
                             HistoryView()
                                 .onAppear { markHistorySeen() }
@@ -509,6 +511,7 @@ public struct ContentView: View {
         }
         .environment(\.appVisualDensity, settings.visualDensity)
         .environment(\.defaultMinListRowHeight, settings.visualDensity.minimumListRowHeight)
+        .controlSize(density.isCompact ? .small : .regular)
     }
 
     // MARK: - Floating Controls with Glass Effect
@@ -530,8 +533,8 @@ public struct ContentView: View {
     @available(iOS 26.0, *)
     @ViewBuilder
     private var floatingControlsGlass: some View {
-        GlassEffectContainer(spacing: 16) {
-            HStack(spacing: 16) {
+        GlassEffectContainer(spacing: density.isCompact ? 8 : 16) {
+            HStack(spacing: density.isCompact ? 8 : 16) {
                 // Primary action - Start/Stop
                 Button {
                     Task {
@@ -539,8 +542,8 @@ public struct ContentView: View {
                     }
                 } label: {
                     Image(systemName: isAnyRecording ? "stop.fill" : "mic.fill")
-                        .font(.system(size: 28))
-                        .frame(width: 64, height: 64)
+                        .font(.system(size: primarySymbolSize))
+                        .frame(width: primaryControlSize, height: primaryControlSize)
                 }
                 .buttonStyle(.glassProminent)
                 .tint(isAnyRecording ? .red : .brandAccent)
@@ -554,8 +557,8 @@ public struct ContentView: View {
                         showingPostProcessing = true
                     } label: {
                         Image(systemName: "wand.and.stars")
-                            .font(.system(size: 20))
-                            .frame(width: 48, height: 48)
+                            .font(.system(size: secondarySymbolSize))
+                            .frame(width: secondaryControlSize, height: secondaryControlSize)
                     }
                     .buttonStyle(.glass)
                     .tint(.purple)
@@ -568,8 +571,8 @@ public struct ContentView: View {
                         copyToClipboard()
                     } label: {
                         Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                            .font(.system(size: 20))
-                            .frame(width: 48, height: 48)
+                            .font(.system(size: secondarySymbolSize))
+                            .frame(width: secondaryControlSize, height: secondaryControlSize)
                     }
                     .buttonStyle(.glass)
                     .tint(.brandAccentWarm)
@@ -587,7 +590,7 @@ public struct ContentView: View {
 
     @ViewBuilder
     private var floatingControlsFallback: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: density.isCompact ? 8 : 16) {
             // Primary action - Start/Stop
             Button {
                 Task {
@@ -595,8 +598,8 @@ public struct ContentView: View {
                 }
             } label: {
                 Image(systemName: isAnyRecording ? "stop.fill" : "mic.fill")
-                    .font(.system(size: 28))
-                    .frame(width: 64, height: 64)
+                    .font(.system(size: primarySymbolSize))
+                    .frame(width: primaryControlSize, height: primaryControlSize)
             }
             .buttonStyle(.borderedProminent)
             .tint(isAnyRecording ? .red : .accentColor)
@@ -610,8 +613,8 @@ public struct ContentView: View {
                     showingPostProcessing = true
                 } label: {
                     Image(systemName: "wand.and.stars")
-                        .font(.system(size: 20))
-                        .frame(width: 48, height: 48)
+                        .font(.system(size: secondarySymbolSize))
+                        .frame(width: secondaryControlSize, height: secondaryControlSize)
                 }
                 .buttonStyle(.bordered)
                 .tint(.purple)
@@ -624,8 +627,8 @@ public struct ContentView: View {
                     copyToClipboard()
                 } label: {
                     Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                        .font(.system(size: 20))
-                        .frame(width: 48, height: 48)
+                        .font(.system(size: secondarySymbolSize))
+                        .frame(width: secondaryControlSize, height: secondaryControlSize)
                 }
                 .buttonStyle(.bordered)
                 .clipShape(Circle())
@@ -639,6 +642,30 @@ public struct ContentView: View {
     }
 
     // MARK: - Computed Properties
+
+    private var density: AppVisualDensity {
+        settings.visualDensity
+    }
+
+    private var usesInlineDensityLayout: Bool {
+        density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
+    }
+
+    private var primaryControlSize: CGFloat {
+        density.isCompact ? 48 : 64
+    }
+
+    private var secondaryControlSize: CGFloat {
+        density.isCompact ? 44 : 48
+    }
+
+    private var primarySymbolSize: CGFloat {
+        density.isCompact ? 20 : 28
+    }
+
+    private var secondarySymbolSize: CGFloat {
+        density.isCompact ? 16 : 20
+    }
 
     private var hasTextToShow: Bool {
         !currentText.isEmpty

--- a/Sources/SpeakiOS/Views/ConversationListView.swift
+++ b/Sources/SpeakiOS/Views/ConversationListView.swift
@@ -7,6 +7,7 @@ import SpeakCore
 /// Shows a list of OpenClaw conversations with the ability to create new ones.
 public struct ConversationListView: View {
     @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @ObservedObject private var store = ConversationStore.shared
     @ObservedObject private var settings = OpenClawSettings.shared
     @EnvironmentObject private var deepLinkRouter: DeepLinkRouter
@@ -26,10 +27,11 @@ public struct ConversationListView: View {
             }
         }
         .navigationTitle("OpenClaw")
+        .navigationBarTitleDisplayMode(usesInlineDensityLayout ? .inline : .automatic)
         .environment(\.defaultMinListRowHeight, density.minimumListRowHeight)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                HStack(spacing: 12) {
+                HStack(spacing: density.isCompact ? 8 : 12) {
                     NavigationLink {
                         OpenClawSettingsView()
                     } label: {
@@ -58,6 +60,10 @@ public struct ConversationListView: View {
         } message: {
             Text("This will permanently delete all \(store.conversations.count) conversations.")
         }
+    }
+
+    private var usesInlineDensityLayout: Bool {
+        density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
     }
 
     // MARK: - States
@@ -128,9 +134,45 @@ public struct ConversationListView: View {
 
 struct ConversationRow: View {
     @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let conversation: OpenClawClient.Conversation
 
     var body: some View {
+        Group {
+            if usesInlineDensityLayout {
+                HStack(spacing: density.inlineSpacing) {
+                    Text(conversation.title)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
+
+                    if let lastMessage = conversation.messages.last {
+                        Text(lastMessage.content)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .layoutPriority(-1)
+                    }
+
+                    Spacer(minLength: 4)
+
+                    Label("\(conversation.messages.count)", systemImage: "bubble.left")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+
+                    Text(conversation.updatedAt, style: .relative)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            } else {
+                regularContent
+            }
+        }
+        .padding(.vertical, density.listRowVerticalPadding)
+        .frame(minHeight: density.minimumListRowHeight)
+    }
+
+    private var regularContent: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(conversation.title)
@@ -157,7 +199,10 @@ struct ConversationRow: View {
                     .foregroundStyle(.tertiary)
             }
         }
-        .padding(.vertical, density.listRowVerticalPadding)
+    }
+
+    private var usesInlineDensityLayout: Bool {
+        density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
     }
 }
 

--- a/Sources/SpeakiOS/Views/HistoryItemRow.swift
+++ b/Sources/SpeakiOS/Views/HistoryItemRow.swift
@@ -7,6 +7,7 @@ import SpeakSync
 
 struct HistoryItemRow: View {
     @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let item: iOSHistoryItem
     let isSynced: Bool
     var isReprocessing: Bool = false
@@ -17,45 +18,8 @@ struct HistoryItemRow: View {
     @State private var isExpanded = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: density == .compact ? 5 : 8) {
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(item.createdAt, style: .date)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text(item.createdAt, style: .time)
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
-
-                Spacer()
-
-                HStack(spacing: 8) {
-                    if isReprocessing {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-
-                    Image(
-                        systemName: isSynced ? "icloud.fill" : "icloud.slash"
-                    )
-                    .font(.caption2)
-                    .foregroundStyle(
-                        isSynced ? .green : .secondary.opacity(0.5)
-                    )
-
-                    Label(
-                        "\(item.wordCount)",
-                        systemImage: "text.word.spacing"
-                    )
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                    Text(formatDuration(item.duration))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
+        VStack(alignment: .leading, spacing: density.isCompact ? density.cardContentSpacing : 8) {
+            metadataHeader
 
             transcriptSection(title: "Original", text: item.transcription)
 
@@ -74,51 +38,10 @@ struct HistoryItemRow: View {
                     .lineLimit(isExpanded ? nil : 2)
             }
 
-            HStack {
-                Text(modelDisplayName)
-                    .font(.caption2)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(
-                        Color.secondary.opacity(0.15),
-                        in: Capsule()
-                    )
-
-                if item.hasPolishedText {
-                    Label("Polished", systemImage: "wand.and.stars")
-                        .font(.caption2)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(
-                            Color.purple.opacity(0.15),
-                            in: Capsule()
-                        )
-                }
-
-                if item.originPlatform != "ios" {
-                    Text(platformDisplayName)
-                        .font(.caption2)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(
-                            Color.blue.opacity(0.15),
-                            in: Capsule()
-                        )
-                }
-
-                Spacer()
-
-                if max(item.transcription.count, item.postProcessedTranscription?.count ?? 0) > 150 {
-                    Button {
-                        isExpanded.toggle()
-                    } label: {
-                        Text(isExpanded ? "Show less" : "Show more")
-                            .font(.caption)
-                    }
-                }
-            }
+            metadataFooter
         }
         .padding(.vertical, density.listRowVerticalPadding)
+        .frame(minHeight: density.minimumListRowHeight)
         .contentShape(Rectangle())
         .onTapGesture {
             if max(item.transcription.count, item.postProcessedTranscription?.count ?? 0) > 150 {
@@ -157,16 +80,154 @@ struct HistoryItemRow: View {
         }
     }
 
-    private func transcriptSection(title: String, text: String) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
-            Text(title.uppercased())
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(.secondary)
-            Text(text)
-                .font(.body)
-                .lineLimit(isExpanded ? nil : 3)
+    @ViewBuilder
+    private var metadataHeader: some View {
+        if usesInlineDensityLayout {
+            HStack(spacing: density.inlineSpacing) {
+                Text(item.createdAt, format: .dateTime.month(.abbreviated).day().hour().minute())
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+
+                Spacer(minLength: 4)
+                sessionMetrics
+            }
+        } else {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.createdAt, style: .date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(item.createdAt, style: .time)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+
+                Spacer()
+                sessionMetrics
+            }
         }
-        .animation(.easeInOut(duration: 0.2), value: isExpanded)
+    }
+
+    private var sessionMetrics: some View {
+        HStack(spacing: density.isCompact ? density.inlineSpacing : 8) {
+            if isReprocessing {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Image(systemName: isSynced ? "icloud.fill" : "icloud.slash")
+                .font(.caption2)
+                .foregroundStyle(isSynced ? .green : .secondary.opacity(0.5))
+                .accessibilityLabel(isSynced ? "Synced" : "Not synced")
+
+            Label("\(item.wordCount)", systemImage: "text.word.spacing")
+                .accessibilityLabel("\(item.wordCount) words")
+
+            Text(formatDuration(item.duration))
+        }
+        .font(density.isCompact ? .caption2 : .caption)
+        .foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder
+    private var metadataFooter: some View {
+        if usesInlineDensityLayout {
+            HStack(spacing: density.inlineSpacing) {
+                Label(modelDisplayName, systemImage: "waveform")
+                    .lineLimit(1)
+
+                if item.hasPolishedText {
+                    Image(systemName: "wand.and.stars")
+                        .foregroundStyle(.purple)
+                        .accessibilityLabel("Polished")
+                }
+
+                if item.originPlatform != "ios" {
+                    Image(systemName: "desktopcomputer")
+                        .foregroundStyle(.blue)
+                        .accessibilityLabel(platformDisplayName)
+                }
+
+                Spacer(minLength: 4)
+
+                if canExpand {
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .accessibilityLabel(isExpanded ? "Show less" : "Show more")
+                }
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        } else {
+            HStack {
+                Text(modelDisplayName)
+                    .font(.caption2)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.secondary.opacity(0.15), in: Capsule())
+
+                if item.hasPolishedText {
+                    Label("Polished", systemImage: "wand.and.stars")
+                        .font(.caption2)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.purple.opacity(0.15), in: Capsule())
+                }
+
+                if item.originPlatform != "ios" {
+                    Text(platformDisplayName)
+                        .font(.caption2)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.blue.opacity(0.15), in: Capsule())
+                }
+
+                Spacer()
+
+                if canExpand {
+                    Button {
+                        isExpanded.toggle()
+                    } label: {
+                        Text(isExpanded ? "Show less" : "Show more")
+                            .font(.caption)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func transcriptSection(title: String, text: String) -> some View {
+        if usesInlineDensityLayout {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                if title == "Polished" {
+                    Image(systemName: "wand.and.stars")
+                        .foregroundStyle(.purple)
+                        .accessibilityLabel(title)
+                }
+                Text(text)
+                    .font(.subheadline)
+                    .lineLimit(isExpanded ? nil : 1)
+            }
+            .animation(.easeInOut(duration: 0.2), value: isExpanded)
+        } else {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title.uppercased())
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(text)
+                    .font(.body)
+                    .lineLimit(isExpanded ? nil : 3)
+            }
+            .animation(.easeInOut(duration: 0.2), value: isExpanded)
+        }
+    }
+
+    private var usesInlineDensityLayout: Bool {
+        density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
+    }
+
+    private var canExpand: Bool {
+        max(item.transcription.count, item.postProcessedTranscription?.count ?? 0) > 150
     }
 
     private var modelDisplayName: String {
@@ -202,14 +263,43 @@ struct HistoryItemRow: View {
 }
 
 // MARK: - Sync Status Banner
-
 struct SyncStatusBanner: View {
+    @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @ObservedObject var syncEngine: HistorySyncEngine
     let syncedCount: Int
     let unsyncedCount: Int
     let totalCount: Int
 
     var body: some View {
+        Group {
+            if density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) {
+                HStack(spacing: density.inlineSpacing) {
+                    Image(systemName: syncIcon)
+                        .foregroundStyle(syncIconColor)
+
+                    Text(syncEngine.state.statusMessage)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 4)
+
+                    Text(totalCount == 0 ? "0" : "\(syncedCount)/\(totalCount)")
+                        .foregroundStyle(.secondary)
+
+                    if syncEngine.state.isSyncing {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+                .font(.caption)
+            } else {
+                regularContent
+            }
+        }
+        .padding(.vertical, density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) ? 0 : 4)
+    }
+
+    private var regularContent: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 10) {
                 Image(systemName: syncIcon)
@@ -243,7 +333,6 @@ struct SyncStatusBanner: View {
                     .lineLimit(2)
             }
         }
-        .padding(.vertical, 4)
     }
 
     private var syncProgressBar: some View {

--- a/Sources/SpeakiOS/Views/HistoryItemRow.swift
+++ b/Sources/SpeakiOS/Views/HistoryItemRow.swift
@@ -151,8 +151,14 @@ struct HistoryItemRow: View {
                 Spacer(minLength: 4)
 
                 if canExpand {
-                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .accessibilityLabel(isExpanded ? "Show less" : "Show more")
+                    Button {
+                        isExpanded.toggle()
+                    } label: {
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    }
+                    .buttonStyle(.plain)
+                    .frame(minWidth: 44, minHeight: 44)
+                    .accessibilityLabel(isExpanded ? "Show less" : "Show more")
                 }
             }
             .font(.caption2)
@@ -262,139 +268,4 @@ struct HistoryItemRow: View {
     }
 }
 
-// MARK: - Sync Status Banner
-struct SyncStatusBanner: View {
-    @Environment(\.appVisualDensity) private var density
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @ObservedObject var syncEngine: HistorySyncEngine
-    let syncedCount: Int
-    let unsyncedCount: Int
-    let totalCount: Int
-
-    var body: some View {
-        Group {
-            if density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) {
-                HStack(spacing: density.inlineSpacing) {
-                    Image(systemName: syncIcon)
-                        .foregroundStyle(syncIconColor)
-
-                    Text(syncEngine.state.statusMessage)
-                        .lineLimit(1)
-
-                    Spacer(minLength: 4)
-
-                    Text(totalCount == 0 ? "0" : "\(syncedCount)/\(totalCount)")
-                        .foregroundStyle(.secondary)
-
-                    if syncEngine.state.isSyncing {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                }
-                .font(.caption)
-            } else {
-                regularContent
-            }
-        }
-        .padding(.vertical, density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) ? 0 : 4)
-    }
-
-    private var regularContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 10) {
-                Image(systemName: syncIcon)
-                    .foregroundStyle(syncIconColor)
-                    .font(.body)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(syncEngine.state.statusMessage)
-                        .font(.subheadline.weight(.medium))
-                    Text(syncSummary)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
-                if syncEngine.state.isSyncing {
-                    ProgressView()
-                        .controlSize(.small)
-                }
-            }
-
-            if totalCount > 0 {
-                syncProgressBar
-            }
-
-            if let error = syncEngine.state.error {
-                Text(error.localizedDescription)
-                    .font(.caption2)
-                    .foregroundStyle(.red)
-                    .lineLimit(2)
-            }
-        }
-    }
-
-    private var syncProgressBar: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(Color.secondary.opacity(0.15))
-                    .frame(height: 4)
-                Capsule()
-                    .fill(syncBarColor)
-                    .frame(
-                        width: geometry.size.width * syncFraction,
-                        height: 4
-                    )
-            }
-        }
-        .frame(height: 4)
-    }
-
-    private var syncFraction: CGFloat {
-        guard totalCount > 0 else { return 0 }
-        return CGFloat(syncedCount) / CGFloat(totalCount)
-    }
-
-    private var syncSummary: String {
-        if totalCount == 0 {
-            return "No entries"
-        }
-        if unsyncedCount == 0 {
-            return "All \(totalCount) entries synced"
-        }
-        return "\(syncedCount)/\(totalCount) synced · \(unsyncedCount) pending"
-    }
-
-    private var syncIcon: String {
-        if syncEngine.state.isSyncing {
-            return "arrow.triangle.2.circlepath.icloud"
-        }
-        if syncEngine.state.error != nil {
-            return "exclamationmark.icloud"
-        }
-        if unsyncedCount == 0, totalCount > 0 {
-            return "checkmark.icloud.fill"
-        }
-        return "icloud.fill"
-    }
-
-    private var syncIconColor: Color {
-        if syncEngine.state.error != nil {
-            return .orange
-        }
-        if unsyncedCount == 0, totalCount > 0 {
-            return .green
-        }
-        return .blue
-    }
-
-    private var syncBarColor: Color {
-        if syncEngine.state.error != nil {
-            return .orange
-        }
-        return .green
-    }
-}
 #endif

--- a/Sources/SpeakiOS/Views/HistorySyncStatusBanner.swift
+++ b/Sources/SpeakiOS/Views/HistorySyncStatusBanner.swift
@@ -1,0 +1,144 @@
+#if os(iOS)
+import SpeakCore
+import SpeakSync
+import SwiftUI
+
+struct SyncStatusBanner: View {
+    @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @ObservedObject var syncEngine: HistorySyncEngine
+    let syncedCount: Int
+    let unsyncedCount: Int
+    let totalCount: Int
+
+    var body: some View {
+        Group {
+            if usesInlineDensityLayout {
+                HStack(spacing: density.inlineSpacing) {
+                    Image(systemName: syncIcon)
+                        .foregroundStyle(syncIconColor)
+
+                    Text(syncEngine.state.statusMessage)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 4)
+
+                    Text(totalCount == 0 ? "0" : "\(syncedCount)/\(totalCount)")
+                        .foregroundStyle(.secondary)
+
+                    if syncEngine.state.isSyncing {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+                .font(.caption)
+            } else {
+                regularContent
+            }
+        }
+        .padding(.vertical, usesInlineDensityLayout ? 0 : 4)
+    }
+
+    private var regularContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                Image(systemName: syncIcon)
+                    .foregroundStyle(syncIconColor)
+                    .font(.body)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(syncEngine.state.statusMessage)
+                        .font(.subheadline.weight(.medium))
+                    Text(syncSummary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if syncEngine.state.isSyncing {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            if totalCount > 0 {
+                syncProgressBar
+            }
+
+            if let error = syncEngine.state.error {
+                Text(error.localizedDescription)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    private var syncProgressBar: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.secondary.opacity(0.15))
+                    .frame(height: 4)
+                Capsule()
+                    .fill(syncBarColor)
+                    .frame(
+                        width: geometry.size.width * syncFraction,
+                        height: 4
+                    )
+            }
+        }
+        .frame(height: 4)
+    }
+
+    private var usesInlineDensityLayout: Bool {
+        density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
+    }
+
+    private var syncFraction: CGFloat {
+        guard totalCount > 0 else { return 0 }
+        return CGFloat(syncedCount) / CGFloat(totalCount)
+    }
+
+    private var syncSummary: String {
+        if totalCount == 0 {
+            return "No entries"
+        }
+        if unsyncedCount == 0 {
+            return "All \(totalCount) entries synced"
+        }
+        return "\(syncedCount)/\(totalCount) synced · \(unsyncedCount) pending"
+    }
+
+    private var syncIcon: String {
+        if syncEngine.state.isSyncing {
+            return "arrow.triangle.2.circlepath.icloud"
+        }
+        if syncEngine.state.error != nil {
+            return "exclamationmark.icloud"
+        }
+        if unsyncedCount == 0, totalCount > 0 {
+            return "checkmark.icloud.fill"
+        }
+        return "icloud.fill"
+    }
+
+    private var syncIconColor: Color {
+        if syncEngine.state.error != nil {
+            return .orange
+        }
+        if unsyncedCount == 0, totalCount > 0 {
+            return .green
+        }
+        return .blue
+    }
+
+    private var syncBarColor: Color {
+        if syncEngine.state.error != nil {
+            return .orange
+        }
+        return .green
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Views/HistoryView.swift
+++ b/Sources/SpeakiOS/Views/HistoryView.swift
@@ -8,6 +8,7 @@ import SpeakSync
 // swiftlint:disable:next type_body_length
 public struct HistoryView: View {
     @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @StateObject private var historyManager = iOSHistoryManager.shared
     @ObservedObject private var syncEngine = HistorySyncEngine.shared
     @State private var showingClearConfirmation = false
@@ -43,6 +44,7 @@ public struct HistoryView: View {
             }
         }
         .navigationTitle("History")
+        .navigationBarTitleDisplayMode(usesInlineDensityLayout ? .inline : .automatic)
         .environment(\.defaultMinListRowHeight, density.minimumListRowHeight)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
@@ -207,7 +209,7 @@ public struct HistoryView: View {
 
     private var statsHeader: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: density == .compact ? 14 : 24) {
+            HStack(spacing: density.isCompact ? 8 : 24) {
                 statBadge(value: "\(statistics.totalSessions)", label: "Sessions")
                 statBadge(value: formatDuration(statistics.averageSessionLength), label: "Average")
                 statBadge(value: formatDuration(statistics.cumulativeRecordingDuration), label: "Total Time")
@@ -217,18 +219,34 @@ public struct HistoryView: View {
             .padding(.horizontal, 4)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 8)
+        .padding(.vertical, density.isCompact ? 0 : 8)
     }
 
+    @ViewBuilder
     private func statBadge(value: String, label: String) -> some View {
-        VStack(spacing: 4) {
-            Text(value)
-                .font(.title2.bold())
-                .foregroundStyle(.primary)
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+        if usesInlineDensityLayout {
+            HStack(alignment: .firstTextBaseline, spacing: 2) {
+                Text(value)
+                    .font(.caption.bold())
+                    .foregroundStyle(.primary)
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            VStack(spacing: 4) {
+                Text(value)
+                    .font(.title2.bold())
+                    .foregroundStyle(.primary)
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
+    }
+
+    private var usesInlineDensityLayout: Bool {
+        density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
     }
 
     private var query: HistorySearchQuery {

--- a/Sources/SpeakiOS/Views/OpenClawChatComponents.swift
+++ b/Sources/SpeakiOS/Views/OpenClawChatComponents.swift
@@ -1,0 +1,101 @@
+#if os(iOS)
+import SpeakCore
+import SwiftUI
+
+struct MessageBubble: View {
+    @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    let message: OpenClawClient.ChatMessage
+
+    var isUser: Bool { message.role == "user" }
+
+    var body: some View {
+        HStack {
+            if isUser { Spacer(minLength: density.isCompact ? 20 : 60) }
+
+            Group {
+                if density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) {
+                    HStack(alignment: .lastTextBaseline, spacing: density.inlineSpacing) {
+                        messageText
+                        timestampText
+                    }
+                } else {
+                    VStack(alignment: isUser ? .trailing : .leading, spacing: 4) {
+                        messageText
+                        timestampText
+                    }
+                }
+            }
+            .padding(.horizontal, density.isCompact ? 8 : 14)
+            .padding(.vertical, density.isCompact ? 4 : 10)
+            .background(
+                isUser ? Color.accentColor : Color(.systemGray5),
+                in: RoundedRectangle(cornerRadius: density.isCompact ? 10 : 18)
+            )
+
+            if !isUser { Spacer(minLength: density.isCompact ? 20 : 60) }
+        }
+    }
+
+    private var messageText: some View {
+        Text(message.content)
+            .font(density.isCompact ? .subheadline : .body)
+            .foregroundStyle(isUser ? .white : .primary)
+            .textSelection(.enabled)
+    }
+
+    private var timestampText: some View {
+        Text(message.timestamp, style: .time)
+            .font(.caption2)
+            .foregroundStyle(isUser ? .white.opacity(0.7) : .secondary)
+    }
+}
+
+struct RecordingIndicator: View {
+    @Environment(\.appVisualDensity) private var density
+    let partialText: String
+    let showAcknowledgeHint: Bool
+    @State private var pulseScale: CGFloat = 1.0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(.red)
+                    .frame(width: 12, height: 12)
+                    .scaleEffect(pulseScale)
+                    .animation(
+                        .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                        value: pulseScale
+                    )
+
+                if partialText.isEmpty {
+                    Text("Listening…")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .italic()
+                } else {
+                    Text(partialText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if showAcknowledgeHint {
+                Text(
+                    density.isCompact
+                        ? "Tap chat, headset, or keyword to send."
+                        : "Tap the chat area, use headset tap, or say your keyword to send."
+                )
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(density.isCompact ? 1 : nil)
+            }
+        }
+        .padding(.horizontal, density.isCompact ? density.pagePadding : 16)
+        .onAppear {
+            pulseScale = 1.3
+        }
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Views/OpenClawChatView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawChatView.swift
@@ -2,14 +2,13 @@
 import SwiftUI
 import SpeakCore
 
-// MARK: - OpenClaw Chat View
-
 /// Main voice chat interface for OpenClaw conversations.
 public struct OpenClawChatView: View {
     @StateObject private var coordinator = OpenClawChatCoordinator()
     @ObservedObject private var store = ConversationStore.shared
     @ObservedObject private var settings = OpenClawSettings.shared
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.appVisualDensity) private var density
     @State private var textInput = ""
     @State private var showingSettings = false
 
@@ -25,7 +24,7 @@ public struct OpenClawChatView: View {
             // Messages
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 12) {
+                    LazyVStack(alignment: .leading, spacing: density.isCompact ? density.cardContentSpacing : 12) {
                         if let conv = coordinator.currentConversation {
                             ForEach(coordinator.isBufferingForTTS
                                 ? Array(conv.messages.prefix(coordinator.messageCountBeforeResponse))
@@ -66,11 +65,11 @@ public struct OpenClawChatView: View {
                                     .font(.subheadline)
                                     .foregroundStyle(.secondary)
                             }
-                            .padding(.horizontal)
+                            .padding(.horizontal, density.isCompact ? density.pagePadding : 16)
                             .id("processing")
                         }
                     }
-                    .padding()
+                    .padding(density.isCompact ? density.pagePadding : 16)
                 }
                 .onChange(of: coordinator.currentConversation?.messages.count) { _, _ in
                     withAnimation(.easeOut(duration: 0.2)) {
@@ -183,38 +182,38 @@ public struct OpenClawChatView: View {
             .tint(.accentColor)
             .frame(minHeight: 44)
 
-            if settings.conversationModeEnabled {
+            if settings.conversationModeEnabled && !density.isCompact {
                 Text("Tap the chat area to acknowledge")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, density.isCompact ? 8 : 12)
+        .padding(.vertical, density.isCompact ? 0 : 10)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: density.isCompact ? 10 : 14, style: .continuous)
                 .fill(Color(.secondarySystemBackground))
         )
-        .padding(.horizontal)
-        .padding(.top, 8)
+        .padding(.horizontal, density.isCompact ? 8 : 16)
+        .padding(.top, density.isCompact ? 4 : 8)
     }
 
     @ViewBuilder
     private var inputBar: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: density.isCompact ? 6 : 12) {
             // Text field
             TextField("Type a message…", text: $textInput, axis: .vertical)
                 .font(.body)
                 .lineLimit(1...5)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 12)
-                .frame(minHeight: 50)
+                .padding(.horizontal, density.isCompact ? 8 : 14)
+                .padding(.vertical, density.isCompact ? 6 : 12)
+                .frame(minHeight: density.isCompact ? 44 : 50)
                 .background(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    RoundedRectangle(cornerRadius: density.isCompact ? 10 : 16, style: .continuous)
                         .fill(Color(.secondarySystemBackground))
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    RoundedRectangle(cornerRadius: density.isCompact ? 10 : 16, style: .continuous)
                         .strokeBorder(Color(.separator).opacity(0.28), lineWidth: 1)
                 )
                 .submitLabel(.send)
@@ -233,9 +232,9 @@ public struct OpenClawChatView: View {
                 }
             } label: {
                 Image(systemName: coordinator.isRecording ? "stop.circle.fill" : "mic.circle.fill")
-                    .font(.system(size: 32))
+                    .font(.system(size: density.isCompact ? 24 : 32))
                     .foregroundStyle(coordinator.isRecording ? .red : Color.accentColor)
-                    .frame(width: 52, height: 52)
+                    .frame(width: density.isCompact ? 44 : 52, height: density.isCompact ? 44 : 52)
             }
             .accessibilityLabel(coordinator.isRecording ? "Stop recording" : "Start voice input")
 
@@ -245,16 +244,16 @@ public struct OpenClawChatView: View {
                     sendTextIfNeeded()
                 } label: {
                     Image(systemName: "arrow.up.circle.fill")
-                        .font(.system(size: 32))
+                        .font(.system(size: density.isCompact ? 24 : 32))
                         .foregroundStyle(Color.accentColor)
-                        .frame(width: 52, height: 52)
+                        .frame(width: density.isCompact ? 44 : 52, height: density.isCompact ? 44 : 52)
                 }
                 .transition(.scale.combined(with: .opacity))
                 .accessibilityLabel("Send message")
             }
         }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
+        .padding(.horizontal, density.isCompact ? 8 : 16)
+        .padding(.vertical, density.isCompact ? 4 : 8)
         .background(.bar)
         .animation(.spring(response: 0.2), value: textInput.isEmpty)
     }
@@ -299,39 +298,58 @@ extension OpenClawChatView {
 // MARK: - Message Bubble
 
 struct MessageBubble: View {
+    @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let message: OpenClawClient.ChatMessage
 
     var isUser: Bool { message.role == "user" }
 
     var body: some View {
         HStack {
-            if isUser { Spacer(minLength: 60) }
+            if isUser { Spacer(minLength: density.isCompact ? 20 : 60) }
 
-            VStack(alignment: isUser ? .trailing : .leading, spacing: 4) {
-                Text(message.content)
-                    .font(.body)
-                    .foregroundStyle(isUser ? .white : .primary)
-                    .textSelection(.enabled)
-
-                Text(message.timestamp, style: .time)
-                    .font(.caption2)
-                    .foregroundStyle(isUser ? .white.opacity(0.7) : .secondary)
+            Group {
+                if density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) {
+                    HStack(alignment: .lastTextBaseline, spacing: density.inlineSpacing) {
+                        messageText
+                        timestampText
+                    }
+                } else {
+                    VStack(alignment: isUser ? .trailing : .leading, spacing: 4) {
+                        messageText
+                        timestampText
+                    }
+                }
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
+            .padding(.horizontal, density.isCompact ? 8 : 14)
+            .padding(.vertical, density.isCompact ? 4 : 10)
             .background(
                 isUser ? Color.accentColor : Color(.systemGray5),
-                in: RoundedRectangle(cornerRadius: 18)
+                in: RoundedRectangle(cornerRadius: density.isCompact ? 10 : 18)
             )
 
-            if !isUser { Spacer(minLength: 60) }
+            if !isUser { Spacer(minLength: density.isCompact ? 20 : 60) }
         }
+    }
+
+    private var messageText: some View {
+        Text(message.content)
+            .font(density.isCompact ? .subheadline : .body)
+            .foregroundStyle(isUser ? .white : .primary)
+            .textSelection(.enabled)
+    }
+
+    private var timestampText: some View {
+        Text(message.timestamp, style: .time)
+            .font(.caption2)
+            .foregroundStyle(isUser ? .white.opacity(0.7) : .secondary)
     }
 }
 
 // MARK: - Recording Indicator
 
 struct RecordingIndicator: View {
+    @Environment(\.appVisualDensity) private var density
     let partialText: String
     let showAcknowledgeHint: Bool
     @State private var pulseScale: CGFloat = 1.0
@@ -360,13 +378,13 @@ struct RecordingIndicator: View {
                 }
             }
 
-            if showAcknowledgeHint {
+            if showAcknowledgeHint && !density.isCompact {
                 Text("Tap the chat area, use headset tap, or say your keyword to send.")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
             }
         }
-        .padding(.horizontal)
+        .padding(.horizontal, density.isCompact ? density.pagePadding : 16)
         .onAppear {
             pulseScale = 1.3
         }

--- a/Sources/SpeakiOS/Views/OpenClawChatView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawChatView.swift
@@ -182,9 +182,12 @@ public struct OpenClawChatView: View {
             .tint(.accentColor)
             .frame(minHeight: 44)
 
-            if settings.conversationModeEnabled && !density.isCompact {
-                Text("Tap the chat area to acknowledge")
-                    .font(.caption)
+            if settings.conversationModeEnabled {
+                Label(
+                    density.isCompact ? "Tap chat to send" : "Tap the chat area to acknowledge",
+                    systemImage: "hand.tap"
+                )
+                    .font(density.isCompact ? .caption2 : .caption)
                     .foregroundStyle(.secondary)
             }
         }
@@ -207,7 +210,7 @@ public struct OpenClawChatView: View {
                 .lineLimit(1...5)
                 .padding(.horizontal, density.isCompact ? 8 : 14)
                 .padding(.vertical, density.isCompact ? 6 : 12)
-                .frame(minHeight: density.isCompact ? 44 : 50)
+                .frame(minHeight: density.isCompact ? 48 : 50)
                 .background(
                     RoundedRectangle(cornerRadius: density.isCompact ? 10 : 16, style: .continuous)
                         .fill(Color(.secondarySystemBackground))
@@ -291,102 +294,6 @@ extension OpenClawChatView {
         textInput = ""
         Task {
             await coordinator.sendTextMessage(text)
-        }
-    }
-}
-
-// MARK: - Message Bubble
-
-struct MessageBubble: View {
-    @Environment(\.appVisualDensity) private var density
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    let message: OpenClawClient.ChatMessage
-
-    var isUser: Bool { message.role == "user" }
-
-    var body: some View {
-        HStack {
-            if isUser { Spacer(minLength: density.isCompact ? 20 : 60) }
-
-            Group {
-                if density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) {
-                    HStack(alignment: .lastTextBaseline, spacing: density.inlineSpacing) {
-                        messageText
-                        timestampText
-                    }
-                } else {
-                    VStack(alignment: isUser ? .trailing : .leading, spacing: 4) {
-                        messageText
-                        timestampText
-                    }
-                }
-            }
-            .padding(.horizontal, density.isCompact ? 8 : 14)
-            .padding(.vertical, density.isCompact ? 4 : 10)
-            .background(
-                isUser ? Color.accentColor : Color(.systemGray5),
-                in: RoundedRectangle(cornerRadius: density.isCompact ? 10 : 18)
-            )
-
-            if !isUser { Spacer(minLength: density.isCompact ? 20 : 60) }
-        }
-    }
-
-    private var messageText: some View {
-        Text(message.content)
-            .font(density.isCompact ? .subheadline : .body)
-            .foregroundStyle(isUser ? .white : .primary)
-            .textSelection(.enabled)
-    }
-
-    private var timestampText: some View {
-        Text(message.timestamp, style: .time)
-            .font(.caption2)
-            .foregroundStyle(isUser ? .white.opacity(0.7) : .secondary)
-    }
-}
-
-// MARK: - Recording Indicator
-
-struct RecordingIndicator: View {
-    @Environment(\.appVisualDensity) private var density
-    let partialText: String
-    let showAcknowledgeHint: Bool
-    @State private var pulseScale: CGFloat = 1.0
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 12) {
-                Circle()
-                    .fill(.red)
-                    .frame(width: 12, height: 12)
-                    .scaleEffect(pulseScale)
-                    .animation(
-                        .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
-                        value: pulseScale
-                    )
-
-                if partialText.isEmpty {
-                    Text("Listening…")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .italic()
-                } else {
-                    Text(partialText)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            if showAcknowledgeHint && !density.isCompact {
-                Text("Tap the chat area, use headset tap, or say your keyword to send.")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-        }
-        .padding(.horizontal, density.isCompact ? density.pagePadding : 16)
-        .onAppear {
-            pulseScale = 1.3
         }
     }
 }

--- a/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
@@ -38,10 +38,12 @@ public struct OpenClawSettingsView: View {
                         testState = .idle
                     }
 
-                Text("Enter host:port for local connections or a Tailscale/public hostname. "
-                     + "The ws:// or wss:// prefix is added automatically.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if !appSettings.visualDensity.isCompact {
+                    Text("Enter host:port for local connections or a Tailscale/public hostname. "
+                         + "The ws:// or wss:// prefix is added automatically.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
 
                 SecureField("Gateway Token", text: $tokenInput)
                     .textContentType(.password)
@@ -149,11 +151,13 @@ public struct OpenClawSettingsView: View {
                         Slider(value: $settings.ttsSpeed, in: 0.5...2.0, step: 0.1)
                     }
 
-                    Text(
-                        "Requires a Deepgram API key in the main app settings."
-                    )
+                    if !appSettings.visualDensity.isCompact {
+                        Text(
+                            "Requires a Deepgram API key in the main app settings."
+                        )
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    }
 
                     Button {
                         Task { await testVoice() }
@@ -182,7 +186,7 @@ public struct OpenClawSettingsView: View {
                     Label("Summarise for Voice", systemImage: "text.quote")
                 }
 
-                if settings.summariseResponses {
+                if settings.summariseResponses && !appSettings.visualDensity.isCompact {
                     Text(
                         "Long responses will be summarised into concise voice-friendly text "
                             + "before speaking (requires OpenRouter API key)."
@@ -195,7 +199,7 @@ public struct OpenClawSettingsView: View {
                     Label("Prioritise Low Latency", systemImage: "hare")
                 }
 
-                if settings.lowLatencySpeech {
+                if settings.lowLatencySpeech && !appSettings.visualDensity.isCompact {
                     Text("Skips the extra summarisation step before speaking for faster responses.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -229,19 +233,24 @@ public struct OpenClawSettingsView: View {
                 }
             }
 
-            Section("How It Works") {
-                VStack(alignment: .leading, spacing: 8) {
-                    InfoStepRow(number: 1, text: "Tap the mic to record your voice message")
-                    InfoStepRow(number: 2, text: "Your speech is transcribed using your selected model")
-                    InfoStepRow(number: 3, text: "The text is sent to your OpenClaw agent")
-                    InfoStepRow(number: 4, text: "The response is spoken back to you")
-                    InfoStepRow(number: 5, text: "In conversation mode, listening can restart automatically")
+            if !appSettings.visualDensity.isCompact {
+                Section("How It Works") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        InfoStepRow(number: 1, text: "Tap the mic to record your voice message")
+                        InfoStepRow(number: 2, text: "Your speech is transcribed using your selected model")
+                        InfoStepRow(number: 3, text: "The text is sent to your OpenClaw agent")
+                        InfoStepRow(number: 4, text: "The response is spoken back to you")
+                        InfoStepRow(number: 5, text: "In conversation mode, listening can restart automatically")
+                    }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
             }
         }
+        .environment(\.defaultMinListRowHeight, appSettings.visualDensity.minimumListRowHeight)
+        .listSectionSpacing(appSettings.visualDensity.listSectionSpacing)
         .navigationTitle("OpenClaw Settings")
         .navigationBarTitleDisplayMode(.inline)
+        .controlSize(appSettings.visualDensity.isCompact ? .small : .regular)
     }
 
     // MARK: - Connection Test

--- a/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 public struct OpenClawSettingsView: View {
     @ObservedObject private var settings = OpenClawSettings.shared
     @ObservedObject private var appSettings = AppSettings.shared
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var tokenInput = ""
     @State private var urlInput = ""
     @State private var testState: OpenClawConnectionTester.Result = .idle
@@ -38,7 +39,7 @@ public struct OpenClawSettingsView: View {
                         testState = .idle
                     }
 
-                if !appSettings.visualDensity.isCompact {
+                if !usesInlineDensityLayout {
                     Text("Enter host:port for local connections or a Tailscale/public hostname. "
                          + "The ws:// or wss:// prefix is added automatically.")
                         .font(.caption)
@@ -151,7 +152,7 @@ public struct OpenClawSettingsView: View {
                         Slider(value: $settings.ttsSpeed, in: 0.5...2.0, step: 0.1)
                     }
 
-                    if !appSettings.visualDensity.isCompact {
+                    if !usesInlineDensityLayout {
                         Text(
                             "Requires a Deepgram API key in the main app settings."
                         )
@@ -186,7 +187,7 @@ public struct OpenClawSettingsView: View {
                     Label("Summarise for Voice", systemImage: "text.quote")
                 }
 
-                if settings.summariseResponses && !appSettings.visualDensity.isCompact {
+                if settings.summariseResponses && !usesInlineDensityLayout {
                     Text(
                         "Long responses will be summarised into concise voice-friendly text "
                             + "before speaking (requires OpenRouter API key)."
@@ -199,7 +200,7 @@ public struct OpenClawSettingsView: View {
                     Label("Prioritise Low Latency", systemImage: "hare")
                 }
 
-                if settings.lowLatencySpeech && !appSettings.visualDensity.isCompact {
+                if settings.lowLatencySpeech && !usesInlineDensityLayout {
                     Text("Skips the extra summarisation step before speaking for faster responses.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -233,7 +234,7 @@ public struct OpenClawSettingsView: View {
                 }
             }
 
-            if !appSettings.visualDensity.isCompact {
+            if !usesInlineDensityLayout {
                 Section("How It Works") {
                     VStack(alignment: .leading, spacing: 8) {
                         InfoStepRow(number: 1, text: "Tap the mic to record your voice message")
@@ -251,6 +252,10 @@ public struct OpenClawSettingsView: View {
         .navigationTitle("OpenClaw Settings")
         .navigationBarTitleDisplayMode(.inline)
         .controlSize(appSettings.visualDensity.isCompact ? .small : .regular)
+    }
+
+    private var usesInlineDensityLayout: Bool {
+        appSettings.visualDensity.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
     }
 
     // MARK: - Connection Test

--- a/Sources/SpeakiOS/Views/PostProcessingView.swift
+++ b/Sources/SpeakiOS/Views/PostProcessingView.swift
@@ -219,6 +219,7 @@ enum PostProcessingError: LocalizedError {
 /// Full-screen post-processing view with editable text and model selection.
 public struct PostProcessingView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.appVisualDensity) private var density
     @StateObject private var processor = iOSPostProcessingManager.shared
     @ObservedObject private var settings = AppSettings.shared
     
@@ -239,25 +240,36 @@ public struct PostProcessingView: View {
             VStack(spacing: 0) {
                 // Input/Output area
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 16) {
+                    VStack(
+                        alignment: .leading,
+                        spacing: density.isCompact ? density.sectionSpacing : 16
+                    ) {
                         // Input section
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(
+                            alignment: .leading,
+                            spacing: density.isCompact ? density.cardContentSpacing : 8
+                        ) {
                             Label("Input", systemImage: "text.alignleft")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                             
                             TextEditor(text: $inputText)
                                 .font(.body)
-                                .frame(minHeight: 120)
-                                .padding(8)
+                                .frame(minHeight: density.isCompact ? 64 : 120)
+                                .padding(density.isCompact ? 4 : 8)
                                 .background(Color(.secondarySystemBackground))
-                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                                .clipShape(
+                                    RoundedRectangle(cornerRadius: density.isCompact ? 8 : 10)
+                                )
                                 .focused($isTextFieldFocused)
                         }
                         
                         // Output section (shows during/after processing)
                         if processor.isProcessing || !processor.streamingText.isEmpty || !processor.processedText.isEmpty {
-                            VStack(alignment: .leading, spacing: 8) {
+                            VStack(
+                                alignment: .leading,
+                                spacing: density.isCompact ? density.cardContentSpacing : 8
+                            ) {
                                 HStack {
                                     Label("Output", systemImage: "wand.and.stars")
                                         .font(.caption)
@@ -274,9 +286,11 @@ public struct PostProcessingView: View {
                                 Text(processor.isProcessing ? processor.streamingText : processor.processedText)
                                     .font(.body)
                                     .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(12)
+                                    .padding(density.isCompact ? 6 : 12)
                                     .background(Color(.tertiarySystemBackground))
-                                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                                    .clipShape(
+                                        RoundedRectangle(cornerRadius: density.isCompact ? 8 : 10)
+                                    )
                                     .textSelection(.enabled)
                             }
                         }
@@ -288,13 +302,13 @@ public struct PostProcessingView: View {
                                 .foregroundStyle(.red)
                         }
                     }
-                    .padding()
+                    .padding(density.isCompact ? density.pagePadding : 16)
                 }
                 
                 Divider()
                 
                 // Model & Settings bar
-                VStack(spacing: 12) {
+                VStack(spacing: density.isCompact ? density.cardContentSpacing : 12) {
                     // Model selector
                     Button {
                         showingModelPicker = true
@@ -307,15 +321,18 @@ public struct PostProcessingView: View {
                             Image(systemName: "chevron.up.chevron.down")
                                 .font(.caption)
                         }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 10)
+                        .padding(.horizontal, density.isCompact ? 8 : 12)
+                        .padding(.vertical, density.isCompact ? 0 : 10)
+                        .frame(minHeight: density.isCompact ? 44 : nil)
                         .background(Color(.secondarySystemBackground))
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .clipShape(
+                            RoundedRectangle(cornerRadius: density.isCompact ? 6 : 8)
+                        )
                     }
                     .buttonStyle(.plain)
                     
                     // Action buttons
-                    HStack(spacing: 12) {
+                    HStack(spacing: density.isCompact ? 6 : 12) {
                         // Prompt settings
                         Button {
                             showingPromptEditor = true
@@ -373,7 +390,7 @@ public struct PostProcessingView: View {
                             .foregroundStyle(.orange)
                     }
                 }
-                .padding()
+                .padding(density.isCompact ? density.pagePadding : 16)
                 .background(Color(.systemBackground))
             }
             .navigationTitle("Post-Process")
@@ -403,7 +420,9 @@ public struct PostProcessingView: View {
             }
         }
     }
-    
+}
+
+private extension PostProcessingView {
     private var modelDisplayName: String {
         ModelCatalog.friendlyName(for: settings.postProcessingModel)
     }
@@ -423,9 +442,11 @@ public struct PostProcessingView: View {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text(model.displayName)
                                     .foregroundStyle(.primary)
-                                Text(model.description ?? "")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                if !density.isCompact {
+                                    Text(model.description ?? "")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
                             
                             Spacer()
@@ -468,11 +489,16 @@ public struct PostProcessingView: View {
                 Section {
                     TextEditor(text: $settings.postProcessingPrompt)
                         .font(.system(.body, design: .monospaced))
-                        .frame(minHeight: 200)
+                        .frame(minHeight: density.isCompact ? 100 : 200)
                 } header: {
                     Text("Custom System Prompt")
                 } footer: {
-                    Text("Leave empty to use the default prompt. The prompt instructs the AI how to clean up your transcription.")
+                    if !density.isCompact {
+                        Text(
+                            "Leave empty to use the default prompt. "
+                                + "The prompt instructs the AI how to clean up your transcription."
+                        )
+                    }
                 }
                 
                 Section {

--- a/Sources/SpeakiOS/Views/RecordingsView.swift
+++ b/Sources/SpeakiOS/Views/RecordingsView.swift
@@ -56,6 +56,7 @@ public struct RecordingsView: View {
         }
         .navigationTitle("Recordings")
         .environment(\.defaultMinListRowHeight, density.minimumListRowHeight)
+        .listSectionSpacing(density.listSectionSpacing)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear { reload() }
         .onDisappear { stopPlayback() }
@@ -144,13 +145,14 @@ public struct RecordingsView: View {
 
 struct RecordingRow: View {
     @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let recording: RecordingInfo
     let isPlaying: Bool
     let onPlay: () -> Void
     let onDelete: () -> Void
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: density.isCompact ? 6 : 12) {
             // Play/Stop button
             Button(action: onPlay) {
                 Image(
@@ -158,7 +160,7 @@ struct RecordingRow: View {
                         ? "stop.circle.fill"
                         : "play.circle.fill"
                 )
-                .font(.system(size: 32))
+                .font(.system(size: density.isCompact ? 24 : 32))
                 .foregroundStyle(
                     isPlaying ? .red : Color.accentColor
                 )
@@ -169,33 +171,56 @@ struct RecordingRow: View {
                 isPlaying ? "Stop playback" : "Play recording"
             )
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(recording.startedAt, style: .date)
-                    .font(.subheadline.weight(.medium))
-
-                HStack(spacing: 8) {
+            if usesInlineDensityLayout {
+                HStack(spacing: 4) {
+                    Text(recording.startedAt, format: .dateTime.month(.abbreviated).day())
+                        .fontWeight(.medium)
+                        .foregroundStyle(.primary)
                     Text(recording.startedAt, style: .time)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
                     Text("·")
                         .foregroundStyle(.tertiary)
-
                     Text(formattedDuration(recording.duration))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
                     Text("·")
                         .foregroundStyle(.tertiary)
-
                     Text(
                         ByteCountFormatter.string(
                             fromByteCount: recording.fileSize,
                             countStyle: .file
                         )
                     )
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(recording.startedAt, style: .date)
+                        .font(.subheadline.weight(.medium))
+
+                    HStack(spacing: 8) {
+                        Text(recording.startedAt, style: .time)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Text("·")
+                            .foregroundStyle(.tertiary)
+
+                        Text(formattedDuration(recording.duration))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Text("·")
+                            .foregroundStyle(.tertiary)
+
+                        Text(
+                            ByteCountFormatter.string(
+                                fromByteCount: recording.fileSize,
+                                countStyle: .file
+                            )
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
                 }
             }
 
@@ -207,6 +232,11 @@ struct RecordingRow: View {
             }
         }
         .padding(.vertical, density.listRowVerticalPadding)
+        .frame(minHeight: density.minimumListRowHeight)
+    }
+
+    private var usesInlineDensityLayout: Bool {
+        density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
     }
 }
 

--- a/Sources/SpeakiOS/Views/RecordingsView.swift
+++ b/Sources/SpeakiOS/Views/RecordingsView.swift
@@ -191,6 +191,7 @@ struct RecordingRow: View {
                     .lineLimit(1)
                 }
                 .font(.caption)
+                .lineLimit(1)
                 .foregroundStyle(.secondary)
             } else {
                 VStack(alignment: .leading, spacing: 4) {

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -676,7 +676,7 @@ public struct SettingsView: View {
                 }
                 .pickerStyle(.segmented)
 
-                if !settings.visualDensity.isCompact {
+                if !usesInlineDensityLayout {
                     Text(
                         "Compact restructures screens around inline controls, shorter cards, "
                             + "and grouped status rows while keeping controls easy to tap."
@@ -716,7 +716,7 @@ public struct SettingsView: View {
                     .pickerStyle(.navigationLink)
                     .accessibilityIdentifier("appleOnDeviceModelPicker")
 
-                    if !settings.visualDensity.isCompact {
+                    if !usesInlineDensityLayout {
                         Text("Uses Apple's built-in speech engine. Audio stays on this device.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -780,7 +780,7 @@ public struct SettingsView: View {
                         .accessibilityIdentifier("remoteBatchModelPicker")
                     }
 
-                    if !settings.visualDensity.isCompact {
+                    if !usesInlineDensityLayout {
                         Text(settings.transcriptionMode == .streaming
                             ? "Text appears while audio is streamed to the selected provider."
                             : "Audio is uploaded after recording for a more complete transcript.")
@@ -828,7 +828,7 @@ public struct SettingsView: View {
                     Label("Auto-Start Recording", systemImage: "mic.badge.plus")
                 }
 
-                if settings.autoStartRecording && !settings.visualDensity.isCompact {
+                if settings.autoStartRecording && !usesInlineDensityLayout {
                     Text("Recording starts automatically when you open the app.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -838,7 +838,7 @@ public struct SettingsView: View {
                     Label("Live Activities", systemImage: "platter.filled.bottom.iphone")
                 }
 
-                if settings.liveActivitiesEnabled && !settings.visualDensity.isCompact {
+                if settings.liveActivitiesEnabled && !usesInlineDensityLayout {
                     Text("Shows transcription progress on Lock Screen and Dynamic Island.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -859,7 +859,7 @@ public struct SettingsView: View {
                 }
                 .accessibilityIdentifier("hardwareTriggerSettingsLink")
 
-                if !settings.visualDensity.isCompact {
+                if !usesInlineDensityLayout {
                     Text(
                         "Trigger transcription from the Action Button, Siri, Lock Screen, "
                             + "Control Center, or Back Tap."
@@ -874,7 +874,7 @@ public struct SettingsView: View {
                     Label("Auto-Polish After Recording", systemImage: "wand.and.stars")
                 }
 
-                if settings.autoPostProcess && !settings.visualDensity.isCompact {
+                if settings.autoPostProcess && !usesInlineDensityLayout {
                     Text("Automatically opens polish view after each recording.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -973,7 +973,7 @@ public struct SettingsView: View {
                     Label("Import from QR Code", systemImage: "qrcode.viewfinder")
                 }
 
-                if !settings.visualDensity.isCompact {
+                if !usesInlineDensityLayout {
                     Text("Just Speak to It uses iCloud for settings and history when available. "
                         + "If iCloud is unavailable, Bonjour Transport can send sessions to a paired Mac "
                         + "on your local network; QR transfer remains available for manual setup.")
@@ -1005,7 +1005,7 @@ public struct SettingsView: View {
                     Label("Saved Recordings", systemImage: "waveform.circle")
                 }
 
-                if !settings.visualDensity.isCompact {
+                if !usesInlineDensityLayout {
                     Text(
                         "Audio is saved locally during transcription so you can "
                             + "replay or re-transcribe if connectivity was lost."
@@ -1037,7 +1037,7 @@ public struct SettingsView: View {
                     Label("Debug Logging", systemImage: "ant")
                 }
 
-                if SpeakLogger.isDebugMode && !settings.visualDensity.isCompact {
+                if SpeakLogger.isDebugMode && !usesInlineDensityLayout {
                     Text("Debug mode logs additional details for troubleshooting.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -1121,22 +1121,25 @@ public struct SettingsView: View {
         HStack(spacing: settings.visualDensity.inlineSpacing) {
             Label("Manage Keys", systemImage: "key.viewfinder")
             Spacer()
-            Text("\(storedAPIKeyCount)/4")
+            Text("\(storedAPIKeyCount)/\(managedAPIKeyCount)")
                 .font(.caption.monospacedDigit())
-                .foregroundStyle(storedAPIKeyCount == 4 ? .green : .secondary)
+                .foregroundStyle(storedAPIKeyCount == managedAPIKeyCount ? .green : .secondary)
         }
-        .accessibilityLabel("\(storedAPIKeyCount) of 4 API keys stored. Manage keys.")
+        .accessibilityLabel(
+            "\(storedAPIKeyCount) of \(managedAPIKeyCount) API keys stored. Manage keys."
+        )
     }
 
     private var storedAPIKeyCount: Int {
-        [
-            settings.hasDeepgramKey,
-            settings.hasElevenLabsKey,
-            settings.hasOpenRouterKey,
-            settings.hasOpenAIKey
-        ]
-        .filter { $0 }
-        .count
+        managedAPIKeyEntries.filter(\.isStored).count
+    }
+
+    private var managedAPIKeyCount: Int {
+        managedAPIKeyEntries.count
+    }
+
+    private var managedAPIKeyEntries: [APIKeyListEntry] {
+        APIKeysView.entries(for: settings)
     }
 
     private func apiKeyStatusRow(name: String, systemImage: String, isStored: Bool) -> some View {
@@ -1474,6 +1477,10 @@ struct APIKeysView: View {
     }
 
     private var allEntries: [APIKeyListEntry] {
+        Self.entries(for: settings)
+    }
+
+    fileprivate static func entries(for settings: AppSettings) -> [APIKeyListEntry] {
         [
             APIKeyListEntry(
                 id: "deepgram", title: "Deepgram", category: "Transcription", isStored: settings.hasDeepgramKey

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -660,6 +660,7 @@ public struct SettingsView: View {
     @StateObject private var settings = AppSettings.shared
     @Environment(\.openURL) private var openURL
     @Environment(\.openClawEnabled) private var openClawEnabled
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var showingAPIKeys = false
     @State private var missingTranscriptionAPIKeyAlert: IOSMissingTranscriptionAPIKeyAlert?
 
@@ -675,9 +676,14 @@ public struct SettingsView: View {
                 }
                 .pickerStyle(.segmented)
 
-                Text("Compact reduces whitespace across lists, forms, and cards while keeping controls easy to tap.")
+                if !settings.visualDensity.isCompact {
+                    Text(
+                        "Compact restructures screens around inline controls, shorter cards, "
+                            + "and grouped status rows while keeping controls easy to tap."
+                    )
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                }
             }
 
             Section("Transcription") {
@@ -710,9 +716,11 @@ public struct SettingsView: View {
                     .pickerStyle(.navigationLink)
                     .accessibilityIdentifier("appleOnDeviceModelPicker")
 
-                    Text("Uses Apple's built-in speech engine. Audio stays on this device.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if !settings.visualDensity.isCompact {
+                        Text("Uses Apple's built-in speech engine. Audio stays on this device.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 } else {
                     Picker("Remote Mode", selection: remoteTranscriptionModeBinding) {
                         ForEach(IOSRemoteTranscriptionMode.allCases) { mode in
@@ -772,11 +780,13 @@ public struct SettingsView: View {
                         .accessibilityIdentifier("remoteBatchModelPicker")
                     }
 
-                    Text(settings.transcriptionMode == .streaming
-                        ? "Text appears while audio is streamed to the selected provider."
-                        : "Audio is uploaded after recording for a more complete transcript.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if !settings.visualDensity.isCompact {
+                        Text(settings.transcriptionMode == .streaming
+                            ? "Text appears while audio is streamed to the selected provider."
+                            : "Audio is uploaded after recording for a more complete transcript.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 if transcriptionLocationBinding.wrappedValue == .remote,
@@ -818,7 +828,7 @@ public struct SettingsView: View {
                     Label("Auto-Start Recording", systemImage: "mic.badge.plus")
                 }
 
-                if settings.autoStartRecording {
+                if settings.autoStartRecording && !settings.visualDensity.isCompact {
                     Text("Recording starts automatically when you open the app.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -828,7 +838,7 @@ public struct SettingsView: View {
                     Label("Live Activities", systemImage: "platter.filled.bottom.iphone")
                 }
 
-                if settings.liveActivitiesEnabled {
+                if settings.liveActivitiesEnabled && !settings.visualDensity.isCompact {
                     Text("Shows transcription progress on Lock Screen and Dynamic Island.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -849,9 +859,14 @@ public struct SettingsView: View {
                 }
                 .accessibilityIdentifier("hardwareTriggerSettingsLink")
 
-                Text("Trigger transcription from the Action Button, Siri, Lock Screen, Control Center, or Back Tap.")
+                if !settings.visualDensity.isCompact {
+                    Text(
+                        "Trigger transcription from the Action Button, Siri, Lock Screen, "
+                            + "Control Center, or Back Tap."
+                    )
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                }
             }
 
             Section("Post-Processing") {
@@ -859,7 +874,7 @@ public struct SettingsView: View {
                     Label("Auto-Polish After Recording", systemImage: "wand.and.stars")
                 }
 
-                if settings.autoPostProcess {
+                if settings.autoPostProcess && !settings.visualDensity.isCompact {
                     Text("Automatically opens polish view after each recording.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -885,46 +900,39 @@ public struct SettingsView: View {
             }
 
             Section("API Keys") {
-                HStack {
-                    Label("Deepgram", systemImage: "waveform")
-                        .accessibilityLabel("Deepgram API Key")
-                    Spacer()
-                    Text(settings.hasDeepgramKey ? "Stored" : "Missing")
-                        .foregroundStyle(settings.hasDeepgramKey ? .green : .secondary)
-                }
-                .accessibilityElement(children: .combine)
+                if usesInlineDensityLayout {
+                    NavigationLink {
+                        APIKeysView(settings: settings)
+                    } label: {
+                        compactAPIKeySummary
+                    }
+                } else {
+                    apiKeyStatusRow(
+                        name: "Deepgram",
+                        systemImage: "waveform",
+                        isStored: settings.hasDeepgramKey
+                    )
+                    apiKeyStatusRow(
+                        name: "ElevenLabs",
+                        systemImage: "mic.and.signal.meter",
+                        isStored: settings.hasElevenLabsKey
+                    )
+                    apiKeyStatusRow(
+                        name: "OpenRouter",
+                        systemImage: "network",
+                        isStored: settings.hasOpenRouterKey
+                    )
+                    apiKeyStatusRow(
+                        name: "OpenAI",
+                        systemImage: "brain.head.profile",
+                        isStored: settings.hasOpenAIKey
+                    )
 
-                HStack {
-                    Label("ElevenLabs", systemImage: "mic.and.signal.meter")
-                        .accessibilityLabel("ElevenLabs API Key")
-                    Spacer()
-                    Text(settings.hasElevenLabsKey ? "Stored" : "Missing")
-                        .foregroundStyle(settings.hasElevenLabsKey ? .green : .secondary)
-                }
-                .accessibilityElement(children: .combine)
-
-                HStack {
-                    Label("OpenRouter", systemImage: "network")
-                        .accessibilityLabel("OpenRouter API Key")
-                    Spacer()
-                    Text(settings.hasOpenRouterKey ? "Stored" : "Missing")
-                        .foregroundStyle(settings.hasOpenRouterKey ? .green : .secondary)
-                }
-                .accessibilityElement(children: .combine)
-
-                HStack {
-                    Label("OpenAI", systemImage: "brain.head.profile")
-                        .accessibilityLabel("OpenAI API Key")
-                    Spacer()
-                    Text(settings.hasOpenAIKey ? "Stored" : "Missing")
-                        .foregroundStyle(settings.hasOpenAIKey ? .green : .secondary)
-                }
-                .accessibilityElement(children: .combine)
-
-                NavigationLink {
-                    APIKeysView(settings: settings)
-                } label: {
-                    Label("Manage Keys", systemImage: "key.viewfinder")
+                    NavigationLink {
+                        APIKeysView(settings: settings)
+                    } label: {
+                        Label("Manage Keys", systemImage: "key.viewfinder")
+                    }
                 }
             }
 
@@ -939,37 +947,11 @@ public struct SettingsView: View {
                     iCloudCloudKitAvailable: HistorySyncEngine.shared.state.isCloudAvailable
                 )
 
-                HStack {
-                    Label("Preferred Sync", systemImage: "arrow.triangle.branch")
-                    Spacer()
-                    Text(syncStatus.preferredBackend.displayName)
-                        .foregroundStyle(syncStatus.preferredBackend != .localOnly ? .green : .secondary)
+                if usesInlineDensityLayout {
+                    compactSyncStatus(syncStatus)
+                } else {
+                    syncStatusRows(syncStatus)
                 }
-                .accessibilityElement(children: .combine)
-
-                HStack {
-                    Label("iCloud Keychain", systemImage: "key.icloud")
-                    Spacer()
-                    Text(syncStatus.iCloudKeychainAvailable ? "Available" : "Local only")
-                        .foregroundStyle(syncStatus.iCloudKeychainAvailable ? .green : .secondary)
-                }
-                .accessibilityElement(children: .combine)
-
-                HStack {
-                    Label("iCloud Settings", systemImage: "icloud")
-                    Spacer()
-                    Text(syncStatus.iCloudKVStoreAvailable ? "Available" : "Local only")
-                        .foregroundStyle(syncStatus.iCloudKVStoreAvailable ? .green : .secondary)
-                }
-                .accessibilityElement(children: .combine)
-
-                HStack {
-                    Label("Bonjour Transport", systemImage: "network")
-                    Spacer()
-                    Text(syncStatus.transportAvailable ? "Ready" : "Unavailable")
-                        .foregroundStyle(syncStatus.transportAvailable ? .green : .secondary)
-                }
-                .accessibilityElement(children: .combine)
 
                 if let lastSync = syncStatus.lastSyncDate {
                     LabeledContent("Last Sync") {
@@ -991,11 +973,13 @@ public struct SettingsView: View {
                     Label("Import from QR Code", systemImage: "qrcode.viewfinder")
                 }
 
-                Text("Just Speak to It uses iCloud for settings and history when available. "
-                    + "If iCloud is unavailable, Bonjour Transport can send sessions to a paired Mac "
-                    + "on your local network; QR transfer remains available for manual setup.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if !settings.visualDensity.isCompact {
+                    Text("Just Speak to It uses iCloud for settings and history when available. "
+                        + "If iCloud is unavailable, Bonjour Transport can send sessions to a paired Mac "
+                        + "on your local network; QR transfer remains available for manual setup.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             if openClawEnabled {
@@ -1021,12 +1005,14 @@ public struct SettingsView: View {
                     Label("Saved Recordings", systemImage: "waveform.circle")
                 }
 
-                Text(
-                    "Audio is saved locally during transcription so you can "
-                        + "replay or re-transcribe if connectivity was lost."
-                )
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                if !settings.visualDensity.isCompact {
+                    Text(
+                        "Audio is saved locally during transcription so you can "
+                            + "replay or re-transcribe if connectivity was lost."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
             }
 
             Section("Send to Mac") {
@@ -1051,7 +1037,7 @@ public struct SettingsView: View {
                     Label("Debug Logging", systemImage: "ant")
                 }
 
-                if SpeakLogger.isDebugMode {
+                if SpeakLogger.isDebugMode && !settings.visualDensity.isCompact {
                     Text("Debug mode logs additional details for troubleshooting.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -1059,28 +1045,32 @@ public struct SettingsView: View {
             }
 
             Section("About") {
-                LabeledContent("Version") {
-                    let ver = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
-                    let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
-                    Text("\(ver) (\(build))")
-                        .foregroundStyle(.secondary)
-                }
+                if usesInlineDensityLayout {
+                    compactBuildSummary
+                } else {
+                    LabeledContent("Version") {
+                        Text("\(appVersion) (\(appBuild))")
+                            .foregroundStyle(.secondary)
+                    }
 
-                LabeledContent("Commit") {
-                    Text(BuildInfo.gitCommitShort)
-                        .foregroundStyle(.secondary)
-                        .font(.system(.body, design: .monospaced))
-                }
+                    LabeledContent("Commit") {
+                        Text(BuildInfo.gitCommitShort)
+                            .foregroundStyle(.secondary)
+                            .font(.system(.body, design: .monospaced))
+                    }
 
-                LabeledContent("SpeakCore") {
-                    Text(SpeakCore.version)
-                        .foregroundStyle(.secondary)
+                    LabeledContent("SpeakCore") {
+                        Text(SpeakCore.version)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }
         .environment(\.defaultMinListRowHeight, settings.visualDensity.minimumListRowHeight)
         .listSectionSpacing(settings.visualDensity.listSectionSpacing)
         .navigationTitle("Settings")
+        .navigationBarTitleDisplayMode(usesInlineDensityLayout ? .inline : .automatic)
+        .controlSize(settings.visualDensity.isCompact ? .small : .regular)
         .navigationDestination(isPresented: $showingAPIKeys) {
             APIKeysView(settings: settings)
         }
@@ -1100,6 +1090,144 @@ public struct SettingsView: View {
 
     private var postProcessingModelName: String {
         ModelCatalog.friendlyName(for: settings.postProcessingModel)
+    }
+
+    private var usesInlineDensityLayout: Bool {
+        settings.visualDensity.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
+    }
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+    }
+
+    private var appBuild: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+    }
+
+    private var compactBuildSummary: some View {
+        HStack(spacing: settings.visualDensity.inlineSpacing) {
+            Label("\(appVersion) (\(appBuild))", systemImage: "app.badge")
+            Spacer()
+            Text(BuildInfo.gitCommitShort)
+                .font(.caption.monospaced())
+            Text("Core \(SpeakCore.version)")
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var compactAPIKeySummary: some View {
+        HStack(spacing: settings.visualDensity.inlineSpacing) {
+            Label("Manage Keys", systemImage: "key.viewfinder")
+            Spacer()
+            Text("\(storedAPIKeyCount)/4")
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(storedAPIKeyCount == 4 ? .green : .secondary)
+        }
+        .accessibilityLabel("\(storedAPIKeyCount) of 4 API keys stored. Manage keys.")
+    }
+
+    private var storedAPIKeyCount: Int {
+        [
+            settings.hasDeepgramKey,
+            settings.hasElevenLabsKey,
+            settings.hasOpenRouterKey,
+            settings.hasOpenAIKey
+        ]
+        .filter { $0 }
+        .count
+    }
+
+    private func apiKeyStatusRow(name: String, systemImage: String, isStored: Bool) -> some View {
+        HStack {
+            Label(name, systemImage: systemImage)
+                .accessibilityLabel("\(name) API Key")
+            Spacer()
+            Text(isStored ? "Stored" : "Missing")
+                .foregroundStyle(isStored ? .green : .secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func compactSyncStatus(_ status: SyncStatus) -> some View {
+        HStack(spacing: settings.visualDensity.inlineSpacing) {
+            Label(status.preferredBackend.displayName, systemImage: "arrow.triangle.branch")
+                .lineLimit(1)
+            Spacer()
+            syncAvailabilityIcon(
+                "key.icloud",
+                available: status.iCloudKeychainAvailable,
+                label: "iCloud Keychain"
+            )
+            syncAvailabilityIcon(
+                "icloud",
+                available: status.iCloudKVStoreAvailable,
+                label: "iCloud Settings"
+            )
+            syncAvailabilityIcon(
+                "network",
+                available: status.transportAvailable,
+                label: "Bonjour Transport"
+            )
+        }
+        .font(.caption)
+    }
+
+    private func syncAvailabilityIcon(
+        _ systemImage: String,
+        available: Bool,
+        label: String
+    ) -> some View {
+        Image(systemName: available ? systemImage : "xmark.circle")
+            .foregroundStyle(available ? .green : .secondary)
+            .accessibilityLabel("\(label): \(available ? "available" : "unavailable")")
+    }
+
+    private func syncStatusRows(_ status: SyncStatus) -> some View {
+        Group {
+            HStack {
+                Label("Preferred Sync", systemImage: "arrow.triangle.branch")
+                Spacer()
+                Text(status.preferredBackend.displayName)
+                    .foregroundStyle(status.preferredBackend != .localOnly ? .green : .secondary)
+            }
+            .accessibilityElement(children: .combine)
+
+            syncStatusRow(
+                name: "iCloud Keychain",
+                systemImage: "key.icloud",
+                value: status.iCloudKeychainAvailable ? "Available" : "Local only",
+                isAvailable: status.iCloudKeychainAvailable
+            )
+            syncStatusRow(
+                name: "iCloud Settings",
+                systemImage: "icloud",
+                value: status.iCloudKVStoreAvailable ? "Available" : "Local only",
+                isAvailable: status.iCloudKVStoreAvailable
+            )
+            syncStatusRow(
+                name: "Bonjour Transport",
+                systemImage: "network",
+                value: status.transportAvailable ? "Ready" : "Unavailable",
+                isAvailable: status.transportAvailable
+            )
+        }
+    }
+
+    private func syncStatusRow(
+        name: String,
+        systemImage: String,
+        value: String,
+        isAvailable: Bool
+    ) -> some View {
+        HStack {
+            Label(name, systemImage: systemImage)
+            Spacer()
+            Text(value)
+                .foregroundStyle(isAvailable ? .green : .secondary)
+        }
+        .accessibilityElement(children: .combine)
     }
 }
 
@@ -1322,6 +1450,7 @@ struct PostProcessingSettingsView: View {
 // swiftlint:disable:next type_body_length
 struct APIKeysView: View {
     @ObservedObject var settings: AppSettings
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var deepgramKey = ""
     @State private var openRouterKey = ""
     @State private var openAIKey = ""
@@ -1404,6 +1533,12 @@ struct APIKeysView: View {
         .environment(\.defaultMinListRowHeight, settings.visualDensity.minimumListRowHeight)
         .listSectionSpacing(settings.visualDensity.listSectionSpacing)
         .navigationTitle("API Keys")
+        .navigationBarTitleDisplayMode(
+            settings.visualDensity.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
+                ? .inline
+                : .automatic
+        )
+        .controlSize(settings.visualDensity.isCompact ? .small : .regular)
         .searchable(text: $searchText, prompt: "Provider or use")
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {

--- a/Tests/SpeakCoreTests/APIKeyListQueryTests.swift
+++ b/Tests/SpeakCoreTests/APIKeyListQueryTests.swift
@@ -37,34 +37,4 @@ final class APIKeyListQueryTests: XCTestCase {
         )
     }
 
-    func testDensityMetrics_preserveNormalModeAndTripleCompactSpacing() {
-        XCTAssertEqual(AppVisualDensity.normal.sectionSpacing, 20)
-        XCTAssertEqual(AppVisualDensity.normal.pagePadding, 24)
-        XCTAssertEqual(AppVisualDensity.normal.cardPadding, 24)
-        XCTAssertEqual(AppVisualDensity.normal.cardContentSpacing, 18)
-        XCTAssertEqual(AppVisualDensity.normal.listRowVerticalPadding, 4)
-        XCTAssertEqual(AppVisualDensity.normal.minimumListRowHeight, 44)
-        XCTAssertEqual(AppVisualDensity.normal.listSectionSpacing, 24)
-
-        XCTAssertLessThanOrEqual(
-            AppVisualDensity.compact.pagePadding,
-            AppVisualDensity.normal.pagePadding / 3
-        )
-        XCTAssertLessThanOrEqual(
-            AppVisualDensity.compact.cardPadding,
-            AppVisualDensity.normal.cardPadding / 3
-        )
-        XCTAssertLessThanOrEqual(
-            AppVisualDensity.compact.sectionSpacing,
-            AppVisualDensity.normal.sectionSpacing / 3
-        )
-        XCTAssertTrue(AppVisualDensity.compact.prefersInlineLayout(dynamicTypeSize: .large))
-        XCTAssertFalse(AppVisualDensity.compact.prefersInlineLayout(dynamicTypeSize: .accessibility1))
-        XCTAssertFalse(AppVisualDensity.normal.prefersInlineLayout(dynamicTypeSize: .large))
-        #if os(iOS)
-        XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 44)
-        #else
-        XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 28)
-        #endif
-    }
 }

--- a/Tests/SpeakCoreTests/APIKeyListQueryTests.swift
+++ b/Tests/SpeakCoreTests/APIKeyListQueryTests.swift
@@ -37,10 +37,34 @@ final class APIKeyListQueryTests: XCTestCase {
         )
     }
 
-    func testNormalDensity_preservesExistingMetrics() {
+    func testDensityMetrics_preserveNormalModeAndTripleCompactSpacing() {
+        XCTAssertEqual(AppVisualDensity.normal.sectionSpacing, 20)
         XCTAssertEqual(AppVisualDensity.normal.pagePadding, 24)
         XCTAssertEqual(AppVisualDensity.normal.cardPadding, 24)
-        XCTAssertLessThan(AppVisualDensity.compact.pagePadding, AppVisualDensity.normal.pagePadding)
-        XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 38)
+        XCTAssertEqual(AppVisualDensity.normal.cardContentSpacing, 18)
+        XCTAssertEqual(AppVisualDensity.normal.listRowVerticalPadding, 4)
+        XCTAssertEqual(AppVisualDensity.normal.minimumListRowHeight, 44)
+        XCTAssertEqual(AppVisualDensity.normal.listSectionSpacing, 24)
+
+        XCTAssertLessThanOrEqual(
+            AppVisualDensity.compact.pagePadding,
+            AppVisualDensity.normal.pagePadding / 3
+        )
+        XCTAssertLessThanOrEqual(
+            AppVisualDensity.compact.cardPadding,
+            AppVisualDensity.normal.cardPadding / 3
+        )
+        XCTAssertLessThanOrEqual(
+            AppVisualDensity.compact.sectionSpacing,
+            AppVisualDensity.normal.sectionSpacing / 3
+        )
+        XCTAssertTrue(AppVisualDensity.compact.prefersInlineLayout(dynamicTypeSize: .large))
+        XCTAssertFalse(AppVisualDensity.compact.prefersInlineLayout(dynamicTypeSize: .accessibility1))
+        XCTAssertFalse(AppVisualDensity.normal.prefersInlineLayout(dynamicTypeSize: .large))
+        #if os(iOS)
+        XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 44)
+        #else
+        XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 28)
+        #endif
     }
 }

--- a/Tests/SpeakCoreTests/AppVisualDensityTests.swift
+++ b/Tests/SpeakCoreTests/AppVisualDensityTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import SpeakCore
+
+final class AppVisualDensityTests: XCTestCase {
+    func testMetrics_preserveNormalModeAndTripleCompactSpacing() {
+        XCTAssertEqual(AppVisualDensity.normal.sectionSpacing, 20)
+        XCTAssertEqual(AppVisualDensity.normal.pagePadding, 24)
+        XCTAssertEqual(AppVisualDensity.normal.cardPadding, 24)
+        XCTAssertEqual(AppVisualDensity.normal.cardContentSpacing, 18)
+        XCTAssertEqual(AppVisualDensity.normal.listRowVerticalPadding, 4)
+        XCTAssertEqual(AppVisualDensity.normal.minimumListRowHeight, 44)
+        XCTAssertEqual(AppVisualDensity.normal.listSectionSpacing, 24)
+
+        XCTAssertLessThanOrEqual(
+            AppVisualDensity.compact.pagePadding,
+            AppVisualDensity.normal.pagePadding / 3
+        )
+        XCTAssertLessThanOrEqual(
+            AppVisualDensity.compact.cardPadding,
+            AppVisualDensity.normal.cardPadding / 3
+        )
+        XCTAssertLessThanOrEqual(
+            AppVisualDensity.compact.sectionSpacing,
+            AppVisualDensity.normal.sectionSpacing / 3
+        )
+        XCTAssertTrue(AppVisualDensity.compact.prefersInlineLayout(dynamicTypeSize: .large))
+        XCTAssertFalse(AppVisualDensity.compact.prefersInlineLayout(dynamicTypeSize: .accessibility1))
+        XCTAssertFalse(AppVisualDensity.normal.prefersInlineLayout(dynamicTypeSize: .large))
+        #if os(iOS)
+        XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 44)
+        #else
+        XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 28)
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary

- turn Compact into a distinct high-density layout system with 6–8pt spacing, smaller cards, tighter grids, and reduced decorative chrome
- restructure macOS dashboard, history, settings, sidebar, corrections, troubleshooting, charts, and voice output around inline headings, metrics, and icon actions
- condense iOS transcription, history, recordings, settings, post-processing, and OpenClaw screens while retaining 44pt touch targets
- preserve Normal mode's existing screen-specific measurements and fall back from forced inline layouts at accessibility Dynamic Type sizes

## Verification

- `swift test --filter APIKeyListQueryTests` — 4 tests passed, including compact/normal density invariants
- baseline-aware strict SwiftLint — 0 violations across all 20 changed Swift files
- SwiftFormat — clean
- macOS package sources compiled successfully
- `SpeakiOSLib` compiled for arm64 and x86_64 iOS Simulator

## Existing project-level iOS blockers

The full generated Xcode app wrapper still stops after the library compile because `SpeakiOS.xcodeproj` does not include the existing `SpeakiOSApp/FeatureFlags.swift`, and its widget target imports package modules without declaring those dependencies. Neither project file was changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive compact-density layouts across dashboards, history, settings, chat, recordings, troubleshooting, and voice output screens.
  * Improved support for Dynamic Type by switching between inline and stacked layouts as appropriate.
  * Updated cards, grids, charts, controls, navigation, typography, spacing, and touch targets for better space efficiency.
  * Simplified compact views by hiding secondary explanatory text while preserving key information and actions.

* **Tests**
  * Expanded coverage for density metrics, inline-layout behavior, spacing, and platform-specific row heights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->