### PR TITLE
feat: [mac][ios] add xAI Grok Voice live transcription

### DIFF
--- a/Sources/SpeakApp/SharedClientLiveController.swift
+++ b/Sources/SpeakApp/SharedClientLiveController.swift
@@ -1,0 +1,226 @@
+import AVFoundation
+import Foundation
+import SpeakCore
+
+/// macOS capture/controller path for providers implemented by a shared
+/// `StreamingTranscriptionClient`.
+///
+/// Platform-specific code owns microphone capture and PCM conversion; the
+/// provider transport and event parsing stay in SpeakCore and are shared with
+/// iOS.
+@MainActor
+final class SharedClientLiveController: NSObject, LiveTranscriptionController {
+  weak var delegate: LiveTranscriptionSessionDelegate?
+  private(set) var isRunning = false
+
+  private let permissionsManager: PermissionsManager
+  private let audioDeviceManager: AudioInputDeviceManager
+  private let secureStorage: SecureAppStorage
+
+  private var currentLanguage: String?
+  private var currentModel: String?
+  private var client: StreamingTranscriptionClient?
+  private var audioEngine = AVAudioEngine()
+  private var activeInputSession: AudioInputDeviceManager.SessionContext?
+  private var startedAt: Date?
+  private var latestTranscript = ""
+  private var isStopping = false
+
+  init(
+    permissionsManager: PermissionsManager,
+    audioDeviceManager: AudioInputDeviceManager,
+    secureStorage: SecureAppStorage
+  ) {
+    self.permissionsManager = permissionsManager
+    self.audioDeviceManager = audioDeviceManager
+    self.secureStorage = secureStorage
+  }
+
+  func configure(language: String?, model: String) {
+    currentLanguage = language
+    currentModel = model
+  }
+
+  func start() async throws {
+    guard !isRunning else { return }
+    guard (await permissionsManager.ensureGranted(.microphone)).isGranted else {
+      throw TranscriptionManagerError.microphonePermissionMissing
+    }
+    guard let model = currentModel,
+          let route = LiveTranscriptionRouting.route(for: model),
+          let keyIdentifier = route.apiKeyIdentifier else {
+      throw LiveTranscriptionClientError.unknownModel(currentModel ?? "")
+    }
+
+    let apiKey = try await loadAPIKey(identifier: keyIdentifier)
+    guard let client = LiveTranscriptionClientFactory.makeClient(
+      for: route,
+      apiKey: apiKey,
+      language: currentLanguage
+    ) else {
+      throw LiveTranscriptionClientError.providerNotAvailable(route.provider)
+    }
+
+    activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    audioEngine = AVAudioEngine()
+    latestTranscript = ""
+    isStopping = false
+    self.client = client
+
+    do {
+      client.start(
+        onTranscript: { [weak self] text, isFinal in
+          Task { @MainActor [weak self] in
+            self?.handleTranscript(text, isFinal: isFinal)
+          }
+        },
+        onError: { [weak self] error in
+          Task { @MainActor [weak self] in
+            guard let self, self.isRunning else { return }
+            self.delegate?.liveTranscriber(self, didFail: error)
+          }
+        }
+      )
+      try installAudioTap(route: route, client: client)
+      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
+      startedAt = Date()
+      isRunning = true
+    } catch {
+      await cleanupAfterFailedStart()
+      throw error
+    }
+  }
+
+  func stop() async {
+    guard isRunning, !isStopping else { return }
+    isStopping = true
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+
+    if let finalizingClient = client as? FinalizingStreamingTranscriptionClient {
+      if let finalTranscript = await finalizingClient.finishAndWait(),
+         latestTranscript != finalTranscript {
+        handleTranscript(finalTranscript, isFinal: true)
+      }
+    } else {
+      client?.stop()
+    }
+    client = nil
+    isRunning = false
+    isStopping = false
+
+    let result = TranscriptionResult(
+      text: latestTranscript,
+      segments: [],
+      confidence: nil,
+      duration: startedAt.map { Date().timeIntervalSince($0) } ?? 0,
+      modelIdentifier: currentModel ?? "",
+      cost: nil,
+      rawPayload: nil,
+      debugInfo: nil
+    )
+    delegate?.liveTranscriber(self, didFinishWith: result)
+    await endActiveInputSession()
+  }
+
+  private func loadAPIKey(identifier: String) async throws -> String {
+    let apiKey: String
+    do {
+      apiKey = try await secureStorage.secret(identifier: identifier)
+    } catch let error as SecureAppStorageError {
+      if case .valueNotFound = error {
+        throw TranscriptionProviderError.apiKeyMissing
+      }
+      throw error
+    }
+    guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw TranscriptionProviderError.apiKeyMissing
+    }
+    return apiKey
+  }
+
+  private func handleTranscript(_ text: String, isFinal: Bool) {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    latestTranscript = trimmed
+    delegate?.liveTranscriber(self, didUpdateWith: LiveTranscriptionUpdate(
+      text: trimmed,
+      isFinal: isFinal,
+      confidence: nil
+    ))
+    delegate?.liveTranscriber(self, didUpdatePartial: trimmed)
+    if isFinal {
+      delegate?.liveTranscriber(self, didDetectUtteranceBoundary: trimmed)
+    }
+  }
+
+  private func installAudioTap(
+    route: LiveTranscriptionRoute,
+    client: StreamingTranscriptionClient
+  ) throws {
+    let inputNode = audioEngine.inputNode
+    inputNode.removeTap(onBus: 0)
+    let inputFormat = inputNode.outputFormat(forBus: 0)
+    guard audioInputFormatIsUsable(inputFormat) else {
+      throw TranscriptionManagerError.noUsableAudioInput
+    }
+    guard let targetFormat = AVAudioFormat(
+      commonFormat: .pcmFormatFloat32,
+      sampleRate: Double(route.sampleRate),
+      channels: 1,
+      interleaved: false
+    ), let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+      throw TranscriptionManagerError.noUsableAudioInput
+    }
+
+    inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
+      let ratio = targetFormat.sampleRate / inputFormat.sampleRate
+      let capacity = AVAudioFrameCount(ceil(Double(buffer.frameLength) * ratio)) + 1
+      guard let output = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else {
+        return
+      }
+      var conversionError: NSError?
+      var didProvideInput = false
+      let status = converter.convert(to: output, error: &conversionError) { _, outStatus in
+        guard !didProvideInput else {
+          outStatus.pointee = .noDataNow
+          return nil
+        }
+        didProvideInput = true
+        outStatus.pointee = .haveData
+        return buffer
+      }
+      guard status != .error, conversionError == nil,
+            let channelData = output.floatChannelData?[0] else {
+        return
+      }
+
+      let frameCount = Int(output.frameLength)
+      guard frameCount > 0 else { return }
+      var samples = [Int16](repeating: 0, count: frameCount)
+      for index in 0..<frameCount {
+        let clamped = max(-1, min(1, channelData[index]))
+        samples[index] = Int16(clamped * Float(Int16.max))
+      }
+      client.sendAudio(samples.withUnsafeBufferPointer { Data(buffer: $0) })
+    }
+  }
+
+  private func cleanupAfterFailedStart() async {
+    audioEngine.stop()
+    audioEngine.inputNode.removeTap(onBus: 0)
+    client?.stop()
+    client = nil
+    isRunning = false
+    isStopping = false
+    latestTranscript = ""
+    startedAt = nil
+    await endActiveInputSession()
+  }
+
+  private func endActiveInputSession() async {
+    guard let session = activeInputSession else { return }
+    activeInputSession = nil
+    await audioDeviceManager.endUsingPreferredInput(session: session)
+  }
+}

