### PR TITLE
fix(mac): name FluidAudio model in history

### DIFF
--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -668,6 +668,9 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
 
         let lowercased = trimmed.lowercased()
         if lowercased.hasPrefix("local/") {
+            if lowercased == "local/streaming/fluidaudio/parakeet-realtime-eou-120m" {
+                return "Parakeet Realtime EOU 120M"
+            }
             if lowercased == "local/post-processing/rules" {
                 return "Local Cleanup (Offline)"
             }

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import SpeakCore
 
+// swiftlint:disable:next type_body_length
 final class ModelCatalogTests: XCTestCase {
 
     // MARK: - LatencyTier Ordering

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -40,6 +40,12 @@ final class ModelCatalogTests: XCTestCase {
 
     func testFriendlyName_downloadedLocalModels_returnsSpecificName() {
         XCTAssertEqual(
+            ModelCatalog.friendlyName(
+                for: "local/streaming/fluidaudio/parakeet-realtime-eou-120m"
+            ),
+            "Parakeet Realtime EOU 120M"
+        )
+        XCTAssertEqual(
             ModelCatalog.friendlyName(for: "local/post-processing/qwen3-0.6b-q4"),
             "Qwen3 0.6B Q4"
         )


### PR DESCRIPTION
## Motivation

FluidAudio sessions were saved with the exact local streaming model identifier, but the shared model catalogue fell back to the generic “Downloaded Local Model” label. History therefore hid which downloaded model produced the transcript.

## What changed

- map the FluidAudio Parakeet streaming identifier to “Parakeet Realtime EOU 120M” in the shared friendly-name resolver
- add regression coverage alongside the existing downloaded-local model cases

## Things we learnt that changed the direction

History already uses the shared `ModelCatalog.friendlyName` path in compact and expanded views, so no view-specific logic is necessary.

## How to test

- `swift test --filter ModelCatalogTests` — 29 passed
- `git diff --check`

## Review confidence

High. This is an exact identifier mapping with focused regression coverage and no runtime behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a clear display name for the local Parakeet Realtime EOU 120M streaming model.

- **Bug Fixes**
  - Improved model identification so downloaded Parakeet models appear with a friendly, recognizable name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->