### PR TITLE
fix(mac): densify compact settings layouts

### DIFF
--- a/Sources/SpeakApp/MainView.swift
+++ b/Sources/SpeakApp/MainView.swift
@@ -90,16 +90,8 @@ struct MainView: View {
       .speakTooltip("Start or stop a recording from anywhere in Speak. We'll let you know when we're listening.")
       .accessibilityLabel(accessibilityLabelForRecordButton)
     }
-    ToolbarItem(placement: .status) {
-      if settings.visualDensity.isCompact {
-        Image(systemName: "waveform.badge.magnifyingglass")
-          .font(.caption)
-          .foregroundStyle(.secondary)
-          .accessibilityLabel(
-            "Current mode: \(environment.settings.effectiveTranscriptionModeDisplayName)"
-          )
-          .speakTooltip(environment.settings.effectiveTranscriptionModeDisplayName)
-      } else {
+    if !settings.visualDensity.isCompact {
+      ToolbarItem(placement: .status) {
         VStack(alignment: .trailing, spacing: 2) {
           Text(environment.settings.effectiveTranscriptionModeDisplayName)
             .font(.caption)

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -856,7 +856,7 @@ struct SettingsView: View {
   }
 
   private var generalSettings: some View {
-    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
+    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
       SettingsCard(title: "Appearance", systemImage: "paintpalette", tint: Color.brandAccent) {
         VStack(alignment: .leading, spacing: 12) {
           Text("Choose how Speak looks across light, dark, or system themes.")
@@ -1349,7 +1349,7 @@ struct SettingsView: View {
   }
 
   private var transcriptionSettings: some View {
-    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
+    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
       SettingsCard(title: "Transcription mode", systemImage: "waveform", tint: Color.teal) {
         VStack(alignment: .leading, spacing: 12) {
           Picker("Where transcription runs", selection: transcriptionLocationBinding) {
@@ -2714,7 +2714,7 @@ struct SettingsView: View {
   }
 
   private var postProcessingSettings: some View {
-    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
+    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
       if settings.isActiveAssemblyAILiveModel {
         preprocessingSettings
       } else {
@@ -2993,7 +2993,7 @@ struct SettingsView: View {
   }
 
   private var voiceOutputSettings: some View {
-    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
+    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
       SettingsCard(title: "Default Voice", systemImage: "speaker.wave.3", tint: Color.brandLagoonDeep) {
         VStack(alignment: .leading, spacing: 12) {
           VStack(alignment: .leading, spacing: 8) {
@@ -3709,13 +3709,19 @@ struct SettingsView: View {
 
   private var apiKeySettings: some View {
     ScrollViewReader { proxy in
-      LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
-        apiKeyListControls
+      VStack(spacing: settings.visualDensity.sectionSpacing) {
+        SpeakAdaptiveSettingsLayout(
+          density: settings.visualDensity,
+          compactMinimumWidth: 320,
+          maximumColumns: 2
+        ) {
+          apiKeyListControls
 
-        if DistributionChannel.current.supportsEncryptedCloudKitKeySync {
-          CloudKitKeySyncSettingsCard(secureStorage: environment.secureStorage)
-        } else {
-          LocalKeychainStorageCard()
+          if DistributionChannel.current.supportsEncryptedCloudKitKeySync {
+            CloudKitKeySyncSettingsCard(secureStorage: environment.secureStorage)
+          } else {
+            LocalKeychainStorageCard()
+          }
         }
 
         if visibleMacAPIKeyItems.isEmpty {
@@ -3726,9 +3732,14 @@ struct SettingsView: View {
           )
           .padding(.vertical, 24)
         } else {
-          ForEach(visibleMacAPIKeyItems) { item in
-            macAPIKeyView(for: item)
-              .id(item.id)
+          SpeakAdaptiveSettingsLayout(
+            density: settings.visualDensity,
+            compactMinimumWidth: 320
+          ) {
+            ForEach(visibleMacAPIKeyItems) { item in
+              macAPIKeyView(for: item)
+                .id(item.id)
+            }
           }
         }
       }
@@ -3754,32 +3765,62 @@ struct SettingsView: View {
 
   private var apiKeyListControls: some View {
     SettingsCard(title: "Find API Keys", systemImage: "magnifyingglass", tint: .brandAccent) {
-      VStack(alignment: .leading, spacing: settings.visualDensity == .compact ? 8 : 12) {
-        TextField("Search provider or category", text: $apiKeySearchText)
-          .textFieldStyle(.roundedBorder)
-          .accessibilityLabel("Search API keys")
+      if settings.visualDensity.isCompact {
+        ViewThatFits(in: .horizontal) {
+          HStack(spacing: settings.visualDensity.inlineSpacing) {
+            TextField("Search provider or category", text: $apiKeySearchText)
+              .textFieldStyle(.roundedBorder)
+              .accessibilityLabel("Search API keys")
 
-        HStack(spacing: 12) {
-          Picker("Status", selection: $apiKeyStatusFilter) {
-            ForEach(APIKeyStatusFilter.allCases) { filter in
-              Text(filter.displayName).tag(filter)
-            }
+            apiKeyFilterControls
           }
-          .pickerStyle(.menu)
 
-          Picker("Sort", selection: $apiKeySortOrder) {
-            ForEach(APIKeySortOrder.allCases) { order in
-              Text(order.displayName).tag(order)
-            }
+          VStack(alignment: .leading, spacing: settings.visualDensity.inlineSpacing) {
+            TextField("Search provider or category", text: $apiKeySearchText)
+              .textFieldStyle(.roundedBorder)
+              .accessibilityLabel("Search API keys")
+            apiKeyFilterControls
           }
-          .pickerStyle(.menu)
+        }
+      } else {
+        VStack(alignment: .leading, spacing: 12) {
+          TextField("Search provider or category", text: $apiKeySearchText)
+            .textFieldStyle(.roundedBorder)
+            .accessibilityLabel("Search API keys")
 
-          Spacer()
-          Text("\(visibleMacAPIKeyItems.count) of \(allMacAPIKeyItems.count)")
-            .font(.caption.monospacedDigit())
-            .foregroundStyle(.secondary)
+          apiKeyFilterControls
         }
       }
+    }
+  }
+
+  private var apiKeyFilterControls: some View {
+    HStack(spacing: settings.visualDensity.inlineSpacing) {
+      Picker("Status", selection: $apiKeyStatusFilter) {
+        ForEach(APIKeyStatusFilter.allCases) { filter in
+          Text(filter.displayName).tag(filter)
+        }
+      }
+      .pickerStyle(.menu)
+
+      Picker("Sort", selection: $apiKeySortOrder) {
+        ForEach(APIKeySortOrder.allCases) { order in
+          Text(order.displayName).tag(order)
+        }
+      }
+      .pickerStyle(.menu)
+
+      Spacer(minLength: 0)
+      Text(
+        settings.visualDensity.isCompact
+          ? "\(visibleMacAPIKeyItems.count)/\(allMacAPIKeyItems.count)"
+          : "\(visibleMacAPIKeyItems.count) of \(allMacAPIKeyItems.count)"
+      )
+        .font(.caption.monospacedDigit())
+        .foregroundStyle(.secondary)
+        .accessibilityLabel(
+          "\(visibleMacAPIKeyItems.count) of \(allMacAPIKeyItems.count) API keys shown"
+        )
     }
   }
 
@@ -3972,6 +4013,7 @@ struct SettingsView: View {
     )
   }
 
+  // swiftlint:disable:next cyclomatic_complexity function_body_length
   private func apiKeyCard(
     title: String,
     systemImage: String,
@@ -4001,69 +4043,149 @@ struct SettingsView: View {
     statusLabel: String = "Status"
   ) -> some View {
     SettingsCard(title: title, systemImage: systemImage, tint: tint) {
-      VStack(alignment: .leading, spacing: 14) {
-        HStack(alignment: .center, spacing: 12) {
-          Label(statusLabel, systemImage: statusIcon)
-            .foregroundStyle(isStored ? statusTint : Color.secondary)
-            .labelStyle(.titleAndIcon)
-          statusBadge(isStored: isStored, color: statusTint)
-        }
+      if settings.visualDensity.isCompact {
+        VStack(alignment: .leading, spacing: settings.visualDensity.cardContentSpacing) {
+          HStack(spacing: settings.visualDensity.inlineSpacing) {
+            Label(isStored ? "Saved" : "Not set", systemImage: statusIcon)
+              .font(.caption.weight(.semibold))
+              .foregroundStyle(isStored ? statusTint : Color.secondary)
 
-        if let link, let linkLabel {
-          Link(destination: link) {
-            Label(linkLabel, systemImage: "arrow.up.forward.square")
-              .font(.caption)
-          }
-          .speakTooltip("Open \(title)'s site to create or manage your API key in your browser.")
-        }
-
-        SecureField(keyFieldLabel, text: keyBinding)
-          .textContentType(.password)
-          .privacySensitive()
-          .textFieldStyle(.roundedBorder)
-          .speakTooltip("Paste your \(title) key exactly as issued; Speak stores it securely in your Keychain.")
-
-        Text(descriptionText)
-          .font(.caption)
-          .foregroundStyle(.secondary)
-
-        HStack(spacing: 12) {
-          Button(action: onSave) {
-            if isValidationInFlight(validationState) {
-              ProgressView()
-                .controlSize(.small)
-            } else {
-              Label(saveButtonTitle, systemImage: "arrow.down.circle")
+            if let link, let linkLabel {
+              Link(destination: link) {
+                Label(linkLabel, systemImage: "arrow.up.forward.square")
+                  .labelStyle(.iconOnly)
+              }
+              .speakTooltip("Open \(title)'s site to create or manage your API key in your browser.")
+              .accessibilityLabel(linkLabel)
             }
-          }
-          .disabled(isSaveDisabled)
-          .buttonStyle(.borderedProminent)
-          .tint(tint)
-          .speakTooltip(saveTooltip)
 
-          if let onValidate, isStored {
-            Button(action: onValidate) {
+            Spacer(minLength: 0)
+          }
+
+          HStack(spacing: settings.visualDensity.inlineSpacing) {
+            SecureField(keyFieldLabel, text: keyBinding)
+              .textContentType(.password)
+              .privacySensitive()
+              .textFieldStyle(.roundedBorder)
+              .speakTooltip("Paste your \(title) key exactly as issued; Speak stores it securely in your Keychain.")
+
+            Button(action: onSave) {
               if isValidationInFlight(validationState) {
                 ProgressView()
                   .controlSize(.small)
               } else {
-                Label(validateButtonTitle, systemImage: "checkmark.shield")
+                Label(saveButtonTitle, systemImage: "arrow.down.circle")
+                  .labelStyle(.iconOnly)
               }
             }
-            .disabled(isValidateDisabled)
-            .buttonStyle(.bordered)
-            .speakTooltip(validateTooltip)
-          }
+            .disabled(isSaveDisabled)
+            .buttonStyle(.borderedProminent)
+            .tint(tint)
+            .speakTooltip(saveTooltip)
+            .accessibilityLabel(saveButtonTitle)
 
-          if let onRemove, isStored {
-            Button(removeButtonTitle, role: .destructive, action: onRemove)
+            if let onValidate, isStored {
+              Button(action: onValidate) {
+                if isValidationInFlight(validationState) {
+                  ProgressView()
+                    .controlSize(.small)
+                } else {
+                  Label(validateButtonTitle, systemImage: "checkmark.shield")
+                    .labelStyle(.iconOnly)
+                }
+              }
+              .disabled(isValidateDisabled)
+              .buttonStyle(.bordered)
+              .speakTooltip(validateTooltip)
+              .accessibilityLabel(validateButtonTitle)
+            }
+
+            if let onRemove, isStored {
+              Button(role: .destructive, action: onRemove) {
+                Label(removeButtonTitle, systemImage: "trash")
+                  .labelStyle(.iconOnly)
+              }
               .disabled(isRemoveDisabled)
+              .buttonStyle(.bordered)
               .speakTooltip(removeTooltip)
+              .accessibilityLabel(removeButtonTitle)
+            }
           }
-        }
 
-        validationStatusView(for: validationState)
-        validationDebugDetails(for: validationState)
+          Text(descriptionText)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .speakTooltip(descriptionText)
+
+          validationStatusView(for: validationState)
+          validationDebugDetails(for: validationState)
+        }
+      } else {
+        VStack(alignment: .leading, spacing: 14) {
+          HStack(alignment: .center, spacing: 12) {
+            Label(statusLabel, systemImage: statusIcon)
+              .foregroundStyle(isStored ? statusTint : Color.secondary)
+              .labelStyle(.titleAndIcon)
+            statusBadge(isStored: isStored, color: statusTint)
+          }
+
+          if let link, let linkLabel {
+            Link(destination: link) {
+              Label(linkLabel, systemImage: "arrow.up.forward.square")
+                .font(.caption)
+            }
+            .speakTooltip("Open \(title)'s site to create or manage your API key in your browser.")
+          }
+
+          SecureField(keyFieldLabel, text: keyBinding)
+            .textContentType(.password)
+            .privacySensitive()
+            .textFieldStyle(.roundedBorder)
+            .speakTooltip("Paste your \(title) key exactly as issued; Speak stores it securely in your Keychain.")
+
+          Text(descriptionText)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+          HStack(spacing: 12) {
+            Button(action: onSave) {
+              if isValidationInFlight(validationState) {
+                ProgressView()
+                  .controlSize(.small)
+              } else {
+                Label(saveButtonTitle, systemImage: "arrow.down.circle")
+              }
+            }
+            .disabled(isSaveDisabled)
+            .buttonStyle(.borderedProminent)
+            .tint(tint)
+            .speakTooltip(saveTooltip)
+
+            if let onValidate, isStored {
+              Button(action: onValidate) {
+                if isValidationInFlight(validationState) {
+                  ProgressView()
+                    .controlSize(.small)
+                } else {
+                  Label(validateButtonTitle, systemImage: "checkmark.shield")
+                }
+              }
+              .disabled(isValidateDisabled)
+              .buttonStyle(.bordered)
+              .speakTooltip(validateTooltip)
+            }
+
+            if let onRemove, isStored {
+              Button(removeButtonTitle, role: .destructive, action: onRemove)
+                .disabled(isRemoveDisabled)
+                .speakTooltip(removeTooltip)
+            }
+          }
+
+          validationStatusView(for: validationState)
+          validationDebugDetails(for: validationState)
+        }
       }
     }
     .speakTooltip(tooltip)
@@ -4516,7 +4638,7 @@ struct SettingsView: View {
   }
 
   private var hotKeySettings: some View {
-    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
+    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
       SettingsCard(title: "Trigger Key", systemImage: "keyboard", tint: Color.blue) {
         VStack(alignment: .leading, spacing: 12) {
           Text("Choose which key triggers recording.")
@@ -4601,7 +4723,7 @@ struct SettingsView: View {
   }
 
   private var permissionsSettings: some View {
-    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
+    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
       SettingsCard(title: "System permissions", systemImage: "lock.shield", tint: Color.red) {
         VStack(alignment: .leading, spacing: 12) {
           ForEach(PermissionType.availablePermissions(for: DistributionChannel.current)) { permission in
@@ -4704,7 +4826,7 @@ struct SettingsView: View {
   }
 
   private var aboutSettings: some View {
-    LazyVStack(spacing: settings.visualDensity.sectionSpacing) {
+    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
       SettingsCard(title: "Just Speak to It", systemImage: "info.circle", tint: Color.blue) {
         VStack(alignment: .leading, spacing: 16) {
           HStack(alignment: .top, spacing: 16) {

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -200,6 +200,33 @@ struct SettingsView: View {
     case finished(APIKeyValidationResult)
   }
 
+  private struct APIKeyCardConfiguration {
+    let title: String
+    let tint: Color
+    let statusIcon: String
+    let statusTint: Color
+    let isStored: Bool
+    let descriptionText: String
+    let keyFieldLabel: String
+    let keyBinding: Binding<String>
+    let onSave: () -> Void
+    let onValidate: (() -> Void)?
+    let onRemove: (() -> Void)?
+    let isSaveDisabled: Bool
+    let isValidateDisabled: Bool
+    let isRemoveDisabled: Bool
+    let validationState: ValidationViewState
+    let saveButtonTitle: String
+    let saveTooltip: String
+    let validateButtonTitle: String
+    let validateTooltip: String
+    let removeButtonTitle: String
+    let removeTooltip: String
+    let link: URL?
+    let linkLabel: String?
+    let statusLabel: String
+  }
+
   private var isOpenRouterKeyStored: Bool {
     isAPIKeyStored(openRouterKeyIdentifier)
   }
@@ -856,7 +883,7 @@ struct SettingsView: View {
   }
 
   private var generalSettings: some View {
-    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
+    SpeakDensitySettingsSection(density: settings.visualDensity) {
       SettingsCard(title: "Appearance", systemImage: "paintpalette", tint: Color.brandAccent) {
         VStack(alignment: .leading, spacing: 12) {
           Text("Choose how Speak looks across light, dark, or system themes.")
@@ -1349,7 +1376,7 @@ struct SettingsView: View {
   }
 
   private var transcriptionSettings: some View {
-    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
+    SpeakDensitySettingsSection(density: settings.visualDensity) {
       SettingsCard(title: "Transcription mode", systemImage: "waveform", tint: Color.teal) {
         VStack(alignment: .leading, spacing: 12) {
           Picker("Where transcription runs", selection: transcriptionLocationBinding) {
@@ -2714,7 +2741,7 @@ struct SettingsView: View {
   }
 
   private var postProcessingSettings: some View {
-    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
+    SpeakDensitySettingsSection(density: settings.visualDensity) {
       if settings.isActiveAssemblyAILiveModel {
         preprocessingSettings
       } else {
@@ -2993,7 +3020,7 @@ struct SettingsView: View {
   }
 
   private var voiceOutputSettings: some View {
-    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
+    SpeakDensitySettingsSection(density: settings.visualDensity) {
       SettingsCard(title: "Default Voice", systemImage: "speaker.wave.3", tint: Color.brandLagoonDeep) {
         VStack(alignment: .leading, spacing: 12) {
           VStack(alignment: .leading, spacing: 8) {
@@ -3710,7 +3737,7 @@ struct SettingsView: View {
   private var apiKeySettings: some View {
     ScrollViewReader { proxy in
       VStack(spacing: settings.visualDensity.sectionSpacing) {
-        SpeakAdaptiveSettingsLayout(
+        SpeakDensitySettingsSection(
           density: settings.visualDensity,
           compactMinimumWidth: 320,
           maximumColumns: 2
@@ -3732,7 +3759,7 @@ struct SettingsView: View {
           )
           .padding(.vertical, 24)
         } else {
-          SpeakAdaptiveSettingsLayout(
+          SpeakDensitySettingsSection(
             density: settings.visualDensity,
             compactMinimumWidth: 320
           ) {
@@ -3770,9 +3797,11 @@ struct SettingsView: View {
           HStack(spacing: settings.visualDensity.inlineSpacing) {
             TextField("Search provider or category", text: $apiKeySearchText)
               .textFieldStyle(.roundedBorder)
+              .frame(minWidth: 180)
               .accessibilityLabel("Search API keys")
 
             apiKeyFilterControls
+              .fixedSize(horizontal: true, vertical: false)
           }
 
           VStack(alignment: .leading, spacing: settings.visualDensity.inlineSpacing) {
@@ -4013,7 +4042,6 @@ struct SettingsView: View {
     )
   }
 
-  // swiftlint:disable:next cyclomatic_complexity function_body_length
   private func apiKeyCard(
     title: String,
     systemImage: String,
@@ -4042,153 +4070,223 @@ struct SettingsView: View {
     linkLabel: String?,
     statusLabel: String = "Status"
   ) -> some View {
-    SettingsCard(title: title, systemImage: systemImage, tint: tint) {
+    let configuration = APIKeyCardConfiguration(
+      title: title,
+      tint: tint,
+      statusIcon: statusIcon,
+      statusTint: statusTint,
+      isStored: isStored,
+      descriptionText: descriptionText,
+      keyFieldLabel: keyFieldLabel,
+      keyBinding: keyBinding,
+      onSave: onSave,
+      onValidate: onValidate,
+      onRemove: onRemove,
+      isSaveDisabled: isSaveDisabled,
+      isValidateDisabled: isValidateDisabled,
+      isRemoveDisabled: isRemoveDisabled,
+      validationState: validationState,
+      saveButtonTitle: saveButtonTitle,
+      saveTooltip: saveTooltip,
+      validateButtonTitle: validateButtonTitle,
+      validateTooltip: validateTooltip,
+      removeButtonTitle: removeButtonTitle,
+      removeTooltip: removeTooltip,
+      link: link,
+      linkLabel: linkLabel,
+      statusLabel: statusLabel
+    )
+
+    return SettingsCard(title: title, systemImage: systemImage, tint: tint) {
       if settings.visualDensity.isCompact {
-        VStack(alignment: .leading, spacing: settings.visualDensity.cardContentSpacing) {
-          HStack(spacing: settings.visualDensity.inlineSpacing) {
-            Label(isStored ? "Saved" : "Not set", systemImage: statusIcon)
-              .font(.caption.weight(.semibold))
-              .foregroundStyle(isStored ? statusTint : Color.secondary)
-
-            if let link, let linkLabel {
-              Link(destination: link) {
-                Label(linkLabel, systemImage: "arrow.up.forward.square")
-                  .labelStyle(.iconOnly)
-              }
-              .speakTooltip("Open \(title)'s site to create or manage your API key in your browser.")
-              .accessibilityLabel(linkLabel)
-            }
-
-            Spacer(minLength: 0)
-          }
-
-          HStack(spacing: settings.visualDensity.inlineSpacing) {
-            SecureField(keyFieldLabel, text: keyBinding)
-              .textContentType(.password)
-              .privacySensitive()
-              .textFieldStyle(.roundedBorder)
-              .speakTooltip("Paste your \(title) key exactly as issued; Speak stores it securely in your Keychain.")
-
-            Button(action: onSave) {
-              if isValidationInFlight(validationState) {
-                ProgressView()
-                  .controlSize(.small)
-              } else {
-                Label(saveButtonTitle, systemImage: "arrow.down.circle")
-                  .labelStyle(.iconOnly)
-              }
-            }
-            .disabled(isSaveDisabled)
-            .buttonStyle(.borderedProminent)
-            .tint(tint)
-            .speakTooltip(saveTooltip)
-            .accessibilityLabel(saveButtonTitle)
-
-            if let onValidate, isStored {
-              Button(action: onValidate) {
-                if isValidationInFlight(validationState) {
-                  ProgressView()
-                    .controlSize(.small)
-                } else {
-                  Label(validateButtonTitle, systemImage: "checkmark.shield")
-                    .labelStyle(.iconOnly)
-                }
-              }
-              .disabled(isValidateDisabled)
-              .buttonStyle(.bordered)
-              .speakTooltip(validateTooltip)
-              .accessibilityLabel(validateButtonTitle)
-            }
-
-            if let onRemove, isStored {
-              Button(role: .destructive, action: onRemove) {
-                Label(removeButtonTitle, systemImage: "trash")
-                  .labelStyle(.iconOnly)
-              }
-              .disabled(isRemoveDisabled)
-              .buttonStyle(.bordered)
-              .speakTooltip(removeTooltip)
-              .accessibilityLabel(removeButtonTitle)
-            }
-          }
-
-          Text(descriptionText)
-            .font(.caption2)
-            .foregroundStyle(.secondary)
-            .lineLimit(2)
-            .speakTooltip(descriptionText)
-
-          validationStatusView(for: validationState)
-          validationDebugDetails(for: validationState)
-        }
+        compactAPIKeyCardBody(configuration)
       } else {
-        VStack(alignment: .leading, spacing: 14) {
-          HStack(alignment: .center, spacing: 12) {
-            Label(statusLabel, systemImage: statusIcon)
-              .foregroundStyle(isStored ? statusTint : Color.secondary)
-              .labelStyle(.titleAndIcon)
-            statusBadge(isStored: isStored, color: statusTint)
-          }
-
-          if let link, let linkLabel {
-            Link(destination: link) {
-              Label(linkLabel, systemImage: "arrow.up.forward.square")
-                .font(.caption)
-            }
-            .speakTooltip("Open \(title)'s site to create or manage your API key in your browser.")
-          }
-
-          SecureField(keyFieldLabel, text: keyBinding)
-            .textContentType(.password)
-            .privacySensitive()
-            .textFieldStyle(.roundedBorder)
-            .speakTooltip("Paste your \(title) key exactly as issued; Speak stores it securely in your Keychain.")
-
-          Text(descriptionText)
-            .font(.caption)
-            .foregroundStyle(.secondary)
-
-          HStack(spacing: 12) {
-            Button(action: onSave) {
-              if isValidationInFlight(validationState) {
-                ProgressView()
-                  .controlSize(.small)
-              } else {
-                Label(saveButtonTitle, systemImage: "arrow.down.circle")
-              }
-            }
-            .disabled(isSaveDisabled)
-            .buttonStyle(.borderedProminent)
-            .tint(tint)
-            .speakTooltip(saveTooltip)
-
-            if let onValidate, isStored {
-              Button(action: onValidate) {
-                if isValidationInFlight(validationState) {
-                  ProgressView()
-                    .controlSize(.small)
-                } else {
-                  Label(validateButtonTitle, systemImage: "checkmark.shield")
-                }
-              }
-              .disabled(isValidateDisabled)
-              .buttonStyle(.bordered)
-              .speakTooltip(validateTooltip)
-            }
-
-            if let onRemove, isStored {
-              Button(removeButtonTitle, role: .destructive, action: onRemove)
-                .disabled(isRemoveDisabled)
-                .speakTooltip(removeTooltip)
-            }
-          }
-
-          validationStatusView(for: validationState)
-          validationDebugDetails(for: validationState)
-        }
+        regularAPIKeyCardBody(configuration)
       }
     }
     .speakTooltip(tooltip)
+  }
+
+  private func compactAPIKeyCardBody(_ configuration: APIKeyCardConfiguration) -> some View {
+    VStack(alignment: .leading, spacing: settings.visualDensity.cardContentSpacing) {
+      compactAPIKeyStatus(configuration)
+
+      HStack(spacing: settings.visualDensity.inlineSpacing) {
+        SecureField(configuration.keyFieldLabel, text: configuration.keyBinding)
+          .textContentType(.password)
+          .privacySensitive()
+          .textFieldStyle(.roundedBorder)
+          .speakTooltip("Paste the key exactly as issued; Speak stores it securely in your Keychain.")
+
+        compactAPIKeySaveButton(configuration)
+        compactAPIKeyValidateButton(configuration)
+        compactAPIKeyRemoveButton(configuration)
+      }
+
+      Text(configuration.descriptionText)
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .lineLimit(2)
+        .speakTooltip(configuration.descriptionText)
+
+      validationStatusView(for: configuration.validationState)
+      validationDebugDetails(for: configuration.validationState)
+    }
+  }
+
+  private func compactAPIKeyStatus(_ configuration: APIKeyCardConfiguration) -> some View {
+    HStack(spacing: settings.visualDensity.inlineSpacing) {
+      Label(
+        configuration.isStored ? "Saved" : "Not set",
+        systemImage: configuration.statusIcon
+      )
+      .font(.caption.weight(.semibold))
+      .foregroundStyle(
+        configuration.isStored ? configuration.statusTint : Color.secondary
+      )
+
+      if let link = configuration.link, let linkLabel = configuration.linkLabel {
+        Link(destination: link) {
+          Label(linkLabel, systemImage: "arrow.up.forward.square")
+            .labelStyle(.iconOnly)
+        }
+        .speakTooltip("Open \(configuration.title)'s site to manage your API key.")
+        .accessibilityLabel(linkLabel)
+      }
+
+      Spacer(minLength: 0)
+    }
+  }
+
+  private func compactAPIKeySaveButton(_ configuration: APIKeyCardConfiguration) -> some View {
+    Button(action: configuration.onSave) {
+      if isValidationInFlight(configuration.validationState) {
+        ProgressView()
+          .controlSize(.small)
+      } else {
+        Label(configuration.saveButtonTitle, systemImage: "arrow.down.circle")
+          .labelStyle(.iconOnly)
+      }
+    }
+    .disabled(configuration.isSaveDisabled)
+    .buttonStyle(.borderedProminent)
+    .tint(configuration.tint)
+    .speakTooltip(configuration.saveTooltip)
+    .accessibilityLabel(configuration.saveButtonTitle)
+  }
+
+  @ViewBuilder
+  private func compactAPIKeyValidateButton(_ configuration: APIKeyCardConfiguration) -> some View {
+    if let onValidate = configuration.onValidate, configuration.isStored {
+      Button(action: onValidate) {
+        if isValidationInFlight(configuration.validationState) {
+          ProgressView()
+            .controlSize(.small)
+        } else {
+          Label(configuration.validateButtonTitle, systemImage: "checkmark.shield")
+            .labelStyle(.iconOnly)
+        }
+      }
+      .disabled(configuration.isValidateDisabled)
+      .buttonStyle(.bordered)
+      .speakTooltip(configuration.validateTooltip)
+      .accessibilityLabel(configuration.validateButtonTitle)
+    }
+  }
+
+  @ViewBuilder
+  private func compactAPIKeyRemoveButton(_ configuration: APIKeyCardConfiguration) -> some View {
+    if let onRemove = configuration.onRemove, configuration.isStored {
+      Button(role: .destructive, action: onRemove) {
+        Label(configuration.removeButtonTitle, systemImage: "trash")
+          .labelStyle(.iconOnly)
+      }
+      .disabled(configuration.isRemoveDisabled)
+      .buttonStyle(.bordered)
+      .speakTooltip(configuration.removeTooltip)
+      .accessibilityLabel(configuration.removeButtonTitle)
+    }
+  }
+
+  private func regularAPIKeyCardBody(_ configuration: APIKeyCardConfiguration) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack(alignment: .center, spacing: 12) {
+        Label(configuration.statusLabel, systemImage: configuration.statusIcon)
+          .foregroundStyle(
+            configuration.isStored ? configuration.statusTint : Color.secondary
+          )
+          .labelStyle(.titleAndIcon)
+        statusBadge(isStored: configuration.isStored, color: configuration.statusTint)
+      }
+
+      if let link = configuration.link, let linkLabel = configuration.linkLabel {
+        Link(destination: link) {
+          Label(linkLabel, systemImage: "arrow.up.forward.square")
+            .font(.caption)
+        }
+        .speakTooltip("Open \(configuration.title)'s site to create or manage your API key.")
+      }
+
+      SecureField(configuration.keyFieldLabel, text: configuration.keyBinding)
+        .textContentType(.password)
+        .privacySensitive()
+        .textFieldStyle(.roundedBorder)
+        .speakTooltip("Paste the key exactly as issued; Speak stores it securely in your Keychain.")
+
+      Text(configuration.descriptionText)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      HStack(spacing: 12) {
+        regularAPIKeySaveButton(configuration)
+        regularAPIKeyValidateButton(configuration)
+        regularAPIKeyRemoveButton(configuration)
+      }
+
+      validationStatusView(for: configuration.validationState)
+      validationDebugDetails(for: configuration.validationState)
+    }
+  }
+
+  private func regularAPIKeySaveButton(_ configuration: APIKeyCardConfiguration) -> some View {
+    Button(action: configuration.onSave) {
+      if isValidationInFlight(configuration.validationState) {
+        ProgressView()
+          .controlSize(.small)
+      } else {
+        Label(configuration.saveButtonTitle, systemImage: "arrow.down.circle")
+      }
+    }
+    .disabled(configuration.isSaveDisabled)
+    .buttonStyle(.borderedProminent)
+    .tint(configuration.tint)
+    .speakTooltip(configuration.saveTooltip)
+  }
+
+  @ViewBuilder
+  private func regularAPIKeyValidateButton(_ configuration: APIKeyCardConfiguration) -> some View {
+    if let onValidate = configuration.onValidate, configuration.isStored {
+      Button(action: onValidate) {
+        if isValidationInFlight(configuration.validationState) {
+          ProgressView()
+            .controlSize(.small)
+        } else {
+          Label(configuration.validateButtonTitle, systemImage: "checkmark.shield")
+        }
+      }
+      .disabled(configuration.isValidateDisabled)
+      .buttonStyle(.bordered)
+      .speakTooltip(configuration.validateTooltip)
+    }
+  }
+
+  @ViewBuilder
+  private func regularAPIKeyRemoveButton(_ configuration: APIKeyCardConfiguration) -> some View {
+    if let onRemove = configuration.onRemove, configuration.isStored {
+      Button(configuration.removeButtonTitle, role: .destructive, action: onRemove)
+        .disabled(configuration.isRemoveDisabled)
+        .speakTooltip(configuration.removeTooltip)
+    }
   }
 
   private struct CloudKitKeySyncSettingsCard: View {
@@ -4638,7 +4736,7 @@ struct SettingsView: View {
   }
 
   private var hotKeySettings: some View {
-    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
+    SpeakDensitySettingsSection(density: settings.visualDensity) {
       SettingsCard(title: "Trigger Key", systemImage: "keyboard", tint: Color.blue) {
         VStack(alignment: .leading, spacing: 12) {
           Text("Choose which key triggers recording.")
@@ -4723,7 +4821,7 @@ struct SettingsView: View {
   }
 
   private var permissionsSettings: some View {
-    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
+    SpeakDensitySettingsSection(density: settings.visualDensity) {
       SettingsCard(title: "System permissions", systemImage: "lock.shield", tint: Color.red) {
         VStack(alignment: .leading, spacing: 12) {
           ForEach(PermissionType.availablePermissions(for: DistributionChannel.current)) { permission in
@@ -4826,7 +4924,7 @@ struct SettingsView: View {
   }
 
   private var aboutSettings: some View {
-    SpeakAdaptiveSettingsLayout(density: settings.visualDensity) {
+    SpeakDensitySettingsSection(density: settings.visualDensity) {
       SettingsCard(title: "Just Speak to It", systemImage: "info.circle", tint: Color.blue) {
         VStack(alignment: .leading, spacing: 16) {
           HStack(alignment: .top, spacing: 16) {

--- a/Sources/SpeakApp/SideBarView.swift
+++ b/Sources/SpeakApp/SideBarView.swift
@@ -209,17 +209,24 @@ struct SideBarView: View {
   @ViewBuilder
   private func shortcutHint(for item: SidebarItem) -> some View {
     let binding = shortcutManager.binding(for: item.shortcutAction)
-    if !settings.visualDensity.isCompact,
-       settings.showSidebarShortcutHints,
+    if settings.showSidebarShortcutHints,
        binding.isEnabled {
       Text(binding.displayString)
-        .font(.caption2.monospaced())
+        .font(
+          settings.visualDensity.isCompact
+            ? .system(size: 9, weight: .medium, design: .monospaced)
+            : .caption2.monospaced()
+        )
         .foregroundStyle(.secondary)
-        .padding(.horizontal, 6)
-        .padding(.vertical, 2)
-        .background(Capsule().fill(Color.secondary.opacity(0.10)))
+        .padding(.horizontal, settings.visualDensity.isCompact ? 0 : 6)
+        .padding(.vertical, settings.visualDensity.isCompact ? 0 : 2)
+        .background {
+          if !settings.visualDensity.isCompact {
+            Capsule().fill(Color.secondary.opacity(0.10))
+          }
+        }
         .minimumScaleFactor(0.8)
-        .layoutPriority(-1)
+        .layoutPriority(settings.visualDensity.isCompact ? 4 : -1)
         .accessibilityHidden(true)
     }
   }

--- a/Sources/SpeakApp/SpeakAdaptiveSettingsLayout.swift
+++ b/Sources/SpeakApp/SpeakAdaptiveSettingsLayout.swift
@@ -1,6 +1,43 @@
 import SpeakCore
 import SwiftUI
 
+/// Preserves lazy single-column rendering in normal density while opting
+/// compact density into the width-aware layout.
+struct SpeakDensitySettingsSection<Content: View>: View {
+  let density: AppVisualDensity
+  let compactMinimumWidth: CGFloat
+  let maximumColumns: Int
+  @ViewBuilder let content: Content
+
+  init(
+    density: AppVisualDensity,
+    compactMinimumWidth: CGFloat = 340,
+    maximumColumns: Int = 3,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.density = density
+    self.compactMinimumWidth = compactMinimumWidth
+    self.maximumColumns = maximumColumns
+    self.content = content()
+  }
+
+  var body: some View {
+    if density.isCompact {
+      SpeakAdaptiveSettingsLayout(
+        density: density,
+        compactMinimumWidth: compactMinimumWidth,
+        maximumColumns: maximumColumns
+      ) {
+        content
+      }
+    } else {
+      LazyVStack(spacing: density.sectionSpacing) {
+        content
+      }
+    }
+  }
+}
+
 /// A single-column settings stack in normal mode and a balanced masonry grid
 /// in compact mode. Unlike `LazyVGrid`, shorter cards do not inherit the height
 /// of the tallest card in their row, so compact mode does not manufacture a
@@ -9,6 +46,11 @@ struct SpeakAdaptiveSettingsLayout: Layout {
   let density: AppVisualDensity
   let compactMinimumWidth: CGFloat
   let maximumColumns: Int
+
+  struct LayoutCache {
+    var width: CGFloat?
+    var measurement: Measurement?
+  }
 
   init(
     density: AppVisualDensity,
@@ -23,10 +65,12 @@ struct SpeakAdaptiveSettingsLayout: Layout {
   func sizeThatFits(
     proposal: ProposedViewSize,
     subviews: Subviews,
-    cache: inout ()
+    cache: inout LayoutCache
   ) -> CGSize {
     let width = resolvedWidth(for: proposal, subviews: subviews)
     let result = measure(width: width, subviews: subviews)
+    cache.width = width
+    cache.measurement = result
     return CGSize(width: width, height: result.height)
   }
 
@@ -34,9 +78,16 @@ struct SpeakAdaptiveSettingsLayout: Layout {
     in bounds: CGRect,
     proposal: ProposedViewSize,
     subviews: Subviews,
-    cache: inout ()
+    cache: inout LayoutCache
   ) {
-    let result = measure(width: bounds.width, subviews: subviews)
+    let result: Measurement
+    if cache.width == bounds.width, let cachedMeasurement = cache.measurement {
+      result = cachedMeasurement
+    } else {
+      result = measure(width: bounds.width, subviews: subviews)
+      cache.width = bounds.width
+      cache.measurement = result
+    }
 
     for (index, subview) in subviews.enumerated() {
       guard result.origins.indices.contains(index) else { continue }
@@ -49,6 +100,14 @@ struct SpeakAdaptiveSettingsLayout: Layout {
         proposal: ProposedViewSize(width: result.columnWidth, height: nil)
       )
     }
+  }
+
+  func makeCache(subviews: Subviews) -> LayoutCache {
+    LayoutCache()
+  }
+
+  func updateCache(_ cache: inout LayoutCache, subviews: Subviews) {
+    cache = LayoutCache()
   }
 
   private func resolvedWidth(for proposal: ProposedViewSize, subviews: Subviews) -> CGFloat {
@@ -106,7 +165,7 @@ struct SpeakAdaptiveSettingsLayout: Layout {
     }?.offset ?? 0
   }
 
-  private struct Measurement {
+  struct Measurement {
     let columnWidth: CGFloat
     let origins: [CGPoint]
     let height: CGFloat

--- a/Sources/SpeakApp/SpeakAdaptiveSettingsLayout.swift
+++ b/Sources/SpeakApp/SpeakAdaptiveSettingsLayout.swift
@@ -1,0 +1,114 @@
+import SpeakCore
+import SwiftUI
+
+/// A single-column settings stack in normal mode and a balanced masonry grid
+/// in compact mode. Unlike `LazyVGrid`, shorter cards do not inherit the height
+/// of the tallest card in their row, so compact mode does not manufacture a
+/// second kind of whitespace while trying to remove the first.
+struct SpeakAdaptiveSettingsLayout: Layout {
+  let density: AppVisualDensity
+  let compactMinimumWidth: CGFloat
+  let maximumColumns: Int
+
+  init(
+    density: AppVisualDensity,
+    compactMinimumWidth: CGFloat = 340,
+    maximumColumns: Int = 3
+  ) {
+    self.density = density
+    self.compactMinimumWidth = compactMinimumWidth
+    self.maximumColumns = maximumColumns
+  }
+
+  func sizeThatFits(
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) -> CGSize {
+    let width = resolvedWidth(for: proposal, subviews: subviews)
+    let result = measure(width: width, subviews: subviews)
+    return CGSize(width: width, height: result.height)
+  }
+
+  func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    let result = measure(width: bounds.width, subviews: subviews)
+
+    for (index, subview) in subviews.enumerated() {
+      guard result.origins.indices.contains(index) else { continue }
+      subview.place(
+        at: CGPoint(
+          x: bounds.minX + result.origins[index].x,
+          y: bounds.minY + result.origins[index].y
+        ),
+        anchor: .topLeading,
+        proposal: ProposedViewSize(width: result.columnWidth, height: nil)
+      )
+    }
+  }
+
+  private func resolvedWidth(for proposal: ProposedViewSize, subviews: Subviews) -> CGFloat {
+    if let proposedWidth = proposal.width, proposedWidth.isFinite {
+      return proposedWidth
+    }
+
+    let idealWidth = subviews
+      .map { $0.sizeThatFits(.unspecified).width }
+      .filter(\.isFinite)
+      .max() ?? compactMinimumWidth
+    return max(compactMinimumWidth, idealWidth)
+  }
+
+  private func measure(width: CGFloat, subviews: Subviews) -> Measurement {
+    guard !subviews.isEmpty else {
+      return Measurement(columnWidth: width, origins: [], height: 0)
+    }
+
+    let spacing = density.sectionSpacing
+    let columnCount = density.adaptiveColumnCount(
+      availableWidth: width,
+      minimumColumnWidth: compactMinimumWidth,
+      maximumColumns: maximumColumns
+    )
+    let totalSpacing = spacing * CGFloat(columnCount - 1)
+    let columnWidth = max(1, (width - totalSpacing) / CGFloat(columnCount))
+    var columnHeights = Array(repeating: CGFloat.zero, count: columnCount)
+    var origins: [CGPoint] = []
+
+    for subview in subviews {
+      let column = shortestColumn(in: columnHeights)
+      let size = subview.sizeThatFits(
+        ProposedViewSize(width: columnWidth, height: nil)
+      )
+      origins.append(
+        CGPoint(
+          x: CGFloat(column) * (columnWidth + spacing),
+          y: columnHeights[column]
+        )
+      )
+      columnHeights[column] += size.height + spacing
+    }
+
+    let height = max(0, (columnHeights.max() ?? spacing) - spacing)
+    return Measurement(columnWidth: columnWidth, origins: origins, height: height)
+  }
+
+  private func shortestColumn(in heights: [CGFloat]) -> Int {
+    heights.enumerated().min { lhs, rhs in
+      if lhs.element == rhs.element {
+        return lhs.offset < rhs.offset
+      }
+      return lhs.element < rhs.element
+    }?.offset ?? 0
+  }
+
+  private struct Measurement {
+    let columnWidth: CGFloat
+    let origins: [CGPoint]
+    let height: CGFloat
+  }
+}

--- a/Sources/SpeakApp/Views/Settings/PronunciationDictionaryView.swift
+++ b/Sources/SpeakApp/Views/Settings/PronunciationDictionaryView.swift
@@ -1,8 +1,13 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+// This view includes the dictionary editor and its import/export form.
+// swiftlint:disable file_length type_body_length
+
 /// View for managing the pronunciation dictionary.
 struct PronunciationDictionaryView: View {
+    @Environment(\.appVisualDensity) private var density
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @EnvironmentObject private var pronunciationManager: PronunciationManager
     @State private var searchText = ""
     @State private var selectedCategory: PronunciationEntry.Category?
@@ -94,58 +99,127 @@ struct PronunciationDictionaryView: View {
     // MARK: - Header
 
     private var headerView: some View {
-        VStack(spacing: 12) {
-            HStack {
-                Text("Pronunciation Dictionary")
-                    .font(.title2.bold())
-                Spacer()
-                HStack(spacing: 8) {
-                    Button {
-                        showingImportSheet = true
-                    } label: {
-                        Label("Import", systemImage: "square.and.arrow.down")
+        Group {
+            if density.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: density.inlineSpacing) {
+                        compactHeaderTitle
+                        searchField
+                        compactHeaderActions
                     }
-                    .buttonStyle(.bordered)
 
-                    Button {
-                        showingExportSheet = true
-                    } label: {
-                        Label("Export", systemImage: "square.and.arrow.up")
+                    VStack(alignment: .leading, spacing: density.inlineSpacing) {
+                        HStack(spacing: density.inlineSpacing) {
+                            compactHeaderTitle
+                            Spacer(minLength: 0)
+                            compactHeaderActions
+                        }
+                        searchField
                     }
-                    .buttonStyle(.bordered)
-                    .disabled(pronunciationManager.entries.isEmpty)
-
-                    Button {
-                        showingAddSheet = true
-                    } label: {
-                        Label("Add", systemImage: "plus")
+                }
+            } else {
+                VStack(spacing: 12) {
+                    HStack {
+                        Text("Pronunciation Dictionary")
+                            .font(.title2.bold())
+                        Spacer()
+                        regularHeaderActions
                     }
-                    .buttonStyle(.borderedProminent)
+                    searchField
                 }
             }
-
-            HStack {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                TextField("Search words or pronunciations...", text: $searchText)
-                    .textFieldStyle(.plain)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(8)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Color(nsColor: .controlBackgroundColor))
-            )
         }
-        .padding()
+        .padding(density.isCompact ? 8 : 16)
+    }
+
+    private var compactHeaderTitle: some View {
+        Label("Dictionary", systemImage: "text.book.closed")
+            .font(.caption.weight(.semibold))
+            .fixedSize()
+    }
+
+    private var searchField: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Search words or pronunciations...", text: $searchText)
+                .textFieldStyle(.plain)
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(density.isCompact ? 5 : 8)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+    }
+
+    private var compactHeaderActions: some View {
+        HStack(spacing: density.inlineSpacing) {
+            Button {
+                showingImportSheet = true
+            } label: {
+                Label("Import", systemImage: "square.and.arrow.down")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.bordered)
+            .speakTooltip("Import pronunciation entries.")
+
+            Button {
+                showingExportSheet = true
+            } label: {
+                Label("Export", systemImage: "square.and.arrow.up")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.bordered)
+            .disabled(pronunciationManager.entries.isEmpty)
+            .speakTooltip("Export pronunciation entries.")
+
+            Button {
+                showingAddSheet = true
+            } label: {
+                Label("Add", systemImage: "plus")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderedProminent)
+            .speakTooltip("Add a pronunciation entry.")
+        }
+        .fixedSize()
+    }
+
+    private var regularHeaderActions: some View {
+        HStack(spacing: 8) {
+            Button {
+                showingImportSheet = true
+            } label: {
+                Label("Import", systemImage: "square.and.arrow.down")
+            }
+            .buttonStyle(.bordered)
+
+            Button {
+                showingExportSheet = true
+            } label: {
+                Label("Export", systemImage: "square.and.arrow.up")
+            }
+            .buttonStyle(.bordered)
+            .disabled(pronunciationManager.entries.isEmpty)
+
+            Button {
+                showingAddSheet = true
+            } label: {
+                Label("Add", systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+        }
     }
 
     // MARK: - Category Tabs
@@ -175,8 +249,8 @@ struct PronunciationDictionaryView: View {
                     }
                 }
             }
-            .padding(.horizontal)
-            .padding(.vertical, 8)
+            .padding(.horizontal, density.isCompact ? 8 : 16)
+            .padding(.vertical, density.isCompact ? 4 : 8)
         }
         .background(Color(nsColor: .windowBackgroundColor))
     }
@@ -184,7 +258,11 @@ struct PronunciationDictionaryView: View {
     // MARK: - Entries List
 
     private var entriesListView: some View {
-        List {
+        LazyVGrid(
+            columns: entryColumns,
+            alignment: .leading,
+            spacing: density.isCompact ? density.sectionSpacing : 8
+        ) {
             ForEach(filteredEntries) { entry in
                 PronunciationEntryRow(entry: entry)
                     .contentShape(Rectangle())
@@ -204,25 +282,23 @@ struct PronunciationDictionaryView: View {
                             Label("Delete", systemImage: "trash")
                         }
                     }
-                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        Button(role: .destructive) {
-                            pronunciationManager.deleteEntry(entry)
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
-                    }
-                    .swipeActions(edge: .leading) {
-                        Button {
-                            editingEntry = entry
-                        } label: {
-                            Label("Edit", systemImage: "pencil")
-                        }
-                        .tint(.accentColor)
-                    }
             }
         }
-        .listStyle(.inset)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, density.isCompact ? 8 : 16)
+        .padding(.bottom, density.isCompact ? 8 : 16)
+    }
+
+    private var entryColumns: [GridItem] {
+        if density.isCompact {
+            return [
+                GridItem(
+                    .adaptive(minimum: 260, maximum: 380),
+                    spacing: density.sectionSpacing,
+                    alignment: .top
+                )
+            ]
+        }
+        return [GridItem(.flexible(), alignment: .top)]
     }
 
     // MARK: - Empty State
@@ -265,7 +341,8 @@ struct PronunciationDictionaryView: View {
                 .buttonStyle(.bordered)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity)
+        .frame(minHeight: 260)
         .padding()
     }
 
@@ -301,9 +378,12 @@ struct PronunciationDictionaryView: View {
     }
 }
 
+// swiftlint:enable type_body_length
+
 // MARK: - Category Tab
 
 private struct CategoryTab: View {
+    @Environment(\.appVisualDensity) private var density
     let title: String
     let count: Int
     var systemImage: String?
@@ -318,18 +398,22 @@ private struct CategoryTab: View {
                         .imageScale(.small)
                 }
                 Text(title)
-                    .font(.subheadline.weight(isSelected ? .semibold : .regular))
+                    .font(
+                        density.isCompact
+                            ? .caption2.weight(isSelected ? .semibold : .regular)
+                            : .subheadline.weight(isSelected ? .semibold : .regular)
+                    )
                 Text("\(count)")
-                    .font(.caption)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
+                    .font(density.isCompact ? .caption2 : .caption)
+                    .padding(.horizontal, density.isCompact ? 4 : 6)
+                    .padding(.vertical, density.isCompact ? 1 : 2)
                     .background(
                         Capsule()
                             .fill(isSelected ? Color.white.opacity(0.2) : Color.secondary.opacity(0.15))
                     )
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+            .padding(.horizontal, density.isCompact ? 7 : 12)
+            .padding(.vertical, density.isCompact ? 3 : 6)
             .background(
                 Capsule()
                     .fill(isSelected ? Color.accentColor : Color.clear)
@@ -343,14 +427,16 @@ private struct CategoryTab: View {
 // MARK: - Entry Row
 
 private struct PronunciationEntryRow: View {
+    @Environment(\.appVisualDensity) private var density
     let entry: PronunciationEntry
 
     var body: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: density.isCompact ? density.inlineSpacing : 12) {
+            VStack(alignment: .leading, spacing: density.isCompact ? 2 : 4) {
                 HStack(spacing: 8) {
                     Text(entry.word)
-                        .font(.headline)
+                        .font(density.isCompact ? .caption.weight(.semibold) : .headline)
+                        .lineLimit(1)
 
                     if entry.isRegex {
                         Text("REGEX")
@@ -382,8 +468,9 @@ private struct PronunciationEntryRow: View {
                         .imageScale(.small)
                         .foregroundStyle(.tertiary)
                     Text(entry.pronunciation)
-                        .font(.subheadline)
+                        .font(density.isCompact ? .caption2 : .subheadline)
                         .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
             }
 
@@ -405,7 +492,12 @@ private struct PronunciationEntryRow: View {
                 .imageScale(.small)
                 .foregroundStyle(.tertiary)
         }
-        .padding(.vertical, 4)
+        .padding(density.isCompact ? 7 : 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Color(nsColor: .controlBackgroundColor).opacity(density.isCompact ? 0.7 : 1),
+            in: RoundedRectangle(cornerRadius: density.isCompact ? 8 : 10, style: .continuous)
+        )
     }
 }
 
@@ -622,3 +714,5 @@ struct PronunciationDocument: FileDocument {
         return FileWrapper(regularFileWithContents: data)
     }
 }
+
+// swiftlint:enable file_length

--- a/Sources/SpeakApp/Views/Settings/PronunciationDictionaryView.swift
+++ b/Sources/SpeakApp/Views/Settings/PronunciationDictionaryView.swift
@@ -156,7 +156,7 @@ struct PronunciationDictionaryView: View {
             }
         }
         .padding(density.isCompact ? 5 : 8)
-        .frame(maxWidth: .infinity)
+        .frame(minWidth: density.isCompact ? 220 : nil, maxWidth: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(Color(nsColor: .controlBackgroundColor))
@@ -470,7 +470,7 @@ private struct PronunciationEntryRow: View {
                     Text(entry.pronunciation)
                         .font(density.isCompact ? .caption2 : .subheadline)
                         .foregroundStyle(.secondary)
-                        .lineLimit(1)
+                        .lineLimit(density.isCompact ? 1 : nil)
                 }
             }
 

--- a/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
@@ -6,7 +6,7 @@ struct ShortcutsSettingsView: View {
     @ObservedObject var shortcutManager: ShortcutManager
 
     var body: some View {
-        SpeakAdaptiveSettingsLayout(
+        SpeakDensitySettingsSection(
             density: density,
             compactMinimumWidth: 460,
             maximumColumns: 2
@@ -102,6 +102,7 @@ struct ShortcutsSettingsView: View {
                     .labelsHidden()
                     .toggleStyle(.switch)
                     .controlSize(.mini)
+                    .accessibilityLabel("Enable \(action.displayName) shortcut")
 
                     Text(action.displayName)
                         .font(.caption)
@@ -149,6 +150,7 @@ struct ShortcutsSettingsView: View {
                 .labelsHidden()
                 .toggleStyle(.switch)
                 .controlSize(.small)
+                .accessibilityLabel("Enable \(action.displayName) shortcut")
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(action.displayName)

--- a/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
@@ -2,34 +2,40 @@ import SwiftUI
 
 /// Settings view for configuring keyboard shortcuts.
 struct ShortcutsSettingsView: View {
-    @EnvironmentObject private var environment: AppEnvironment
+    @Environment(\.appVisualDensity) private var density
     @ObservedObject var shortcutManager: ShortcutManager
 
-    @State private var selectedAction: ShortcutAction?
-
     var body: some View {
-        LazyVStack(spacing: 20) {
+        SpeakAdaptiveSettingsLayout(
+            density: density,
+            compactMinimumWidth: 460,
+            maximumColumns: 2
+        ) {
             ShortcutSettingsCard(title: "Global Shortcuts", systemImage: "globe", tint: .brandLagoon) {
-                VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: density.cardContentSpacing) {
                     Text("These shortcuts work system-wide, even when Speak is not focused.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    ForEach(ShortcutAction.allCases.filter { $0.isGlobalByDefault }) { action in
-                        shortcutRow(for: action)
+                    LazyVGrid(columns: shortcutColumns, alignment: .leading, spacing: density.inlineSpacing) {
+                        ForEach(ShortcutAction.allCases.filter { $0.isGlobalByDefault }) { action in
+                            shortcutRow(for: action)
+                        }
                     }
                 }
             }
             .speakTooltip("Configure shortcuts that work anywhere in macOS.")
 
             ShortcutSettingsCard(title: "App Shortcuts", systemImage: "app.badge", tint: .brandAccentWarm) {
-                VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: density.cardContentSpacing) {
                     Text("These shortcuts only work when Speak is the active app.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    ForEach(ShortcutAction.allCases.filter { !$0.isGlobalByDefault }) { action in
-                        shortcutRow(for: action)
+                    LazyVGrid(columns: shortcutColumns, alignment: .leading, spacing: density.inlineSpacing) {
+                        ForEach(ShortcutAction.allCases.filter { !$0.isGlobalByDefault }) { action in
+                            shortcutRow(for: action)
+                        }
                     }
                 }
             }
@@ -67,76 +73,147 @@ struct ShortcutsSettingsView: View {
         }
     }
 
+    private var shortcutColumns: [GridItem] {
+        if density.isCompact {
+            return [
+                GridItem(
+                    .adaptive(minimum: 220, maximum: 320),
+                    spacing: density.inlineSpacing,
+                    alignment: .top
+                )
+            ]
+        }
+        return [GridItem(.flexible(), alignment: .top)]
+    }
+
     @ViewBuilder
     // swiftlint:disable:next function_body_length
     private func shortcutRow(for action: ShortcutAction) -> some View {
         let binding = shortcutManager.binding(for: action)
         let isRecording = shortcutManager.isRecordingShortcut && shortcutManager.recordingAction == action
 
-        HStack(spacing: 12) {
-            Toggle("", isOn: Binding(
-                get: { binding.isEnabled },
-                set: { shortcutManager.setEnabled($0, for: action) }
-            ))
-            .labelsHidden()
-            .toggleStyle(.switch)
-            .controlSize(.small)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(action.displayName)
-                    .font(.subheadline)
-                    .foregroundStyle(binding.isEnabled ? .primary : .secondary)
-
-                if action.isGlobalByDefault {
-                    Toggle("Global", isOn: Binding(
-                        get: { binding.isGlobal },
-                        set: { shortcutManager.setGlobal($0, for: action) }
+        if density.isCompact {
+            VStack(alignment: .leading, spacing: density.inlineSpacing) {
+                HStack(spacing: density.inlineSpacing) {
+                    Toggle("", isOn: Binding(
+                        get: { binding.isEnabled },
+                        set: { shortcutManager.setEnabled($0, for: action) }
                     ))
+                    .labelsHidden()
                     .toggleStyle(.switch)
                     .controlSize(.mini)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                }
-            }
 
-            Spacer()
+                    Text(action.displayName)
+                        .font(.caption)
+                        .foregroundStyle(binding.isEnabled ? .primary : .secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
 
-            Button {
-                if isRecording {
-                    shortcutManager.stopRecording()
-                } else {
-                    shortcutManager.startRecording(for: action)
-                }
-            } label: {
-                if isRecording {
-                    HStack(spacing: 4) {
-                        Image(systemName: "keyboard")
-                        Text("Press keys...")
+                    Spacer(minLength: 0)
+
+                    if action.isGlobalByDefault {
+                        Button {
+                            shortcutManager.setGlobal(!binding.isGlobal, for: action)
+                        } label: {
+                            Image(systemName: binding.isGlobal ? "globe.americas.fill" : "globe.americas")
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(binding.isGlobal ? Color.brandLagoon : .secondary)
+                        .speakTooltip(binding.isGlobal ? "Make this shortcut app-only." : "Make this shortcut global.")
+                        .accessibilityLabel(binding.isGlobal ? "Global shortcut" : "App-only shortcut")
                     }
-                    .font(.caption)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Color.accentColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 6))
-                } else {
-                    Text(binding.displayString)
-                        .font(.system(.caption, design: .monospaced))
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Color.secondary.opacity(0.15), in: RoundedRectangle(cornerRadius: 6))
+
+                    shortcutRecorder(for: action, binding: binding, isRecording: isRecording)
+                }
+
+                if isRecording, let recordingError = shortcutManager.recordingError {
+                    Label(recordingError, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .buttonStyle(.plain)
-            .speakTooltip("Click to record a new shortcut for this action.")
-        }
-        .padding(.vertical, 4)
-        .opacity(binding.isEnabled ? 1.0 : 0.6)
+            .padding(6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                Color.secondary.opacity(0.07),
+                in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+            )
+            .opacity(binding.isEnabled ? 1.0 : 0.6)
+        } else {
+            HStack(spacing: 12) {
+                Toggle("", isOn: Binding(
+                    get: { binding.isEnabled },
+                    set: { shortcutManager.setEnabled($0, for: action) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
 
-        if isRecording, let recordingError = shortcutManager.recordingError {
-            Label(recordingError, systemImage: "exclamationmark.triangle.fill")
-                .font(.caption)
-                .foregroundStyle(.red)
-                .fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(action.displayName)
+                        .font(.subheadline)
+                        .foregroundStyle(binding.isEnabled ? .primary : .secondary)
+
+                    if action.isGlobalByDefault {
+                        Toggle("Global", isOn: Binding(
+                            get: { binding.isGlobal },
+                            set: { shortcutManager.setGlobal($0, for: action) }
+                        ))
+                        .toggleStyle(.switch)
+                        .controlSize(.mini)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                shortcutRecorder(for: action, binding: binding, isRecording: isRecording)
+            }
+            .padding(.vertical, 4)
+            .opacity(binding.isEnabled ? 1.0 : 0.6)
+
+            if isRecording, let recordingError = shortcutManager.recordingError {
+                Label(recordingError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
+    }
+
+    private func shortcutRecorder(
+        for action: ShortcutAction,
+        binding: KeyBinding,
+        isRecording: Bool
+    ) -> some View {
+        Button {
+            if isRecording {
+                shortcutManager.stopRecording()
+            } else {
+                shortcutManager.startRecording(for: action)
+            }
+        } label: {
+            if isRecording {
+                HStack(spacing: 4) {
+                    Image(systemName: "keyboard")
+                    Text("Press keys...")
+                }
+                .font(.caption)
+                .padding(.horizontal, density.isCompact ? 5 : 8)
+                .padding(.vertical, density.isCompact ? 2 : 4)
+                .background(Color.accentColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 6))
+            } else {
+                Text(binding.displayString)
+                    .font(.system(.caption, design: .monospaced))
+                    .padding(.horizontal, density.isCompact ? 5 : 8)
+                    .padding(.vertical, density.isCompact ? 2 : 4)
+                    .background(Color.secondary.opacity(0.15), in: RoundedRectangle(cornerRadius: 6))
+            }
+        }
+        .buttonStyle(.plain)
+        .speakTooltip("Click to record a new shortcut for this action.")
     }
 }
 
@@ -148,33 +225,13 @@ private struct ShortcutSettingsCard<Content: View>: View {
     @ViewBuilder let content: Content
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            HStack(spacing: 14) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(tint.opacity(0.15))
-                        .frame(width: 44, height: 44)
-                    Image(systemName: systemImage)
-                        .foregroundStyle(tint)
-                        .font(.system(size: 20, weight: .semibold))
-                }
-
-                Text(title)
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                Spacer()
-            }
-
+        SpeakDensityCard(
+            title: title,
+            systemImage: systemImage,
+            tint: tint,
+            regularCornerRadius: 26
+        ) {
             content
         }
-        .padding(24)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 26, style: .continuous)
-                .stroke(tint.opacity(0.12), lineWidth: 1)
-                .allowsHitTesting(false)
-        )
-        .shadow(color: tint.opacity(0.08), radius: 18, x: 0, y: 12)
     }
 }

--- a/Sources/SpeakCore/AppVisualDensity.swift
+++ b/Sources/SpeakCore/AppVisualDensity.swift
@@ -43,6 +43,8 @@ public enum AppVisualDensity: String, CaseIterable, Identifiable, Sendable {
 
         let safeMaximum = max(1, maximumColumns)
         let safeMinimum = max(1, minimumColumnWidth)
+        if availableWidth.isNaN { return 1 }
+        guard availableWidth.isFinite else { return safeMaximum }
         let safeWidth = max(0, availableWidth)
         let count = Int((safeWidth + sectionSpacing) / (safeMinimum + sectionSpacing))
         return min(safeMaximum, max(1, count))

--- a/Sources/SpeakCore/AppVisualDensity.swift
+++ b/Sources/SpeakCore/AppVisualDensity.swift
@@ -31,6 +31,23 @@ public enum AppVisualDensity: String, CaseIterable, Identifiable, Sendable {
     public var gridMinimumWidth: CGFloat { isCompact ? 240 : 340 }
     public var chartHeight: CGFloat { isCompact ? 132 : 200 }
 
+    /// Returns the number of columns that can usefully fit in a settings canvas.
+    /// Normal mode deliberately remains single-column; compact mode turns spare
+    /// horizontal space into additional information density.
+    public func adaptiveColumnCount(
+        availableWidth: CGFloat,
+        minimumColumnWidth: CGFloat = 340,
+        maximumColumns: Int = 3
+    ) -> Int {
+        guard isCompact else { return 1 }
+
+        let safeMaximum = max(1, maximumColumns)
+        let safeMinimum = max(1, minimumColumnWidth)
+        let safeWidth = max(0, availableWidth)
+        let count = Int((safeWidth + sectionSpacing) / (safeMinimum + sectionSpacing))
+        return min(safeMaximum, max(1, count))
+    }
+
     public var minimumListRowHeight: CGFloat {
         #if os(iOS)
         // Compact iOS rows remove internal whitespace but retain Apple's

--- a/Tests/SpeakAppTests/PronunciationManagerTests.swift
+++ b/Tests/SpeakAppTests/PronunciationManagerTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import SpeakApp
+
+@MainActor
+final class PronunciationManagerTests: XCTestCase {
+  private var suiteName = ""
+  private var defaults: UserDefaults!
+
+  override func setUp() {
+    super.setUp()
+    suiteName = "PronunciationManagerTests.\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)
+    defaults.removePersistentDomain(forName: suiteName)
+  }
+
+  override func tearDown() {
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults = nil
+    suiteName = ""
+    super.tearDown()
+  }
+
+  func testFreshStore_exposesAllDefaultEntries() {
+    let manager = PronunciationManager(defaults: defaults)
+
+    XCTAssertEqual(manager.entries.count, PronunciationEntry.defaultEntries.count)
+    XCTAssertFalse(manager.entries.isEmpty)
+  }
+
+  func testSearchAndCategoryFiltering_keepVisibleEntriesAvailable() {
+    let manager = PronunciationManager(defaults: defaults)
+
+    XCTAssertTrue(manager.search("API").contains { $0.word == "API" })
+    XCTAssertTrue(
+      manager.entries(for: .technical).allSatisfy {
+        $0.category == PronunciationEntry.Category.technical.rawValue
+      }
+    )
+  }
+}

--- a/Tests/SpeakAppTests/PronunciationManagerTests.swift
+++ b/Tests/SpeakAppTests/PronunciationManagerTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import SpeakApp
 
-@MainActor
 final class PronunciationManagerTests: XCTestCase {
   private var suiteName = ""
   private var defaults: UserDefaults!
@@ -20,6 +19,7 @@ final class PronunciationManagerTests: XCTestCase {
     super.tearDown()
   }
 
+  @MainActor
   func testFreshStore_exposesAllDefaultEntries() {
     let manager = PronunciationManager(defaults: defaults)
 
@@ -27,12 +27,15 @@ final class PronunciationManagerTests: XCTestCase {
     XCTAssertFalse(manager.entries.isEmpty)
   }
 
+  @MainActor
   func testSearchAndCategoryFiltering_keepVisibleEntriesAvailable() {
     let manager = PronunciationManager(defaults: defaults)
+    let technicalEntries = manager.entries(for: .technical)
 
     XCTAssertTrue(manager.search("API").contains { $0.word == "API" })
+    XCTAssertFalse(technicalEntries.isEmpty)
     XCTAssertTrue(
-      manager.entries(for: .technical).allSatisfy {
+      technicalEntries.allSatisfy {
         $0.category == PronunciationEntry.Category.technical.rawValue
       }
     )

--- a/Tests/SpeakCoreTests/AppVisualDensityTests.swift
+++ b/Tests/SpeakCoreTests/AppVisualDensityTests.swift
@@ -32,4 +32,30 @@ final class AppVisualDensityTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(AppVisualDensity.compact.minimumListRowHeight, 28)
         #endif
     }
+
+    func testAdaptiveColumnCount_usesWidthOnlyInCompactMode() {
+        XCTAssertEqual(
+            AppVisualDensity.normal.adaptiveColumnCount(availableWidth: 1_100),
+            1
+        )
+        XCTAssertEqual(
+            AppVisualDensity.compact.adaptiveColumnCount(availableWidth: 320),
+            1
+        )
+        XCTAssertEqual(
+            AppVisualDensity.compact.adaptiveColumnCount(availableWidth: 700),
+            2
+        )
+        XCTAssertEqual(
+            AppVisualDensity.compact.adaptiveColumnCount(availableWidth: 1_100),
+            3
+        )
+        XCTAssertEqual(
+            AppVisualDensity.compact.adaptiveColumnCount(
+                availableWidth: 2_000,
+                maximumColumns: 2
+            ),
+            2
+        )
+    }
 }

--- a/Tests/SpeakCoreTests/AppVisualDensityTests.swift
+++ b/Tests/SpeakCoreTests/AppVisualDensityTests.swift
@@ -57,5 +57,16 @@ final class AppVisualDensityTests: XCTestCase {
             ),
             2
         )
+        XCTAssertEqual(
+            AppVisualDensity.compact.adaptiveColumnCount(
+                availableWidth: .infinity,
+                maximumColumns: 2
+            ),
+            2
+        )
+        XCTAssertEqual(
+            AppVisualDensity.compact.adaptiveColumnCount(availableWidth: .nan),
+            1
+        )
     }
 }


### PR DESCRIPTION
## Summary

- make compact macOS settings use a balanced 1–3 column layout based on available width while preserving normal mode as a single column
- place API-key status, fields, links, and actions inline; render app shortcuts as adaptive tiles; restore compact sidebar shortcut hints
- remove the low-information compact toolbar status ornament
- fix Pronunciation Dictionary entries disappearing inside the settings scroll view and present them as an adaptive compact grid

## Verification

- `swift test --filter 'AppVisualDensityTests|PronunciationManagerTests'`
- `swift package --disable-dependency-cache plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json`
- `swift build -c release --product SpeakApp`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings screens now adapt fluidly to compact and regular visual densities, including multi-column layouts.
  * API key, shortcut, and pronunciation dictionary views have improved compact layouts and controls.
  * Pronunciation dictionary entries now support grid presentation and context-menu actions.
  * Sidebar shortcut hints remain available in compact mode with optimized styling.
  * Removed the compact toolbar status indicator for a cleaner interface.

* **Tests**
  * Added coverage for pronunciation dictionary behavior and adaptive column sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->