### PR TITLE
feat: [mac][ios] add GPT transcription models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,13 @@ public final class iOSLiveTranscriber: ObservableObject { ... }
 - Keep macOS and iOS OpenAI Realtime wiring in sync when changing endpoint shape, event names, payload fields, or stop/finalisation sequencing.
 
 ### Prompt semantics
-- `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support the Realtime transcription `prompt`; `gpt-realtime-whisper` and `whisper-1` reject it.
+- `gpt-live-transcribe`, `gpt-transcribe`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe`
+  support the Realtime transcription `prompt`; `gpt-realtime-whisper` and `whisper-1` reject it.
+- `gpt-live-transcribe` and `gpt-transcribe` use plural `languages` hints; existing
+  GPT-4o and Whisper integrations use the singular `language` field.
+- Use `gpt-live-transcribe` for low-latency live deltas and `gpt-transcribe` for
+  completed recordings. Although `gpt-transcribe` can run in Realtime after a
+  committed turn, do not present it as a live-delta model.
 - Treat the OpenAI transcription `prompt` as vocabulary/keyterm biasing, not a custom formatting or tone prompt. Keep tone/style changes in post-processing.
 
 ## Accessibility Text Insertion

--- a/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
@@ -101,9 +101,9 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
       currentOnError()?(OpenAIRealtimeError.invalidURL)
       return
     }
-    // All GA transcription models — gpt-realtime-whisper, whisper-1,
-    // gpt-4o-transcribe, gpt-4o-mini-transcribe — use the same
-    // `?intent=transcription` URL with a unified `session.update` payload.
+    // All GA transcription models — including gpt-live-transcribe,
+    // gpt-realtime-whisper and the GPT-4o transcription family — use the
+    // same `?intent=transcription` URL with a unified `session.update` payload.
     // The legacy `?model=<name>` URL creates a realtime *conversation*
     // session and rejects transcription session.updates with
     // `invalid_parameter: Passing a transcription session update event to
@@ -242,33 +242,15 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
     let task = withStateLock { webSocketTask }
     guard let task else { return }
 
-    var transcription: [String: Any] = ["model": model]
-    if let language, !language.isEmpty {
-      transcription["language"] = language
-    }
-    if let prompt, !prompt.isEmpty, OpenAIRealtimeLiveTranscriber.modelSupportsPrompt(model) {
-      transcription["prompt"] = prompt
-    }
-
-    let payload: [String: Any] = [
-      // Unified GA shape for all transcription models. The legacy
-      // `transcription_session.update` event was removed during GA.
-      // Transcription config nests under `session.audio.input.transcription`.
-      // `turn_detection: null` keeps the session push-to-talk so we control
-      // commit boundaries.
-      "type": "session.update",
-      "session": [
-        "type": "transcription",
-        "audio": [
-          "input": [
-            "format": ["type": "audio/pcm", "rate": sampleRate],
-            "transcription": transcription,
-            "noise_reduction": ["type": "near_field"],
-            "turn_detection": NSNull()
-          ]
-        ]
-      ]
-    ]
+    // Unified GA shape for all transcription models. The shared builder keeps
+    // macOS and iOS aligned while handling gpt-live-transcribe's plural
+    // `languages` field and the older models' singular `language` field.
+    let payload = OpenAITranscriptionModels.realtimeSessionUpdatePayload(
+      model: model,
+      language: language,
+      prompt: prompt,
+      sampleRate: sampleRate
+    )
 
     guard let data = try? JSONSerialization.data(withJSONObject: payload),
       let json = String(data: data, encoding: .utf8)
@@ -555,20 +537,7 @@ struct OpenAIRealtimeTranscriptionProvider {
   /// Translates an `openai/...-streaming` model id into the bare model name
   /// expected by the Realtime API.
   static func realtimeModelName(from catalogID: String) -> String {
-    let suffix = catalogID.split(separator: "/").last.map(String.init) ?? catalogID
-    return suffix.replacingOccurrences(of: "-streaming", with: "")
-  }
-}
-
-extension OpenAIRealtimeLiveTranscriber {
-  /// OpenAI Realtime only accepts `input_audio_transcription.prompt` for the
-  /// GPT-4o transcription models. `gpt-realtime-whisper` (Whisper-1) rejects
-  /// the parameter with `invalid_value`. Returning false here means the
-  /// provider silently drops the prompt for unsupported models rather than
-  /// failing the whole session.
-  static func modelSupportsPrompt(_ realtimeModel: String) -> Bool {
-    let name = realtimeModel.lowercased()
-    return name.hasPrefix("gpt-4o-transcribe") || name.hasPrefix("gpt-4o-mini-transcribe")
+    OpenAITranscriptionModels.apiModelName(from: catalogID)
   }
 }
 

