### PR TITLE
feat(ios): add transcription keyboard MVP

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Install iOS Signing Certificate & Profiles
         env:
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           IOS_DISTRIBUTION_P12: ${{ secrets.IOS_DISTRIBUTION_P12 }}
           IOS_DISTRIBUTION_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_PASSWORD }}
           IOS_APPSTORE_PROFILE: ${{ secrets.IOS_APPSTORE_PROFILE }}
@@ -52,8 +53,12 @@ jobs:
           if [ -n "$IOS_DISTRIBUTION_P12" ]; then
             CERT_PATH=$RUNNER_TEMP/ios-distribution.p12
             echo -n "$IOS_DISTRIBUTION_P12" | base64 --decode -o "$CERT_PATH"
+            CERT_PEM_PATH=$RUNNER_TEMP/ios-distribution.pem
+            openssl pkcs12 -in "$CERT_PATH" -clcerts -nokeys \
+              -passin "pass:$IOS_DISTRIBUTION_PASSWORD" -out "$CERT_PEM_PATH"
+            IOS_DISTRIBUTION_CERT_SERIAL=$(openssl x509 -in "$CERT_PEM_PATH" -noout -serial | cut -d= -f2)
             security import "$CERT_PATH" -P "$IOS_DISTRIBUTION_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-            rm -f "$CERT_PATH"
+            rm -f "$CERT_PATH" "$CERT_PEM_PATH"
           fi
 
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
@@ -73,14 +78,21 @@ jobs:
             echo "WIDGET_PROFILE_UUID=$WIDGET_PROFILE_UUID" >> $GITHUB_ENV
             echo "WIDGET_PROFILE_NAME=$WIDGET_PROFILE_NAME" >> $GITHUB_ENV
           fi
+          KEYBOARD_PROFILE_PATH=~/Library/MobileDevice/Provisioning\ Profiles/ios-keyboard-appstore.provisionprofile
           if [ -n "$IOS_KEYBOARD_APPSTORE_PROFILE" ]; then
-            KEYBOARD_PROFILE_PATH=~/Library/MobileDevice/Provisioning\ Profiles/ios-keyboard-appstore.provisionprofile
             echo -n "$IOS_KEYBOARD_APPSTORE_PROFILE" | base64 --decode -o "$KEYBOARD_PROFILE_PATH"
-            KEYBOARD_PROFILE_UUID=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract UUID raw -)
-            KEYBOARD_PROFILE_NAME=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract Name raw -)
-            echo "KEYBOARD_PROFILE_UUID=$KEYBOARD_PROFILE_UUID" >> $GITHUB_ENV
-            echo "KEYBOARD_PROFILE_NAME=$KEYBOARD_PROFILE_NAME" >> $GITHUB_ENV
+          else
+            APP_STORE_CONNECT_KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8 \
+              ruby scripts/create-ios-app-store-profile.rb \
+                --bundle-id com.justspeaktoit.ios.keyboard \
+                --certificate-serial "$IOS_DISTRIBUTION_CERT_SERIAL" \
+                --profile-name "JustSpeakToIt Keyboard App Store" \
+                --output "$KEYBOARD_PROFILE_PATH"
           fi
+          KEYBOARD_PROFILE_UUID=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract UUID raw -)
+          KEYBOARD_PROFILE_NAME=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract Name raw -)
+          echo "KEYBOARD_PROFILE_UUID=$KEYBOARD_PROFILE_UUID" >> $GITHUB_ENV
+          echo "KEYBOARD_PROFILE_NAME=$KEYBOARD_PROFILE_NAME" >> $GITHUB_ENV
 
       - name: Generate Xcode Project
         run: tuist generate --no-open

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -40,6 +40,7 @@ jobs:
           IOS_DISTRIBUTION_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_PASSWORD }}
           IOS_APPSTORE_PROFILE: ${{ secrets.IOS_APPSTORE_PROFILE }}
           IOS_WIDGET_APPSTORE_PROFILE: ${{ secrets.IOS_WIDGET_APPSTORE_PROFILE }}
+          IOS_KEYBOARD_APPSTORE_PROFILE: ${{ secrets.IOS_KEYBOARD_APPSTORE_PROFILE }}
         run: |
           KEYCHAIN_PATH=$RUNNER_TEMP/ios-signing.keychain-db
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
@@ -72,6 +73,14 @@ jobs:
             echo "WIDGET_PROFILE_UUID=$WIDGET_PROFILE_UUID" >> $GITHUB_ENV
             echo "WIDGET_PROFILE_NAME=$WIDGET_PROFILE_NAME" >> $GITHUB_ENV
           fi
+          if [ -n "$IOS_KEYBOARD_APPSTORE_PROFILE" ]; then
+            KEYBOARD_PROFILE_PATH=~/Library/MobileDevice/Provisioning\ Profiles/ios-keyboard-appstore.provisionprofile
+            echo -n "$IOS_KEYBOARD_APPSTORE_PROFILE" | base64 --decode -o "$KEYBOARD_PROFILE_PATH"
+            KEYBOARD_PROFILE_UUID=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract UUID raw -)
+            KEYBOARD_PROFILE_NAME=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract Name raw -)
+            echo "KEYBOARD_PROFILE_UUID=$KEYBOARD_PROFILE_UUID" >> $GITHUB_ENV
+            echo "KEYBOARD_PROFILE_NAME=$KEYBOARD_PROFILE_NAME" >> $GITHUB_ENV
+          fi
 
       - name: Generate Xcode Project
         run: tuist generate --no-open
@@ -80,6 +89,7 @@ jobs:
         env:
           APP_PROFILE_NAME: ${{ env.APP_PROFILE_NAME }}
           WIDGET_PROFILE_NAME: ${{ env.WIDGET_PROFILE_NAME }}