--- a/Sources/SpeakApp/SharedClientLiveController.swift
+++ b/Sources/SpeakApp/SharedClientLiveController.swift
@@ -76,7 +76,7 @@ final class SharedClientLiveController: NSObject, LiveTranscriptionController {
         },
         onError: { [weak self] error in
           Task { @MainActor [weak self] in
-            guard let self, self.isRunning else { return }
+            guard let self else { return }
             self.delegate?.liveTranscriber(self, didFail: error)
           }
         }

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -3970,6 +3970,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private var cartesiaController: CartesiaLiveController
   private var gladiaController: GladiaLiveController
   private var openAIRealtimeController: OpenAIRealtimeLiveController
+  private var sharedClientController: SharedClientLiveController
   #if !APP_STORE
   private var sherpaOnnxController: SherpaOnnxLiveController
   #endif
@@ -4054,6 +4055,11 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     )
     openAIRealtimeController = OpenAIRealtimeLiveController(
       appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    sharedClientController = SharedClientLiveController(
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
       secureStorage: secureStorage
@@ -4163,7 +4169,8 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       ("soniox/", sonioxController),
       ("speechmatics/", speechmaticsController),
       ("cartesia/", cartesiaController),
-      ("gladia/", gladiaController)
+      ("gladia/", gladiaController),
+      ("xai/", sharedClientController)
     ]
   }
 
@@ -4180,6 +4187,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       cartesiaController,
       gladiaController,
       openAIRealtimeController,
+      sharedClientController,
       unsupportedLocalLiveController
     ]
     #if !APP_STORE
@@ -4263,6 +4271,11 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     )
     openAIRealtimeController = OpenAIRealtimeLiveController(
       appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      secureStorage: secureStorage
+    )
+    sharedClientController = SharedClientLiveController(
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
       secureStorage: secureStorage

--- a/Sources/SpeakApp/TranscriptionProviderRegistry.swift
+++ b/Sources/SpeakApp/TranscriptionProviderRegistry.swift
@@ -22,6 +22,7 @@ actor TranscriptionProviderRegistry {
         providers["cartesia"] = CartesiaTranscriptionProvider()
         providers["mistral"] = MistralTranscriptionProvider()
         providers["gladia"] = GladiaTranscriptionProvider()
+        providers["xai"] = XAITranscriptionProvider()
     }
 
     func allProviders() -> [TranscriptionProviderMetadata] {

--- a/Sources/SpeakApp/XAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/XAITranscriptionProvider.swift
@@ -1,0 +1,101 @@
+import Foundation
+import SpeakCore
+
+enum XAITranscriptionProviderError: LocalizedError {
+  case batchNotSupported
+
+  var errorDescription: String? {
+    switch self {
+    case .batchNotSupported:
+      return "xAI Grok Voice is currently available as live streaming transcription only."
+    }
+  }
+}
+
+struct XAITranscriptionProvider: TranscriptionProvider {
+  let metadata = TranscriptionProviderMetadata(
+    id: "xai",
+    displayName: "xAI",
+    systemImage: "waveform.badge.mic",
+    tintColor: "black",
+    website: "https://console.x.ai"
+  )
+
+  private let session: URLSession
+  private let validationURL = URL(string: "https://api.x.ai/v1/models")!
+
+  init(session: URLSession = .shared) {
+    self.session = session
+  }
+
+  func transcribeFile(
+    at url: URL,
+    apiKey: String,
+    model: String,
+    language: String?
+  ) async throws -> TranscriptionResult {
+    _ = (url, apiKey, model, language)
+    throw XAITranscriptionProviderError.batchNotSupported
+  }
+
+  func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
+    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return .failure(message: "API key is empty")
+    }
+
+    var request = URLRequest(url: validationURL)
+    request.httpMethod = "GET"
+    request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+
+    do {
+      let (data, response) = try await session.data(for: request)
+      guard let http = response as? HTTPURLResponse else {
+        return .failure(message: "Received a non-HTTP response")
+      }
+      let debug = debugSnapshot(request: request, response: http, data: data)
+      switch http.statusCode {
+      case 200..<300:
+        return .success(message: "xAI API key validated", debug: debug)
+      case 401, 403:
+        return .failure(message: "xAI rejected the key (HTTP \(http.statusCode))", debug: debug)
+      default:
+        return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
+      }
+    } catch {
+      return .failure(message: "Validation failed: \(error.localizedDescription)")
+    }
+  }
+
+  func requiresAPIKey(for model: String) -> Bool {
+    true
+  }
+
+  func supportedModels() -> [ModelCatalog.Option] {
+    ModelCatalog.liveTranscription.filter { $0.id == XAIVoiceModels.thinkFast2CatalogID }
+  }
+
+  private func debugSnapshot(
+    request: URLRequest,
+    response: HTTPURLResponse,
+    data: Data
+  ) -> APIKeyValidationDebugSnapshot {
+    var requestHeaders = request.allHTTPHeaderFields ?? [:]
+    if requestHeaders["Authorization"] != nil {
+      requestHeaders["Authorization"] = "Bearer [REDACTED]"
+    }
+    return APIKeyValidationDebugSnapshot(
+      url: request.url?.absoluteString ?? "",
+      method: request.httpMethod ?? "GET",
+      requestHeaders: requestHeaders,
+      requestBody: nil,
+      statusCode: response.statusCode,
+      responseHeaders: response.allHeaderFields.reduce(into: [String: String]()) { result, pair in
+        guard let key = pair.key as? String else { return }
+        result[key] = String(describing: pair.value)
+      },
+      responseBody: String(data: data, encoding: .utf8),
+      errorDescription: nil
+    )
+  }
+}

--- a/Sources/SpeakCore/LiveModelCapabilities.swift
+++ b/Sources/SpeakCore/LiveModelCapabilities.swift
@@ -98,6 +98,10 @@ extension ModelCatalog {
         "elevenlabs/scribe-v2-streaming": LiveModelCapabilities(
             supportedSpeedModes: [.instant, .livePolish]
         ),
+        XAIVoiceModels.thinkFast2CatalogID: LiveModelCapabilities(
+            supportedSpeedModes: [.instant, .livePolish],
+            postStopFinalizeBudget: 3.0
+        ),
 
         // AssemblyAI Universal-3.5 Pro Streaming emits incremental turns and
         // one formatted final turn. Keep a non-zero post-stop budget so the

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -703,6 +703,25 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
         return trimmed
     }
 
