### PR TITLE
fix(ios): reconcile CloudKit history sync status

### DIFF
--- a/Sources/SpeakApp/MacHistorySyncAdapter.swift
+++ b/Sources/SpeakApp/MacHistorySyncAdapter.swift
@@ -29,18 +29,20 @@ final class MacHistorySyncAdapter: HistorySyncDelegate {
     func uploadNewItem(_ item: HistoryItem) {
         Task {
             let entry = item.toSyncable()
-            try? await HistorySyncEngine.shared.upload(entry: entry)
-            syncedIDs.insert(item.id)
-            saveSyncedIDs()
+            do {
+                try await HistorySyncEngine.shared.upload(entry: entry)
+            } catch {
+                log.error("History upload failed: \(error.localizedDescription)")
+            }
         }
     }
 
     /// Delete an item from CloudKit when removed locally.
     func deleteItem(id: UUID) {
+        syncedIDs.remove(id)
+        saveSyncedIDs()
         Task {
             try? await HistorySyncEngine.shared.delete(entryID: id)
-            syncedIDs.remove(id)
-            saveSyncedIDs()
         }
     }
 
@@ -53,26 +55,35 @@ final class MacHistorySyncAdapter: HistorySyncDelegate {
             .map { $0.toSyncable() }
     }
 
-    func didReceiveRemoteEntry(_ entry: SyncableHistoryEntry) {
-        guard !historyManager.allItems.contains(where: { $0.id == entry.id })
-        else {
+    func didReceiveRemoteEntry(_ entry: SyncableHistoryEntry) async {
+        if let local = historyManager.allItems.first(where: { $0.id == entry.id }) {
+            if entry.updatedAt > local.updatedAt {
+                await historyManager.update(HistoryItem.fromSyncable(entry))
+                syncedIDs.insert(entry.id)
+            } else if entry.updatedAt == local.updatedAt {
+                syncedIDs.insert(entry.id)
+            } else {
+                syncedIDs.remove(entry.id)
+            }
+            saveSyncedIDs()
             return
         }
 
         let item = HistoryItem.fromSyncable(entry)
-        Task {
-            await historyManager.append(item)
-            syncedIDs.insert(entry.id)
-            saveSyncedIDs()
-        }
+        await historyManager.append(item)
+        syncedIDs.insert(entry.id)
+        saveSyncedIDs()
     }
 
-    func didDeleteRemoteEntry(id: UUID) {
-        Task {
-            await historyManager.remove(id: id)
-            syncedIDs.remove(id)
-            saveSyncedIDs()
-        }
+    func didDeleteRemoteEntry(id: UUID) async {
+        await historyManager.remove(id: id)
+        syncedIDs.remove(id)
+        saveSyncedIDs()
+    }
+
+    func didAcknowledgeSyncedEntries(ids: Set<UUID>) async {
+        syncedIDs.formUnion(ids)
+        saveSyncedIDs()
     }
 
     // MARK: - Synced IDs Tracking

--- a/Sources/SpeakSync/CloudKitHistorySyncTransport.swift
+++ b/Sources/SpeakSync/CloudKitHistorySyncTransport.swift
@@ -1,0 +1,199 @@
+import CloudKit
+import Foundation
+
+@MainActor
+final class CloudKitHistorySyncTransport: HistorySyncTransport {
+    func fetchChanges(after tokenData: Data?) async throws -> HistoryChangePage {
+        guard let database = SyncConfiguration.privateDatabase else {
+            throw SyncError.cloudUnavailable
+        }
+
+        let operation = try makeFetchOperation(after: tokenData)
+        let accumulator = HistoryFetchAccumulator()
+        configureCallbacks(for: operation, accumulator: accumulator)
+        try await execute(operation, on: database)
+        return try accumulator.page()
+    }
+
+    func upload(entries: [SyncableHistoryEntry]) async -> HistoryUploadResult {
+        guard let database = SyncConfiguration.privateDatabase else {
+            return HistoryUploadResult(
+                acknowledgedIDs: [],
+                remoteEntries: [],
+                failures: Dictionary(uniqueKeysWithValues: entries.map { ($0.id, SyncError.cloudUnavailable) })
+            )
+        }
+
+        var acknowledgedIDs: Set<UUID> = []
+        var remoteEntries: [SyncableHistoryEntry] = []
+        var failures: [UUID: Error] = [:]
+
+        // Resolve by record ID before saving so retries against an already
+        // present CloudKit record are acknowledgements, not permanent conflicts.
+        for entry in entries {
+            do {
+                let recordID = CKRecord.ID(
+                    recordName: entry.id.uuidString,
+                    zoneID: SyncConfiguration.zoneID
+                )
+                let existingRecord: CKRecord?
+                do {
+                    existingRecord = try await database.record(for: recordID)
+                } catch let error as CKError where error.code == .unknownItem {
+                    existingRecord = nil
+                }
+
+                if let existingRecord,
+                   let remoteEntry = SyncRecord.entry(from: existingRecord),
+                   remoteEntry.updatedAt >= entry.updatedAt {
+                    acknowledgedIDs.insert(entry.id)
+                    remoteEntries.append(remoteEntry)
+                    continue
+                }
+
+                let record = SyncRecord.record(from: entry, existingRecord: existingRecord)
+                _ = try await database.save(record)
+                acknowledgedIDs.insert(entry.id)
+            } catch {
+                failures[entry.id] = error
+            }
+        }
+
+        return HistoryUploadResult(
+            acknowledgedIDs: acknowledgedIDs,
+            remoteEntries: remoteEntries,
+            failures: failures
+        )
+    }
+
+    func delete(entryID: UUID) async throws {
+        guard let database = SyncConfiguration.privateDatabase else {
+            throw SyncError.cloudUnavailable
+        }
+        let recordID = CKRecord.ID(
+            recordName: entryID.uuidString,
+            zoneID: SyncConfiguration.zoneID
+        )
+        do {
+            try await database.deleteRecord(withID: recordID)
+        } catch let error as CKError where error.code == .unknownItem {
+            // An already absent record is a successful deletion reconciliation.
+        }
+    }
+
+    private func makeFetchOperation(after tokenData: Data?) throws -> CKFetchRecordZoneChangesOperation {
+        let config = CKFetchRecordZoneChangesOperation.ZoneConfiguration()
+        if let tokenData {
+            config.previousServerChangeToken = try NSKeyedUnarchiver.unarchivedObject(
+                ofClass: CKServerChangeToken.self,
+                from: tokenData
+            )
+        }
+
+        let operation = CKFetchRecordZoneChangesOperation(
+            recordZoneIDs: [SyncConfiguration.zoneID],
+            configurationsByRecordZoneID: [SyncConfiguration.zoneID: config]
+        )
+        // Consume one explicit page at a time. HistorySyncEngine advances the
+        // token only after every page has been reconciled locally.
+        operation.fetchAllChanges = false
+        return operation
+    }
+
+    private func configureCallbacks(
+        for operation: CKFetchRecordZoneChangesOperation,
+        accumulator: HistoryFetchAccumulator
+    ) {
+        operation.recordWasChangedBlock = { _, result in
+            switch result {
+            case .success(let record) where record.recordType == SyncConfiguration.recordType:
+                if let entry = SyncRecord.entry(from: record) {
+                    accumulator.append(change: .changed(entry))
+                }
+            case .success:
+                // Other record types share the zone (for example encrypted
+                // secrets) and belong to their own reconciliation subsystem.
+                break
+            case .failure(let error):
+                accumulator.append(error: error)
+            }
+        }
+        operation.recordWithIDWasDeletedBlock = { recordID, recordType in
+            if recordType == SyncConfiguration.recordType,
+               let id = UUID(uuidString: recordID.recordName) {
+                accumulator.append(change: .deleted(id))
+            }
+        }
+        operation.recordZoneChangeTokensUpdatedBlock = { _, token, _ in
+            accumulator.update(token: token)
+        }
+        operation.recordZoneFetchResultBlock = { _, result in
+            switch result {
+            case .success(let (token, _, moreComing)):
+                accumulator.update(token: token, moreComing: moreComing)
+            case .failure(let error):
+                accumulator.append(error: error)
+            }
+        }
+    }
+
+    private func execute(
+        _ operation: CKFetchRecordZoneChangesOperation,
+        on database: CKDatabase
+    ) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            operation.fetchRecordZoneChangesResultBlock = { result in
+                switch result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+            database.add(operation)
+        }
+    }
+}
+
+private final class HistoryFetchAccumulator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var changes: [HistoryRemoteChange] = []
+    private var token: CKServerChangeToken?
+    private var moreComing = false
+    private var errors: [Error] = []
+
+    func append(change: HistoryRemoteChange) {
+        lock.withLock { changes.append(change) }
+    }
+
+    func append(error: Error) {
+        lock.withLock { errors.append(error) }
+    }
+
+    func update(token: CKServerChangeToken?, moreComing: Bool? = nil) {
+        lock.withLock {
+            if let token {
+                self.token = token
+            }
+            if let moreComing {
+                self.moreComing = moreComing
+            }
+        }
+    }
+
+    func page() throws -> HistoryChangePage {
+        try lock.withLock {
+            if let error = errors.first {
+                throw error
+            }
+            let tokenData = try token.map {
+                try NSKeyedArchiver.archivedData(withRootObject: $0, requiringSecureCoding: true)
+            }
+            return HistoryChangePage(
+                changes: changes,
+                serverChangeTokenData: tokenData,
+                moreComing: moreComing
+            )
+        }
+    }
+}

--- a/Sources/SpeakSync/HistorySyncEngine.swift
+++ b/Sources/SpeakSync/HistorySyncEngine.swift
@@ -3,165 +3,214 @@ import Combine
 import Foundation
 import os.log
 
-/// Delegate protocol that platforms implement to handle synced entries.
+/// Delegate protocol that platforms implement to reconcile synced entries.
 @MainActor
 public protocol HistorySyncDelegate: AnyObject {
-    /// Return all local entries that should be uploaded.
+    /// Return local entries that are not currently acknowledged by CloudKit.
     func pendingEntries() -> [SyncableHistoryEntry]
 
-    /// Called when a new or updated entry arrives from CloudKit.
-    func didReceiveRemoteEntry(_ entry: SyncableHistoryEntry)
+    /// Reconcile a new, duplicate, or updated entry from CloudKit.
+    func didReceiveRemoteEntry(_ entry: SyncableHistoryEntry) async
 
-    /// Called when an entry is deleted remotely.
-    func didDeleteRemoteEntry(id: UUID)
+    /// Reconcile a CloudKit tombstone.
+    func didDeleteRemoteEntry(id: UUID) async
+
+    /// Record IDs that CloudKit has acknowledged.
+    func didAcknowledgeSyncedEntries(ids: Set<UUID>) async
 }
 
-/// Result of a CloudKit zone-changes fetch operation.
-private struct FetchChangesResult {
-    var records: [CKRecord]
-    var deletedIDs: [CKRecord.ID]
-    var serverChangeToken: CKServerChangeToken?
+enum HistoryRemoteChange {
+    case changed(SyncableHistoryEntry)
+    case deleted(UUID)
+
+    var id: UUID {
+        switch self {
+        case .changed(let entry):
+            return entry.id
+        case .deleted(let id):
+            return id
+        }
+    }
+}
+
+struct HistoryChangePage {
+    var changes: [HistoryRemoteChange]
+    var serverChangeTokenData: Data?
+    var moreComing: Bool
+}
+
+struct HistoryUploadResult {
+    var acknowledgedIDs: Set<UUID>
+    var remoteEntries: [SyncableHistoryEntry]
+    var failures: [UUID: Error]
+
+    static func success(ids: Set<UUID>) -> HistoryUploadResult {
+        HistoryUploadResult(acknowledgedIDs: ids, remoteEntries: [], failures: [:])
+    }
+}
+
+@MainActor
+protocol HistorySyncTransport: AnyObject {
+    func fetchChanges(after tokenData: Data?) async throws -> HistoryChangePage
+    func upload(entries: [SyncableHistoryEntry]) async -> HistoryUploadResult
+    func delete(entryID: UUID) async throws
+}
+
+/// Keeps only the final event for each record while preserving the order of
+/// those final events. This makes duplicate changes and tombstones deterministic
+/// across CloudKit pages.
+enum HistoryChangeReconciler {
+    static func coalesced(_ changes: [HistoryRemoteChange]) -> [HistoryRemoteChange] {
+        var latestByID: [UUID: (offset: Int, change: HistoryRemoteChange)] = [:]
+        for (offset, change) in changes.enumerated() {
+            latestByID[change.id] = (offset, change)
+        }
+        return latestByID.values
+            .sorted { $0.offset < $1.offset }
+            .map(\.change)
+    }
 }
 
 /// Main sync engine handling CloudKit operations for transcription history.
 @MainActor
 public final class HistorySyncEngine: ObservableObject {
-
-    // MARK: - Published State
-
     @Published public private(set) var state = SyncState()
-
-    // MARK: - Private Properties
-
-    private weak var delegate: HistorySyncDelegate?
-    private let log = Logger(
-        subsystem: "com.justspeaktoit",
-        category: "HistorySync"
-    )
-
-    // MARK: - Singleton
 
     public static let shared = HistorySyncEngine()
 
-    private init() {}
+    private weak var delegate: HistorySyncDelegate?
+    private let transport: HistorySyncTransport
+    private let defaults: UserDefaults
+    private let log = Logger(subsystem: "com.justspeaktoit", category: "HistorySync")
 
-    // MARK: - Initialization
+    private convenience init() {
+        self.init(
+            transport: CloudKitHistorySyncTransport(),
+            defaults: .standard,
+            cloudAvailable: false
+        )
+    }
 
-    /// Initialize the sync engine with a delegate.
+    init(
+        transport: HistorySyncTransport,
+        defaults: UserDefaults,
+        cloudAvailable: Bool,
+        delegate: HistorySyncDelegate? = nil
+    ) {
+        self.transport = transport
+        self.defaults = defaults
+        self.delegate = delegate
+        state.isCloudAvailable = cloudAvailable
+    }
+
     public func initialize(delegate: HistorySyncDelegate) async {
         self.delegate = delegate
         await checkCloudAvailability()
-
         if state.isCloudAvailable {
             await setupCloudKitInfrastructure()
         }
     }
 
-    // MARK: - Public API
-
-    /// Manually trigger a full sync.
+    /// Manually trigger a complete fetch, reconciliation, and upload pass.
     public func sync() async {
+        state.pendingUploadCount = delegate?.pendingEntries().count ?? 0
+        state.pendingDownloadCount = 0
+
         guard state.isCloudAvailable else {
+            state.error = SyncError.cloudUnavailable
             log.warning("Sync requested but iCloud unavailable")
             return
         }
-
         guard !state.isSyncing else {
             log.info("Sync already in progress")
+            return
+        }
+        guard delegate != nil else {
+            state.error = SyncError.delegateUnavailable
             return
         }
 
         state.isSyncing = true
         state.error = nil
-
         defer { state.isSyncing = false }
 
         do {
             try await fetchRemoteChanges()
             try await uploadPendingEntries()
+            state.pendingDownloadCount = 0
+            state.pendingUploadCount = delegate?.pendingEntries().count ?? 0
+            guard state.pendingUploadCount == 0 else {
+                throw SyncError.reconciliationIncomplete(state.pendingUploadCount)
+            }
             state.lastSyncTime = Date()
-            log.info("Sync completed successfully")
+            log.info("Sync reconciliation completed successfully")
         } catch {
             state.error = error
+            state.pendingUploadCount = delegate?.pendingEntries().count ?? state.pendingUploadCount
             log.error("Sync failed: \(error.localizedDescription)")
         }
     }
 
-    /// Upload a single entry to CloudKit.
+    /// Upload a single entry and acknowledge it only after CloudKit confirms it.
     public func upload(entry: SyncableHistoryEntry) async throws {
-        guard state.isCloudAvailable,
-              let database = SyncConfiguration.privateDatabase else {
+        guard state.isCloudAvailable else {
             throw SyncError.cloudUnavailable
         }
-
-        let record = SyncRecord.record(from: entry)
-
-        do {
-            _ = try await database.save(record)
-            log.debug("Uploaded entry: \(entry.id.uuidString)")
-        } catch {
-            throw SyncError.cloudKit(error)
+        let result = await transport.upload(entries: [entry])
+        await applyUploadResult(result)
+        state.pendingUploadCount = delegate?.pendingEntries().count ?? 0
+        if let error = result.failures[entry.id] {
+            let syncError = SyncError.cloudKit(error)
+            state.error = syncError
+            throw syncError
         }
+        state.error = nil
+        log.debug("Uploaded entry: \(entry.id.uuidString)")
     }
 
-    /// Delete an entry from CloudKit.
     public func delete(entryID: UUID) async throws {
-        guard state.isCloudAvailable,
-              let database = SyncConfiguration.privateDatabase else {
+        guard state.isCloudAvailable else {
             throw SyncError.cloudUnavailable
         }
-
-        let recordID = CKRecord.ID(
-            recordName: entryID.uuidString,
-            zoneID: SyncConfiguration.zoneID
-        )
-
         do {
-            try await database.deleteRecord(
-                withID: recordID
-            )
+            try await transport.delete(entryID: entryID)
             log.debug("Deleted entry: \(entryID.uuidString)")
-        } catch let error as CKError where error.code == .unknownItem {
-            // Already deleted — not an error
         } catch {
             throw SyncError.cloudKit(error)
         }
     }
-
-    // MARK: - Cloud Availability
 
     private func checkCloudAvailability() async {
         guard SyncConfiguration.hasCloudKitEntitlement else {
             state.isCloudAvailable = false
+            state.error = SyncError.cloudUnavailable
             log.warning("CloudKit entitlement missing; history sync disabled")
             return
         }
-
         do {
             let status = try await SyncConfiguration.container?.accountStatus() ?? .noAccount
-            state.isCloudAvailable = (status == .available)
+            state.isCloudAvailable = status == .available
+            state.error = state.isCloudAvailable ? nil : SyncError.cloudUnavailable
         } catch {
             state.isCloudAvailable = false
+            state.error = SyncError.cloudKit(error)
             log.warning("iCloud check failed: \(error.localizedDescription)")
         }
     }
 
-    // MARK: - Infrastructure Setup
-
     private func setupCloudKitInfrastructure() async {
-        if !UserDefaults.standard.bool(forKey: SyncConfiguration.zoneCreatedKey) {
+        if !defaults.bool(forKey: SyncConfiguration.zoneCreatedKey) {
             do {
                 try await createCustomZone()
-                UserDefaults.standard.set(true, forKey: SyncConfiguration.zoneCreatedKey)
+                defaults.set(true, forKey: SyncConfiguration.zoneCreatedKey)
             } catch {
                 log.error("Zone creation failed: \(error.localizedDescription)")
             }
         }
-
-        if !UserDefaults.standard.bool(forKey: SyncConfiguration.subscriptionCreatedKey) {
+        if !defaults.bool(forKey: SyncConfiguration.subscriptionCreatedKey) {
             do {
                 try await createSubscription()
-                UserDefaults.standard.set(true, forKey: SyncConfiguration.subscriptionCreatedKey)
+                defaults.set(true, forKey: SyncConfiguration.subscriptionCreatedKey)
             } catch {
                 log.warning("Subscription failed: \(error.localizedDescription)")
             }
@@ -173,7 +222,7 @@ public final class HistorySyncEngine: ObservableObject {
         do {
             _ = try await database.save(SyncConfiguration.recordZone)
         } catch let error as CKError where error.code == .serverRecordChanged {
-            // Zone already exists
+            // Zone already exists.
         }
     }
 
@@ -186,133 +235,77 @@ public final class HistorySyncEngine: ObservableObject {
         _ = try await database.save(subscription)
     }
 
-    // MARK: - Fetch Remote Changes
-
     private func fetchRemoteChanges() async throws {
-        let changeToken = loadChangeToken()
-        let result = try await executeFetchOperation(changeToken: changeToken)
+        var tokenData = defaults.data(forKey: SyncConfiguration.syncTokenKey)
+        var finalTokenData = tokenData
+        var allChanges: [HistoryRemoteChange] = []
 
-        for record in result.records {
-            if let entry = SyncRecord.entry(from: record) {
-                delegate?.didReceiveRemoteEntry(entry)
-            }
-        }
+        while true {
+            let page = try await transport.fetchChanges(after: tokenData)
+            allChanges.append(contentsOf: page.changes)
+            state.pendingDownloadCount = allChanges.count
 
-        for recordID in result.deletedIDs {
-            if let uuid = UUID(uuidString: recordID.recordName) {
-                delegate?.didDeleteRemoteEntry(id: uuid)
-            }
-        }
-
-        if let token = result.serverChangeToken {
-            saveChangeToken(token)
-        }
-
-        state.pendingDownloadCount = result.records.count
-        log.info("Fetched \(result.records.count) records, \(result.deletedIDs.count) deletions")
-    }
-
-    private func loadChangeToken() -> CKServerChangeToken? {
-        guard let data = UserDefaults.standard.data(forKey: SyncConfiguration.syncTokenKey) else {
-            return nil
-        }
-        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: CKServerChangeToken.self, from: data)
-    }
-
-    private func saveChangeToken(_ token: CKServerChangeToken) {
-        if let data = try? NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true) {
-            UserDefaults.standard.set(data, forKey: SyncConfiguration.syncTokenKey)
-        }
-    }
-
-    private func executeFetchOperation(
-        changeToken: CKServerChangeToken?
-    ) async throws -> FetchChangesResult {
-        guard let database = SyncConfiguration.privateDatabase else {
-            throw SyncError.cloudUnavailable
-        }
-
-        let config = CKFetchRecordZoneChangesOperation.ZoneConfiguration()
-        config.previousServerChangeToken = changeToken
-
-        let operation = CKFetchRecordZoneChangesOperation(
-            recordZoneIDs: [SyncConfiguration.zoneID],
-            configurationsByRecordZoneID: [SyncConfiguration.zoneID: config]
-        )
-
-        var fetchedRecords: [CKRecord] = []
-        var deletedIDs: [CKRecord.ID] = []
-        var newToken: CKServerChangeToken?
-
-        operation.recordWasChangedBlock = { _, result in
-            if case .success(let record) = result {
-                fetchedRecords.append(record)
-            }
-        }
-
-        operation.recordWithIDWasDeletedBlock = { recordID, _ in
-            deletedIDs.append(recordID)
-        }
-
-        operation.recordZoneChangeTokensUpdatedBlock = { _, token, _ in
-            newToken = token
-        }
-
-        operation.recordZoneFetchResultBlock = { _, result in
-            if case .success(let (token, _, _)) = result {
-                newToken = token
-            }
-        }
-
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            operation.fetchRecordZoneChangesResultBlock = { result in
-                switch result {
-                case .success:
-                    cont.resume()
-                case .failure(let error):
-                    cont.resume(throwing: error)
+            if let pageToken = page.serverChangeTokenData {
+                guard !page.moreComing || pageToken != tokenData else {
+                    throw SyncError.invalidChangePage
                 }
+                tokenData = pageToken
+                finalTokenData = pageToken
+            } else if page.moreComing {
+                throw SyncError.invalidChangePage
             }
-            database.add(operation)
+
+            if !page.moreComing {
+                break
+            }
         }
 
-        return FetchChangesResult(
-            records: fetchedRecords,
-            deletedIDs: deletedIDs,
-            serverChangeToken: newToken
-        )
-    }
+        let changes = HistoryChangeReconciler.coalesced(allChanges)
+        state.pendingDownloadCount = changes.count
+        for change in changes {
+            switch change {
+            case .changed(let entry):
+                await delegate?.didReceiveRemoteEntry(entry)
+            case .deleted(let id):
+                await delegate?.didDeleteRemoteEntry(id: id)
+            }
+            state.pendingDownloadCount -= 1
+        }
 
-    // MARK: - Upload
+        if let finalTokenData {
+            defaults.set(finalTokenData, forKey: SyncConfiguration.syncTokenKey)
+        }
+        log.info("Reconciled \(changes.count) final remote changes")
+    }
 
     private func uploadPendingEntries() async throws {
         guard let delegate else { return }
-        guard let database = SyncConfiguration.privateDatabase else {
-            throw SyncError.cloudUnavailable
-        }
 
-        let entries = delegate.pendingEntries()
-        guard !entries.isEmpty else { return }
+        while true {
+            let pending = delegate.pendingEntries()
+            state.pendingUploadCount = pending.count
+            guard !pending.isEmpty else { return }
 
-        state.pendingUploadCount = entries.count
-        let records = entries.map { SyncRecord.record(from: $0) }
+            let batch = Array(pending.prefix(SyncConfiguration.batchSize))
+            let result = await transport.upload(entries: batch)
+            await applyUploadResult(result)
+            state.pendingUploadCount = delegate.pendingEntries().count
 
-        let operation = CKModifyRecordsOperation(recordsToSave: records, recordIDsToDelete: nil)
-        operation.savePolicy = .changedKeys
-        operation.isAtomic = false
-
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            operation.modifyRecordsResultBlock = { result in
-                switch result {
-                case .success:
-                    cont.resume()
-                case .failure(let error):
-                    cont.resume(throwing: error)
-                }
+            if !result.failures.isEmpty {
+                throw SyncError.partialUploadFailure(result.failures.count)
             }
-            database.add(operation)
+            guard state.pendingUploadCount < pending.count else {
+                throw SyncError.reconciliationIncomplete(state.pendingUploadCount)
+            }
         }
+    }
 
-        log.info("Uploaded \(records.count) records")
+    private func applyUploadResult(_ result: HistoryUploadResult) async {
+        for entry in result.remoteEntries {
+            await delegate?.didReceiveRemoteEntry(entry)
+        }
+        if !result.acknowledgedIDs.isEmpty {
+            await delegate?.didAcknowledgeSyncedEntries(ids: result.acknowledgedIDs)
+        }
     }
 }

--- a/Sources/SpeakSync/SyncModels.swift
+++ b/Sources/SpeakSync/SyncModels.swift
@@ -83,6 +83,10 @@ public final class SyncState: ObservableObject {
 public enum SyncError: LocalizedError {
     case cloudUnavailable
     case cloudKit(Error)
+    case delegateUnavailable
+    case invalidChangePage
+    case partialUploadFailure(Int)
+    case reconciliationIncomplete(Int)
     case encodingFailed
     case decodingFailed
 
@@ -92,6 +96,14 @@ public enum SyncError: LocalizedError {
             return "iCloud is not available. Please sign in to iCloud in Settings."
         case .cloudKit(let error):
             return "CloudKit error: \(error.localizedDescription)"
+        case .delegateUnavailable:
+            return "History sync is not ready yet"
+        case .invalidChangePage:
+            return "CloudKit returned another history page without a change token"
+        case .partialUploadFailure(let count):
+            return "Failed to upload \(count) history entr\(count == 1 ? "y" : "ies")"
+        case .reconciliationIncomplete(let count):
+            return "History reconciliation left \(count) entr\(count == 1 ? "y" : "ies") pending"
         case .encodingFailed:
             return "Failed to encode data for sync"
         case .decodingFailed:

--- a/Sources/SpeakiOS/Views/HistorySyncStatusBanner.swift
+++ b/Sources/SpeakiOS/Views/HistorySyncStatusBanner.swift
@@ -97,8 +97,7 @@ struct SyncStatusBanner: View {
     }
 
     private var syncFraction: CGFloat {
-        guard totalCount > 0 else { return 0 }
-        return CGFloat(syncedCount) / CGFloat(totalCount)
+        CGFloat(HistorySyncProgress.fraction(syncedCount: syncedCount, totalCount: totalCount))
     }
 
     private var syncSummary: String {
@@ -139,6 +138,14 @@ struct SyncStatusBanner: View {
             return .orange
         }
         return .green
+    }
+}
+
+enum HistorySyncProgress {
+    static func fraction(syncedCount: Int, totalCount: Int) -> Double {
+        guard totalCount > 0 else { return 0 }
+        let rawFraction = Double(syncedCount) / Double(totalCount)
+        return min(max(rawFraction, 0), 1)
     }
 }
 #endif

--- a/Sources/SpeakiOS/Views/iOSHistoryManager.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryManager.swift
@@ -18,6 +18,7 @@ public final class iOSHistoryManager: ObservableObject {
     private let fileURL: URL
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+    private let userDefaults: UserDefaults
 
     /// Whether CloudKit sync is wired up. Disabled in unit tests so persistence
     /// can be exercised in isolation.
@@ -29,20 +30,28 @@ public final class iOSHistoryManager: ObservableObject {
     private var hasLoadedFromDisk = false
 
     /// IDs of entries that have been synced to CloudKit.
-    private(set) var syncedIDs: Set<UUID> = []
-    private let syncedIDsKey = "speak.sync.syncedHistoryIDs"
+    @Published private(set) var syncedIDs: Set<UUID> = []
+    static let syncedIDsKey = "speak.sync.syncedHistoryIDs"
+
+    private var currentItemIDs: Set<UUID> {
+        Set(items.map(\.id))
+    }
+
+    private var reconciledSyncedIDs: Set<UUID> {
+        syncedIDs.intersection(currentItemIDs)
+    }
 
     /// Number of entries synced to CloudKit.
-    public var syncedCount: Int { syncedIDs.count }
+    public var syncedCount: Int { reconciledSyncedIDs.count }
 
     /// Number of entries not yet synced.
     public var unsyncedCount: Int {
-        items.filter { !syncedIDs.contains($0.id) }.count
+        items.count - syncedCount
     }
 
     /// Whether a specific item has been synced.
     public func isSynced(_ item: iOSHistoryItem) -> Bool {
-        syncedIDs.contains(item.id)
+        currentItemIDs.contains(item.id) && syncedIDs.contains(item.id)
     }
 
     private convenience init() {
@@ -52,16 +61,18 @@ public final class iOSHistoryManager: ObservableObject {
         )[0]
         self.init(
             fileURL: documentsURL.appendingPathComponent("transcription-history.json"),
-            syncEnabled: true
+            syncEnabled: true,
+            userDefaults: .standard
         )
     }
 
     /// Designated initializer. `fileURL` and `syncEnabled` are injectable so
     /// tests can exercise persistence against a temporary file without touching
     /// CloudKit.
-    init(fileURL: URL, syncEnabled: Bool) {
+    init(fileURL: URL, syncEnabled: Bool, userDefaults: UserDefaults = .standard) {
         self.fileURL = fileURL
         self.syncEnabled = syncEnabled
+        self.userDefaults = userDefaults
 
         encoder.dateEncodingStrategy = .iso8601
         decoder.dateDecodingStrategy = .iso8601
@@ -135,12 +146,12 @@ public final class iOSHistoryManager: ObservableObject {
         loadHistoryFromDiskIfNeeded()
         items.removeAll { $0.id == item.id }
         saveHistory()
+        syncedIDs.remove(item.id)
+        saveSyncedIDs()
 
         guard syncEnabled else { return }
         Task {
             try? await HistorySyncEngine.shared.delete(entryID: item.id)
-            syncedIDs.remove(item.id)
-            saveSyncedIDs()
         }
     }
 
@@ -150,14 +161,14 @@ public final class iOSHistoryManager: ObservableObject {
         let allIDs = items.map(\.id)
         items.removeAll()
         saveHistory()
+        syncedIDs.removeAll()
+        saveSyncedIDs()
 
         guard syncEnabled else { return }
         Task {
             for entryID in allIDs {
                 try? await HistorySyncEngine.shared.delete(entryID: entryID)
             }
-            syncedIDs.removeAll()
-            saveSyncedIDs()
         }
     }
 
@@ -256,6 +267,7 @@ public final class iOSHistoryManager: ObservableObject {
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             // Nothing to load — safe to start from an empty list.
             hasLoadedFromDisk = true
+            pruneStaleSyncedIDs()
             return
         }
 
@@ -267,6 +279,7 @@ public final class iOSHistoryManager: ObservableObject {
             // background recording) must be retried, never treated as "loaded"
             // and then clobbered by the next save.
             hasLoadedFromDisk = true
+            pruneStaleSyncedIDs()
         } catch {
             print("[iOSHistoryManager] Failed to load history: \(error)")
         }
@@ -290,8 +303,8 @@ public final class iOSHistoryManager: ObservableObject {
     // MARK: - Synced IDs Tracking
 
     private func loadSyncedIDs() {
-        if let strings = UserDefaults.standard.stringArray(
-            forKey: syncedIDsKey
+        if let strings = userDefaults.stringArray(
+            forKey: Self.syncedIDsKey
         ) {
             syncedIDs = Set(strings.compactMap { UUID(uuidString: $0) })
         }
@@ -299,7 +312,15 @@ public final class iOSHistoryManager: ObservableObject {
 
     private func saveSyncedIDs() {
         let strings = syncedIDs.map(\.uuidString)
-        UserDefaults.standard.set(strings, forKey: syncedIDsKey)
+        userDefaults.set(strings, forKey: Self.syncedIDsKey)
+    }
+
+    private func pruneStaleSyncedIDs() {
+        guard hasLoadedFromDisk else { return }
+        let reconciled = reconciledSyncedIDs
+        guard reconciled != syncedIDs else { return }
+        syncedIDs = reconciled
+        saveSyncedIDs()
     }
 }
 
@@ -307,13 +328,29 @@ public final class iOSHistoryManager: ObservableObject {
 
 extension iOSHistoryManager: HistorySyncDelegate {
     public func pendingEntries() -> [SyncableHistoryEntry] {
-        items
+        pruneStaleSyncedIDs()
+        return items
             .filter { !syncedIDs.contains($0.id) }
             .map { $0.toSyncable() }
     }
 
-    public func didReceiveRemoteEntry(_ entry: SyncableHistoryEntry) {
-        guard !items.contains(where: { $0.id == entry.id }) else {
+    public func didReceiveRemoteEntry(_ entry: SyncableHistoryEntry) async {
+        if let index = items.firstIndex(where: { $0.id == entry.id }) {
+            let local = items[index]
+            if entry.updatedAt > local.updatedAt {
+                items[index] = iOSHistoryItem.fromSyncable(entry)
+                items.sort { $0.createdAt > $1.createdAt }
+                saveHistory()
+                syncedIDs.insert(entry.id)
+            } else if entry.updatedAt == local.updatedAt {
+                // An already-present duplicate is an acknowledgement.
+                syncedIDs.insert(entry.id)
+            } else {
+                // The local entry is newer and must remain pending for upload.
+                syncedIDs.remove(entry.id)
+            }
+            pruneStaleSyncedIDs()
+            saveSyncedIDs()
             return
         }
 
@@ -325,10 +362,16 @@ extension iOSHistoryManager: HistorySyncDelegate {
         saveSyncedIDs()
     }
 
-    public func didDeleteRemoteEntry(id: UUID) {
+    public func didDeleteRemoteEntry(id: UUID) async {
         items.removeAll { $0.id == id }
         saveHistory()
         syncedIDs.remove(id)
+        saveSyncedIDs()
+    }
+
+    public func didAcknowledgeSyncedEntries(ids: Set<UUID>) async {
+        syncedIDs.formUnion(ids.intersection(currentItemIDs))
+        pruneStaleSyncedIDs()
         saveSyncedIDs()
     }
 }

--- a/Sources/SpeakiOS/Views/iOSHistoryModels.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryModels.swift
@@ -9,6 +9,7 @@ import SpeakSync
 public struct iOSHistoryItem: Identifiable, Codable {
     public let id: UUID
     public let createdAt: Date
+    public let updatedAt: Date
     public let transcription: String
     /// Polished (post-processed) text, when the entry has been reprocessed.
     public let postProcessedTranscription: String?
@@ -23,6 +24,7 @@ public struct iOSHistoryItem: Identifiable, Codable {
     public init(
         id: UUID = UUID(),
         createdAt: Date = Date(),
+        updatedAt: Date? = nil,
         transcription: String,
         postProcessedTranscription: String? = nil,
         model: String,
@@ -33,6 +35,7 @@ public struct iOSHistoryItem: Identifiable, Codable {
     ) {
         self.id = id
         self.createdAt = createdAt
+        self.updatedAt = updatedAt ?? createdAt
         self.transcription = transcription
         self.postProcessedTranscription = postProcessedTranscription
         self.model = model
@@ -53,10 +56,11 @@ public struct iOSHistoryItem: Identifiable, Codable {
     }
 
     /// Returns a copy with the polished transcript set and any prior error cleared.
-    public func withPostProcessed(_ text: String) -> iOSHistoryItem {
+    public func withPostProcessed(_ text: String, updatedAt: Date = Date()) -> iOSHistoryItem {
         iOSHistoryItem(
             id: id,
             createdAt: createdAt,
+            updatedAt: updatedAt,
             transcription: transcription,
             postProcessedTranscription: text,
             model: model,
@@ -72,6 +76,7 @@ public struct iOSHistoryItem: Identifiable, Codable {
         iOSHistoryItem(
             id: id,
             createdAt: createdAt,
+            updatedAt: updatedAt,
             transcription: transcription,
             postProcessedTranscription: postProcessedTranscription,
             model: model,
@@ -93,7 +98,7 @@ public struct iOSHistoryItem: Identifiable, Codable {
             duration: duration,
             wordCount: wordCount,
             originPlatform: originPlatform,
-            updatedAt: createdAt
+            updatedAt: updatedAt
         )
     }
 
@@ -102,6 +107,7 @@ public struct iOSHistoryItem: Identifiable, Codable {
         iOSHistoryItem(
             id: entry.id,
             createdAt: entry.createdAt,
+            updatedAt: entry.updatedAt,
             transcription: entry.rawTranscription ?? entry.postProcessedText ?? "",
             postProcessedTranscription: entry.postProcessedText,
             model: entry.model,
@@ -109,6 +115,33 @@ public struct iOSHistoryItem: Identifiable, Codable {
             wordCount: entry.wordCount,
             originPlatform: entry.originPlatform
         )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case createdAt
+        case updatedAt
+        case transcription
+        case postProcessedTranscription
+        case model
+        case duration
+        case wordCount
+        case originPlatform
+        case errorMessage
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? createdAt
+        transcription = try container.decode(String.self, forKey: .transcription)
+        postProcessedTranscription = try container.decodeIfPresent(String.self, forKey: .postProcessedTranscription)
+        model = try container.decode(String.self, forKey: .model)
+        duration = try container.decode(TimeInterval.self, forKey: .duration)
+        wordCount = try container.decode(Int.self, forKey: .wordCount)
+        originPlatform = try container.decodeIfPresent(String.self, forKey: .originPlatform) ?? "ios"
+        errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
     }
 }
 

--- a/Tests/SpeakSyncTests/HistorySyncEngineTests.swift
+++ b/Tests/SpeakSyncTests/HistorySyncEngineTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import XCTest
+
+@testable import SpeakSync
+
+@MainActor
+final class HistorySyncEngineTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "HistorySyncEngineTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        try await super.tearDown()
+    }
+
+    func testFullBatchSuccessAcknowledgesEveryEntryAndResetsPendingCounts() async {
+        let entries = [makeEntry(text: "one"), makeEntry(text: "two")]
+        let transport = FakeHistorySyncTransport(
+            pages: [.empty],
+            uploads: [.success(ids: Set(entries.map(\.id)))]
+        )
+        let delegate = FakeHistorySyncDelegate(entries: entries)
+        let engine = makeEngine(transport: transport, delegate: delegate)
+
+        await engine.sync()
+
+        XCTAssertEqual(delegate.acknowledgedIDs, Set(entries.map(\.id)))
+        XCTAssertEqual(engine.state.pendingUploadCount, 0)
+        XCTAssertEqual(engine.state.pendingDownloadCount, 0)
+        XCTAssertNil(engine.state.error)
+        XCTAssertNotNil(engine.state.lastSyncTime)
+    }
+
+    func testFailedUploadRemainsPendingUntilRetrySucceeds() async {
+        let entry = makeEntry(text: "retry")
+        let failure = TestFailure()
+        let transport = FakeHistorySyncTransport(
+            pages: [.empty, .empty],
+            uploads: [
+                HistoryUploadResult(acknowledgedIDs: [], remoteEntries: [], failures: [entry.id: failure]),
+                .success(ids: [entry.id])
+            ]
+        )
+        let delegate = FakeHistorySyncDelegate(entries: [entry])
+        let engine = makeEngine(transport: transport, delegate: delegate)
+
+        await engine.sync()
+        XCTAssertEqual(engine.state.pendingUploadCount, 1)
+        XCTAssertNotNil(engine.state.error)
+        XCTAssertNil(engine.state.lastSyncTime)
+
+        await engine.sync()
+        XCTAssertEqual(engine.state.pendingUploadCount, 0)
+        XCTAssertNil(engine.state.error)
+        XCTAssertNotNil(engine.state.lastSyncTime)
+    }
+
+    func testPaginationCoalescesDuplicatesAndAppliesFinalTombstone() async {
+        let deleted = makeEntry(text: "delete me")
+        let duplicateID = UUID()
+        let firstDuplicate = makeEntry(id: duplicateID, text: "old", updatedAt: Date(timeIntervalSince1970: 10))
+        let finalDuplicate = makeEntry(id: duplicateID, text: "new", updatedAt: Date(timeIntervalSince1970: 20))
+        let token1 = Data("page-1".utf8)
+        let token2 = Data("page-2".utf8)
+        let transport = FakeHistorySyncTransport(
+            pages: [
+                HistoryChangePage(
+                    changes: [.changed(deleted), .changed(firstDuplicate)],
+                    serverChangeTokenData: token1,
+                    moreComing: true
+                ),
+                HistoryChangePage(
+                    changes: [.deleted(deleted.id), .changed(finalDuplicate)],
+                    serverChangeTokenData: token2,
+                    moreComing: false
+                )
+            ],
+            uploads: []
+        )
+        let delegate = FakeHistorySyncDelegate(entries: [deleted])
+        let engine = makeEngine(transport: transport, delegate: delegate)
+
+        await engine.sync()
+
+        XCTAssertEqual(transport.requestedTokens, [nil, token1])
+        XCTAssertEqual(defaults.data(forKey: SyncConfiguration.syncTokenKey), token2)
+        XCTAssertEqual(delegate.deletedIDs, [deleted.id])
+        XCTAssertFalse(delegate.receivedEntries.contains { $0.id == deleted.id })
+        XCTAssertEqual(delegate.receivedEntries.filter { $0.id == duplicateID }.count, 1)
+        XCTAssertEqual(delegate.receivedEntries.first { $0.id == duplicateID }?.rawTranscription, "new")
+        XCTAssertEqual(engine.state.pendingDownloadCount, 0)
+    }
+
+    func testPaginationWithoutAdvancingTokenFailsTruthfully() async {
+        let transport = FakeHistorySyncTransport(
+            pages: [HistoryChangePage(changes: [], serverChangeTokenData: nil, moreComing: true)],
+            uploads: []
+        )
+        let delegate = FakeHistorySyncDelegate(entries: [])
+        let engine = makeEngine(transport: transport, delegate: delegate)
+
+        await engine.sync()
+
+        XCTAssertNotNil(engine.state.error)
+        XCTAssertNil(engine.state.lastSyncTime)
+        XCTAssertEqual(engine.state.pendingDownloadCount, 0)
+    }
+
+    func testPaginationWithRepeatedTokenFailsInsteadOfLooping() async {
+        let repeatedToken = Data("same-page".utf8)
+        defaults.set(repeatedToken, forKey: SyncConfiguration.syncTokenKey)
+        let transport = FakeHistorySyncTransport(
+            pages: [
+                HistoryChangePage(
+                    changes: [],
+                    serverChangeTokenData: repeatedToken,
+                    moreComing: true
+                )
+            ],
+            uploads: []
+        )
+        let delegate = FakeHistorySyncDelegate(entries: [])
+        let engine = makeEngine(transport: transport, delegate: delegate)
+
+        await engine.sync()
+
+        XCTAssertNotNil(engine.state.error)
+        XCTAssertNil(engine.state.lastSyncTime)
+        XCTAssertEqual(transport.requestedTokens, [repeatedToken])
+    }
+
+    private func makeEngine(
+        transport: FakeHistorySyncTransport,
+        delegate: FakeHistorySyncDelegate
+    ) -> HistorySyncEngine {
+        let engine = HistorySyncEngine(
+            transport: transport,
+            defaults: defaults,
+            cloudAvailable: true,
+            delegate: delegate
+        )
+        return engine
+    }
+
+    private func makeEntry(
+        id: UUID = UUID(),
+        text: String,
+        updatedAt: Date = Date(timeIntervalSince1970: 10)
+    ) -> SyncableHistoryEntry {
+        SyncableHistoryEntry(
+            id: id,
+            createdAt: Date(timeIntervalSince1970: 1),
+            rawTranscription: text,
+            postProcessedText: nil,
+            model: "test",
+            duration: 1,
+            wordCount: 1,
+            originPlatform: "ios",
+            updatedAt: updatedAt
+        )
+    }
+}
+
+private extension HistoryChangePage {
+    static var empty: HistoryChangePage {
+        HistoryChangePage(changes: [], serverChangeTokenData: nil, moreComing: false)
+    }
+}
+
+@MainActor
+private final class FakeHistorySyncTransport: HistorySyncTransport {
+    private var pages: [HistoryChangePage]
+    private var uploads: [HistoryUploadResult]
+    private(set) var requestedTokens: [Data?] = []
+
+    init(pages: [HistoryChangePage], uploads: [HistoryUploadResult]) {
+        self.pages = pages
+        self.uploads = uploads
+    }
+
+    func fetchChanges(after tokenData: Data?) async throws -> HistoryChangePage {
+        requestedTokens.append(tokenData)
+        return pages.isEmpty ? .empty : pages.removeFirst()
+    }
+
+    func upload(entries: [SyncableHistoryEntry]) async -> HistoryUploadResult {
+        uploads.isEmpty ? .success(ids: Set(entries.map(\.id))) : uploads.removeFirst()
+    }
+
+    func delete(entryID _: UUID) async throws {}
+}
+
+@MainActor
+private final class FakeHistorySyncDelegate: HistorySyncDelegate {
+    private var entriesByID: [UUID: SyncableHistoryEntry]
+    private(set) var acknowledgedIDs: Set<UUID> = []
+    private(set) var receivedEntries: [SyncableHistoryEntry] = []
+    private(set) var deletedIDs: [UUID] = []
+
+    init(entries: [SyncableHistoryEntry]) {
+        entriesByID = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+    }
+
+    func pendingEntries() -> [SyncableHistoryEntry] {
+        entriesByID.values.filter { !acknowledgedIDs.contains($0.id) }
+    }
+
+    func didReceiveRemoteEntry(_ entry: SyncableHistoryEntry) async {
+        receivedEntries.append(entry)
+        if entry.updatedAt >= (entriesByID[entry.id]?.updatedAt ?? .distantPast) {
+            entriesByID[entry.id] = entry
+            acknowledgedIDs.insert(entry.id)
+        }
+    }
+
+    func didDeleteRemoteEntry(id: UUID) async {
+        deletedIDs.append(id)
+        entriesByID.removeValue(forKey: id)
+        acknowledgedIDs.remove(id)
+    }
+
+    func didAcknowledgeSyncedEntries(ids: Set<UUID>) async {
+        acknowledgedIDs.formUnion(ids.intersection(Set(entriesByID.keys)))
+    }
+}
+
+private struct TestFailure: LocalizedError {
+    var errorDescription: String? { "test failure" }
+}

--- a/Tests/SpeakiOSTests/HistoryItemModelTests.swift
+++ b/Tests/SpeakiOSTests/HistoryItemModelTests.swift
@@ -60,6 +60,7 @@ final class HistoryItemModelTests: XCTestCase {
         XCTAssertNil(item.postProcessedTranscription)
         XCTAssertNil(item.errorMessage)
         XCTAssertEqual(item.bestText, "hello")
+        XCTAssertEqual(item.updatedAt, item.createdAt)
     }
 }
 #endif

--- a/Tests/SpeakiOSTests/HistorySyncReconciliationTests.swift
+++ b/Tests/SpeakiOSTests/HistorySyncReconciliationTests.swift
@@ -1,0 +1,197 @@
+#if os(iOS)
+import Foundation
+import SpeakSync
+import XCTest
+
+@testable import SpeakiOSLib
+
+@MainActor
+final class HistorySyncReconciliationTests: XCTestCase {
+    private var tempDirectory: URL!
+    private var fileURL: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        fileURL = tempDirectory.appendingPathComponent("transcription-history.json")
+        suiteName = "HistorySyncReconciliationTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDirectory)
+        defaults.removePersistentDomain(forName: suiteName)
+        try await super.tearDown()
+    }
+
+    func testLegacyAcknowledgementsArePrunedToCurrentLocalIDsAndCountsStayValid() throws {
+        let localItems = (0..<19).map { makeItem(text: "local \($0)") }
+        try writeHistory(localItems)
+        let acknowledgedLocalIDs = Set(localItems.prefix(5).map(\.id))
+        let staleIDs = Set((0..<39).map { _ in UUID() })
+        defaults.set(
+            acknowledgedLocalIDs.union(staleIDs).map(\.uuidString),
+            forKey: iOSHistoryManager.syncedIDsKey
+        )
+
+        let manager = makeManager()
+
+        XCTAssertEqual(manager.items.count, 19)
+        XCTAssertEqual(manager.syncedCount, 5)
+        XCTAssertEqual(manager.unsyncedCount, 14)
+        XCTAssertGreaterThanOrEqual(manager.syncedCount, 0)
+        XCTAssertLessThanOrEqual(manager.syncedCount, manager.items.count)
+        XCTAssertEqual(manager.unsyncedCount, manager.items.count - manager.syncedCount)
+        XCTAssertEqual(persistedAcknowledgedIDs(), acknowledgedLocalIDs)
+    }
+
+    func testLocalDeletePrunesAcknowledgementImmediately() async throws {
+        let item = makeItem(text: "delete")
+        try writeHistory([item])
+        let manager = makeManager()
+        await manager.didAcknowledgeSyncedEntries(ids: [item.id])
+        XCTAssertEqual(manager.syncedCount, 1)
+
+        manager.remove(item)
+
+        XCTAssertEqual(manager.items.count, 0)
+        XCTAssertEqual(manager.syncedCount, 0)
+        XCTAssertEqual(manager.unsyncedCount, 0)
+        XCTAssertTrue(persistedAcknowledgedIDs().isEmpty)
+    }
+
+    func testAlreadyPresentRemoteDuplicateBecomesAcknowledgedWithoutDuplication() async throws {
+        let item = makeItem(text: "same")
+        try writeHistory([item])
+        let manager = makeManager()
+
+        await manager.didReceiveRemoteEntry(item.toSyncable())
+
+        XCTAssertEqual(manager.items.count, 1)
+        XCTAssertEqual(manager.syncedCount, 1)
+        XCTAssertEqual(manager.unsyncedCount, 0)
+    }
+
+    func testNewerRemoteUpdateReplacesLocalUsingUpdatedAt() async throws {
+        let local = makeItem(
+            text: "old",
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+        try writeHistory([local])
+        let manager = makeManager()
+        let remote = makeEntry(
+            id: local.id,
+            text: "new",
+            createdAt: local.createdAt,
+            updatedAt: Date(timeIntervalSince1970: 30)
+        )
+
+        await manager.didReceiveRemoteEntry(remote)
+
+        XCTAssertEqual(manager.items.first?.transcription, "new")
+        XCTAssertEqual(manager.items.first?.updatedAt, remote.updatedAt)
+        XCTAssertEqual(manager.syncedCount, 1)
+    }
+
+    func testOlderRemoteUpdateLeavesNewerLocalEntryPending() async throws {
+        let local = makeItem(
+            text: "local-newer",
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 30)
+        )
+        try writeHistory([local])
+        defaults.set([local.id.uuidString], forKey: iOSHistoryManager.syncedIDsKey)
+        let manager = makeManager()
+        let remote = makeEntry(
+            id: local.id,
+            text: "remote-older",
+            createdAt: local.createdAt,
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+
+        await manager.didReceiveRemoteEntry(remote)
+
+        XCTAssertEqual(manager.items.first?.transcription, "local-newer")
+        XCTAssertEqual(manager.syncedCount, 0)
+        XCTAssertEqual(manager.unsyncedCount, 1)
+    }
+
+    func testRemoteTombstoneRemovesItemAndAcknowledgement() async throws {
+        let item = makeItem(text: "remote delete")
+        try writeHistory([item])
+        defaults.set([item.id.uuidString], forKey: iOSHistoryManager.syncedIDsKey)
+        let manager = makeManager()
+
+        await manager.didDeleteRemoteEntry(id: item.id)
+
+        XCTAssertTrue(manager.items.isEmpty)
+        XCTAssertEqual(manager.syncedCount, 0)
+        XCTAssertEqual(manager.unsyncedCount, 0)
+        XCTAssertTrue(persistedAcknowledgedIDs().isEmpty)
+    }
+
+    func testProgressFractionClampsLegacyOrCorruptCounts() {
+        XCTAssertEqual(HistorySyncProgress.fraction(syncedCount: 44, totalCount: 19), 1)
+        XCTAssertEqual(HistorySyncProgress.fraction(syncedCount: -1, totalCount: 19), 0)
+        XCTAssertEqual(HistorySyncProgress.fraction(syncedCount: 5, totalCount: 20), 0.25)
+        XCTAssertEqual(HistorySyncProgress.fraction(syncedCount: 5, totalCount: 0), 0)
+    }
+
+    private func makeManager() -> iOSHistoryManager {
+        iOSHistoryManager(fileURL: fileURL, syncEnabled: false, userDefaults: defaults)
+    }
+
+    private func writeHistory(_ items: [iOSHistoryItem]) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(items).write(to: fileURL, options: .atomic)
+    }
+
+    private func persistedAcknowledgedIDs() -> Set<UUID> {
+        Set(
+            (defaults.stringArray(forKey: iOSHistoryManager.syncedIDsKey) ?? [])
+                .compactMap(UUID.init(uuidString:))
+        )
+    }
+
+    private func makeItem(
+        text: String,
+        createdAt: Date = Date(timeIntervalSince1970: 10),
+        updatedAt: Date = Date(timeIntervalSince1970: 10)
+    ) -> iOSHistoryItem {
+        iOSHistoryItem(
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            transcription: text,
+            model: "test",
+            duration: 1,
+            wordCount: 1
+        )
+    }
+
+    private func makeEntry(
+        id: UUID,
+        text: String,
+        createdAt: Date,
+        updatedAt: Date
+    ) -> SyncableHistoryEntry {
+        SyncableHistoryEntry(
+            id: id,
+            createdAt: createdAt,
+            rawTranscription: text,
+            postProcessedText: nil,
+            model: "test",
+            duration: 1,
+            wordCount: 1,
+            originPlatform: "ios",
+            updatedAt: updatedAt
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## What changed

- Reconciles synced history IDs against current local transcription IDs and persists stale-ID pruning.
- Makes pending counts derive from `total - synced`, with `0 <= synced <= total`.
- Acknowledges every successful upload, including retry duplicates already present in CloudKit.
- Resolves local/remote updates using persisted `updatedAt`.
- Fetches every CloudKit zone-change page, coalesces duplicate events deterministically, applies tombstones, and rejects missing/repeated pagination tokens.
- Defines last sync as successful completion of fetch + reconciliation + upload with zero pending entries, while retaining truthful pending/error state on failure.
- Clamps the History progress fraction to `0...1`, so legacy/corrupt counters such as 44/19 cannot overflow the bar.
- Keeps history record/tombstone processing filtered to `TranscriptionHistory`; `CloudKitKeySync` and encrypted-secret records are untouched.

## Root cause

The iOS UI used the raw persisted `syncedIDs.count` while pending entries were calculated independently from current local items. Deleted history left stale acknowledgements behind, batch uploads did not acknowledge success, duplicate remote records returned early, and sync counters were not reset after reconciliation. That allowed impossible combinations such as 44 synced of 19 total with 17 pending and an over-width progress bar.

## Validation

- `swift test`: 671 tests passed, 11 existing skips, 0 failures.
- `swift test --filter HistorySyncEngineTests`: 5/5 passed after final pagination hardening.
- SwiftFormat: 0/10 changed files require formatting.
- SwiftLint strict with repository baseline: 0 violations.
- `xcodebuild build-for-testing -workspace "Just Speak to It.xcworkspace" -scheme SpeakiOS -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO`: **TEST BUILD SUCCEEDED**, including the new iOS reconciliation/status tests.

Focused coverage includes stale-ID pruning/deletion, remote duplicates, retry success, full-batch acknowledgement, pagination and repeated-token protection, tombstones, updated records, count invariants, and clamped progress.

## Runtime test-host note

A focused simulator `test-without-building` attempt was made. The existing hosted test configuration exited before XCTest connected because `SpeakCore`/`SpeakSync` classes are linked into both the app and package test framework; no reconciliation assertion ran or failed. This PR does not expand into that unrelated project-linkage issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudKit history synchronization with paginated change fetching, uploads, acknowledgements, and deletions.
  * Added timestamp-based conflict resolution for local and remote history updates.
  * Added clearer synchronization error reporting and progress handling.
  * Synced history status now updates promptly and remains accurate after deletions or remote changes.
  * Added support for tracking item update timestamps while preserving legacy data compatibility.

* **Bug Fixes**
  * Prevented stale synchronization records from inflating synced counts.
  * Improved upload failure visibility and remote change reconciliation.

* **Tests**
  * Added comprehensive coverage for synchronization, pagination, conflict resolution, persistence, and progress limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->