--- a/Sources/SpeakApp/OpenAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAITranscriptionProvider.swift
@@ -52,9 +52,15 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
     }
 
     if let language {
-      // OpenAI expects ISO-639-1 (2-letter code), not full locale (e.g., "en" not "en_GB")
+      // OpenAI expects ISO-639-1 (2-letter code), not full locale (e.g., "en" not "en_GB").
+      // The new GPT Transcribe family accepts plural language hints while
+      // existing GPT-4o and Whisper models retain the singular field.
       let languageCode = extractLanguageCode(from: language)
-      body.appendFormField(named: "language", value: languageCode, boundary: boundary)
+      body.appendFormField(
+        named: OpenAITranscriptionModels.batchLanguageFieldName(for: modelName),
+        value: languageCode,
+        boundary: boundary
+      )
     }
 
     body.appendFileField(
@@ -129,6 +135,11 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
         id: "openai/whisper-1",
         displayName: "Whisper",
         description: "OpenAI's speech recognition model. Fast and accurate."
+      ),
+      ModelCatalog.Option(
+        id: OpenAITranscriptionModels.gptTranscribeCatalogID,
+        displayName: "GPT Transcribe",
+        description: "Recommended high-accuracy model for recorded speech and multilingual audio."
       ),
       ModelCatalog.Option(
         id: "openai/gpt-4o-mini-transcribe",

--- a/Sources/SpeakApp/OpenAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAITranscriptionProvider.swift
@@ -52,15 +52,15 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
     }
 
     if let language {
-      // OpenAI expects ISO-639-1 (2-letter code), not full locale (e.g., "en" not "en_GB").
-      // The new GPT Transcribe family accepts plural language hints while
-      // existing GPT-4o and Whisper models retain the singular field.
-      let languageCode = extractLanguageCode(from: language)
-      body.appendFormField(
-        named: OpenAITranscriptionModels.batchLanguageFieldName(for: modelName),
-        value: languageCode,
-        boundary: boundary
-      )
+        // OpenAI expects ISO-639-1 (2-letter code), not full locale (e.g., "en" not "en_GB").
+        // The new GPT Transcribe family accepts plural language hints while
+        // existing GPT-4o and Whisper models retain the singular field.
+        let languageCode = extractLanguageCode(from: language)
+        body.appendFormField(
+            named: OpenAITranscriptionModels.batchLanguageFieldName(for: modelName),
+            value: languageCode,
+            boundary: boundary
+        )
     }
 
     body.appendFileField(
@@ -130,33 +130,9 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
   }
 
   func supportedModels() -> [ModelCatalog.Option] {
-    [
-      ModelCatalog.Option(
-        id: "openai/whisper-1",
-        displayName: "Whisper",
-        description: "OpenAI's speech recognition model. Fast and accurate."
-      ),
-      ModelCatalog.Option(
-        id: OpenAITranscriptionModels.gptTranscribeCatalogID,
-        displayName: "GPT Transcribe",
-        description: "Recommended high-accuracy model for recorded speech and multilingual audio."
-      ),
-      ModelCatalog.Option(
-        id: "openai/gpt-4o-mini-transcribe",
-        displayName: "GPT-4o mini Transcribe",
-        description: "Fast, low-cost transcription model with improved accuracy vs Whisper-1."
-      ),
-      ModelCatalog.Option(
-        id: "openai/gpt-4o-transcribe",
-        displayName: "GPT-4o Transcribe",
-        description: "Flagship transcription model with strong accuracy on noisy, accented audio."
-      ),
-      ModelCatalog.Option(
-        id: "openai/gpt-4o-transcribe-diarize",
-        displayName: "GPT-4o Transcribe Diarize",
-        description: "Speaker-aware GPT-4o transcription model with diarized JSON segments."
-      )
-    ]
+    ModelCatalog.batchTranscription.filter {
+        OpenAITranscriptionModels.directBatchModelIDs.contains($0.id)
+    }
   }
 
   private func responseFormat(for modelName: String) -> String {

--- a/Sources/SpeakCore/LiveModelCapabilities.swift
+++ b/Sources/SpeakCore/LiveModelCapabilities.swift
@@ -116,6 +116,13 @@ extension ModelCatalog {
             postStopFinalizeBudget: 0.5
         ),
 
+        // OpenAI's recommended live transcription model emits low-latency
+        // deltas and a completed event for each committed audio item.
+        OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID: LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish],
+            postStopFinalizeBudget: 0.5
+        ),
+
         // OpenAI gpt-4o-mini-transcribe / gpt-4o-transcribe over the
         // Realtime API: same WebSocket transport and event shape as
         // gpt-realtime-whisper, with the added benefit of supporting the

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -171,6 +171,13 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
                 + "ElevenLabs API key — the key must have speech-to-text (Scribe) access.",
             estimatedLatencyMs: 200, latencyTier: .fast),
         Option(
+            id: OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID,
+            displayName: "OpenAI GPT Live Transcribe (Streaming)",
+            description: "OpenAI's recommended low-latency speech-to-text model with live transcript "
+                + "deltas and multilingual context hints. Reuses your OpenAI API key.",
+            latencyTier: .fast,
+            tags: [.fast, .leading]),
+        Option(
             id: "openai/gpt-realtime-whisper-streaming",
             displayName: "OpenAI GPT Realtime Whisper (Streaming)",
             description: "OpenAI's gpt-realtime-whisper — low-latency streaming transcription with "
@@ -193,6 +200,13 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
 
     public static let batchTranscription: [Option] = appleBatchTranscriptionOptions + [
         // Dedicated transcription providers (OpenAI, Rev.ai, etc.)
+        Option(
+            id: OpenAITranscriptionModels.gptTranscribeCatalogID,
+            displayName: "GPT Transcribe (OpenAI)",
+            description: "OpenAI's recommended high-accuracy model for recorded speech, with multilingual "
+                + "and domain-context support.",
+            latencyTier: .fast,
+            tags: [.quality, .leading]),
         Option(
             id: "openai/whisper-1", displayName: "Whisper (OpenAI)",
             description: "OpenAI's speech recognition model. Fast and accurate.",

--- a/Sources/SpeakCore/ModelCredentialRequirement.swift
+++ b/Sources/SpeakCore/ModelCredentialRequirement.swift
@@ -81,7 +81,7 @@ public enum ModelCredentialResolver {
         // These models use OpenAI's own audio transcription endpoint. Other
         // OpenAI-prefixed audio models in the batch catalogue are OpenRouter
         // models, so an identifier prefix alone is not sufficient here.
-        if openAIBatchModelIdentifiers.contains(modelIdentifier) {
+        if OpenAITranscriptionModels.directBatchModelIDs.contains(modelIdentifier) {
             return .apiKey(identifier: "openai.apiKey", providerName: "OpenAI")
         }
 
@@ -180,13 +180,6 @@ public enum ModelCredentialResolver {
         identifier: "openrouter.apiKey",
         providerName: "OpenRouter"
     )
-
-    private static let openAIBatchModelIdentifiers: Set<String> = [
-        "openai/whisper-1",
-        "openai/gpt-4o-mini-transcribe",
-        "openai/gpt-4o-transcribe",
-        "openai/gpt-4o-transcribe-diarize"
-    ]
 
     private static let directBatchProviderIdentifiers: Set<String> = [
         "assemblyai",

--- a/Sources/SpeakCore/OpenAITranscriptionModels.swift
+++ b/Sources/SpeakCore/OpenAITranscriptionModels.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// OpenAI speech-to-text identifiers and wire-format differences shared by
+/// the macOS and iOS transcription clients.
+public enum OpenAITranscriptionModels {
+    public static let gptTranscribeCatalogID = "openai/gpt-transcribe"
+    public static let gptLiveTranscribeStreamingCatalogID = "openai/gpt-live-transcribe-streaming"
+
+    public static let gptTranscribeAPIName = "gpt-transcribe"
+    public static let gptLiveTranscribeAPIName = "gpt-live-transcribe"
+
+    /// Models sent directly to OpenAI's `/v1/audio/transcriptions` endpoint.
+    public static let directBatchModelIDs: Set<String> = [
+        "openai/whisper-1",
+        gptTranscribeCatalogID,
+        "openai/gpt-4o-mini-transcribe",
+        "openai/gpt-4o-transcribe",
+        "openai/gpt-4o-transcribe-diarize"
+    ]
+
+    /// Converts a catalogue identifier to the model name expected by OpenAI.
+    public static func apiModelName(from identifier: String) -> String {
+        var name = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        if name.hasPrefix("openai/") {
+            name = String(name.dropFirst("openai/".count))
+        }
+        if name.hasSuffix("-streaming") {
+            name = String(name.dropLast("-streaming".count))
+        }
+        return name
+    }
+
+    /// The new GPT transcription family accepts an array of language hints.
+    /// Existing GPT-4o and Whisper integrations retain the singular field.
+    public static func usesLanguageHintsArray(_ apiModelName: String) -> Bool {
+        belongs(apiModelName, to: gptTranscribeAPIName)
+            || belongs(apiModelName, to: gptLiveTranscribeAPIName)
+    }
+
+    public static func batchLanguageFieldName(for apiModelName: String) -> String {
+        usesLanguageHintsArray(apiModelName) ? "languages[]" : "language"
+    }
+
+    /// Builds the GA Realtime transcription-session update used on both
+    /// platforms, including each model family's language and prompt semantics.
+    public static func realtimeSessionUpdatePayload(
+        model: String,
+        language: String?,
+        prompt: String?,
+        sampleRate: Int
+    ) -> [String: Any] {
+        let apiModelName = apiModelName(from: model)
+        var transcription: [String: Any] = ["model": apiModelName]
+
+        if let language = nonEmpty(language) {
+            if usesLanguageHintsArray(apiModelName) {
+                transcription["languages"] = [language]
+            } else {
+                transcription["language"] = language
+            }
+        }
+
+        if let prompt = nonEmpty(prompt), supportsRealtimePrompt(apiModelName) {
+            transcription["prompt"] = prompt
+        }
+
+        return [
+            "type": "session.update",
+            "session": [
+                "type": "transcription",
+                "audio": [
+                    "input": [
+                        "format": ["type": "audio/pcm", "rate": sampleRate],
+                        "transcription": transcription,
+                        "noise_reduction": ["type": "near_field"],
+                        "turn_detection": NSNull()
+                    ]
+                ]
+            ]
+        ]
+    }
+
+    public static func supportsRealtimePrompt(_ modelName: String) -> Bool {
+        let normalised = apiModelName(from: modelName).lowercased()
+        return belongs(normalised, to: gptTranscribeAPIName)
+            || belongs(normalised, to: gptLiveTranscribeAPIName)
+            || normalised.hasPrefix("gpt-4o-transcribe")
+            || normalised.hasPrefix("gpt-4o-mini-transcribe")
+    }
+
+    private static func belongs(_ modelName: String, to family: String) -> Bool {
+        let normalised = apiModelName(from: modelName).lowercased()
+        return normalised == family || normalised.hasPrefix("\(family)-")
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/SpeakCore/OpenAITranscriptionModels.swift
+++ b/Sources/SpeakCore/OpenAITranscriptionModels.swift
@@ -37,6 +37,7 @@ public enum OpenAITranscriptionModels {
             || belongs(apiModelName, to: gptLiveTranscribeAPIName)
     }
 
+    /// Returns the multipart field name used for this model's language hint.
     public static func batchLanguageFieldName(for apiModelName: String) -> String {
         usesLanguageHintsArray(apiModelName) ? "languages[]" : "language"
     }
@@ -80,6 +81,7 @@ public enum OpenAITranscriptionModels {
         ]
     }
 
+    /// Whether a Realtime transcription session accepts prompt-based context.
     public static func supportsRealtimePrompt(_ modelName: String) -> Bool {
         let normalised = apiModelName(from: modelName).lowercased()
         return belongs(normalised, to: gptTranscribeAPIName)

--- a/Sources/SpeakiOS/Services/OpenAIRealtimeLiveTranscriber.swift
+++ b/Sources/SpeakiOS/Services/OpenAIRealtimeLiveTranscriber.swift
@@ -67,7 +67,7 @@ public final class OpenAIRealtimeLiveTranscriber: ObservableObject {
     // MARK: - Configuration
 
     public var language: String? = Locale.current.language.languageCode?.identifier
-    /// Catalogue id like `openai/gpt-realtime-whisper-streaming`. The
+    /// Catalogue id like `openai/gpt-live-transcribe-streaming`. The
     /// `-streaming` suffix is stripped before being sent to OpenAI.
     public var modelID: String = "gpt-realtime-whisper-streaming"
 
@@ -472,14 +472,7 @@ public final class OpenAIRealtimeLiveTranscriber: ObservableObject {
     /// already-stripped `gpt-realtime-whisper-streaming`) to the OpenAI API
     /// model name `gpt-realtime-whisper`.
     static func realtimeModelName(from modelID: String) -> String {
-        var name = modelID
-        if name.hasPrefix("openai/") {
-            name = String(name.dropFirst("openai/".count))
-        }
-        if name.hasSuffix("-streaming") {
-            name = String(name.dropLast("-streaming".count))
-        }
-        return name
+        OpenAITranscriptionModels.apiModelName(from: modelID)
     }
 
     /// Normalises a BCP-47 locale identifier (e.g. "en-GB", "en_US") to the
@@ -512,7 +505,6 @@ public enum OpenAIRealtimeError: LocalizedError, Sendable {
 
 // MARK: - WebSocket client
 
-// swiftlint:disable type_body_length
 /// WebSocket client for the OpenAI Realtime API in transcription mode.
 /// Off-MainActor; `@unchecked Sendable` with `NSLock` state guarding,
 /// matching the macOS implementation.
@@ -616,27 +608,14 @@ final class OpenAIRealtimeWebSocketClient: @unchecked Sendable {
 
     private func sendSessionUpdate() {
         // turn_detection: null mirrors the macOS provider — push-to-talk
-        // semantics. Deltas may only arrive after we send commit.
-        var transcription: [String: Any] = [:]
-        transcription["model"] = model
-        if let language { transcription["language"] = language }
-
-        let payload: [String: Any] = [
-            // Unified GA shape for all transcription models. The legacy
-            // `transcription_session.update` event was removed during GA.
-            "type": "session.update",
-            "session": [
-                "type": "transcription",
-                "audio": [
-                    "input": [
-                        "format": ["type": "audio/pcm", "rate": sampleRate],
-                        "transcription": transcription,
-                        "noise_reduction": ["type": "near_field"],
-                        "turn_detection": NSNull()
-                    ]
-                ]
-            ]
-        ]
+        // semantics. The shared builder also selects `languages` for the new
+        // GPT transcription family and `language` for existing models.
+        let payload = OpenAITranscriptionModels.realtimeSessionUpdatePayload(
+            model: model,
+            language: language,
+            prompt: nil,
+            sampleRate: sampleRate
+        )
         sendJSON(payload)
     }
 
@@ -908,5 +887,4 @@ private final class WaitToken: @unchecked Sendable {
         }
     }
 }
-// swiftlint:enable type_body_length
 #endif

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -52,7 +52,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         if batchTranscriber != nil { return ModelCatalog.friendlyName(for: currentModel) }
         if currentModel.hasPrefix("deepgram") { return "Deepgram" }
         if currentModel.hasPrefix("elevenlabs") { return "ElevenLabs" }
-        if currentModel.hasPrefix("openai") { return "OpenAI gpt-realtime-whisper" }
+        if currentModel.hasPrefix("openai") { return ModelCatalog.friendlyName(for: currentModel) }
         return "Apple Speech"
     }
 

--- a/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
+++ b/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
@@ -136,7 +136,11 @@ private struct IOSBatchTranscriptionClient {
             body.appendFormField(name: "chunking_strategy", value: "auto", boundary: boundary)
         }
         if let languageCode = language?.split(whereSeparator: { $0 == "_" || $0 == "-" }).first {
-            body.appendFormField(name: "language", value: String(languageCode), boundary: boundary)
+            body.appendFormField(
+                name: OpenAITranscriptionModels.batchLanguageFieldName(for: modelName),
+                value: String(languageCode),
+                boundary: boundary
+            )
         }
         body.appendFile(
             name: "file",

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -42,7 +42,7 @@ final class TranscriberCoordinator: ObservableObject {
             return "ElevenLabs"
         }
         if currentModel.hasPrefix("openai") {
-            return "OpenAI gpt-realtime-whisper"
+            return ModelCatalog.friendlyName(for: currentModel)
         }
         return "Apple Speech"
     }

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -501,12 +501,7 @@ public final class AppSettings: ObservableObject {
         return openRouterAPIKey
     }
 
-    public static let openAIBatchModelIDs: Set<String> = [
-        "openai/whisper-1",
-        "openai/gpt-4o-mini-transcribe",
-        "openai/gpt-4o-transcribe",
-        "openai/gpt-4o-transcribe-diarize"
-    ]
+    public static let openAIBatchModelIDs = OpenAITranscriptionModels.directBatchModelIDs
 
     /// Remote streaming models with an implemented iOS recording path. Shared
     /// catalogue entries that remain macOS-only are omitted rather than shown
@@ -1823,7 +1818,7 @@ struct PrivacyView: View {
                 FeatureRow(
                     icon: "waveform.badge.mic",
                     title: "OpenAI",
-                    description: "Audio streamed to OpenAI servers for transcription (gpt-realtime-whisper)."
+                    description: "Audio streamed to OpenAI servers using your selected transcription model."
                 )
             }
 
@@ -2272,7 +2267,7 @@ private struct IOSMissingTranscriptionAPIKeyAlert: Identifiable {
                     displayName: "OpenAI",
                     website: "https://platform.openai.com"
                 ),
-                modelName: "OpenAI gpt-realtime-whisper",
+                modelName: ModelCatalog.friendlyName(for: modelID),
                 hasKey: settings.hasOpenAIKey
             )
         } else {

--- a/Tests/SpeakAppTests/ModelCredentialResolverTests.swift
+++ b/Tests/SpeakAppTests/ModelCredentialResolverTests.swift
@@ -10,6 +10,13 @@ final class ModelCredentialResolverTests: XCTestCase {
             ),
             .apiKey(identifier: "deepgram.apiKey", providerName: "Deepgram")
         )
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID,
+                purpose: .liveTranscription
+            ),
+            .apiKey(identifier: "openai.apiKey", providerName: "OpenAI")
+        )
     }
 
     func testAppleAndLocalModels_DoNotRequireCredential() {
@@ -30,6 +37,13 @@ final class ModelCredentialResolverTests: XCTestCase {
     }
 
     func testBatchModels_DistinguishOpenAIFromOpenRouter() {
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: OpenAITranscriptionModels.gptTranscribeCatalogID,
+                purpose: .batchTranscription
+            ),
+            .apiKey(identifier: "openai.apiKey", providerName: "OpenAI")
+        )
         XCTAssertEqual(
             ModelCredentialResolver.requirement(
                 for: "openai/gpt-4o-transcribe",

--- a/Tests/SpeakAppTests/OpenAIRealtimeProviderTests.swift
+++ b/Tests/SpeakAppTests/OpenAIRealtimeProviderTests.swift
@@ -19,6 +19,16 @@ final class OpenAIRealtimeProviderTests: XCTestCase {
         XCTAssertEqual(option.displayName, "OpenAI GPT Realtime Whisper (Streaming)")
     }
 
+    func testModelCatalog_includesGPTLiveTranscribeStreaming() throws {
+        let option = try XCTUnwrap(
+            ModelCatalog.liveTranscription.first {
+                $0.id == OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID
+            }
+        )
+
+        XCTAssertEqual(option.displayName, "OpenAI GPT Live Transcribe (Streaming)")
+    }
+
     func testCapabilities_supportsInstantAndLivePolish() {
         let capabilities = ModelCatalog.liveCapabilities(for: "openai/gpt-realtime-whisper-streaming")
         XCTAssertTrue(capabilities.supportedSpeedModes.contains(.instant))
@@ -29,6 +39,17 @@ final class OpenAIRealtimeProviderTests: XCTestCase {
         let capabilities = ModelCatalog.liveCapabilities(for: "openai/gpt-realtime-whisper-streaming")
         // Per-segment .completed events arrive during the session, so the
         // post-stop wait should be much smaller than AssemblyAI's 2s.
+        XCTAssertGreaterThan(capabilities.postStopFinalizeBudget, 0)
+        XCTAssertLessThanOrEqual(capabilities.postStopFinalizeBudget, 1.0)
+    }
+
+    func testGPTLiveTranscribeCapabilities_supportLiveModesAndSmallFinalizeBudget() {
+        let capabilities = ModelCatalog.liveCapabilities(
+            for: OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID
+        )
+
+        XCTAssertTrue(capabilities.supportedSpeedModes.contains(.instant))
+        XCTAssertTrue(capabilities.supportedSpeedModes.contains(.livePolish))
         XCTAssertGreaterThan(capabilities.postStopFinalizeBudget, 0)
         XCTAssertLessThanOrEqual(capabilities.postStopFinalizeBudget, 1.0)
     }
@@ -47,6 +68,14 @@ final class OpenAIRealtimeProviderTests: XCTestCase {
             from: "openai/gpt-realtime-whisper"
         )
         XCTAssertEqual(name, "gpt-realtime-whisper")
+    }
+
+    func testRealtimeModelName_mapsGPTLiveTranscribeCatalogID() {
+        let name = OpenAIRealtimeTranscriptionProvider.realtimeModelName(
+            from: OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID
+        )
+
+        XCTAssertEqual(name, OpenAITranscriptionModels.gptLiveTranscribeAPIName)
     }
 
     // MARK: - Event parser

--- a/Tests/SpeakAppTests/OpenAITranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/OpenAITranscriptionProviderTests.swift
@@ -5,23 +5,26 @@ import XCTest
 @testable import SpeakCore
 
 final class OpenAITranscriptionProviderTests: XCTestCase {
-  func testModelCatalogBatchTranscription_includesGPT4oTranscribeDiarize() {
+  func testModelCatalogBatchTranscription_includesCurrentOpenAIModels() {
     let ids = ModelCatalog.batchTranscription.map(\.id)
 
+    XCTAssertTrue(ids.contains(OpenAITranscriptionModels.gptTranscribeCatalogID))
     XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe-diarize"))
   }
 
-  func testSupportedModels_includeGPT4oTranscriptionFamily() {
+  func testSupportedModels_includeOpenAITranscriptionFamily() {
     let ids = OpenAITranscriptionProvider().supportedModels().map(\.id)
 
     XCTAssertTrue(ids.contains("openai/whisper-1"))
+    XCTAssertTrue(ids.contains(OpenAITranscriptionModels.gptTranscribeCatalogID))
     XCTAssertTrue(ids.contains("openai/gpt-4o-mini-transcribe"))
     XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe"))
     XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe-diarize"))
   }
 
-  func testProviderRegistry_routesGPT4oTranscriptionFamilyToOpenAIProvider() async {
+  func testProviderRegistry_routesOpenAITranscriptionFamilyToOpenAIProvider() async {
     for model in [
+      OpenAITranscriptionModels.gptTranscribeCatalogID,
       "openai/gpt-4o-mini-transcribe",
       "openai/gpt-4o-transcribe",
       "openai/gpt-4o-transcribe-diarize"
@@ -29,6 +32,32 @@ final class OpenAITranscriptionProviderTests: XCTestCase {
       let provider = await TranscriptionProviderRegistry.shared.provider(forModel: model)
       XCTAssertEqual(provider?.metadata.id, "openai", "\(model) should route to OpenAI provider")
     }
+  }
+
+  func testTranscribeFileWithGPTTranscribe_usesJSONAndPluralLanguageHints() async throws {
+    let requestObserver = OpenAIRequestObserver()
+    OpenAIMockURLProtocol.requestHandler = { request in
+      await requestObserver.store(request: request)
+      return try Self.makeResponse(for: request, body: #"{"text":"hello world","languages":[{"code":"en"}]}"#)
+    }
+    defer { OpenAIMockURLProtocol.requestHandler = nil }
+
+    let result = try await makeProvider().transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-openai-key",
+      model: OpenAITranscriptionModels.gptTranscribeCatalogID,
+      language: "en_GB"
+    )
+
+    let capturedBody = await requestObserver.capturedBodyString()
+    let body = try XCTUnwrap(capturedBody)
+    XCTAssertTrue(body.contains("gpt-transcribe"))
+    XCTAssertTrue(body.contains(#"name="response_format""#))
+    XCTAssertTrue(body.contains("\r\njson\r\n"))
+    XCTAssertTrue(body.contains(#"name="languages[]""#))
+    XCTAssertFalse(body.contains(#"name="language""#))
+    XCTAssertTrue(body.contains("\r\nen\r\n"))
+    XCTAssertEqual(result.text, "hello world")
   }
 
   func testTranscribeFileWithGPT4oTranscribe_usesJSONResponseFormat() async throws {

--- a/Tests/SpeakAppTests/OpenAITranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/OpenAITranscriptionProviderTests.swift
@@ -5,60 +5,61 @@ import XCTest
 @testable import SpeakCore
 
 final class OpenAITranscriptionProviderTests: XCTestCase {
-  func testModelCatalogBatchTranscription_includesCurrentOpenAIModels() {
-    let ids = ModelCatalog.batchTranscription.map(\.id)
+    func testModelCatalogBatchTranscription_includesCurrentOpenAIModels() {
+        let ids = ModelCatalog.batchTranscription.map(\.id)
 
-    XCTAssertTrue(ids.contains(OpenAITranscriptionModels.gptTranscribeCatalogID))
-    XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe-diarize"))
-  }
-
-  func testSupportedModels_includeOpenAITranscriptionFamily() {
-    let ids = OpenAITranscriptionProvider().supportedModels().map(\.id)
-
-    XCTAssertTrue(ids.contains("openai/whisper-1"))
-    XCTAssertTrue(ids.contains(OpenAITranscriptionModels.gptTranscribeCatalogID))
-    XCTAssertTrue(ids.contains("openai/gpt-4o-mini-transcribe"))
-    XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe"))
-    XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe-diarize"))
-  }
-
-  func testProviderRegistry_routesOpenAITranscriptionFamilyToOpenAIProvider() async {
-    for model in [
-      OpenAITranscriptionModels.gptTranscribeCatalogID,
-      "openai/gpt-4o-mini-transcribe",
-      "openai/gpt-4o-transcribe",
-      "openai/gpt-4o-transcribe-diarize"
-    ] {
-      let provider = await TranscriptionProviderRegistry.shared.provider(forModel: model)
-      XCTAssertEqual(provider?.metadata.id, "openai", "\(model) should route to OpenAI provider")
+        XCTAssertTrue(ids.contains(OpenAITranscriptionModels.gptTranscribeCatalogID))
+        XCTAssertTrue(ids.contains("openai/gpt-4o-transcribe-diarize"))
     }
-  }
 
-  func testTranscribeFileWithGPTTranscribe_usesJSONAndPluralLanguageHints() async throws {
-    let requestObserver = OpenAIRequestObserver()
-    OpenAIMockURLProtocol.requestHandler = { request in
-      await requestObserver.store(request: request)
-      return try Self.makeResponse(for: request, body: #"{"text":"hello world","languages":[{"code":"en"}]}"#)
+    func testSupportedModels_areCanonicalDirectOpenAIOptions() {
+        let expected = ModelCatalog.batchTranscription.filter {
+            OpenAITranscriptionModels.directBatchModelIDs.contains($0.id)
+        }
+
+        XCTAssertEqual(OpenAITranscriptionProvider().supportedModels(), expected)
     }
-    defer { OpenAIMockURLProtocol.requestHandler = nil }
 
-    let result = try await makeProvider().transcribeFile(
-      at: try makeAudioFile(),
-      apiKey: "test-openai-key",
-      model: OpenAITranscriptionModels.gptTranscribeCatalogID,
-      language: "en_GB"
-    )
+    func testProviderRegistry_routesOpenAITranscriptionFamilyToOpenAIProvider() async {
+        for model in [
+            OpenAITranscriptionModels.gptTranscribeCatalogID,
+            "openai/gpt-4o-mini-transcribe",
+            "openai/gpt-4o-transcribe",
+            "openai/gpt-4o-transcribe-diarize"
+        ] {
+            let provider = await TranscriptionProviderRegistry.shared.provider(forModel: model)
+            XCTAssertEqual(provider?.metadata.id, "openai", "\(model) should route to OpenAI provider")
+        }
+    }
 
-    let capturedBody = await requestObserver.capturedBodyString()
-    let body = try XCTUnwrap(capturedBody)
-    XCTAssertTrue(body.contains("gpt-transcribe"))
-    XCTAssertTrue(body.contains(#"name="response_format""#))
-    XCTAssertTrue(body.contains("\r\njson\r\n"))
-    XCTAssertTrue(body.contains(#"name="languages[]""#))
-    XCTAssertFalse(body.contains(#"name="language""#))
-    XCTAssertTrue(body.contains("\r\nen\r\n"))
-    XCTAssertEqual(result.text, "hello world")
-  }
+    func testTranscribeFileWithGPTTranscribe_usesJSONAndPluralLanguageHints() async throws {
+        let requestObserver = OpenAIRequestObserver()
+        OpenAIMockURLProtocol.requestHandler = { request in
+            await requestObserver.store(request: request)
+            return try Self.makeResponse(
+                for: request,
+                body: #"{"text":"hello world","languages":[{"code":"en"}]}"#
+            )
+        }
+        defer { OpenAIMockURLProtocol.requestHandler = nil }
+
+        let result = try await makeProvider().transcribeFile(
+            at: try makeAudioFile(),
+            apiKey: "test-openai-key",
+            model: OpenAITranscriptionModels.gptTranscribeCatalogID,
+            language: "en_GB"
+        )
+
+        let capturedBody = await requestObserver.capturedBodyString()
+        let body = try XCTUnwrap(capturedBody)
+        XCTAssertTrue(body.contains("gpt-transcribe"))
+        XCTAssertTrue(body.contains(#"name="response_format""#))
+        XCTAssertTrue(body.contains("\r\njson\r\n"))
+        XCTAssertTrue(body.contains(#"name="languages[]""#))
+        XCTAssertFalse(body.contains(#"name="language""#))
+        XCTAssertTrue(body.contains("\r\nen\r\n"))
+        XCTAssertEqual(result.text, "hello world")
+    }
 
   func testTranscribeFileWithGPT4oTranscribe_usesJSONResponseFormat() async throws {
     let requestObserver = OpenAIRequestObserver()

--- a/Tests/SpeakCoreTests/LiveTranscriptionRoutingTests.swift
+++ b/Tests/SpeakCoreTests/LiveTranscriptionRoutingTests.swift
@@ -41,11 +41,16 @@ final class LiveTranscriptionRoutingTests: XCTestCase {
         // Act
         let whisper = LiveTranscriptionRouting.route(for: "openai/gpt-realtime-whisper-streaming")
         let mini = LiveTranscriptionRouting.route(for: "openai/gpt-4o-mini-transcribe-streaming")
+        let live = LiveTranscriptionRouting.route(
+            for: OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID
+        )
 
         // Assert
         XCTAssertEqual(whisper?.apiModelName, "gpt-realtime-whisper")
         XCTAssertEqual(whisper?.sampleRate, 24_000)
         XCTAssertEqual(mini?.apiModelName, "gpt-4o-mini-transcribe")
+        XCTAssertEqual(live?.apiModelName, OpenAITranscriptionModels.gptLiveTranscribeAPIName)
+        XCTAssertEqual(live?.sampleRate, 24_000)
     }
 
     func testRoute_apple_hasNoAPIKeyAndPreservesID() {

--- a/Tests/SpeakCoreTests/OpenAITranscriptionModelsTests.swift
+++ b/Tests/SpeakCoreTests/OpenAITranscriptionModelsTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import XCTest
+
+@testable import SpeakCore
+
+final class OpenAITranscriptionModelsTests: XCTestCase {
+    func testIdentifiers_mapCatalogModelsToOpenAIAPINames() {
+        XCTAssertEqual(
+            OpenAITranscriptionModels.apiModelName(
+                from: OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID
+            ),
+            "gpt-live-transcribe"
+        )
+        XCTAssertEqual(
+            OpenAITranscriptionModels.apiModelName(
+                from: OpenAITranscriptionModels.gptTranscribeCatalogID
+            ),
+            "gpt-transcribe"
+        )
+    }
+
+    func testLanguageFields_preserveEachModelFamilyWireContract() {
+        XCTAssertEqual(
+            OpenAITranscriptionModels.batchLanguageFieldName(for: "gpt-transcribe"),
+            "languages[]"
+        )
+        XCTAssertEqual(
+            OpenAITranscriptionModels.batchLanguageFieldName(for: "gpt-4o-transcribe"),
+            "language"
+        )
+    }
+
+    func testRealtimePayload_gptLiveTranscribeUsesLanguagesAndPrompt() throws {
+        let input = try realtimeInput(
+            model: "gpt-live-transcribe",
+            language: "en",
+            prompt: "Just Speak to It, OpenAI"
+        )
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+
+        XCTAssertEqual(transcription["model"] as? String, "gpt-live-transcribe")
+        XCTAssertEqual(transcription["languages"] as? [String], ["en"])
+        XCTAssertNil(transcription["language"])
+        XCTAssertEqual(transcription["prompt"] as? String, "Just Speak to It, OpenAI")
+        XCTAssertTrue(input["turn_detection"] is NSNull)
+    }
+
+    func testRealtimePayload_existingModelsKeepSingularLanguageAndPromptRules() throws {
+        let gpt4oInput = try realtimeInput(
+            model: "gpt-4o-transcribe",
+            language: "en",
+            prompt: "Just Speak to It"
+        )
+        let gpt4o = try XCTUnwrap(gpt4oInput["transcription"] as? [String: Any])
+        XCTAssertEqual(gpt4o["language"] as? String, "en")
+        XCTAssertNil(gpt4o["languages"])
+        XCTAssertEqual(gpt4o["prompt"] as? String, "Just Speak to It")
+
+        let whisperInput = try realtimeInput(
+            model: "gpt-realtime-whisper",
+            language: "en",
+            prompt: "This field is unsupported"
+        )
+        let whisper = try XCTUnwrap(whisperInput["transcription"] as? [String: Any])
+        XCTAssertEqual(whisper["language"] as? String, "en")
+        XCTAssertNil(whisper["prompt"])
+    }
+
+    private func realtimeInput(
+        model: String,
+        language: String?,
+        prompt: String?
+    ) throws -> [String: Any] {
+        let payload = OpenAITranscriptionModels.realtimeSessionUpdatePayload(
+            model: model,
+            language: language,
+            prompt: prompt,
+            sampleRate: 24_000
+        )
+        XCTAssertEqual(payload["type"] as? String, "session.update")
+        let session = try XCTUnwrap(payload["session"] as? [String: Any])
+        XCTAssertEqual(session["type"] as? String, "transcription")
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        return try XCTUnwrap(audio["input"] as? [String: Any])
+    }
+}

--- a/Tests/SpeakiOSTests/PlatformFeatureVisibilityTests.swift
+++ b/Tests/SpeakiOSTests/PlatformFeatureVisibilityTests.swift
@@ -20,6 +20,7 @@ final class PlatformFeatureVisibilityTests: XCTestCase {
                 .allSatisfy { !visibleIDs.contains($0.id) }
         )
         XCTAssertFalse(visibleIDs.contains { $0.hasPrefix("speechmatics/") })
+        XCTAssertTrue(visibleIDs.contains(OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID))
     }
 
     func testRemoteBatchPicker_omitsProvidersWithoutAnIOSUploadPath() {
@@ -28,6 +29,14 @@ final class PlatformFeatureVisibilityTests: XCTestCase {
         })
 
         XCTAssertEqual(visibleProviders, ["google", "openai"])
+        XCTAssertTrue(
+            AppSettings.supportedBatchModels.contains {
+                $0.id == OpenAITranscriptionModels.gptTranscribeCatalogID
+            }
+        )
+        XCTAssertTrue(
+            AppSettings.openAIBatchModelIDs.contains(OpenAITranscriptionModels.gptTranscribeCatalogID)
+        )
     }
 }
 #endif


### PR DESCRIPTION
## Summary

- add `gpt-live-transcribe` to the macOS and iOS Streaming pickers using the GA Realtime transcription-session schema
- add `gpt-transcribe` to the macOS and iOS Batch pickers using OpenAI `/v1/audio/transcriptions`
- centralise OpenAI model IDs, prompt support, and singular/plural language-hint wire contracts so both platforms stay aligned
- preserve all existing OpenAI model behaviour and defaults, and resolve iOS model labels from the selected catalogue entry

## Official documentation checked

- https://developers.openai.com/api/docs/models/gpt-live-transcribe
- https://developers.openai.com/api/docs/models/gpt-transcribe
- https://developers.openai.com/api/docs/guides/realtime-transcription
- https://developers.openai.com/api/docs/guides/speech-to-text

`gpt-transcribe` is intentionally a Batch option here: in Realtime it waits for a committed turn, whereas `gpt-live-transcribe` emits the low-latency deltas expected by the app Streaming mode.

## Validation

- 46 focused regression tests pass
- strict SwiftLint: 0 violations across 288 files
- targeted SwiftFormat lint: clean
- release macOS `SpeakApp` build: pass
- release `SpeakiOSLib` build: pass
- generated iOS app + simulator test run (`SpeakiOSTests`, `SpeakiOSUITests`): pass
- live OpenAI Realtime probe accepted the exact `gpt-live-transcribe` session payload
- live OpenAI batch probe transcribed a generated WAV with `gpt-transcribe` and plural `languages[]` hints

Tracking: `justspeaktoit-abo`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI GPT Live Transcribe for low-latency live transcription.
  * Added GPT Transcribe for batch recordings.
  * Added model-specific language hints and prompt support.
  * Improved model names shown throughout the app and settings.

* **Bug Fixes**
  * Corrected transcription request formatting and model routing for supported OpenAI models.
  * Improved credential selection for newly supported transcription models.

* **Tests**
  * Expanded coverage for model discovery, routing, capabilities, payloads, and language hints.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->