+    /// User-facing transcription label shared by the iOS recording surfaces.
+    public static func transcriptionDisplayName(
+        for identifier: String,
+        isBatch: Bool
+    ) -> String {
+        if isBatch { return friendlyName(for: identifier) }
+        guard let route = LiveTranscriptionRouting.route(for: identifier) else {
+            return "Apple Speech"
+        }
+        switch route.provider {
+        case .apple:
+            return "Apple Speech"
+        case .deepgram, .elevenlabs:
+            return route.provider.displayName
+        default:
+            return friendlyName(for: identifier)
+        }
+    }
+
     private static func friendlyLocalModelName(from identifier: String, prefixes: [String]) -> String {
         var working = identifier
         let lowercased = identifier.lowercased()

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -171,6 +171,14 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
                 + "ElevenLabs API key — the key must have speech-to-text (Scribe) access.",
             estimatedLatencyMs: 200, latencyTier: .fast),
         Option(
+            id: XAIVoiceModels.thinkFast2CatalogID,
+            displayName: "Grok Voice Think Fast 2.0 (Streaming)",
+            description: "xAI's flagship realtime voice model, used in transcription-only mode "
+                + "with cumulative live captions and no assistant response.",
+            estimatedLatencyMs: 200,
+            latencyTier: .fast,
+            tags: [.fast, .leading]),
+        Option(
             id: OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID,
             displayName: "OpenAI GPT Live Transcribe (Streaming)",
             description: "OpenAI's recommended low-latency speech-to-text model with live transcript "

--- a/Sources/SpeakCore/ModelCredentialRequirement.swift
+++ b/Sources/SpeakCore/ModelCredentialRequirement.swift
@@ -173,7 +173,8 @@ public enum ModelCredentialResolver {
         "openrouter": "OpenRouter",
         "revai": "Rev.ai",
         "soniox": "Soniox",
-        "speechmatics": "Speechmatics"
+        "speechmatics": "Speechmatics",
+        "xai": "xAI"
     ]
 
     private static let openRouterRequirement = ModelCredentialRequirement.apiKey(

--- a/Sources/SpeakCore/StreamingTranscriptionClient.swift
+++ b/Sources/SpeakCore/StreamingTranscriptionClient.swift
@@ -32,6 +32,14 @@ public protocol StreamingTranscriptionClient: AnyObject {
     func stop()
 }
 
+/// Optional graceful-finalisation path for providers that only emit their
+/// definitive transcript after the input buffer is committed.
+public protocol FinalizingStreamingTranscriptionClient: StreamingTranscriptionClient {
+    /// Commits pending input, waits for the provider's final transcript (with
+    /// an implementation-defined timeout), then closes the connection.
+    func finishAndWait() async -> String?
+}
+
 // MARK: - Providers
 
 /// The set of live streaming transcription providers the app knows about.
@@ -50,6 +58,7 @@ public enum LiveTranscriptionProviderID: String, Sendable, CaseIterable, Hashabl
     case elevenlabs
     case openai
     case speechmatics
+    case xai
 
     /// Keychain identifier for this provider's API key, or `nil` for on-device
     /// providers that need no credential. Matches the identifiers used by both
@@ -68,8 +77,8 @@ public enum LiveTranscriptionProviderID: String, Sendable, CaseIterable, Hashabl
     /// PCM sample rate (Hz) the provider's streaming client expects.
     public var expectedSampleRate: Int {
         switch self {
-        case .openai:
-            // OpenAI's Realtime transcription API ingests 24 kHz PCM16.
+        case .openai, .xai:
+            // OpenAI and xAI's Realtime transcription APIs ingest 24 kHz PCM16.
             return 24_000
         default:
             return 16_000
@@ -83,7 +92,8 @@ public enum LiveTranscriptionProviderID: String, Sendable, CaseIterable, Hashabl
     /// iOS path so the two never drift.
     public var isSupportedOnIOS: Bool {
         switch self {
-        case .apple, .deepgram, .elevenlabs, .openai, .cartesia, .soniox, .modulate, .assemblyai, .gladia:
+        case .apple, .deepgram, .elevenlabs, .openai, .cartesia, .soniox, .modulate, .assemblyai,
+             .gladia, .xai:
             return true
         case .speechmatics:
             return false
@@ -104,6 +114,7 @@ public enum LiveTranscriptionProviderID: String, Sendable, CaseIterable, Hashabl
         case .elevenlabs: return "ElevenLabs"
         case .openai: return "OpenAI"
         case .speechmatics: return "Speechmatics"
+        case .xai: return "xAI"
         }
     }
 }
@@ -295,8 +306,23 @@ public enum LiveTranscriptionClientFactory {
                 language: language,
                 sampleRate: route.sampleRate
             )
+        case .xai:
+            return makeXAIClient(for: route, apiKey: apiKey, language: language)
         case .apple, .openai, .speechmatics:
             return nil
         }
+    }
+
+    private static func makeXAIClient(
+        for route: LiveTranscriptionRoute,
+        apiKey: String,
+        language: String?
+    ) -> XAILiveClient {
+        XAILiveClient(
+            apiKey: apiKey,
+            model: route.apiModelName,
+            language: language,
+            sampleRate: route.sampleRate
+        )
     }
 }