+          KEYBOARD_PROFILE_NAME: ${{ env.KEYBOARD_PROFILE_NAME }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           python - <<'PY'
@@ -89,10 +99,11 @@ jobs:
 
           app_profile = os.environ.get("APP_PROFILE_NAME", "")
           widget_profile = os.environ.get("WIDGET_PROFILE_NAME", "")
+          keyboard_profile = os.environ.get("KEYBOARD_PROFILE_NAME", "")
           team_id = os.environ.get("APPLE_TEAM_ID", "")
 
-          if not app_profile or not widget_profile:
-              raise SystemExit("Missing app/widget provisioning profile names")
+          if not app_profile or not widget_profile or not keyboard_profile:
+              raise SystemExit("Missing app/widget/keyboard provisioning profile names")
 
           pbx_path = Path("Just Speak to It.xcodeproj/project.pbxproj")
           text = pbx_path.read_text()
@@ -129,6 +140,8 @@ jobs:
                   settings = match.group("settings")
                   if "PRODUCT_BUNDLE_IDENTIFIER = com.justspeaktoit.ios.JustSpeakToItWidgetExtension;" in settings:
                       settings = patch_release_block(settings, widget_profile)
+                  elif "PRODUCT_BUNDLE_IDENTIFIER = com.justspeaktoit.ios.keyboard;" in settings:
+                      settings = patch_release_block(settings, keyboard_profile)
                   elif "PRODUCT_BUNDLE_IDENTIFIER = com.justspeaktoit.ios;" in settings:
                       settings = patch_release_block(settings, app_profile)
                   return "{}{}{}".format(match.group("prefix"), settings, match.group("suffix"))
@@ -205,30 +218,41 @@ jobs:
         run: |
           APP_PATH="build/SpeakiOS.xcarchive/Products/Applications/JustSpeakToIt.app"
           WIDGET_PATH="$APP_PATH/PlugIns/JustSpeakToItWidgetExtension.appex"
+          KEYBOARD_PATH="$APP_PATH/PlugIns/JustSpeakKeyboard.appex"
 
           APP_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_PATH/Info.plist")
           WIDGET_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$WIDGET_PATH/Info.plist")
+          KEYBOARD_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$KEYBOARD_PATH/Info.plist")
           APP_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_PATH/Info.plist")
           WIDGET_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$WIDGET_PATH/Info.plist")
+          KEYBOARD_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$KEYBOARD_PATH/Info.plist")
 
           [ "$APP_VERSION" = "$VERSION" ] || { echo "App version mismatch: expected '$VERSION', got '$APP_VERSION'"; exit 1; }
           [ "$WIDGET_VERSION" = "$VERSION" ] || { echo "Widget version mismatch: expected '$VERSION', got '$WIDGET_VERSION'"; exit 1; }
+          [ "$KEYBOARD_VERSION" = "$VERSION" ] || { echo "Keyboard version mismatch: expected '$VERSION', got '$KEYBOARD_VERSION'"; exit 1; }
           [ "$APP_BUILD" = "$BUILD_NUMBER" ] || { echo "App build mismatch: expected '$BUILD_NUMBER', got '$APP_BUILD'"; exit 1; }
           [ "$WIDGET_BUILD" = "$BUILD_NUMBER" ] || { echo "Widget build mismatch: expected '$BUILD_NUMBER', got '$WIDGET_BUILD'"; exit 1; }
+          [ "$KEYBOARD_BUILD" = "$BUILD_NUMBER" ] || { echo "Keyboard build mismatch: expected '$BUILD_NUMBER', got '$KEYBOARD_BUILD'"; exit 1; }
 
           codesign -d --entitlements - --xml "$APP_PATH" > "$RUNNER_TEMP/app-entitlements.plist"
           codesign -d --entitlements - --xml "$WIDGET_PATH" > "$RUNNER_TEMP/widget-entitlements.plist"
+          codesign -d --entitlements - --xml "$KEYBOARD_PATH" > "$RUNNER_TEMP/keyboard-entitlements.plist"
           APP_GROUP=$(/usr/libexec/PlistBuddy \
             -c 'Print :com.apple.security.application-groups:0' \
             "$RUNNER_TEMP/app-entitlements.plist" 2>/dev/null || true)
           WIDGET_GROUP=$(/usr/libexec/PlistBuddy \
             -c 'Print :com.apple.security.application-groups:0' \
             "$RUNNER_TEMP/widget-entitlements.plist" 2>/dev/null || true)
+          KEYBOARD_GROUP=$(/usr/libexec/PlistBuddy \
+            -c 'Print :com.apple.security.application-groups:0' \
+            "$RUNNER_TEMP/keyboard-entitlements.plist" 2>/dev/null || true)
 
           [ "$APP_GROUP" = "group.com.justspeaktoit.ios" ] \
             || { echo "App group mismatch: expected 'group.com.justspeaktoit.ios', got '${APP_GROUP:-missing}'"; exit 1; }
           [ "$WIDGET_GROUP" = "group.com.justspeaktoit.ios" ] \
             || { echo "Widget group mismatch: expected 'group.com.justspeaktoit.ios', got '${WIDGET_GROUP:-missing}'"; exit 1; }
+          [ "$KEYBOARD_GROUP" = "group.com.justspeaktoit.ios" ] \
+            || { echo "Keyboard group mismatch: expected 'group.com.justspeaktoit.ios', got '${KEYBOARD_GROUP:-missing}'"; exit 1; }
 
       - name: Export IPA
         env:
@@ -237,6 +261,7 @@ jobs:
         run: |
           APP_PROFILE_UUID=$(security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/ios-appstore.provisionprofile" | plutil -extract UUID raw -)
           WIDGET_PROFILE_UUID=$(security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/ios-widget-appstore.provisionprofile" | plutil -extract UUID raw -)
+          KEYBOARD_PROFILE_UUID=$(security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/ios-keyboard-appstore.provisionprofile" | plutil -extract UUID raw -)
           cat > ExportOptions.plist << 'PLIST'
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -256,6 +281,8 @@ jobs:
                   <string>APP_PROFILE_UUID_PLACEHOLDER</string>
                   <key>com.justspeaktoit.ios.JustSpeakToItWidgetExtension</key>
                   <string>WIDGET_PROFILE_UUID_PLACEHOLDER</string>
+                  <key>com.justspeaktoit.ios.keyboard</key>
+                  <string>KEYBOARD_PROFILE_UUID_PLACEHOLDER</string>
               </dict>
               <key>uploadSymbols</key>
               <true/>
@@ -268,6 +295,7 @@ jobs:
           sed -i '' "s/APPLE_TEAM_ID_PLACEHOLDER/${APPLE_TEAM_ID}/g" ExportOptions.plist
           sed -i '' "s/APP_PROFILE_UUID_PLACEHOLDER/${APP_PROFILE_UUID}/g" ExportOptions.plist
           sed -i '' "s/WIDGET_PROFILE_UUID_PLACEHOLDER/${WIDGET_PROFILE_UUID}/g" ExportOptions.plist
+          sed -i '' "s/KEYBOARD_PROFILE_UUID_PLACEHOLDER/${KEYBOARD_PROFILE_UUID}/g" ExportOptions.plist
           
           xcodebuild -exportArchive \
             -archivePath build/SpeakiOS.xcarchive \

--- a/Docs/ios-keyboard-mvp-verification.md
+++ b/Docs/ios-keyboard-mvp-verification.md
@@ -1,0 +1,159 @@
+# iOS Custom Keyboard MVP Verification
+
+## Scope and architecture
+
+The Just Speak keyboard is intentionally transcription-first. It does not
+implement ordinary typing, autocorrection, or an Apple-keyboard clone. The
+globe control uses `UIInputViewController.handleInputModeList(from:with:)` so a
+user can return to a system keyboard for typing.
+
+Apple does not allow a custom keyboard extension to access the microphone. The
+supported handoff is therefore:
+
+1. The keyboard creates a short-lived, nonce-scoped request in
+   `group.com.justspeaktoit.ios`.
+2. The keyboard opens `justspeaktoit://keyboard?request=<uuid>` through its
+   extension context.
+3. The containing app validates the nonce and records through the existing
+   `TranscriptionRecordingService` using the selected local or remote model.
+4. The app writes one final transcript to the matching versioned record.
+5. After the user returns to the originating app, the keyboard inserts the
+   matching result with `textDocumentProxy.insertText` and deletes it.
+
+Requests expire after three minutes, transcription finalisation after 90
+seconds, and completed results after 60 seconds. A mismatched nonce can neither
+read nor clear another request. Keyboard-originated dictation does not write to
+History or the clipboard, does not publish partial text through the legacy App
+Group keys, and deletes temporary batch audio after transcription.
+
+## Simulator verification
+
+Run from a generated workspace on a booted iOS Simulator:
+
+```bash
+tuist generate --no-open
+xcodebuild test \
+  -workspace "Just Speak to It.xcworkspace" \
+  -scheme SpeakiOS \
+  -destination "platform=iOS Simulator,id=<BOOTED_UDID>" \
+  -only-testing:SpeakiOSTests \
+  -only-testing:SpeakiOSUITests
+```
+
+Verify the installed app contains both extensions:
+
+```bash
+find "<JustSpeakToIt.app>/PlugIns" -maxdepth 1 -type d -name '*.appex' -print
+```
+
+Expected entries are `JustSpeakKeyboard.appex` and
+`JustSpeakToItWidgetExtension.appex`. Simulator keyboard enablement can vary by
+runtime. When the system permits it, open Settings and follow General ›
+Keyboard › Keyboards › Add New Keyboard, then select Just Speak. Do not modify
+Simulator preference files directly.
+
+For a deterministic containing-app capture screen, launch the Debug app with:
+
+```text
+--keyboard-handoff-demo
+JUSTSPEAKTOIT_SIMULATOR_TRANSCRIPT=Simulator keyboard result
+```
+
+Tap **Finish & Transcribe** and confirm the screen reaches **Ready to Insert**.
+The nonce, transcript, API keys, and surrounding text must not appear in logs.
+
+## Physical-device matrix
+
+Use a development or TestFlight build signed with App Group
+`group.com.justspeaktoit.ios` for the app and keyboard extension. The TestFlight
+workflow also needs a provisioning profile for bundle ID
+`com.justspeaktoit.ios.keyboard`, stored as GitHub secret
+`IOS_KEYBOARD_APPSTORE_PROFILE`.
+
+### Enablement and Full Access
+
+1. Launch Just Speak once and open Settings › Set Up Keyboard.
+2. Tap **Open iOS Settings**.
+3. Go to General › Keyboard › Keyboards › Add New Keyboard › Just Speak.
+4. Open Just Speak in the keyboard list and enable **Allow Full Access**.
+5. Return to Just Speak. The observed status updates after the extension has
+   actually been opened; iOS does not expose a complete enabled-keyboard query
+   to containing apps.
+6. Turn Full Access off and verify the keyboard shows the explanatory blocked
+   state and does not open the app or create a request.
+
+The Full Access explanation must remain explicit: it enables the shared App
+Group handoff and any network use required by the user's chosen cloud model. It
+does not grant microphone access to the keyboard, and the keyboard does not
+inspect or transmit surrounding text.
+
+### Local/offline happy path
+
+1. In Just Speak, select Local and an installed Apple Speech model.
+2. Disable network connectivity.
+3. Open Notes or another standard text editor and focus a normal text field.
+4. Hold the globe key and choose Just Speak.
+5. Tap **Speak in Just Speak**. Confirm the containing app opens and requests
+   microphone/speech permission only there.
+6. Speak, tap **Finish & Transcribe**, and wait for **Ready to Insert**.
+7. Return to Notes using the app switcher or Back gesture where available,
+   choose Just Speak again if iOS changed keyboards, and confirm the text is
+   inserted once at the cursor or over the current selection.
+8. Reopen the keyboard and confirm the result is not inserted again.
+
+iOS does not provide a public API that returns an extension directly to the
+originating third-party app, so the UI truthfully asks the user to return.
+
+### Cloud-model happy path
+
+Repeat the happy path with a configured remote streaming model and then a
+remote batch model. Confirm:
+
+- the selected model name appears in the capture screen;
+- missing credentials or network failures produce a generic safe error;
+- no API key, provider response body, transcript, nonce, or surrounding text is
+  emitted to device logs;
+- batch audio is removed after success and after cancellation/failure;
+- the final result is inserted once and expires if the user waits over 60
+  seconds before returning.
+
+### Cancellation and recovery
+
+1. Cancel from the keyboard before completing the handoff. Confirm nothing is
+   inserted and a newer request still works.
+2. Cancel while recording in the app. Confirm recording stops, partial audio is
+   deleted, and the keyboard reports cancellation.
+3. Leave the flow open beyond its timeout. Confirm a timeout state, no
+   insertion, and a successful retry with a fresh nonce.
+4. Force-quit Just Speak during recording and confirm a retry does not consume
+   stale state.
+5. Start an ordinary Just Speak recording first, then trigger the keyboard.
+   Confirm the keyboard request reports recording unavailable without taking
+   over the existing session.
+
+### System limitations
+
+Confirm Just Speak is absent and the system keyboard remains active in:
+
+- secure/password fields;
+- phone-pad fields;
+- an app known to disable third-party keyboards.
+
+Also verify portrait and landscape on iPhone, split/full-width layouts on iPad,
+light and dark appearance, large Accessibility text sizes, VoiceOver focus and
+labels, Switch Control targets, and touch targets of at least 44 points.
+
+## App Review and privacy evidence
+
+- `RequestsOpenAccess` is declared because the extension uses an App Group and
+  may hand off to user-selected cloud transcription in the containing app.
+- The extension contains no microphone permission or audio APIs.
+- The containing app's existing microphone and speech usage descriptions apply
+  when capture begins.
+- Only a schema version, request UUID, timestamps, phase, safe failure enum, and
+  final transcript are shared. The final transcript is removed on insertion or
+  timeout.
+- No private settings URL, responder-chain URL workaround, Apple keyboard asset,
+  or copied Apple keyboard layout is used.
+- App Review notes should describe the manual return-to-origin step and the
+  secure-field, phone-pad, and host-app restrictions exactly as users see them.

--- a/JustSpeakKeyboard/Info.plist
+++ b/JustSpeakKeyboard/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Just Speak</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <key>IsASCIICapable</key>
+            <true/>
+            <key>PrefersRightToLeft</key>
+            <false/>
+            <key>PrimaryLanguage</key>
+            <string>en-GB</string>
+            <key>RequestsOpenAccess</key>
+            <true/>
+        </dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.keyboard-service</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).KeyboardViewController</string>
+    </dict>
+</dict>
+</plist>

--- a/JustSpeakKeyboard/JustSpeakKeyboard.entitlements
+++ b/JustSpeakKeyboard/JustSpeakKeyboard.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.justspeaktoit.ios</string>
+    </array>
+</dict>
+</plist>

--- a/JustSpeakKeyboard/KeyboardViewController.swift
+++ b/JustSpeakKeyboard/KeyboardViewController.swift
@@ -1,0 +1,528 @@
+import SpeakCore
+import SwiftUI
+import UIKit
+
+// The controller and its compact SwiftUI surface live together so every
+// keyboard state and supported input-mode action remains auditable in one file.
+// swiftlint:disable file_length
+
+final class KeyboardViewController: UIInputViewController {
+    private let model = KeyboardViewModel()
+    private var host: UIHostingController<KeyboardRootView>?
+    private var heightConstraint: NSLayoutConstraint?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemGroupedBackground
+
+        let root = KeyboardRootView(
+            model: model,
+            showsInputModeSwitch: needsInputModeSwitchKey,
+            openContainingApp: { [weak self] url in
+                self?.openContainingApp(url)
+            },
+            insertText: { [weak self] text in
+                self?.textDocumentProxy.insertText(text)
+            },
+            showInputModeList: { [weak self] button, event in
+                self?.handleInputModeList(from: button, with: event)
+            }
+        )
+        let host = UIHostingController(rootView: root)
+        host.view.backgroundColor = .clear
+        addChild(host)
+        view.addSubview(host.view)
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            host.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            host.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            host.view.topAnchor.constraint(equalTo: view.topAnchor),
+            host.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        host.didMove(toParent: self)
+        self.host = host
+        updatePreferredHeight()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        model.activate(hasFullAccess: hasFullAccess)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        model.deactivate()
+        super.viewDidDisappear(animated)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updatePreferredHeight()
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate { [weak self] _ in
+            self?.updatePreferredHeight()
+        }
+    }
+
+    override func textDidChange(_ textInput: UITextInput?) {
+        super.textDidChange(textInput)
+        model.activate(hasFullAccess: hasFullAccess)
+    }
+
+    private func openContainingApp(_ url: URL) {
+        guard let extensionContext else {
+            model.appOpenCompleted(succeeded: false)
+            return
+        }
+        extensionContext.open(url) { [weak model] succeeded in
+            Task { @MainActor in
+                model?.appOpenCompleted(succeeded: succeeded)
+            }
+        }
+    }
+
+    private func updatePreferredHeight() {
+        let isLandscape = view.window?.windowScene?.interfaceOrientation.isLandscape
+            ?? (traitCollection.verticalSizeClass == .compact)
+        let isPad = traitCollection.userInterfaceIdiom == .pad
+        var height: CGFloat
+        if isLandscape {
+            height = isPad ? 220 : 205
+        } else {
+            height = isPad ? 280 : 260
+        }
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            height += isPad ? 80 : 60
+        }
+
+        if let heightConstraint {
+            guard heightConstraint.constant != height else { return }
+            heightConstraint.constant = height
+            return
+        }
+        let constraint = view.heightAnchor.constraint(equalToConstant: height)
+        constraint.priority = .init(999)
+        constraint.isActive = true
+        heightConstraint = constraint
+    }
+}
+
+@MainActor
+final class KeyboardViewModel: ObservableObject {
+    enum Presentation: Equatable {
+        case idle
+        case openingApp
+        case recording
+        case transcribing
+        case inserted
+        case missingFullAccess
+        case unavailable
+        case cancelled
+        case error(KeyboardHandoffRecord.FailureCode)
+    }
+
+    @Published private(set) var presentation: Presentation = .idle
+    @Published private(set) var hasFullAccess = false
+
+    private let store: KeyboardHandoffStore
+    private let consumer: KeyboardHandoffConsumer
+    private var requestID: UUID?
+    private var pollTask: Task<Void, Never>?
+    private var insertText: ((String) -> Void)?
+
+    init(store: KeyboardHandoffStore = .shared) {
+        self.store = store
+        self.consumer = KeyboardHandoffConsumer(store: store)
+    }
+
+    func activate(hasFullAccess: Bool) {
+        self.hasFullAccess = hasFullAccess
+        store.recordExtensionObservation(hasFullAccess: hasFullAccess)
+
+        guard KeyboardLaunchPolicy.blockReason(
+            hasFullAccess: hasFullAccess,
+            sharedContainerAvailable: store.isAvailable
+        ) == nil else {
+            presentation = hasFullAccess ? .unavailable : .missingFullAccess
+            return
+        }
+
+        if requestID == nil {
+            requestID = store.activeRecord()?.requestID
+        }
+        refresh()
+        startPolling()
+    }
+
+    func deactivate() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    func startHandoff(
+        openContainingApp: (URL) -> Void,
+        insertText: @escaping (String) -> Void
+    ) {
+        self.insertText = insertText
+        guard KeyboardLaunchPolicy.blockReason(
+            hasFullAccess: hasFullAccess,
+            sharedContainerAvailable: store.isAvailable
+        ) == nil else {
+            presentation = hasFullAccess ? .unavailable : .missingFullAccess
+            return
+        }
+
+        do {
+            let request = try store.createRequest()
+            requestID = request.requestID
+            presentation = .openingApp
+
+            var components = URLComponents()
+            components.scheme = "justspeaktoit"
+            components.host = "keyboard"
+            components.queryItems = [
+                URLQueryItem(name: "request", value: request.requestID.uuidString.lowercased())
+            ]
+            guard let url = components.url else {
+                _ = try? store.fail(requestID: request.requestID, code: .invalidRequest)
+                presentation = .error(.invalidRequest)
+                return
+            }
+            openContainingApp(url)
+        } catch {
+            presentation = .unavailable
+        }
+    }
+
+    func appOpenCompleted(succeeded: Bool) {
+        guard !succeeded, let requestID else { return }
+        _ = try? store.fail(requestID: requestID, code: .appUnavailable)
+        presentation = .error(.appUnavailable)
+    }
+
+    func cancel() {
+        guard let requestID else {
+            presentation = .idle
+            return
+        }
+        _ = try? store.cancel(requestID: requestID)
+        self.requestID = nil
+        presentation = .cancelled
+    }
+
+    func retry(
+        openContainingApp: (URL) -> Void,
+        insertText: @escaping (String) -> Void
+    ) {
+        if let requestID {
+            store.clear(requestID: requestID)
+        }
+        requestID = nil
+        startHandoff(openContainingApp: openContainingApp, insertText: insertText)
+    }
+
+    private func startPolling() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                self?.refresh()
+                try? await Task.sleep(for: .milliseconds(350))
+            }
+        }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func refresh() {
+        guard hasFullAccess else {
+            presentation = .missingFullAccess
+            return
+        }
+        guard let requestID else {
+            if presentation != .inserted && presentation != .cancelled {
+                presentation = .idle
+            }
+            return
+        }
+        guard let record = store.record(matching: requestID) else {
+            presentation = .error(.timedOut)
+            self.requestID = nil
+            return
+        }
+
+        switch record.phase {
+        case .requested:
+            presentation = .openingApp
+        case .recording:
+            presentation = .recording
+        case .transcribing:
+            presentation = .transcribing
+        case .completed:
+            guard let insertText else {
+                presentation = .error(.unknown)
+                return
+            }
+            if consumer.insertReadyResult(requestID: requestID, insert: insertText) {
+                self.requestID = nil
+                presentation = .inserted
+            }
+        case .cancelled:
+            self.requestID = nil
+            presentation = .cancelled
+        case .failed:
+            self.requestID = nil
+            presentation = .error(record.failureCode ?? .unknown)
+        }
+    }
+}
+
+private struct KeyboardRootView: View {
+    @ObservedObject var model: KeyboardViewModel
+    let showsInputModeSwitch: Bool
+    let openContainingApp: (URL) -> Void
+    let insertText: (String) -> Void
+    let showInputModeList: (UIButton, UIEvent) -> Void
+
+    var body: some View {
+        GeometryReader { proxy in
+            VStack(spacing: 10) {
+                if proxy.size.width >= 620 {
+                    HStack(spacing: 22) {
+                        statusCopy
+                        Spacer(minLength: 12)
+                        primaryControl
+                    }
+                } else {
+                    statusCopy
+                    primaryControl
+                }
+
+                Spacer(minLength: 0)
+                bottomBar
+            }
+            .padding(.horizontal, proxy.size.width >= 620 ? 28 : 14)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(uiColor: .systemGroupedBackground))
+        }
+    }
+
+    private var statusCopy: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(title, systemImage: statusSymbol)
+                .font(.headline)
+                .foregroundStyle(statusTint)
+                .accessibilityAddTraits(.isHeader)
+            Text(detail)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("keyboardStatusDetail")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var primaryControl: some View {
+        switch model.presentation {
+        case .idle, .inserted, .cancelled:
+            Button {
+                model.startHandoff(openContainingApp: openContainingApp, insertText: insertText)
+            } label: {
+                Label("Speak in Just Speak", systemImage: "mic.fill")
+                    .font(.headline)
+                    .frame(maxWidth: 330, minHeight: 52)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.blue)
+            .accessibilityIdentifier("keyboardTranscribeButton")
+
+        case .missingFullAccess:
+            Text("Enable Full Access in Settings to use secure handoff.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 330, minHeight: 44)
+
+        case .openingApp, .recording, .transcribing:
+            HStack(spacing: 10) {
+                ProgressView()
+                Text(progressLabel)
+                    .font(.headline)
+            }
+            .frame(maxWidth: 330, minHeight: 52)
+            .accessibilityElement(children: .combine)
+
+        case .unavailable, .error:
+            Button {
+                model.retry(openContainingApp: openContainingApp, insertText: insertText)
+            } label: {
+                Label("Try Again", systemImage: "arrow.clockwise")
+                    .font(.headline)
+                    .frame(maxWidth: 330, minHeight: 48)
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("keyboardRetryButton")
+        }
+    }
+
+    private var bottomBar: some View {
+        HStack {
+            if showsInputModeSwitch {
+                InputModeSwitchButton(action: showInputModeList)
+                    .frame(width: 48, height: 44)
+                    .accessibilityLabel("Next keyboard")
+                    .accessibilityHint("Touch and hold to choose another keyboard")
+            }
+
+            Text("Audio is captured only in Just Speak. Results are deleted after insertion.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity)
+                .multilineTextAlignment(.center)
+
+            if canCancel {
+                Button("Cancel") {
+                    model.cancel()
+                }
+                .font(.subheadline.weight(.semibold))
+                .frame(minWidth: 48, minHeight: 44)
+                .accessibilityIdentifier("keyboardCancelButton")
+            } else {
+                Color.clear
+                    .frame(width: showsInputModeSwitch ? 48 : 0, height: 44)
+                    .accessibilityHidden(true)
+            }
+        }
+    }
+
+    private var canCancel: Bool {
+        switch model.presentation {
+        case .openingApp, .recording, .transcribing:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private var title: String {
+        switch model.presentation {
+        case .idle: return "Ready to transcribe"
+        case .openingApp: return "Opening Just Speak"
+        case .recording: return "Recording in Just Speak"
+        case .transcribing: return "Finishing transcript"
+        case .inserted: return "Inserted"
+        case .missingFullAccess: return "Full Access is off"
+        case .unavailable: return "Just Speak is unavailable"
+        case .cancelled: return "Cancelled"
+        case .error: return "Couldn’t insert transcript"
+        }
+    }
+
+    private var detail: String {
+        switch model.presentation {
+        case .idle:
+            return "Opens the app for microphone capture, then inserts the matching result here."
+        case .openingApp:
+            return "Complete recording in the Just Speak app, then return here."
+        case .recording:
+            return "Speak in the app. This keyboard never receives microphone audio."
+        case .transcribing:
+            return "Your selected JustSpeakToIt model is producing the final text."
+        case .inserted:
+            return "The one-time result was inserted and removed from shared storage."
+        case .missingFullAccess:
+            return "Full Access is required for the App Group handoff. It never exposes surrounding text."
+        case .unavailable:
+            return "Open the Just Speak app once and check that the keyboard is enabled."
+        case .cancelled:
+            return "No transcript was inserted or retained."
+        case let .error(code):
+            return errorDetail(for: code)
+        }
+    }
+
+    private var statusSymbol: String {
+        switch model.presentation {
+        case .idle: return "waveform"
+        case .openingApp: return "arrow.up.forward.app"
+        case .recording: return "record.circle"
+        case .transcribing: return "ellipsis.bubble"
+        case .inserted: return "checkmark.circle.fill"
+        case .missingFullAccess: return "lock.trianglebadge.exclamationmark"
+        case .unavailable, .error: return "exclamationmark.triangle.fill"
+        case .cancelled: return "xmark.circle"
+        }
+    }
+
+    private var statusTint: Color {
+        switch model.presentation {
+        case .inserted: return .green
+        case .recording: return .red
+        case .missingFullAccess, .unavailable, .error: return .orange
+        default: return .primary
+        }
+    }
+
+    private var progressLabel: String {
+        switch model.presentation {
+        case .recording: return "Recording"
+        case .transcribing: return "Transcribing"
+        default: return "Opening App"
+        }
+    }
+
+    private func errorDetail(for code: KeyboardHandoffRecord.FailureCode) -> String {
+        switch code {
+        case .fullAccessRequired:
+            return "Turn on Full Access in Settings, then try again."
+        case .appUnavailable:
+            return "The containing app could not be opened. Open Just Speak manually and retry."
+        case .recordingUnavailable:
+            return "Recording could not start. Check microphone permission in Just Speak."
+        case .noSpeech:
+            return "No speech was detected. Nothing was inserted."
+        case .timedOut:
+            return "The one-time request expired. Nothing was inserted."
+        case .invalidRequest:
+            return "The request did not match the active keyboard session."
+        case .unknown:
+            return "The handoff ended safely without retaining a transcript."
+        }
+    }
+}
+
+private struct InputModeSwitchButton: UIViewRepresentable {
+    let action: (UIButton, UIEvent) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    func makeUIView(context: Context) -> UIButton {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "globe"), for: .normal)
+        button.tintColor = .label
+        button.accessibilityLabel = "Next keyboard"
+        button.addTarget(
+            context.coordinator,
+            action: #selector(Coordinator.handle(_:event:)),
+            for: .allTouchEvents
+        )
+        return button
+    }
+
+    func updateUIView(_ uiView: UIButton, context: Context) {}
+
+    final class Coordinator: NSObject {
+        let action: (UIButton, UIEvent) -> Void
+
+        init(action: @escaping (UIButton, UIEvent) -> Void) {
+            self.action = action
+        }
+
+        @objc func handle(_ sender: UIButton, event: UIEvent) {
+            action(sender, event)
+        }
+    }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -12,6 +12,7 @@ let version: String = {
 
 let appProfileName = ProcessInfo.processInfo.environment["APP_PROFILE_NAME"]
 let widgetProfileName = ProcessInfo.processInfo.environment["WIDGET_PROFILE_NAME"]
+let keyboardProfileName = ProcessInfo.processInfo.environment["KEYBOARD_PROFILE_NAME"]
 let macAppStoreProfileName = ProcessInfo.processInfo.environment["TUIST_MAC_PROFILE_NAME"]
     ?? ProcessInfo.processInfo.environment["MAC_PROFILE_NAME"]
 
@@ -72,6 +73,13 @@ var iosWidgetSettings: [String: SettingValue] = [
     "MARKETING_VERSION": "\(version)"
 ]
 
+var iosKeyboardSettings: [String: SettingValue] = [
+    "APPLICATION_EXTENSION_API_ONLY": "YES",
+    "CURRENT_PROJECT_VERSION": "1",
+    "MARKETING_VERSION": "\(version)",
+    "SKIP_INSTALL": "YES"
+]
+
 func configureManualSigning(for settings: inout [String: SettingValue], profileName: String) {
     settings["PROVISIONING_PROFILE_SPECIFIER"] = .string(profileName)
     settings["CODE_SIGN_STYLE"] = "Manual"
@@ -84,6 +92,10 @@ if let appProfileName {
 
 if let widgetProfileName {
     configureManualSigning(for: &iosWidgetSettings, profileName: widgetProfileName)
+}
+
+if let keyboardProfileName {
+    configureManualSigning(for: &iosKeyboardSettings, profileName: keyboardProfileName)
 }
 
 if isAppStoreBuild {
@@ -197,9 +209,24 @@ let project = Project(
                 .package(product: "SpeakCore"),
                 .package(product: "SpeakiOSLib"),
                 .package(product: "SpeakSync"),
-                .target(name: "JustSpeakToItWidgetExtension")
+                .target(name: "JustSpeakToItWidgetExtension"),
+                .target(name: "JustSpeakKeyboard")
             ],
             settings: .settings(base: iosAppSettings)
+        ),
+        .target(
+            name: "JustSpeakKeyboard",
+            destinations: .iOS,
+            product: .appExtension,
+            bundleId: "com.justspeaktoit.ios.keyboard",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .file(path: "JustSpeakKeyboard/Info.plist"),
+            sources: ["JustSpeakKeyboard/**/*.swift"],
+            entitlements: .file(path: "JustSpeakKeyboard/JustSpeakKeyboard.entitlements"),
+            dependencies: [
+                .package(product: "SpeakCore")
+            ],
+            settings: .settings(base: iosKeyboardSettings)
         ),
         .target(
             name: "JustSpeakToItWidgetExtension",
@@ -246,10 +273,12 @@ let project = Project(
             sources: ["Tests/SpeakiOSTests/**"],
             resources: [
                 "SpeakiOS.entitlements",
-                "JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtension.entitlements"
+                "JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtension.entitlements",
+                "JustSpeakKeyboard/JustSpeakKeyboard.entitlements"
             ],
             dependencies: [
                 .target(name: "SpeakiOS"),
+                .package(product: "SpeakCore"),
                 .package(product: "SpeakiOSLib")
             ]
         )

--- a/Sources/SpeakCore/KeyboardHandoff.swift
+++ b/Sources/SpeakCore/KeyboardHandoff.swift
@@ -1,0 +1,383 @@
+import Foundation
+
+/// The only App Group payload used by the custom keyboard handoff.
+///
+/// Audio, API keys, surrounding text, and intermediate transcripts are never
+/// written here. The final transcript exists only until the matching keyboard
+/// consumes it or the short result timeout expires.
+public struct KeyboardHandoffRecord: Codable, Equatable, Sendable {
+    public static let schemaVersion = 1
+
+    public enum Phase: String, Codable, Equatable, Hashable, Sendable {
+        case requested
+        case recording
+        case transcribing
+        case completed
+        case cancelled
+        case failed
+    }
+
+    public enum FailureCode: String, Codable, Equatable, Sendable {
+        case fullAccessRequired
+        case appUnavailable
+        case recordingUnavailable
+        case noSpeech
+        case timedOut
+        case invalidRequest
+        case unknown
+    }
+
+    public let schemaVersion: Int
+    public let requestID: UUID
+    public let createdAt: Date
+    public let updatedAt: Date
+    public let expiresAt: Date
+    public let phase: Phase
+    public let transcript: String?
+    public let failureCode: FailureCode?
+
+    public init(
+        schemaVersion: Int = Self.schemaVersion,
+        requestID: UUID,
+        createdAt: Date,
+        updatedAt: Date,
+        expiresAt: Date,
+        phase: Phase,
+        transcript: String? = nil,
+        failureCode: FailureCode? = nil
+    ) {
+        self.schemaVersion = schemaVersion
+        self.requestID = requestID
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.expiresAt = expiresAt
+        self.phase = phase
+        self.transcript = transcript
+        self.failureCode = failureCode
+    }
+}
+
+public struct KeyboardExtensionObservation: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let lastSeenAt: Date
+    public let hadFullAccess: Bool
+
+    public init(
+        schemaVersion: Int = KeyboardHandoffRecord.schemaVersion,
+        lastSeenAt: Date,
+        hadFullAccess: Bool
+    ) {
+        self.schemaVersion = schemaVersion
+        self.lastSeenAt = lastSeenAt
+        self.hadFullAccess = hadFullAccess
+    }
+}
+
+public enum KeyboardHandoffStoreError: Error, Equatable {
+    case unavailable
+    case noActiveRequest
+    case mismatchedRequest
+    case invalidTransition
+    case invalidTranscript
+}
+
+/// A deliberately small, extension-safe store backed by the shared App Group.
+///
+/// The entire handoff is a single encoded value so readers never combine fields
+/// from different requests. Each mutation validates the nonce and transition.
+public final class KeyboardHandoffStore {
+    public static let appGroupIdentifier = "group.com.justspeaktoit.ios"
+    public static let shared = KeyboardHandoffStore()
+
+    public static let requestLifetime: TimeInterval = 3 * 60
+    public static let transcriptionLifetime: TimeInterval = 90
+    public static let resultLifetime: TimeInterval = 60
+
+    private static let recordKey = "keyboardHandoff.record.v1"
+    private static let observationKey = "keyboardHandoff.extensionObservation.v1"
+
+    private let defaults: UserDefaults?
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private let lock = NSLock()
+
+    public convenience init() {
+        self.init(defaults: UserDefaults(suiteName: Self.appGroupIdentifier))
+    }
+
+    /// Injectable for deterministic tests. Passing `nil` models a missing or
+    /// inaccessible App Group.
+    public init(defaults: UserDefaults?) {
+        self.defaults = defaults
+    }
+
+    public var isAvailable: Bool {
+        defaults != nil
+    }
+
+    @discardableResult
+    public func createRequest(
+        id: UUID = UUID(),
+        now: Date = Date(),
+        lifetime: TimeInterval = requestLifetime
+    ) throws -> KeyboardHandoffRecord {
+        guard defaults != nil else { throw KeyboardHandoffStoreError.unavailable }
+        let record = KeyboardHandoffRecord(
+            requestID: id,
+            createdAt: now,
+            updatedAt: now,
+            expiresAt: now.addingTimeInterval(lifetime),
+            phase: .requested
+        )
+        try write(record)
+        return record
+    }
+
+    public func record(matching requestID: UUID, now: Date = Date()) -> KeyboardHandoffRecord? {
+        lock.withLock {
+            guard let record = readUnlocked(), record.requestID == requestID else { return nil }
+            return normalizeExpiryUnlocked(record, now: now)
+        }
+    }
+
+    public func activeRecord(now: Date = Date()) -> KeyboardHandoffRecord? {
+        lock.withLock {
+            guard let record = readUnlocked() else { return nil }
+            return normalizeExpiryUnlocked(record, now: now)
+        }
+    }
+
+    @discardableResult
+    public func markRecording(requestID: UUID, now: Date = Date()) throws -> KeyboardHandoffRecord {
+        try transition(
+            requestID: requestID,
+            allowedFrom: [.requested],
+            to: .recording,
+            now: now,
+            lifetime: Self.requestLifetime
+        )
+    }
+
+    @discardableResult
+    public func markTranscribing(requestID: UUID, now: Date = Date()) throws -> KeyboardHandoffRecord {
+        try transition(
+            requestID: requestID,
+            allowedFrom: [.recording],
+            to: .transcribing,
+            now: now,
+            lifetime: Self.transcriptionLifetime
+        )
+    }
+
+    @discardableResult
+    public func complete(
+        requestID: UUID,
+        transcript: String,
+        now: Date = Date()
+    ) throws -> KeyboardHandoffRecord {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw KeyboardHandoffStoreError.invalidTranscript }
+        return try transition(
+            requestID: requestID,
+            allowedFrom: [.transcribing],
+            to: .completed,
+            transcript: trimmed,
+            now: now,
+            lifetime: Self.resultLifetime
+        )
+    }
+
+    @discardableResult
+    public func cancel(requestID: UUID, now: Date = Date()) throws -> KeyboardHandoffRecord {
+        try transition(
+            requestID: requestID,
+            allowedFrom: [.requested, .recording, .transcribing],
+            to: .cancelled,
+            now: now,
+            lifetime: Self.resultLifetime
+        )
+    }
+
+    @discardableResult
+    public func fail(
+        requestID: UUID,
+        code: KeyboardHandoffRecord.FailureCode,
+        now: Date = Date()
+    ) throws -> KeyboardHandoffRecord {
+        try transition(
+            requestID: requestID,
+            allowedFrom: [.requested, .recording, .transcribing],
+            to: .failed,
+            failureCode: code,
+            now: now,
+            lifetime: Self.resultLifetime
+        )
+    }
+
+    /// Returns and then promptly removes only the matching, unexpired result.
+    public func consumeResult(requestID: UUID, now: Date = Date()) -> String? {
+        lock.withLock {
+            guard let stored = readUnlocked(),
+                  stored.requestID == requestID,
+                  let record = normalizeExpiryUnlocked(stored, now: now),
+                  record.phase == .completed,
+                  let transcript = record.transcript,
+                  !transcript.isEmpty else {
+                return nil
+            }
+            defaults?.removeObject(forKey: Self.recordKey)
+            defaults?.synchronize()
+            return transcript
+        }
+    }
+
+    /// Removes only the caller's request, so an old keyboard cannot clear a
+    /// newer request after process suspension.
+    public func clear(requestID: UUID) {
+        lock.withLock {
+            guard readUnlocked()?.requestID == requestID else { return }
+            defaults?.removeObject(forKey: Self.recordKey)
+            defaults?.synchronize()
+        }
+    }
+
+    public func recordExtensionObservation(hasFullAccess: Bool, now: Date = Date()) {
+        guard let defaults else { return }
+        let observation = KeyboardExtensionObservation(lastSeenAt: now, hadFullAccess: hasFullAccess)
+        guard let data = try? encoder.encode(observation) else { return }
+        defaults.set(data, forKey: Self.observationKey)
+        defaults.synchronize()
+    }
+
+    public func extensionObservation() -> KeyboardExtensionObservation? {
+        guard let data = defaults?.data(forKey: Self.observationKey) else { return nil }
+        return try? decoder.decode(KeyboardExtensionObservation.self, from: data)
+    }
+
+    private func transition(
+        requestID: UUID,
+        allowedFrom: Set<KeyboardHandoffRecord.Phase>,
+        to phase: KeyboardHandoffRecord.Phase,
+        transcript: String? = nil,
+        failureCode: KeyboardHandoffRecord.FailureCode? = nil,
+        now: Date,
+        lifetime: TimeInterval
+    ) throws -> KeyboardHandoffRecord {
+        try lock.withLock {
+            guard defaults != nil else { throw KeyboardHandoffStoreError.unavailable }
+            guard let stored = readUnlocked() else { throw KeyboardHandoffStoreError.noActiveRequest }
+            guard stored.requestID == requestID else { throw KeyboardHandoffStoreError.mismatchedRequest }
+            guard let current = normalizeExpiryUnlocked(stored, now: now),
+                  allowedFrom.contains(current.phase) else {
+                throw KeyboardHandoffStoreError.invalidTransition
+            }
+
+            let updated = KeyboardHandoffRecord(
+                requestID: current.requestID,
+                createdAt: current.createdAt,
+                updatedAt: now,
+                expiresAt: now.addingTimeInterval(lifetime),
+                phase: phase,
+                transcript: transcript,
+                failureCode: failureCode
+            )
+            try writeUnlocked(updated)
+            return updated
+        }
+    }
+
+    private func write(_ record: KeyboardHandoffRecord) throws {
+        try lock.withLock {
+            try writeUnlocked(record)
+        }
+    }
+
+    private func writeUnlocked(_ record: KeyboardHandoffRecord) throws {
+        guard let defaults else { throw KeyboardHandoffStoreError.unavailable }
+        defaults.set(try encoder.encode(record), forKey: Self.recordKey)
+        defaults.synchronize()
+    }
+
+    private func readUnlocked() -> KeyboardHandoffRecord? {
+        guard let data = defaults?.data(forKey: Self.recordKey),
+              let record = try? decoder.decode(KeyboardHandoffRecord.self, from: data),
+              record.schemaVersion == KeyboardHandoffRecord.schemaVersion else {
+            return nil
+        }
+        return record
+    }
+
+    private func normalizeExpiryUnlocked(
+        _ record: KeyboardHandoffRecord,
+        now: Date
+    ) -> KeyboardHandoffRecord? {
+        guard record.expiresAt <= now else { return record }
+
+        if record.phase == .cancelled || record.phase == .failed {
+            defaults?.removeObject(forKey: Self.recordKey)
+            defaults?.synchronize()
+            return nil
+        }
+
+        let timedOut = KeyboardHandoffRecord(
+            requestID: record.requestID,
+            createdAt: record.createdAt,
+            updatedAt: now,
+            expiresAt: now.addingTimeInterval(Self.resultLifetime),
+            phase: .failed,
+            failureCode: .timedOut
+        )
+        try? writeUnlocked(timedOut)
+        return timedOut
+    }
+}
+
+public enum KeyboardLaunchPolicy {
+    public enum BlockReason: Equatable {
+        case fullAccessRequired
+        case sharedContainerUnavailable
+    }
+
+    public static func blockReason(
+        hasFullAccess: Bool,
+        sharedContainerAvailable: Bool
+    ) -> BlockReason? {
+        if !hasFullAccess {
+            return .fullAccessRequired
+        }
+        if !sharedContainerAvailable {
+            return .sharedContainerUnavailable
+        }
+        return nil
+    }
+}
+
+public struct KeyboardHandoffConsumer {
+    private let store: KeyboardHandoffStore
+
+    public init(store: KeyboardHandoffStore = .shared) {
+        self.store = store
+    }
+
+    /// Inserts only a matching result and clears it immediately afterwards.
+    @discardableResult
+    public func insertReadyResult(
+        requestID: UUID,
+        now: Date = Date(),
+        insert: (String) -> Void
+    ) -> Bool {
+        guard let transcript = store.consumeResult(requestID: requestID, now: now) else {
+            return false
+        }
+        insert(transcript)
+        return true
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ operation: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try operation()
+    }
+}

--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -322,7 +322,7 @@ struct TranscriptionShortcuts: AppShortcutsProvider {
 /// Manages state shared between main app and extensions via App Group.
 public final class SharedTranscriptionState {
     public static let shared = SharedTranscriptionState()
-    public static let appGroupIdentifier = "group.com.justspeaktoit.ios"
+    public static let appGroupIdentifier = KeyboardHandoffStore.appGroupIdentifier
 
     private let defaults: UserDefaults?
 

--- a/Sources/SpeakiOS/Services/DeepLinkRouter.swift
+++ b/Sources/SpeakiOS/Services/DeepLinkRouter.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import Foundation
+import SpeakCore
 import SwiftUI
 
 // MARK: - Deep Link Router
@@ -9,6 +10,7 @@ import SwiftUI
 ///   justspeaktoit://openclaw                     → OpenClaw tab
 ///   justspeaktoit://openclaw/conversation/<id>   → specific conversation
 ///   justspeaktoit://transcribe                   → Transcribe tab
+///   justspeaktoit://keyboard?request=<uuid>       → validated keyboard capture
 @MainActor
 public final class DeepLinkRouter: ObservableObject {
     public static let shared = DeepLinkRouter()
@@ -19,7 +21,14 @@ public final class DeepLinkRouter: ObservableObject {
     /// When set, navigates to this conversation in the OpenClaw tab.
     @Published public var pendingConversationId: String?
 
-    private init() {}
+    /// A validated keyboard request that the containing app should record for.
+    @Published public var keyboardCaptureRequest: KeyboardCaptureRequest?
+
+    private let keyboardStore: KeyboardHandoffStore
+
+    public init(keyboardStore: KeyboardHandoffStore = .shared) {
+        self.keyboardStore = keyboardStore
+    }
 
     /// Handles an incoming deep link URL. Returns `true` if handled.
     @discardableResult
@@ -44,6 +53,18 @@ public final class DeepLinkRouter: ObservableObject {
             pendingConversationId = nil
             return true
 
+        case "keyboard":
+            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                  let requestValue = components.queryItems?.first(where: { $0.name == "request" })?.value,
+                  let requestID = UUID(uuidString: requestValue),
+                  keyboardStore.record(matching: requestID)?.phase == .requested else {
+                return false
+            }
+            selectedTab = 0
+            pendingConversationId = nil
+            keyboardCaptureRequest = KeyboardCaptureRequest(id: requestID)
+            return true
+
         default:
             return false
         }
@@ -54,6 +75,14 @@ public final class DeepLinkRouter: ObservableObject {
         let cid = pendingConversationId
         pendingConversationId = nil
         return cid
+    }
+}
+
+public struct KeyboardCaptureRequest: Identifiable, Equatable {
+    public let id: UUID
+
+    public init(id: UUID) {
+        self.id = id
     }
 }
 #endif

--- a/Sources/SpeakiOS/Services/KeyboardHandoffCaptureCoordinator.swift
+++ b/Sources/SpeakiOS/Services/KeyboardHandoffCaptureCoordinator.swift
@@ -1,0 +1,119 @@
+#if os(iOS)
+import Foundation
+import SpeakCore
+
+@MainActor
+public final class KeyboardHandoffCaptureCoordinator: ObservableObject {
+    public enum Phase: Equatable {
+        case preparing
+        case recording
+        case transcribing
+        case ready
+        case cancelled
+        case error
+    }
+
+    @Published public private(set) var phase: Phase = .preparing
+    @Published public private(set) var message = "Preparing a private one-time handoff…"
+
+    public let requestID: UUID
+
+    private let store: KeyboardHandoffStore
+    private let recordingService: TranscriptionRecordingService
+    private var started = false
+
+    public init(
+        requestID: UUID,
+        store: KeyboardHandoffStore = .shared,
+        recordingService: TranscriptionRecordingService
+    ) {
+        self.requestID = requestID
+        self.store = store
+        self.recordingService = recordingService
+    }
+
+    public convenience init(requestID: UUID) {
+        self.init(
+            requestID: requestID,
+            store: .shared,
+            recordingService: .shared
+        )
+    }
+
+    public func start() async {
+        guard !started else { return }
+        started = true
+
+        guard store.record(matching: requestID)?.phase == .requested else {
+            fail(code: .invalidRequest, message: "This keyboard request is no longer active.")
+            return
+        }
+        guard !recordingService.isRunning else {
+            fail(code: .recordingUnavailable, message: "Another recording is already in progress.")
+            return
+        }
+
+        do {
+            try store.markRecording(requestID: requestID)
+            try await recordingService.startRecording(
+                retainBatchRecording: false,
+                sharesLiveTranscript: false
+            )
+            phase = .recording
+            message = "Speak now. Tap Finish when you’re done."
+        } catch {
+            recordingService.cancelRecording()
+            fail(
+                code: .recordingUnavailable,
+                message: "Recording could not start. Check microphone and speech permissions."
+            )
+        }
+    }
+
+    public func finish() async {
+        guard phase == .recording else { return }
+        do {
+            try store.markTranscribing(requestID: requestID)
+        } catch {
+            recordingService.cancelRecording()
+            fail(code: .invalidRequest, message: "The keyboard request expired before transcription.")
+            return
+        }
+
+        phase = .transcribing
+        message = "Finishing with your selected transcription model…"
+        let result = await recordingService.stopRecording(
+            destination: .historyOnly,
+            saveToHistory: false
+        )
+        let transcript = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !transcript.isEmpty else {
+            fail(code: .noSpeech, message: "No speech was detected. Nothing will be inserted.")
+            return
+        }
+
+        do {
+            try store.complete(requestID: requestID, transcript: transcript)
+            phase = .ready
+            message = "Return to the previous app and choose Just Speak to insert the result."
+        } catch {
+            fail(code: .invalidRequest, message: "The request ended safely before a result could be shared.")
+        }
+    }
+
+    public func cancel() {
+        if recordingService.isRunning {
+            recordingService.cancelRecording()
+        }
+        _ = try? store.cancel(requestID: requestID)
+        phase = .cancelled
+        message = "Cancelled. No transcript was shared with the keyboard."
+    }
+
+    private func fail(code: KeyboardHandoffRecord.FailureCode, message: String) {
+        _ = try? store.fail(requestID: requestID, code: code)
+        phase = .error
+        self.message = message
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -27,6 +27,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     private var batchTranscriber: IOSBatchTranscriber?
     private var startTime: Date?
     private var currentModel: String = ""
+    private var sharesLiveTranscript = true
 
     static let polishingClipboardPlaceholder = "Polishing… please wait"
 
@@ -59,8 +60,10 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     // MARK: - Public API
 
     /// Starts a headless recording session with Live Activity.
-    public func startRecording() async throws {
-        // swiftlint:disable:previous function_body_length
+    public func startRecording( // swiftlint:disable:this function_body_length
+        retainBatchRecording: Bool = true,
+        sharesLiveTranscript: Bool = true
+    ) async throws {
         guard !isRunning else { return }
 
         let settings = AppSettings.shared
@@ -70,6 +73,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         partialText = ""
         wordCount = 0
         startTime = Date()
+        self.sharesLiveTranscript = sharesLiveTranscript
         sharedState.clear()
         sharedState.isRecording = true
         sharedState.recordingStartTime = startTime
@@ -106,7 +110,8 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
                 let transcriber = IOSBatchTranscriber(
                     audioSessionManager: audioSessionManager,
                     model: currentModel,
-                    apiKey: settings.batchAPIKey
+                    apiKey: settings.batchAPIKey,
+                    retainRecording: retainBatchRecording
                 )
                 batchTranscriber = transcriber
                 appleTranscriber = nil
@@ -233,6 +238,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
             appleTranscriber = nil
             sharedTranscriber = nil
             batchTranscriber = nil
+            self.sharesLiveTranscript = true
             sharedState.clearRecordingState()
             activityManager.endActivity()
             throw error
@@ -247,7 +253,10 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     ///   were configurable. Hardware-trigger callers (Action Button, Siri,
     ///   Shortcuts) pass `AppSettings.shared.hardwareTriggerDestination`.
     @discardableResult
-    public func stopRecording(destination: HardwareTriggerDestination? = nil) async -> TranscriptionResult {
+    public func stopRecording(
+        destination: HardwareTriggerDestination? = nil,
+        saveToHistory: Bool = true
+    ) async -> TranscriptionResult {
         isRunning = false
         let duration = elapsedSeconds
 
@@ -276,12 +285,14 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         partialText = text
         wordCount = text.split(whereSeparator: \.isWhitespace).count
 
-        // Record to history (always, regardless of destination).
-        let historyItem = iOSHistoryManager.shared.recordTranscription(
-            text: text,
-            model: currentModel,
-            duration: result.duration
-        )
+        // Keyboard handoffs opt out so transient dictation is not persisted.
+        let historyItem = saveToHistory
+            ? iOSHistoryManager.shared.recordTranscription(
+                text: text,
+                model: currentModel,
+                duration: result.duration
+            )
+            : nil
 
         // Resolve the destination. When nil (legacy callers), preserve the
         // pre-destination behaviour: clipboard + post-process if user opted in.
@@ -290,6 +301,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
 
         // Update shared state
         sharedState.clearRecordingState()
+        sharesLiveTranscript = true
 
         // Complete Live Activity with clipboard confirmation
         activityManager.completeActivity(finalWordCount: wordCount, duration: duration, keepPrimed: true)
@@ -332,6 +344,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         appleTranscriber = nil
         sharedTranscriber = nil
         batchTranscriber = nil
+        sharesLiveTranscript = true
         isRunning = false
         startTime = nil
         partialText = ""
@@ -345,7 +358,9 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     private func handlePartialResult(text: String) {
         partialText = text
         wordCount = text.split(separator: " ").count
-        sharedState.updateTranscript(text)
+        if sharesLiveTranscript {
+            sharedState.updateTranscript(text)
+        }
 
         activityManager.updateActivity(
             status: .listening,
@@ -417,6 +432,10 @@ extension TranscriptionRecordingService {
             return nil
         }
     }
+
+    static func legacySharedTranscript(_ transcript: String, sharesCompletedTranscript: Bool) -> String? {
+        sharesCompletedTranscript ? transcript : nil
+    }
 }
 
 private extension TranscriptionRecordingService {
@@ -485,7 +504,8 @@ private extension TranscriptionRecordingService {
     /// happens regardless of destination.
     func applyDestinationSideEffects(
         text: String,
-        destination: HardwareTriggerDestination
+        destination: HardwareTriggerDestination,
+        sharesCompletedTranscript: Bool? = nil
     ) async {
         guard !text.isEmpty else { return }
         if let clipboardText = Self.clipboardTextAtStop(
@@ -496,10 +516,15 @@ private extension TranscriptionRecordingService {
             await Self.writeClipboardReliably(clipboardText)
         }
 
-        // History-only intentionally leaves the pasteboard untouched. Every
-        // destination still publishes the completed transcript so the Live
+        // Keyboard handoffs keep their result solely in the nonce-scoped store.
+        // Other destinations publish the completed transcript so the Live
         // Activity and foreground handoff can surface it.
-        sharedState.lastCompletedTranscript = text
+        if let sharedTranscript = Self.legacySharedTranscript(
+            text,
+            sharesCompletedTranscript: sharesCompletedTranscript ?? sharesLiveTranscript
+        ) {
+            sharedState.lastCompletedTranscript = sharedTranscript
+        }
     }
 
     /// Pasteboard writes from a background AppIntent can race process

--- a/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
+++ b/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
@@ -12,6 +12,7 @@ public final class IOSBatchTranscriber {
     private let audioEngine = AVAudioEngine()
     private let audioRecorder = AudioRecordingPersistence()
     private let client: IOSBatchTranscriptionClient
+    private let retainRecording: Bool
     private var startTime: Date?
 
     public let model: String
@@ -20,10 +21,12 @@ public final class IOSBatchTranscriber {
         audioSessionManager: AudioSessionManager,
         model: String,
         apiKey: String,
+        retainRecording: Bool = true,
         session: URLSession = .shared
     ) {
         self.audioSessionManager = audioSessionManager
         self.model = model
+        self.retainRecording = retainRecording
         self.client = IOSBatchTranscriptionClient(apiKey: apiKey, session: session)
     }
 
@@ -61,6 +64,11 @@ public final class IOSBatchTranscriber {
         }
         audioSessionManager.deactivate()
         startTime = nil
+        defer {
+            if !retainRecording {
+                AudioRecordingPersistence.deleteRecording(at: recording.url)
+            }
+        }
         return try await client.transcribeFile(at: recording.url, model: model, language: language)
     }
 

--- a/Sources/SpeakiOS/Views/KeyboardCaptureView.swift
+++ b/Sources/SpeakiOS/Views/KeyboardCaptureView.swift
@@ -1,0 +1,213 @@
+#if os(iOS)
+import SpeakCore
+import SwiftUI
+
+public struct KeyboardCaptureView: View {
+    @StateObject private var coordinator: KeyboardHandoffCaptureCoordinator
+    @ObservedObject private var settings = AppSettings.shared
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    public init(requestID: UUID) {
+        _coordinator = StateObject(
+            wrappedValue: KeyboardHandoffCaptureCoordinator(requestID: requestID)
+        )
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: dynamicTypeSize.isAccessibilitySize ? 22 : 30) {
+                    statusHero
+                    privacyCard
+                    actions
+                }
+                .frame(maxWidth: 620)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 32)
+                .frame(maxWidth: .infinity)
+            }
+            .background(Color(uiColor: .systemGroupedBackground))
+            .navigationTitle("Keyboard Transcription")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if canDismiss {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Close") {
+                            dismiss()
+                        }
+                    }
+                }
+            }
+        }
+        .interactiveDismissDisabled(!canDismiss)
+        .task {
+            await coordinator.start()
+        }
+    }
+
+    private var statusHero: some View {
+        VStack(spacing: 18) {
+            ZStack {
+                Circle()
+                    .fill(heroTint.opacity(0.14))
+                    .frame(width: 112, height: 112)
+                Image(systemName: heroSymbol)
+                    .font(.system(size: 48, weight: .semibold))
+                    .foregroundStyle(heroTint)
+                    .symbolEffect(.pulse, isActive: coordinator.phase == .recording)
+            }
+            .accessibilityHidden(true)
+
+            VStack(spacing: 8) {
+                Text(title)
+                    .font(.largeTitle.bold())
+                    .multilineTextAlignment(.center)
+                    .accessibilityIdentifier("keyboardCaptureTitle")
+                Text(coordinator.message)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("keyboardCaptureMessage")
+            }
+
+            if coordinator.phase == .recording || coordinator.phase == .transcribing {
+                HStack(spacing: 5) {
+                    ForEach(0..<7, id: \.self) { index in
+                        Capsule()
+                            .fill(heroTint.gradient)
+                            .frame(width: 5, height: CGFloat(12 + (index % 4) * 8))
+                    }
+                }
+                .accessibilityHidden(true)
+            }
+
+            Label(selectedModelName, systemImage: "cpu")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Selected model: \(selectedModelName)")
+        }
+    }
+
+    private var privacyCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Private handoff", systemImage: "lock.shield")
+                .font(.headline)
+            Text(
+                "The keyboard cannot access the microphone. Just Speak records here with your selected model, "
+                    + "shares one nonce-matched final result, and deletes it after insertion or timeout."
+            )
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            Text("Audio, API keys, surrounding text, and partial transcripts are never placed in shared storage.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var actions: some View {
+        switch coordinator.phase {
+        case .preparing:
+            ProgressView("Preparing…")
+                .controlSize(.large)
+
+        case .recording:
+            VStack(spacing: 12) {
+                Button {
+                    Task {
+                        await coordinator.finish()
+                    }
+                } label: {
+                    Label("Finish & Transcribe", systemImage: "stop.fill")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, minHeight: 54)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .accessibilityIdentifier("finishKeyboardRecordingButton")
+
+                Button("Cancel", role: .cancel) {
+                    coordinator.cancel()
+                }
+                .frame(minHeight: 44)
+                .accessibilityIdentifier("cancelKeyboardRecordingButton")
+            }
+
+        case .transcribing:
+            ProgressView("Finalising transcript…")
+                .controlSize(.large)
+                .accessibilityIdentifier("keyboardTranscribingProgress")
+
+        case .ready:
+            Button {
+                dismiss()
+            } label: {
+                Label("Done", systemImage: "checkmark")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, minHeight: 54)
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("keyboardResultReadyButton")
+
+        case .cancelled, .error:
+            Button("Return to Just Speak") {
+                dismiss()
+            }
+            .buttonStyle(.bordered)
+            .frame(minHeight: 44)
+        }
+    }
+
+    private var canDismiss: Bool {
+        switch coordinator.phase {
+        case .preparing, .recording, .transcribing:
+            return false
+        case .ready, .cancelled, .error:
+            return true
+        }
+    }
+
+    private var title: String {
+        switch coordinator.phase {
+        case .preparing: return "Getting Ready"
+        case .recording: return "Listening"
+        case .transcribing: return "Transcribing"
+        case .ready: return "Ready to Insert"
+        case .cancelled: return "Cancelled"
+        case .error: return "Couldn’t Complete"
+        }
+    }
+
+    private var heroSymbol: String {
+        switch coordinator.phase {
+        case .preparing: return "waveform"
+        case .recording: return "mic.fill"
+        case .transcribing: return "ellipsis.bubble.fill"
+        case .ready: return "checkmark.circle.fill"
+        case .cancelled: return "xmark.circle"
+        case .error: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var heroTint: Color {
+        switch coordinator.phase {
+        case .recording: return .red
+        case .ready: return .green
+        case .error: return .orange
+        default: return .accentColor
+        }
+    }
+
+    private var selectedModelName: String {
+        let modelID = settings.transcriptionMode == .batch
+            ? settings.batchTranscriptionModel
+            : settings.selectedModel
+        return ModelCatalog.friendlyName(for: modelID)
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Views/KeyboardSetupView.swift
+++ b/Sources/SpeakiOS/Views/KeyboardSetupView.swift
@@ -1,0 +1,166 @@
+#if os(iOS)
+import SpeakCore
+import SwiftUI
+import UIKit
+
+public struct KeyboardSetupView: View {
+    @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var observation: KeyboardExtensionObservation?
+
+    public init() {}
+
+    public var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 12) {
+                    Image(systemName: "keyboard.badge.ellipsis")
+                        .font(.system(size: 42, weight: .semibold))
+                        .foregroundStyle(.tint)
+                        .accessibilityHidden(true)
+                    Text("Speak into any supported text field")
+                        .font(.title2.bold())
+                    Text(
+                        "Just Speak is a transcription-first keyboard. Use its globe button "
+                            + "to return to the system keyboard for normal typing."
+                    )
+                    .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 8)
+            }
+
+            Section("Setup") {
+                setupStep(
+                    number: 1,
+                    title: "Add Just Speak",
+                    detail: "In Settings, go to General › Keyboard › Keyboards › Add New Keyboard."
+                )
+                setupStep(
+                    number: 2,
+                    title: "Allow Full Access",
+                    detail: "Open Just Speak in the keyboard list and turn on Allow Full Access."
+                )
+                setupStep(
+                    number: 3,
+                    title: "Choose it in a text field",
+                    detail: "Touch and hold the globe key, then select Just Speak."
+                )
+
+                Button {
+                    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                    openURL(url)
+                } label: {
+                    Label("Open iOS Settings", systemImage: "gear")
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("openKeyboardSettingsButton")
+            }
+
+            Section("Observed Status") {
+                statusRow(
+                    title: "Keyboard opened",
+                    isReady: observation != nil,
+                    readyText: observation.map { "Seen \($0.lastSeenAt.formatted(.relative(presentation: .named)))" }
+                        ?? "Not yet observed"
+                )
+                statusRow(
+                    title: "Full Access",
+                    isReady: observation?.hadFullAccess == true,
+                    readyText: fullAccessStatus
+                )
+                Text(
+                    "iOS does not provide the containing app with a complete keyboard-enabled status API. "
+                        + "These indicators update after the Just Speak keyboard has been opened."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Section("Why Full Access?") {
+                Label("Open the Just Speak app for microphone capture", systemImage: "arrow.up.forward.app")
+                Label("Exchange one nonce-scoped result through the App Group", systemImage: "lock.shield")
+                Label("Use cloud transcription only when your selected model requires it", systemImage: "network")
+                Text(
+                    "The keyboard itself cannot use the microphone. It does not read, persist, "
+                        + "or transmit surrounding text, and shared results expire quickly."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Section("Where It Won’t Appear") {
+                limitation("Secure password fields", symbol: "lock.fill")
+                limitation("Phone-pad fields", symbol: "phone.fill")
+                limitation("Apps that disable third-party keyboards", symbol: "app.badge")
+            }
+
+            Section("What to Expect") {
+                Text(
+                    "Tap Speak in the keyboard, record in Just Speak, finish transcription, "
+                        + "then return to the original app. Just Speak inserts only the matching result."
+                )
+                Text(
+                    "Local Apple Speech can work offline after its language resources are available. "
+                        + "Cloud models need a network connection and the provider key configured in Just Speak."
+                )
+                .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Just Speak Keyboard")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear(perform: refresh)
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                refresh()
+            }
+        }
+    }
+
+    private var fullAccessStatus: String {
+        guard let observation else { return "Open the keyboard to check" }
+        return observation.hadFullAccess ? "Observed on" : "Observed off"
+    }
+
+    private func setupStep(number: Int, title: String, detail: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text("\(number)")
+                .font(.headline)
+                .foregroundStyle(.white)
+                .frame(width: 30, height: 30)
+                .background(.tint, in: Circle())
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.headline)
+                Text(detail)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Step \(number), \(title). \(detail)")
+    }
+
+    private func statusRow(title: String, isReady: Bool, readyText: String) -> some View {
+        HStack {
+            Label(title, systemImage: isReady ? "checkmark.circle.fill" : "circle.dashed")
+                .foregroundStyle(isReady ? .green : .secondary)
+            Spacer()
+            Text(readyText)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func limitation(_ text: String, symbol: String) -> some View {
+        Label(text, systemImage: symbol)
+            .foregroundStyle(.secondary)
+    }
+
+    private func refresh() {
+        observation = KeyboardHandoffStore.shared.extensionObservation()
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -840,6 +840,26 @@ public struct SettingsView: View {
                 }
             }
 
+            Section("Just Speak Keyboard") {
+                NavigationLink {
+                    KeyboardSetupView()
+                } label: {
+                    HStack {
+                        Label("Set Up Keyboard", systemImage: "keyboard")
+                        Spacer()
+                        Text(keyboardStatusLabel)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .accessibilityIdentifier("keyboardSetupLink")
+
+                if !usesInlineDensityLayout {
+                    Text("Transcribe into other apps through a private handoff to Just Speak.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Section("Hardware Trigger") {
                 NavigationLink {
                     HardwareTriggerSettingsView(settings: settings)
@@ -1089,6 +1109,13 @@ public struct SettingsView: View {
 
     private var usesInlineDensityLayout: Bool {
         settings.visualDensity.prefersInlineLayout(dynamicTypeSize: dynamicTypeSize)
+    }
+
+    private var keyboardStatusLabel: String {
+        guard let observation = KeyboardHandoffStore.shared.extensionObservation() else {
+            return "Not observed"
+        }
+        return observation.hadFullAccess ? "Full Access on" : "Full Access off"
     }
 
     private var appVersion: String {

--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -76,6 +76,16 @@ struct SpeakiOSApp: App {
                 .onOpenURL { url in
                     deepLinkRouter.handle(url)
                 }
+                .task {
+                    #if DEBUG && targetEnvironment(simulator)
+                    guard ProcessInfo.processInfo.arguments.contains("--keyboard-handoff-demo"),
+                          deepLinkRouter.keyboardCaptureRequest == nil,
+                          let request = try? KeyboardHandoffStore.shared.createRequest() else {
+                        return
+                    }
+                    deepLinkRouter.keyboardCaptureRequest = KeyboardCaptureRequest(id: request.requestID)
+                    #endif
+                }
         }
     }
 }
@@ -99,8 +109,11 @@ struct MainTabView: View {
                     .tabItem {
                         Label("OpenClaw", systemImage: "bolt.horizontal.icloud.fill")
                     }
-                    .tag(1)
+                .tag(1)
             }
+        }
+        .fullScreenCover(item: $deepLinkRouter.keyboardCaptureRequest) { request in
+            KeyboardCaptureView(requestID: request.id)
         }
     }
 }

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -83,12 +83,48 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertFalse(macTarget.contains("SpeakiOSApp"))
         XCTAssertFalse(macTarget.contains("SpeakiOSLib"))
         XCTAssertFalse(macTarget.contains("JustSpeakToItWidgetExtension"))
+        XCTAssertFalse(macTarget.contains("JustSpeakKeyboard"))
 
         XCTAssertTrue(iosTarget.contains("sources: [\"SpeakiOSApp/**\"]"))
         XCTAssertTrue(iosTarget.contains(".package(product: \"SpeakiOSLib\")"))
+        XCTAssertTrue(iosTarget.contains(".target(name: \"JustSpeakKeyboard\")"))
         XCTAssertFalse(iosTarget.contains("Sources/SpeakApp"))
         XCTAssertFalse(iosTarget.contains("SpeakHotKeys"))
         XCTAssertFalse(iosTarget.contains("Sparkle"))
+    }
+
+    func testIOSKeyboardTargetUsesPublicExtensionConfiguration() throws {
+        let manifest = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("Project.swift"),
+            encoding: .utf8
+        )
+        let keyboardTarget = try targetBlock(named: "JustSpeakKeyboard", in: manifest)
+        let infoPlist = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("JustSpeakKeyboard/Info.plist"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(keyboardTarget.contains("bundleId: \"com.justspeaktoit.ios.keyboard\""))
+        XCTAssertTrue(keyboardTarget.contains("product: .appExtension"))
+        XCTAssertTrue(keyboardTarget.contains("settings: .settings(base: iosKeyboardSettings)"))
+        XCTAssertTrue(manifest.contains("\"APPLICATION_EXTENSION_API_ONLY\": \"YES\""))
+        XCTAssertTrue(infoPlist.contains("com.apple.keyboard-service"))
+        XCTAssertTrue(infoPlist.contains("RequestsOpenAccess"))
+        XCTAssertTrue(infoPlist.contains("$(PRODUCT_MODULE_NAME).KeyboardViewController"))
+    }
+
+    func testIOSReleaseWorkflowSignsAndValidatesKeyboardExtension() throws {
+        let workflow = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-ios.yml"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(workflow.contains("IOS_KEYBOARD_APPSTORE_PROFILE"))
+        XCTAssertTrue(workflow.contains("ios-keyboard-appstore.provisionprofile"))
+        XCTAssertTrue(workflow.contains("com.justspeaktoit.ios.keyboard"))
+        XCTAssertTrue(workflow.contains("KEYBOARD_PROFILE_UUID_PLACEHOLDER"))
+        XCTAssertTrue(workflow.contains("JustSpeakKeyboard.appex"))
+        XCTAssertTrue(workflow.contains("keyboard-entitlements.plist"))
     }
 
     func testIOSApp_declaresRequiredBackgroundModes() throws {

--- a/Tests/SpeakCoreTests/KeyboardHandoffTests.swift
+++ b/Tests/SpeakCoreTests/KeyboardHandoffTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+
+@testable import SpeakCore
+
+final class KeyboardHandoffTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var store: KeyboardHandoffStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "KeyboardHandoffTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+        store = KeyboardHandoffStore(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        store = nil
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testHandoffTransitionsToMatchingConsumableResult() throws {
+        let request = try store.createRequest()
+
+        XCTAssertEqual(try store.markRecording(requestID: request.requestID).phase, .recording)
+        XCTAssertEqual(try store.markTranscribing(requestID: request.requestID).phase, .transcribing)
+        XCTAssertEqual(
+            try store.complete(requestID: request.requestID, transcript: "  Insert this text.  ").phase,
+            .completed
+        )
+
+        XCTAssertEqual(store.consumeResult(requestID: request.requestID), "Insert this text.")
+        XCTAssertNil(store.activeRecord())
+    }
+
+    func testMismatchedNonceCannotReadOrClearResult() throws {
+        let request = try completedRequest(transcript: "Private result")
+        let wrongID = UUID()
+
+        XCTAssertNil(store.record(matching: wrongID))
+        XCTAssertNil(store.consumeResult(requestID: wrongID))
+        store.clear(requestID: wrongID)
+
+        XCTAssertEqual(store.record(matching: request.requestID)?.transcript, "Private result")
+    }
+
+    func testExpiredRequestBecomesTranscriptFreeTimeout() throws {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let request = try store.createRequest(now: now, lifetime: 1)
+
+        let expired = store.record(matching: request.requestID, now: now.addingTimeInterval(2))
+
+        XCTAssertEqual(expired?.phase, .failed)
+        XCTAssertEqual(expired?.failureCode, .timedOut)
+        XCTAssertNil(expired?.transcript)
+        XCTAssertNil(store.consumeResult(requestID: request.requestID, now: now.addingTimeInterval(2)))
+    }
+
+    func testCancelRemovesAnyTranscriptAndBlocksCompletion() throws {
+        let request = try store.createRequest()
+        try store.markRecording(requestID: request.requestID)
+        let cancelled = try store.cancel(requestID: request.requestID)
+
+        XCTAssertEqual(cancelled.phase, .cancelled)
+        XCTAssertNil(cancelled.transcript)
+        XCTAssertThrowsError(
+            try store.markTranscribing(requestID: request.requestID)
+        ) { error in
+            XCTAssertEqual(error as? KeyboardHandoffStoreError, .invalidTransition)
+        }
+    }
+
+    func testConsumerInsertsMatchingResultOnce() throws {
+        let request = try completedRequest(transcript: "One-time result")
+        let consumer = KeyboardHandoffConsumer(store: store)
+        var inserted: [String] = []
+
+        XCTAssertTrue(consumer.insertReadyResult(requestID: request.requestID) { inserted.append($0) })
+        XCTAssertEqual(inserted, ["One-time result"])
+        XCTAssertFalse(consumer.insertReadyResult(requestID: request.requestID) { inserted.append($0) })
+        XCTAssertEqual(inserted, ["One-time result"])
+    }
+
+    func testFullAccessPolicyGatesSharedHandoff() {
+        XCTAssertEqual(
+            KeyboardLaunchPolicy.blockReason(hasFullAccess: false, sharedContainerAvailable: true),
+            .fullAccessRequired
+        )
+        XCTAssertEqual(
+            KeyboardLaunchPolicy.blockReason(hasFullAccess: true, sharedContainerAvailable: false),
+            .sharedContainerUnavailable
+        )
+        XCTAssertNil(
+            KeyboardLaunchPolicy.blockReason(hasFullAccess: true, sharedContainerAvailable: true)
+        )
+    }
+
+    func testExtensionObservationStoresOnlyAccessMetadata() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        store.recordExtensionObservation(hasFullAccess: true, now: now)
+
+        XCTAssertEqual(
+            store.extensionObservation(),
+            KeyboardExtensionObservation(lastSeenAt: now, hadFullAccess: true)
+        )
+        XCTAssertNil(store.activeRecord())
+    }
+
+    private func completedRequest(transcript: String) throws -> KeyboardHandoffRecord {
+        let request = try store.createRequest()
+        try store.markRecording(requestID: request.requestID)
+        try store.markTranscribing(requestID: request.requestID)
+        return try store.complete(requestID: request.requestID, transcript: transcript)
+    }
+}

--- a/Tests/SpeakiOSTests/AppGroupConfigurationTests.swift
+++ b/Tests/SpeakiOSTests/AppGroupConfigurationTests.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import Foundation
+import SpeakCore
 import XCTest
 
 @testable import SpeakiOSLib
@@ -16,6 +17,13 @@ final class AppGroupConfigurationTests: XCTestCase {
         let entitledGroups = try appGroups(inResourceNamed: "JustSpeakToItWidgetExtension")
 
         XCTAssertTrue(entitledGroups.contains(SharedTranscriptionState.appGroupIdentifier))
+    }
+
+    func testKeyboardUsesSameEntitledAppGroup() throws {
+        let entitledGroups = try appGroups(inResourceNamed: "JustSpeakKeyboard")
+
+        XCTAssertEqual(KeyboardHandoffStore.appGroupIdentifier, SharedTranscriptionState.appGroupIdentifier)
+        XCTAssertTrue(entitledGroups.contains(KeyboardHandoffStore.appGroupIdentifier))
     }
 
     private func appGroups(inResourceNamed resourceName: String) throws -> [String] {

--- a/Tests/SpeakiOSTests/KeyboardDeepLinkTests.swift
+++ b/Tests/SpeakiOSTests/KeyboardDeepLinkTests.swift
@@ -1,0 +1,52 @@
+#if os(iOS)
+import SpeakCore
+import XCTest
+
+@testable import SpeakiOSLib
+
+@MainActor
+final class KeyboardDeepLinkTests: XCTestCase {
+    private struct Context {
+        let name: String
+        let defaults: UserDefaults
+        let store: KeyboardHandoffStore
+    }
+
+    func testMatchingRequestOpensKeyboardCapture() throws {
+        let context = makeContext()
+        defer { context.defaults.removePersistentDomain(forName: context.name) }
+        let request = try context.store.createRequest()
+        let router = DeepLinkRouter(keyboardStore: context.store)
+        let url = try XCTUnwrap(
+            URL(string: "justspeaktoit://keyboard?request=\(request.requestID.uuidString)")
+        )
+
+        XCTAssertTrue(router.handle(url))
+        XCTAssertEqual(router.selectedTab, 0)
+        XCTAssertEqual(router.keyboardCaptureRequest?.id, request.requestID)
+    }
+
+    func testUnknownRequestCannotOpenCapture() throws {
+        let context = makeContext()
+        defer { context.defaults.removePersistentDomain(forName: context.name) }
+        let router = DeepLinkRouter(keyboardStore: context.store)
+        let url = try XCTUnwrap(
+            URL(string: "justspeaktoit://keyboard?request=\(UUID().uuidString)")
+        )
+
+        XCTAssertFalse(router.handle(url))
+        XCTAssertNil(router.keyboardCaptureRequest)
+    }
+
+    private func makeContext() -> Context {
+        let name = "KeyboardDeepLinkTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return Context(
+            name: name,
+            defaults: defaults,
+            store: KeyboardHandoffStore(defaults: defaults)
+        )
+    }
+}
+#endif

--- a/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
+++ b/Tests/SpeakiOSTests/TranscriptionRecordingServiceTextTests.swift
@@ -60,6 +60,15 @@ final class TranscriptionRecordingServiceTextTests: XCTestCase {
         )
     }
 
+    func testKeyboardHandoffDoesNotPublishTranscriptToLegacySharedState() {
+        XCTAssertNil(
+            TranscriptionRecordingService.legacySharedTranscript(
+                "Private keyboard transcript",
+                sharesCompletedTranscript: false
+            )
+        )
+    }
+
     @available(iOS 18, *)
     func testLiveActivityStopIntentKeepsAudioRecordingExecutionContext() {
         let intentType: any AudioRecordingIntent.Type = StopTranscriptionRecordingIntent.self

--- a/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
+++ b/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
@@ -74,8 +74,8 @@ final class ActionButtonSettingsUITests: XCTestCase {
 
         XCTAssertTrue(app.navigationBars["Just Speak Keyboard"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.buttons["openKeyboardSettingsButton"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["Why Full Access?"].exists)
-        XCTAssertTrue(app.staticTexts["Where It Won’t Appear"].exists)
+        XCTAssertTrue(scrollUpUntilExists(app.staticTexts["Why Full Access?"]))
+        XCTAssertTrue(scrollUpUntilExists(app.staticTexts["Where It Won’t Appear"]))
     }
 
     private func scrollUpUntilExists(_ element: XCUIElement, maxSwipes: Int = 6) -> Bool {

--- a/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
+++ b/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
@@ -65,6 +65,19 @@ final class ActionButtonSettingsUITests: XCTestCase {
         XCTAssertTrue(readyOrMissingStatus.waitForExistence(timeout: 5))
     }
 
+    func testKeyboardOnboardingExplainsSupportedSetup() {
+        app.buttons["Settings"].tap()
+
+        let keyboardSetupLink = app.buttons["keyboardSetupLink"]
+        XCTAssertTrue(scrollUpUntilExists(keyboardSetupLink))
+        keyboardSetupLink.tap()
+
+        XCTAssertTrue(app.navigationBars["Just Speak Keyboard"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["openKeyboardSettingsButton"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Why Full Access?"].exists)
+        XCTAssertTrue(app.staticTexts["Where It Won’t Appear"].exists)
+    }
+
     private func scrollUpUntilExists(_ element: XCUIElement, maxSwipes: Int = 6) -> Bool {
         if element.waitForExistence(timeout: 1) {
             return true

--- a/scripts/create-ios-app-store-profile.rb
+++ b/scripts/create-ios-app-store-profile.rb
@@ -1,0 +1,134 @@
+#!/usr/bin/env ruby
+
+require "base64"
+require "json"
+require "net/http"
+require "openssl"
+require "optparse"
+require "uri"
+
+options = {
+  api_base: "https://api.appstoreconnect.apple.com",
+}
+
+OptionParser.new do |parser|
+  parser.on("--bundle-id IDENTIFIER") { |value| options[:bundle_id] = value }
+  parser.on("--certificate-serial SERIAL") { |value| options[:certificate_serial] = value }
+  parser.on("--profile-name NAME") { |value| options[:profile_name] = value }
+  parser.on("--output PATH") { |value| options[:output] = value }
+end.parse!
+
+required_options = %i[bundle_id certificate_serial profile_name output]
+missing_options = required_options.reject { |key| options[key] && !options[key].empty? }
+abort("Missing required options: #{missing_options.join(', ')}") unless missing_options.empty?
+
+key_id = ENV.fetch("APP_STORE_CONNECT_KEY_ID")
+issuer_id = ENV.fetch("APP_STORE_CONNECT_ISSUER_ID")
+key_path = ENV.fetch("APP_STORE_CONNECT_KEY_PATH")
+private_key = OpenSSL::PKey::EC.new(File.read(key_path))
+
+def base64url(value)
+  Base64.urlsafe_encode64(value, padding: false)
+end
+
+header = base64url(JSON.generate(alg: "ES256", kid: key_id, typ: "JWT"))
+issued_at = Time.now.to_i
+payload = base64url(JSON.generate(iss: issuer_id, iat: issued_at, exp: issued_at + 1_200, aud: "appstoreconnect-v1"))
+unsigned_token = "#{header}.#{payload}"
+der_signature = private_key.dsa_sign_asn1(OpenSSL::Digest::SHA256.digest(unsigned_token))
+sequence = OpenSSL::ASN1.decode(der_signature)
+raw_signature = sequence.value.map { |integer| integer.value.to_s(2).rjust(32, "\0") }.join
+token = "#{unsigned_token}.#{base64url(raw_signature)}"
+
+def request(api_base:, token:, method:, path:, body: nil)
+  uri = URI.join(api_base, path)
+  request = method.new(uri)
+  request["Authorization"] = "Bearer #{token}"
+  request["Content-Type"] = "application/json"
+  request.body = JSON.generate(body) if body
+  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+  return response if response.is_a?(Net::HTTPSuccess)
+
+  abort("App Store Connect API #{request.method} #{uri.path} failed (#{response.code}): #{response.body}")
+end
+
+def fetch_collection(api_base:, token:, path:)
+  response = request(api_base: api_base, token: token, method: Net::HTTP::Get, path: path)
+  JSON.parse(response.body).fetch("data")
+end
+
+escaped_bundle_id = URI.encode_www_form_component(options[:bundle_id])
+bundle_ids = fetch_collection(
+  api_base: options[:api_base],
+  token: token,
+  path: "/v1/bundleIds?filter%5Bidentifier%5D=#{escaped_bundle_id}"
+)
+abort("No registered bundle ID found for #{options[:bundle_id]}") unless bundle_ids.length == 1
+bundle_resource_id = bundle_ids.first.fetch("id")
+
+serial = options[:certificate_serial].delete(":").upcase.sub(/^0+/, "")
+certificates = fetch_collection(
+  api_base: options[:api_base],
+  token: token,
+  path: "/v1/certificates?filter%5BcertificateType%5D=DISTRIBUTION,IOS_DISTRIBUTION&limit=200"
+)
+certificate = certificates.find do |candidate|
+  candidate_serial = candidate.dig("attributes", "serialNumber").to_s.delete(":").upcase.sub(/^0+/, "")
+  candidate_serial == serial
+end
+abort("No Apple distribution certificate matched serial #{options[:certificate_serial]}") unless certificate
+
+profile_name = "#{options[:profile_name]} #{serial[-8, 8]}"
+escaped_profile_name = URI.encode_www_form_component(profile_name)
+profiles = fetch_collection(
+  api_base: options[:api_base],
+  token: token,
+  path: "/v1/profiles?filter%5Bname%5D=#{escaped_profile_name}&limit=200"
+)
+
+profile = profiles.find { |candidate| candidate.dig("attributes", "profileState") == "ACTIVE" }
+unless profile
+  create_body = {
+    data: {
+      type: "profiles",
+      attributes: {
+        name: profile_name,
+        profileType: "IOS_APP_STORE",
+      },
+      relationships: {
+        bundleId: {
+          data: { type: "bundleIds", id: bundle_resource_id },
+        },
+        certificates: {
+          data: [{ type: "certificates", id: certificate.fetch("id") }],
+        },
+      },
+    },
+  }
+  response = request(
+    api_base: options[:api_base],
+    token: token,
+    method: Net::HTTP::Post,
+    path: "/v1/profiles",
+    body: create_body
+  )
+  profile = JSON.parse(response.body).fetch("data")
+  puts "Created provisioning profile #{profile_name}"
+else
+  puts "Reusing provisioning profile #{profile_name}"
+end
+
+content = profile.dig("attributes", "profileContent")
+unless content
+  response = request(
+    api_base: options[:api_base],
+    token: token,
+    method: Net::HTTP::Get,
+    path: "/v1/profiles/#{profile.fetch('id')}"
+  )
+  content = JSON.parse(response.body).dig("data", "attributes", "profileContent")
+end
+abort("Apple returned a profile without profileContent") unless content
+
+File.binwrite(options[:output], Base64.decode64(content))
+puts "Wrote provisioning profile to #{options[:output]}"


### PR DESCRIPTION
## Why

Let iOS users choose a Just Speak system keyboard and dictate into supported text fields without attempting to clone Apple’s keyboard or use unsupported microphone APIs from an extension.

## What changed

- add a transcription-first `UIInputViewController` keyboard extension with the supported globe/input-mode switch and accessible idle, handoff, recording, transcribing, success, Full Access, cancellation, unavailable, and error states
- add a versioned, nonce-scoped App Group request/result protocol with strict state transitions, expiry, one-time consumption, and stale/mismatched request rejection
- hand microphone capture to the containing app through `justspeaktoit://keyboard?request=<uuid>` and reuse the selected existing transcription engine/model
- keep keyboard dictation out of History, clipboard, legacy shared transcript keys, and retained batch-audio storage
- add in-app keyboard setup/Full Access guidance and honest platform-limit copy
- embed/sign/validate the extension in Tuist and the iOS TestFlight workflow
- add focused handoff, routing, shared-state, distribution, and onboarding coverage plus physical-device/App Review verification steps

## Verification

- `swift test --skip-build`: 676 tests passed, 11 skipped
- strict SwiftLint with the repository baseline: passed
- `tuist generate --no-open`: passed
- XcodeBuildMCP iOS `build-for-testing`: passed; built app contains `JustSpeakKeyboard.appex` and widget extension
- direct macOS Debug Xcode build: passed
- `TUIST_APP_STORE=1` macOS Release Xcode build: passed
- keyboard Info.plist/entitlements and `release-ios.yml` parsing: passed

## Remaining device gates

- Simulator launch/UI screenshots and simulator XCTest execution are pending because no iOS Simulator is currently booted in the host session.
- Physical-device enablement, Full Access, return-to-origin insertion, secure/phone-pad restrictions, and local/cloud model checks follow `Docs/ios-keyboard-mvp-verification.md`.
- The release workflow requires a new `IOS_KEYBOARD_APPSTORE_PROFILE` GitHub secret for `com.justspeaktoit.ios.keyboard`.

This PR is intentionally draft. Do not merge or submit it for App Review until simulator and physical-device gates are complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Just Speak custom keyboard for launching transcription and inserting results directly into text fields.
  * Added keyboard setup guidance, access-status indicators, cancellation, retry, and error handling.
  * Added secure handoff support between the keyboard extension and the main app.

* **Bug Fixes**
  * Improved release signing and validation for the keyboard extension.
  * Prevented keyboard transcripts from being published to legacy shared transcript state.

* **Documentation**
  * Added end-to-end keyboard setup, testing, privacy, and limitation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->