--- a/Sources/SpeakCore/XAILiveClient.swift
+++ b/Sources/SpeakCore/XAILiveClient.swift
@@ -1,0 +1,374 @@
+import Foundation
+
+/// Cross-platform realtime transcription client for xAI Grok Voice.
+///
+/// The Voice API is speech-to-speech capable, but Just Speak to It uses it in
+/// transcription-only mode: manual turn detection, `grok-transcribe` input
+/// captions, and no `response.create` event. That means no assistant audio is
+/// generated or played.
+public final class XAILiveClient: FinalizingStreamingTranscriptionClient, @unchecked Sendable {
+    private static let finishTimeoutSeconds: TimeInterval = 3
+    private static let preconfigurationByteLimit = 24_000 * 2 * 5
+
+    private let apiKey: String
+    private let model: String
+    private let language: String?
+    private let sampleRate: Int
+    private let session: URLSession
+    private let stateLock = NSLock()
+    private let pendingSendGroup = DispatchGroup()
+
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var onTranscript: ((String, Bool) -> Void)?
+    private var onError: ((Error) -> Void)?
+    private var pendingAudio: [Data] = []
+    private var isConfigured = false
+    private var isStopping = false
+    private var latestTranscript = ""
+    private var didReceiveFinalTranscript = false
+    private var finishContinuation: CheckedContinuation<String?, Never>?
+
+    public init(
+        apiKey: String,
+        model: String = XAIVoiceModels.thinkFast2APIName,
+        language: String? = nil,
+        sampleRate: Int = 24_000,
+        session: URLSession = .shared
+    ) {
+        self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.model = model
+        self.language = language
+        self.sampleRate = sampleRate
+        self.session = session
+    }
+
+    public func start(
+        onTranscript: @escaping (String, Bool) -> Void,
+        onError: @escaping (Error) -> Void
+    ) {
+        withStateLock {
+            isConfigured = false
+            isStopping = false
+            pendingAudio = []
+            latestTranscript = ""
+            didReceiveFinalTranscript = false
+            finishContinuation = nil
+            self.onTranscript = onTranscript
+            self.onError = onError
+        }
+
+        guard let url = Self.webSocketURL(model: model) else {
+            onError(StreamingClientError.invalidURL)
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        let task = session.webSocketTask(with: request)
+        withStateLock { webSocketTask = task }
+        task.resume()
+        receiveMessages()
+        sendSessionUpdate(on: task)
+    }
+
+    public func sendAudio(_ audioData: Data) {
+        let task = withStateLock { () -> URLSessionWebSocketTask? in
+            guard isConfigured, !isStopping,
+                  let task = webSocketTask, task.state == .running else {
+                guard !isStopping else { return nil }
+                pendingAudio.append(audioData)
+                trimPendingAudio()
+                return nil
+            }
+            return task
+        }
+        guard let task else { return }
+        sendAudioFrame(audioData, on: task)
+    }
+
+    public func finishAndWait() async -> String? {
+        let task = withStateLock { () -> URLSessionWebSocketTask? in
+            guard !isStopping else { return nil }
+            isStopping = true
+            return webSocketTask
+        }
+        guard let task else { return currentTranscript() }
+
+        flushBufferedAudioForFinish(on: task)
+        await waitForPendingSends()
+        let commitError = await sendAndWait(.string(#"{"type":"input_audio_buffer.commit"}"#), on: task)
+        if let commitError {
+            currentOnError()?(commitError)
+            close(task)
+            return currentTranscript()
+        }
+
+        let transcript = await waitForFinalTranscript()
+        close(task)
+        return transcript
+    }
+
+    public func stop() {
+        let task = withStateLock { () -> URLSessionWebSocketTask? in
+            guard !isStopping else { return nil }
+            isStopping = true
+            return webSocketTask
+        }
+        if let task { close(task) }
+        resumeFinishIfNeeded(with: currentTranscript())
+    }
+}
+
+// MARK: - Connection + events
+
+private extension XAILiveClient {
+    func sendSessionUpdate(on task: URLSessionWebSocketTask) {
+        guard let json = Self.sessionUpdateJSON(sampleRate: sampleRate, language: language) else {
+            currentOnError()?(XAILiveError.encodingFailed)
+            return
+        }
+        send(.string(json), on: task)
+    }
+
+    func receiveMessages() {
+        guard let task = currentWebSocketTask() else { return }
+        task.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let message):
+                self.handleMessage(message)
+                if self.currentWebSocketTask() === task {
+                    self.receiveMessages()
+                }
+            case .failure(let error):
+                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                self.currentOnError()?(self.mapConnectionError(error))
+                self.resumeFinishIfNeeded(with: self.currentTranscript())
+            }
+        }
+    }
+
+    func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+        let text: String?
+        switch message {
+        case .string(let value): text = value
+        case .data(let data): text = String(data: data, encoding: .utf8)
+        @unknown default: text = nil
+        }
+        guard let text else { return }
+
+        if let transcript = Self.transcriptEvent(from: text) {
+            withStateLock {
+                latestTranscript = transcript.text
+                if transcript.isFinal { didReceiveFinalTranscript = true }
+            }
+            currentOnTranscript()?(transcript.text, transcript.isFinal)
+            if transcript.isFinal {
+                resumeFinishIfNeeded(with: transcript.text)
+            }
+            return
+        }
+
+        guard let data = text.data(using: .utf8),
+              let envelope = try? JSONDecoder().decode(XAIEnvelope.self, from: data) else {
+            return
+        }
+        if envelope.type == "session.updated" {
+            flushPendingAudio()
+        } else if envelope.type == "error" {
+            let error = XAILiveError.server(envelope.error?.message ?? "Unknown xAI realtime error")
+            currentOnError()?(error)
+            resumeFinishIfNeeded(with: currentTranscript())
+        }
+    }
+
+    func flushPendingAudio() {
+        let (task, frames) = withStateLock { () -> (URLSessionWebSocketTask?, [Data]) in
+            isConfigured = true
+            let frames = pendingAudio
+            pendingAudio = []
+            return (webSocketTask, frames)
+        }
+        guard let task, task.state == .running else { return }
+        for frame in frames { sendAudioFrame(frame, on: task) }
+    }
+}
+
+// MARK: - Sending + finalisation
+
+private extension XAILiveClient {
+    func sendAudioFrame(_ audioData: Data, on task: URLSessionWebSocketTask) {
+        let payload = XAIInputAudioEvent(
+            type: "input_audio_buffer.append",
+            audio: audioData.base64EncodedString()
+        )
+        guard let data = try? JSONEncoder().encode(payload),
+              let json = String(data: data, encoding: .utf8) else {
+            currentOnError()?(XAILiveError.encodingFailed)
+            return
+        }
+        send(.string(json), on: task)
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message, on task: URLSessionWebSocketTask) {
+        let group = pendingSendGroup
+        group.enter()
+        task.send(message) { [weak self] error in
+            defer { group.leave() }
+            guard let self, let error else { return }
+            if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+            self.currentOnError()?(self.mapConnectionError(error))
+        }
+    }
+
+    func sendAndWait(
+        _ message: URLSessionWebSocketTask.Message,
+        on task: URLSessionWebSocketTask
+    ) async -> Error? {
+        await withCheckedContinuation { continuation in
+            task.send(message) { error in
+                continuation.resume(returning: error)
+            }
+        }
+    }
+
+    func waitForPendingSends(timeout: TimeInterval = 1.5) async {
+        let group = pendingSendGroup
+        await withCheckedContinuation { continuation in
+            let lock = NSLock()
+            var didResume = false
+            let resumeOnce = {
+                lock.lock()
+                defer { lock.unlock() }
+                guard !didResume else { return }
+                didResume = true
+                continuation.resume()
+            }
+
+            group.notify(queue: .global()) {
+                resumeOnce()
+            }
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+                resumeOnce()
+            }
+        }
+    }
+
+    func waitForFinalTranscript() async -> String? {
+        await withCheckedContinuation { continuation in
+            let shouldWait = withStateLock { () -> Bool in
+                guard !didReceiveFinalTranscript else { return false }
+                guard finishContinuation == nil else { return false }
+                finishContinuation = continuation
+                return true
+            }
+            guard shouldWait else {
+                continuation.resume(returning: currentTranscript())
+                return
+            }
+            DispatchQueue.global().asyncAfter(deadline: .now() + Self.finishTimeoutSeconds) { [weak self] in
+                guard let self else { return }
+                self.resumeFinishIfNeeded(with: self.currentTranscript())
+            }
+        }
+    }
+
+    func flushBufferedAudioForFinish(on task: URLSessionWebSocketTask) {
+        let frames = withStateLock { () -> [Data] in
+            let frames = pendingAudio
+            pendingAudio = []
+            return frames
+        }
+        for frame in frames {
+            sendAudioFrame(frame, on: task)
+        }
+    }
+
+    func resumeFinishIfNeeded(with transcript: String?) {
+        let continuation = withStateLock { () -> CheckedContinuation<String?, Never>? in
+            let continuation = finishContinuation
+            finishContinuation = nil
+            return continuation
+        }
+        continuation?.resume(returning: transcript)
+    }
+
+    func close(_ task: URLSessionWebSocketTask) {
+        let shouldClose = withStateLock { () -> Bool in
+            guard webSocketTask === task else { return false }
+            webSocketTask = nil
+            return true
+        }
+        if shouldClose {
+            task.cancel(with: .normalClosure, reason: nil)
+        }
+    }
+}
+
+// MARK: - State + errors
+
+private extension XAILiveClient {
+    func trimPendingAudio() {
+        var total = pendingAudio.reduce(0) { $0 + $1.count }
+        while total > Self.preconfigurationByteLimit, !pendingAudio.isEmpty {
+            total -= pendingAudio.removeFirst().count
+        }
+    }
+
+    func mapConnectionError(_ error: Error) -> Error {
+        let description = (error as NSError).localizedDescription.lowercased()
+        if description.contains("401") || description.contains("403")
+            || description.contains("unauthorized") || description.contains("forbidden") {
+            return StreamingClientError.invalidAPIKey(provider: "xAI")
+        }
+        return error
+    }
+
+    func shouldIgnoreSocketError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
+        return nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected")
+    }
+
+    func withStateLock<T>(_ block: () -> T) -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return block()
+    }
+
+    func currentWebSocketTask() -> URLSessionWebSocketTask? { withStateLock { webSocketTask } }
+    func currentOnTranscript() -> ((String, Bool) -> Void)? { withStateLock { onTranscript } }
+    func currentOnError() -> ((Error) -> Void)? { withStateLock { onError } }
+    func currentTranscript() -> String? {
+        withStateLock { latestTranscript.isEmpty ? nil : latestTranscript }
+    }
+    func isStoppingState() -> Bool { withStateLock { isStopping } }
+}
+
+public enum XAILiveError: LocalizedError {
+    case encodingFailed
+    case server(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .encodingFailed:
+            return "Could not encode the xAI realtime transcription request."
+        case .server(let message):
+            return "xAI realtime transcription failed: \(message)"
+        }
+    }
+}
+
+private struct XAIInputAudioEvent: Encodable {
+    let type: String
+    let audio: String
+}
+
+private struct XAIEnvelope: Decodable {
+    struct ErrorPayload: Decodable {
+        let message: String?
+    }
+
+    let type: String
+    let error: ErrorPayload?
+}

--- a/Sources/SpeakCore/XAILiveProtocol.swift
+++ b/Sources/SpeakCore/XAILiveProtocol.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+extension XAILiveClient {
+    public static func webSocketURL(model: String) -> URL? {
+        var components = URLComponents()
+        components.scheme = "wss"
+        components.host = "api.x.ai"
+        components.path = "/v1/realtime"
+        components.queryItems = [URLQueryItem(name: "model", value: model)]
+        return components.url
+    }
+
+    public static func sessionUpdateJSON(
+        sampleRate: Int,
+        language: String?
+    ) -> String? {
+        var transcription: [String: Any] = [
+            "model": XAIVoiceModels.inputTranscriptionAPIName
+        ]
+        if let languageCode = normalizedLanguageCode(language) {
+            transcription["language_hint"] = languageCode
+        }
+        let payload: [String: Any] = [
+            "type": "session.update",
+            "session": [
+                "reasoning": ["effort": "none"],
+                "turn_detection": NSNull(),
+                "audio": [
+                    "input": [
+                        "format": ["type": "audio/pcm", "rate": sampleRate],
+                        "transport": "json",
+                        "transcription": transcription
+                    ]
+                ]
+            ]
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    public static func transcriptEvent(from json: String) -> (text: String, isFinal: Bool)? {
+        guard let data = json.data(using: .utf8),
+              let event = try? JSONDecoder().decode(XAITranscriptEvent.self, from: data),
+              let transcript = event.transcript?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !transcript.isEmpty else {
+            return nil
+        }
+        switch event.type {
+        case "conversation.item.input_audio_transcription.updated":
+            return (transcript, false)
+        case "conversation.item.input_audio_transcription.completed":
+            return (transcript, true)
+        default:
+            return nil
+        }
+    }
+
+    private static func normalizedLanguageCode(_ language: String?) -> String? {
+        guard let language else { return nil }
+        let normalized = language.replacingOccurrences(of: "_", with: "-")
+        let trimmed = normalized.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+private struct XAITranscriptEvent: Decodable {
+    let type: String
+    let transcript: String?
+}

--- a/Sources/SpeakCore/XAIVoiceModels.swift
+++ b/Sources/SpeakCore/XAIVoiceModels.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Canonical xAI Voice model identifiers shared by the catalogue, routing,
+/// platform settings, and the realtime client.
+public enum XAIVoiceModels {
+    public static let thinkFast2CatalogID = "xai/grok-voice-think-fast-2.0-streaming"
+    public static let thinkFast2APIName = "grok-voice-think-fast-2.0"
+    public static let inputTranscriptionAPIName = "grok-transcribe"
+}

--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -420,7 +420,8 @@ public final class CloudKitKeySync: ObservableObject {
         "assemblyai.apiKey",
         "gladia.apiKey",
         "modulate.apiKey",
-        "soniox.apiKey"
+        "soniox.apiKey",
+        "xai.apiKey"
     ]
 
     @Published public private(set) var status = CloudKitKeySyncStatus()

--- a/Sources/SpeakiOS/Services/SharedClientLiveTranscriber.swift
+++ b/Sources/SpeakiOS/Services/SharedClientLiveTranscriber.swift
@@ -260,8 +260,13 @@ public final class SharedClientLiveTranscriber: ObservableObject {
 
     private func handleTranscript(text: String, isFinal: Bool) {
         if isFinal {
-            if !accumulatedText.isEmpty { accumulatedText += " " }
-            accumulatedText += text
+            if accumulatedText.isEmpty
+                || text == accumulatedText
+                || text.hasPrefix(accumulatedText + " ") {
+                accumulatedText = text
+            } else {
+                accumulatedText += " " + text
+            }
             finalText = accumulatedText
             partialText = accumulatedText
         } else {

--- a/Sources/SpeakiOS/Services/SharedClientLiveTranscriber.swift
+++ b/Sources/SpeakiOS/Services/SharedClientLiveTranscriber.swift
@@ -84,20 +84,28 @@ public final class SharedClientLiveTranscriber: ObservableObject {
     }
 
     public func stop() async -> TranscriptionResult {
-        // `partialText` is the fullest view (finalised text plus any trailing
-        // non-final words); fall back to the accumulated finals if empty.
-        let text = partialText.isEmpty ? accumulatedText : partialText
         guard isRunning else {
+            let text = partialText.isEmpty ? accumulatedText : partialText
             return makeResult(text: text, duration: 0)
         }
 
         audioEngine.stop()
         audioEngine.inputNode.removeTap(onBus: 0)
-        client?.stop()
+        if let finalizingClient = client as? FinalizingStreamingTranscriptionClient {
+            if let finalTranscript = await finalizingClient.finishAndWait(),
+               finalText != finalTranscript {
+                handleTranscript(text: finalTranscript, isFinal: true)
+            }
+        } else {
+            client?.stop()
+        }
         client = nil
         isRunning = false
         audioSessionManager.deactivate()
 
+        // `partialText` is the fullest view (finalised text plus any trailing
+        // non-final words); fall back to the accumulated finals if empty.
+        let text = partialText.isEmpty ? accumulatedText : partialText
         let duration = startTime.map { Date().timeIntervalSince($0) } ?? 0
         let result = makeResult(text: text, duration: duration)
         SpeakLogger.logTranscription(

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -50,15 +50,10 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     }
 
     private var modelDisplayName: String {
-        if batchTranscriber != nil { return ModelCatalog.friendlyName(for: currentModel) }
-        if currentModel.hasPrefix("deepgram") { return "Deepgram" }
-        if currentModel.hasPrefix("elevenlabs") { return "ElevenLabs" }
-        if currentModel.hasPrefix("openai") { return ModelCatalog.friendlyName(for: currentModel) }
-        if let route = LiveTranscriptionRouting.route(for: currentModel),
-           route.provider != .apple {
-            return ModelCatalog.friendlyName(for: currentModel)
-        }
-        return "Apple Speech"
+        ModelCatalog.transcriptionDisplayName(
+            for: currentModel,
+            isBatch: batchTranscriber != nil
+        )
     }
 
     // MARK: - Public API

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -54,6 +54,10 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         if currentModel.hasPrefix("deepgram") { return "Deepgram" }
         if currentModel.hasPrefix("elevenlabs") { return "ElevenLabs" }
         if currentModel.hasPrefix("openai") { return ModelCatalog.friendlyName(for: currentModel) }
+        if let route = LiveTranscriptionRouting.route(for: currentModel),
+           route.provider != .apple {
+            return ModelCatalog.friendlyName(for: currentModel)
+        }
         return "Apple Speech"
     }
 

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -32,23 +32,10 @@ final class TranscriberCoordinator: ObservableObject {
     }
 
     var modelDisplayName: String {
-        if batchTranscriber != nil {
-            return ModelCatalog.friendlyName(for: currentModel)
-        }
-        if currentModel.hasPrefix("deepgram") {
-            return "Deepgram"
-        }
-        if currentModel.hasPrefix("elevenlabs") {
-            return "ElevenLabs"
-        }
-        if currentModel.hasPrefix("openai") {
-            return ModelCatalog.friendlyName(for: currentModel)
-        }
-        if let route = LiveTranscriptionRouting.route(for: currentModel),
-           route.provider != .apple {
-            return ModelCatalog.friendlyName(for: currentModel)
-        }
-        return "Apple Speech"
+        ModelCatalog.transcriptionDisplayName(
+            for: currentModel,
+            isBatch: batchTranscriber != nil
+        )
     }
 
     private var elapsedSeconds: Int {

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -44,6 +44,10 @@ final class TranscriberCoordinator: ObservableObject {
         if currentModel.hasPrefix("openai") {
             return ModelCatalog.friendlyName(for: currentModel)
         }
+        if let route = LiveTranscriptionRouting.route(for: currentModel),
+           route.provider != .apple {
+            return ModelCatalog.friendlyName(for: currentModel)
+        }
         return "Apple Speech"
     }
 

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -133,6 +133,10 @@ public final class AppSettings: ObservableObject {
         didSet { persistSecret(gladiaAPIKey, identifier: Self.gladiaKeyID) }
     }
 
+    @Published public var xAIAPIKey: String {
+        didSet { persistSecret(xAIAPIKey, identifier: Self.xAIKeyID) }
+    }
+
     // MARK: - Canonical secure storage for API keys (SpeakCore)
     //
     // Every API key is stored locally through SpeakCore's SecureStorage using the
@@ -148,6 +152,7 @@ public final class AppSettings: ObservableObject {
     static let modulateKeyID = "modulate.apiKey"
     static let assemblyAIKeyID = "assemblyai.apiKey"
     static let gladiaKeyID = "gladia.apiKey"
+    static let xAIKeyID = "xai.apiKey"
 
     private static let credentialStorage = SecureStorage(
         configuration: SecureStorageConfiguration(
@@ -310,6 +315,7 @@ public final class AppSettings: ObservableObject {
         self.modulateAPIKey = ""
         self.assemblyAIAPIKey = ""
         self.gladiaAPIKey = ""
+        self.xAIAPIKey = ""
         self.liveActivitiesEnabled = liveActivities
         self.visualDensity = density
         self.autoStartRecording = autoStart
@@ -373,6 +379,7 @@ public final class AppSettings: ObservableObject {
     public var hasModulateKey: Bool { !modulateAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     public var hasAssemblyAIKey: Bool { !assemblyAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     public var hasGladiaKey: Bool { !gladiaAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    public var hasXAIKey: Bool { !xAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
 
     /// Identifiers currently available to model pickers. Because this is
     /// derived from the published key values, readiness badges refresh as soon
@@ -388,6 +395,7 @@ public final class AppSettings: ObservableObject {
         if hasModulateKey { identifiers.insert(Self.modulateKeyID) }
         if hasAssemblyAIKey { identifiers.insert(Self.assemblyAIKeyID) }
         if hasGladiaKey { identifiers.insert(Self.gladiaKeyID) }
+        if hasXAIKey { identifiers.insert(Self.xAIKeyID) }
         return identifiers
     }
 
@@ -429,6 +437,10 @@ public final class AppSettings: ObservableObject {
         gladiaAPIKey = await Self.syncedAPIKeyValue(
             identifier: Self.gladiaKeyID,
             currentValue: gladiaAPIKey
+        )
+        xAIAPIKey = await Self.syncedAPIKeyValue(
+            identifier: Self.xAIKeyID,
+            currentValue: xAIAPIKey
         )
     }
 
@@ -487,6 +499,7 @@ public final class AppSettings: ObservableObject {
         case Self.modulateKeyID: return modulateAPIKey
         case Self.assemblyAIKeyID: return assemblyAIAPIKey
         case Self.gladiaKeyID: return gladiaAPIKey
+        case Self.xAIKeyID: return xAIAPIKey
         default: return ""
         }
     }
@@ -1485,6 +1498,7 @@ struct APIKeysView: View {
     @State private var modulateKey = ""
     @State private var assemblyAIKey = ""
     @State private var gladiaKey = ""
+    @State private var xAIKey = ""
     @State private var isValidating = false
     @State private var validationMessage: String?
     @State private var showingValidation = false
@@ -1532,6 +1546,9 @@ struct APIKeysView: View {
             ),
             APIKeyListEntry(
                 id: "gladia", title: "Gladia", category: "Transcription", isStored: settings.hasGladiaKey
+            ),
+            APIKeyListEntry(
+                id: "xai", title: "xAI", category: "Transcription", isStored: settings.hasXAIKey
             )
         ]
     }
@@ -1605,6 +1622,7 @@ struct APIKeysView: View {
                             && modulateKey.isEmpty
                             && assemblyAIKey.isEmpty
                             && gladiaKey.isEmpty
+                            && xAIKey.isEmpty
                     )
                 }
             }
@@ -1680,6 +1698,10 @@ struct APIKeysView: View {
             return KeyPresentation(
                 title: "AssemblyAI", systemImage: "waveform.badge.plus", help: "Get your key from assemblyai.com."
             )
+        case "xai":
+            return KeyPresentation(
+                title: "xAI", systemImage: "waveform.badge.mic", help: "Get your key from console.x.ai."
+            )
         default:
             return KeyPresentation(
                 title: "Gladia", systemImage: "waveform.badge.exclamationmark", help: "Get your key from gladia.io."
@@ -1697,6 +1719,7 @@ struct APIKeysView: View {
         case "soniox": return $sonioxKey
         case "modulate": return $modulateKey
         case "assemblyai": return $assemblyAIKey
+        case "xai": return $xAIKey
         default: return $gladiaKey
         }
     }
@@ -1711,6 +1734,7 @@ struct APIKeysView: View {
         case "soniox": settings.sonioxAPIKey = ""
         case "modulate": settings.modulateAPIKey = ""
         case "assemblyai": settings.assemblyAIAPIKey = ""
+        case "xai": settings.xAIAPIKey = ""
         default: settings.gladiaAPIKey = ""
         }
     }
@@ -1800,6 +1824,13 @@ struct APIKeysView: View {
                 settings.gladiaAPIKey = gladiaKey
                 gladiaKey = ""
                 messages.append("✓ Gladia key saved")
+            }
+
+            // Save xAI key (validated when the realtime session connects)
+            if !xAIKey.isEmpty {
+                settings.xAIAPIKey = xAIKey
+                xAIKey = ""
+                messages.append("✓ xAI key saved")
             }
 
             isValidating = false

--- a/Tests/SpeakAppTests/ModelCredentialResolverTests.swift
+++ b/Tests/SpeakAppTests/ModelCredentialResolverTests.swift
@@ -17,6 +17,13 @@ final class ModelCredentialResolverTests: XCTestCase {
             ),
             .apiKey(identifier: "openai.apiKey", providerName: "OpenAI")
         )
+        XCTAssertEqual(
+            ModelCredentialResolver.requirement(
+                for: XAIVoiceModels.thinkFast2CatalogID,
+                purpose: .liveTranscription
+            ),
+            .apiKey(identifier: "xai.apiKey", providerName: "xAI")
+        )
     }
 
     func testAppleAndLocalModels_DoNotRequireCredential() {

--- a/Tests/SpeakAppTests/XAITranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/XAITranscriptionProviderTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+@testable import SpeakApp
+import SpeakCore
+
+final class XAITranscriptionProviderTests: XCTestCase {
+  func testProviderRegistry_routesGrokVoiceToXAI() async {
+    let provider = await TranscriptionProviderRegistry.shared.provider(
+      forModel: XAIVoiceModels.thinkFast2CatalogID
+    )
+
+    XCTAssertEqual(provider?.metadata.id, "xai")
+    XCTAssertEqual(provider?.metadata.apiKeyIdentifier, "xai.apiKey")
+    XCTAssertEqual(provider?.supportedModels().map(\.id), [XAIVoiceModels.thinkFast2CatalogID])
+  }
+}

--- a/Tests/SpeakCoreTests/LiveTranscriptionRoutingTests.swift
+++ b/Tests/SpeakCoreTests/LiveTranscriptionRoutingTests.swift
@@ -138,7 +138,8 @@ final class LiveTranscriptionRoutingTests: XCTestCase {
             "soniox/stt-rt-v5-streaming",
             "modulate/velma-2-stt-streaming",
             AssemblyAIModels.universal35ProStreamingID,
-            "gladia/solaria-1-streaming"
+            "gladia/solaria-1-streaming",
+            XAIVoiceModels.thinkFast2CatalogID
         ]
 
         // Act / Assert

--- a/Tests/SpeakCoreTests/TranscriptionDisplayNameTests.swift
+++ b/Tests/SpeakCoreTests/TranscriptionDisplayNameTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+@testable import SpeakCore
+
+final class TranscriptionDisplayNameTests: XCTestCase {
+    func testTranscriptionDisplayName_preservesProviderAndBatchLabels() {
+        XCTAssertEqual(
+            ModelCatalog.transcriptionDisplayName(
+                for: "deepgram/nova-3-streaming",
+                isBatch: false
+            ),
+            "Deepgram"
+        )
+        XCTAssertEqual(
+            ModelCatalog.transcriptionDisplayName(
+                for: XAIVoiceModels.thinkFast2CatalogID,
+                isBatch: false
+            ),
+            "Grok Voice Think Fast 2.0 (Streaming)"
+        )
+        XCTAssertEqual(
+            ModelCatalog.transcriptionDisplayName(
+                for: "google/gemini-2.0-flash-001",
+                isBatch: true
+            ),
+            "Gemini 2.0 Flash (OpenRouter)"
+        )
+    }
+}

--- a/Tests/SpeakCoreTests/XAILiveClientTests.swift
+++ b/Tests/SpeakCoreTests/XAILiveClientTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+@testable import SpeakCore
+
+final class XAILiveClientTests: XCTestCase {
+    func testWebSocketURL_pinsThinkFast2Model() throws {
+        let url = try XCTUnwrap(XAILiveClient.webSocketURL(model: XAIVoiceModels.thinkFast2APIName))
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+        XCTAssertEqual(components.scheme, "wss")
+        XCTAssertEqual(components.host, "api.x.ai")
+        XCTAssertEqual(components.path, "/v1/realtime")
+        XCTAssertEqual(components.queryItems?.first?.value, XAIVoiceModels.thinkFast2APIName)
+    }
+
+    func testSessionUpdate_usesManualTranscriptionOnlyMode() throws {
+        let json = try XCTUnwrap(XAILiveClient.sessionUpdateJSON(sampleRate: 24_000, language: "en_GB"))
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let session = try XCTUnwrap(root["session"] as? [String: Any])
+        let reasoning = try XCTUnwrap(session["reasoning"] as? [String: Any])
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let format = try XCTUnwrap(input["format"] as? [String: Any])
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+
+        XCTAssertTrue(session["turn_detection"] is NSNull)
+        XCTAssertEqual(reasoning["effort"] as? String, "none")
+        XCTAssertEqual(format["type"] as? String, "audio/pcm")
+        XCTAssertEqual(format["rate"] as? Int, 24_000)
+        XCTAssertEqual(transcription["model"] as? String, XAIVoiceModels.inputTranscriptionAPIName)
+        XCTAssertEqual(transcription["language_hint"] as? String, "en-GB")
+        XCTAssertNil(root["response"])
+    }
+
+    func testTranscriptEvents_distinguishCumulativeUpdateAndFinal() throws {
+        let update = try XCTUnwrap(XAILiveClient.transcriptEvent(from: """
+        {
+          "type": "conversation.item.input_audio_transcription.updated",
+          "transcript": "Hello wor"
+        }
+        """))
+        let final = try XCTUnwrap(XAILiveClient.transcriptEvent(from: """
+        {
+          "type": "conversation.item.input_audio_transcription.completed",
+          "transcript": "Hello world."
+        }
+        """))
+
+        XCTAssertEqual(update.text, "Hello wor")
+        XCTAssertFalse(update.isFinal)
+        XCTAssertEqual(final.text, "Hello world.")
+        XCTAssertTrue(final.isFinal)
+    }
+
+    func testCatalogueAndRoute_exposeXAIOnBothPlatforms() throws {
+        let option = try XCTUnwrap(ModelCatalog.liveTranscription.first {
+            $0.id == XAIVoiceModels.thinkFast2CatalogID
+        })
+        let route = try XCTUnwrap(LiveTranscriptionRouting.route(for: option.id))
+
+        XCTAssertEqual(route.provider, .xai)
+        XCTAssertEqual(route.apiModelName, XAIVoiceModels.thinkFast2APIName)
+        XCTAssertEqual(route.sampleRate, 24_000)
+        XCTAssertEqual(route.apiKeyIdentifier, "xai.apiKey")
+        XCTAssertTrue(route.isSupportedOnIOS)
+        XCTAssertNotNil(LiveTranscriptionClientFactory.makeClient(
+            for: route,
+            apiKey: "test-key",
+            language: "en-GB"
+        ))
+    }
+}

--- a/Tests/SpeakCoreTests/XAILiveClientTests.swift
+++ b/Tests/SpeakCoreTests/XAILiveClientTests.swift
@@ -10,7 +10,9 @@ final class XAILiveClientTests: XCTestCase {
         XCTAssertEqual(components.scheme, "wss")
         XCTAssertEqual(components.host, "api.x.ai")
         XCTAssertEqual(components.path, "/v1/realtime")
-        XCTAssertEqual(components.queryItems?.first?.value, XAIVoiceModels.thinkFast2APIName)
+        let modelItem = try XCTUnwrap(components.queryItems?.first { $0.name == "model" })
+        XCTAssertEqual(modelItem.name, "model")
+        XCTAssertEqual(modelItem.value, XAIVoiceModels.thinkFast2APIName)
     }
 
     func testSessionUpdate_usesManualTranscriptionOnlyMode() throws {
@@ -69,5 +71,12 @@ final class XAILiveClientTests: XCTestCase {
             apiKey: "test-key",
             language: "en-GB"
         ))
+    }
+
+    func testCapabilities_supportLivePolishAndFinalizationBudget() {
+        let capabilities = ModelCatalog.liveCapabilities(for: XAIVoiceModels.thinkFast2CatalogID)
+
+        XCTAssertTrue(capabilities.supportedSpeedModes.contains(.livePolish))
+        XCTAssertEqual(capabilities.postStopFinalizeBudget, 3.0)
     }
 }

--- a/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
+++ b/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import SpeakSync
 
 final class CloudKitKeySyncTests: XCTestCase {
-    func testSyncableIdentifiersIncludeXAI() {
+    func testSyncableIdentifiers_containsXAI() {
         XCTAssertTrue(CloudKitKeySync.syncableIdentifiers.contains("xai.apiKey"))
     }
 

--- a/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
+++ b/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
@@ -4,6 +4,10 @@ import XCTest
 @testable import SpeakSync
 
 final class CloudKitKeySyncTests: XCTestCase {
+    func testSyncableIdentifiersIncludeXAI() {
+        XCTAssertTrue(CloudKitKeySync.syncableIdentifiers.contains("xai.apiKey"))
+    }
+
     func testEncryptDecryptRoundTripWithCorrectPassphrase() throws {
         let salt = Data("stable-test-salt".utf8)
         let key = EncryptedSecretCrypto.deriveKey(passphrase: "correct horse battery staple", salt: salt)

--- a/Tests/SpeakiOSTests/PlatformFeatureVisibilityTests.swift
+++ b/Tests/SpeakiOSTests/PlatformFeatureVisibilityTests.swift
@@ -21,6 +21,7 @@ final class PlatformFeatureVisibilityTests: XCTestCase {
         )
         XCTAssertFalse(visibleIDs.contains { $0.hasPrefix("speechmatics/") })
         XCTAssertTrue(visibleIDs.contains(OpenAITranscriptionModels.gptLiveTranscribeStreamingCatalogID))
+        XCTAssertTrue(visibleIDs.contains(XAIVoiceModels.thinkFast2CatalogID))
     }
 
     func testRemoteBatchPicker_omitsProvidersWithoutAnIOSUploadPath() {


### PR DESCRIPTION
## Summary

- add xAI Grok Voice Think Fast 2.0 as a live transcription model on macOS and iOS
- use xAI's official realtime WebSocket API in transcription-only mode, with cumulative captions and no assistant response/audio
- share the transport client across platforms and add secure xAI key storage, validation, credential readiness, and CloudKit key sync
- commit buffered audio on stop and wait for the provider's final transcript with bounded timeouts

## User-visible changes

- “Grok Voice Think Fast 2.0 (Streaming)” is selectable in the live model picker on both platforms
- xAI API keys can be stored in Settings and participate in existing secure key sync
- model/provider labels correctly show xAI during recording

## Verification

- `make test` — 702 tests, 11 skipped, 0 failures
- `swift build --target SpeakiOSLib` — passed
- SwiftLint strict with the repository baseline — 0 violations
- SwiftFormat on all changed Swift files — no changes required

The request/event protocol and app wiring are covered by tests. A live microphone session against xAI was not run because no test API key was available.

Beads: `justspeaktoit-29m`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added xAI real-time transcription with Grok Voice Think Fast 2.0.
  * Added xAI API key management in iOS settings, including secure storage and sync.
  * Added live transcription finalization for more accurate results when stopping.
  * Added model availability, routing, and display details across supported platforms.

* **Bug Fixes**
  * Improved final transcript handling and cleanup when ending live sessions.

* **Tests**
  * Added coverage for xAI provider registration, routing, credentials, connectivity helpers, and settings synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->