### PR TITLE
ci(ios): enforce the TestFlight release runbook

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -4,8 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number (leave empty to use VERSION file)'
-        required: false
+        description: 'Required iOS version, e.g. 2.29.2. For manual releases, check App Store Connect first.'
+        required: true
+        type: string
       build_number:
         description: 'Build number (auto-increments if empty)'
         required: false
@@ -174,11 +175,17 @@ jobs:
 
       - name: Determine Version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            VERSION=$(cat VERSION)
+          VERSION=$(printf '%s' "$INPUT_VERSION" | xargs)
+          if [ -z "$VERSION" ]; then
+            echo "::error::iOS release version is required. Check App Store Connect and enter the intended iOS version; VERSION is not authoritative for TestFlight."
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::iOS release version must be semantic version text such as 2.29.2 (without a leading v)."
+            exit 1
           fi
           COMMIT_SHA="${{ github.sha }}"
           SHORT_SHA="${COMMIT_SHA:0:7}"

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -183,7 +183,8 @@ jobs:
             echo "::error::iOS release version is required. Check App Store Connect and enter the intended iOS version; VERSION is not authoritative for TestFlight."
             exit 1
           fi
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          VERSION_PATTERN='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          if [[ ! "$VERSION" =~ $VERSION_PATTERN ]]; then
             echo "::error::iOS release version must be semantic version text such as 2.29.2 (without a leading v)."
             exit 1
           fi
@@ -274,6 +275,9 @@ jobs:
           KEYBOARD_GROUP=$(/usr/libexec/PlistBuddy \
             -c 'Print :com.apple.security.application-groups:0' \
             "$RUNNER_TEMP/keyboard-entitlements.plist" 2>/dev/null || true)
+          APP_ICLOUD_CONTAINER=$(/usr/libexec/PlistBuddy \
+            -c 'Print :com.apple.developer.icloud-container-identifiers:0' \
+            "$RUNNER_TEMP/app-entitlements.plist" 2>/dev/null || true)
 
           [ "$APP_GROUP" = "group.com.justspeaktoit.ios" ] \
             || { echo "App group mismatch: expected 'group.com.justspeaktoit.ios', got '${APP_GROUP:-missing}'"; exit 1; }
@@ -281,6 +285,8 @@ jobs:
             || { echo "Widget group mismatch: expected 'group.com.justspeaktoit.ios', got '${WIDGET_GROUP:-missing}'"; exit 1; }
           [ "$KEYBOARD_GROUP" = "group.com.justspeaktoit.ios" ] \
             || { echo "Keyboard group mismatch: expected 'group.com.justspeaktoit.ios', got '${KEYBOARD_GROUP:-missing}'"; exit 1; }
+          [ "$APP_ICLOUD_CONTAINER" = "iCloud.com.justspeaktoit.ios" ] \
+            || { echo "iCloud container mismatch: expected 'iCloud.com.justspeaktoit.ios', got '${APP_ICLOUD_CONTAINER:-missing}'"; exit 1; }
 
       - name: Export IPA
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,9 +363,9 @@ public final class iOSLiveTranscriber: ObservableObject { ... }
 - App Store Connect Issuer ID: stored in secure notes (do not commit)
 - App Store Connect API key: store base64 in `.env` as `APP_STORE_CONNECT_API_KEY` (do not commit)
 - iOS distribution cert: store base64 in `.env` as `IOS_DISTRIBUTION_P12` (password in `.env` as `IOS_DISTRIBUTION_PASSWORD`)
-- GitHub secrets used by CI: `APP_STORE_CONNECT_API_KEY`, `APP_STORE_CONNECT_ISSUER_ID`, `APPLE_TEAM_ID`, `IOS_DISTRIBUTION_P12`, `IOS_DISTRIBUTION_PASSWORD`, `IOS_APPSTORE_PROFILE`, `IOS_WIDGET_APPSTORE_PROFILE`
+- GitHub secrets used by CI: `APP_STORE_CONNECT_API_KEY`, `APP_STORE_CONNECT_ISSUER_ID`, `APPLE_TEAM_ID`, `IOS_DISTRIBUTION_P12`, `IOS_DISTRIBUTION_PASSWORD`, `IOS_APPSTORE_PROFILE`, `IOS_WIDGET_APPSTORE_PROFILE`; `IOS_KEYBOARD_APPSTORE_PROFILE` is optional when the workflow can reuse or create a valid portal profile
 - Required entitlements: App Group `group.com.justspeaktoit.ios` and iCloud container `iCloud.com.justspeaktoit.ios`
-- The keyboard extension also requires `IOS_KEYBOARD_APPSTORE_PROFILE`; see [`Docs/ios-testflight-release.md`](Docs/ios-testflight-release.md) before changing portal capabilities or regenerating profiles.
+- The keyboard extension accepts `IOS_KEYBOARD_APPSTORE_PROFILE` when set and otherwise uses the validated portal-profile fallback; see [`Docs/ios-testflight-release.md`](Docs/ios-testflight-release.md) before changing portal capabilities or regenerating profiles.
 - Never commit private keys or provisioning profile contents.
 
 ## Sentry Error Monitoring

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,13 +38,14 @@ Manual releases are still possible by creating and pushing a `mac-v*` tag direct
 
 ### iOS Release Process
 
-1. iOS uses **manual workflow dispatch** (not tag-triggered)
-2. Go to Actions → "Release iOS (TestFlight)" → Run workflow
-3. Enter version number (check App Store Connect for current version)
+1. The macOS auto-release workflow dispatches an iOS TestFlight build with the same new version when it creates a release.
+2. For an iOS-only release, go to Actions → "Release iOS (TestFlight)" → Run workflow.
+3. Check App Store Connect for the current iOS version, then enter the intended semantic version explicitly. Never infer it from `VERSION`.
+4. Follow [`Docs/ios-testflight-release.md`](Docs/ios-testflight-release.md) for signing repair, upload, tester assignment, and physical-device verification.
 
 ### VERSION File
 
-The `VERSION` file is a **hint** used as fallback when no tag is present. It does NOT control the release version - the **tag determines the version**. Keep it updated but always verify against actual releases.
+The `VERSION` file is a **hint** used as fallback when no macOS tag is present. It does NOT control an iOS TestFlight release. Keep it updated, but verify macOS against actual tags and iOS against App Store Connect.
 
 ### Post-Release Support
 
@@ -364,6 +365,7 @@ public final class iOSLiveTranscriber: ObservableObject { ... }
 - iOS distribution cert: store base64 in `.env` as `IOS_DISTRIBUTION_P12` (password in `.env` as `IOS_DISTRIBUTION_PASSWORD`)
 - GitHub secrets used by CI: `APP_STORE_CONNECT_API_KEY`, `APP_STORE_CONNECT_ISSUER_ID`, `APPLE_TEAM_ID`, `IOS_DISTRIBUTION_P12`, `IOS_DISTRIBUTION_PASSWORD`, `IOS_APPSTORE_PROFILE`, `IOS_WIDGET_APPSTORE_PROFILE`
 - Required entitlements: App Group `group.com.justspeaktoit.ios` and iCloud container `iCloud.com.justspeaktoit.ios`
+- The keyboard extension also requires `IOS_KEYBOARD_APPSTORE_PROFILE`; see [`Docs/ios-testflight-release.md`](Docs/ios-testflight-release.md) before changing portal capabilities or regenerating profiles.
 - Never commit private keys or provisioning profile contents.
 
 ## Sentry Error Monitoring

--- a/Docs/ios-testflight-release.md
+++ b/Docs/ios-testflight-release.md
@@ -1,0 +1,80 @@
+# iOS TestFlight release and signing runbook
+
+Use this runbook for normal TestFlight releases and for failures involving the iOS app, widget, or transcription keyboard provisioning profiles.
+
+## Release identifiers
+
+| Component | Bundle identifier | Required shared capability |
+| --- | --- | --- |
+| iOS app | `com.justspeaktoit.ios` | App Group and iCloud |
+| Widget | `com.justspeaktoit.ios.JustSpeakToItWidgetExtension` | App Group |
+| Keyboard | `com.justspeaktoit.ios.keyboard` | App Group |
+
+The shared App Group is `group.com.justspeaktoit.ios`. The keyboard App Store profile name starts with `JustSpeakToIt Keyboard App Store`.
+
+Do not commit certificates, private keys, decoded profiles, or their base64 contents.
+
+## Normal release
+
+1. Confirm the intended commit is on `main` and its required checks passed.
+2. Open App Store Connect and check the latest iOS TestFlight marketing version and build number.
+3. Run the GitHub Actions workflow **Release iOS (TestFlight)**. Enter the intended semantic version explicitly, without a leading `v`. The repository `VERSION` file is not authoritative for iOS.
+4. Monitor all distribution gates in the workflow:
+   - signing certificate and three profiles install successfully;
+   - the keyboard profile authorizes `group.com.justspeaktoit.ios`;
+   - the app, widget, and keyboard archive with the requested version and build;
+   - all three archived products retain the shared App Group entitlement;
+   - export and upload to App Store Connect succeed.
+5. Wait for Apple processing to finish. Confirm the exact version and build are visible in App Store Connect and assign the build to the intended internal TestFlight group.
+6. Update the app from TestFlight on a physical iPhone. Confirm the installed version/build, enable the keyboard, and run the device checks below.
+
+An upload is not the completion signal. Processing, tester assignment, installation, and hardware validation are separate gates.
+
+## Repair a keyboard App Group profile
+
+Use this sequence when the workflow reports that the keyboard provisioning profile does not authorize the shared App Group or when archive/export reports an entitlement mismatch.
+
+1. In the Apple Developer portal, open **Certificates, Identifiers & Profiles** → **Identifiers** → `com.justspeaktoit.ios.keyboard`.
+2. Enable **App Groups**, choose **Configure**, associate `group.com.justspeaktoit.ios`, then save and confirm the identifier change.
+3. Open **Profiles**, select the App Store profile whose name starts with `JustSpeakToIt Keyboard App Store`, choose **Edit**, and save or regenerate it. Enabling the capability through the App Store Connect API alone does not reliably attach the App Group to the identifier, and an existing profile does not gain the entitlement until it is regenerated.
+4. If CI uses the `IOS_KEYBOARD_APPSTORE_PROFILE` GitHub secret, replace it with the base64 of the regenerated profile. If the secret is absent, the workflow may reuse or create a portal profile, but it will still fail closed unless that profile contains the shared App Group.
+5. Rerun **Release iOS (TestFlight)** with the explicit intended iOS version.
+
+Prefer reusing and validating the portal profile over deleting profiles. Profile deletion can disrupt other release paths and is not required for this repair.
+
+## Verify a downloaded profile
+
+Decode only the entitlements dictionary. Converting the complete profile to JSON can fail because embedded certificate values are binary data.
+
+```bash
+PROFILE_PATH=/path/to/keyboard.mobileprovision
+PROFILE_PLIST=$(mktemp)
+security cms -D -i "$PROFILE_PATH" > "$PROFILE_PLIST"
+plutil -extract Entitlements xml1 -o - "$PROFILE_PLIST" \
+  | grep -Fq '<string>group.com.justspeaktoit.ios</string>'
+```
+
+The command must exit successfully. The release workflow performs the same exact entitlement check before archiving.
+
+## Physical-device keyboard checks
+
+1. Install or update the processed build from TestFlight and confirm its version/build in the app.
+2. In iOS Settings, enable **Just Speak to It** under **General** → **Keyboard** → **Keyboards**. Enable Full Access only when the app's current onboarding requires it.
+3. Open a text field in another app, switch to the Just Speak to It keyboard, and start transcription.
+4. Confirm the containing app records through the iPhone microphone, returns the nonce-matched result through the App Group, and the keyboard inserts the text at the cursor.
+5. Confirm stale results are not reused and normal Apple keyboard switching remains available.
+
+A custom keyboard extension cannot access the microphone directly. The supported path is keyboard → containing app → microphone/transcription → App Group handoff → `textDocumentProxy.insertText`.
+
+## Completion evidence
+
+Report each state separately:
+
+- PR merged and release commit identified.
+- Release workflow succeeded.
+- App Store Connect processing completed for the exact version/build.
+- Internal tester group assignment confirmed.
+- TestFlight build installed on a physical iPhone.
+- Microphone handoff and keyboard insertion verified end to end.
+
+If a later state is not verified, say so explicitly instead of treating an earlier green gate as shipment.

--- a/Docs/ios-testflight-release.md
+++ b/Docs/ios-testflight-release.md
@@ -23,7 +23,7 @@ Do not commit certificates, private keys, decoded profiles, or their base64 cont
    - signing certificate and three profiles install successfully;
    - the keyboard profile authorizes `group.com.justspeaktoit.ios`;
    - the app, widget, and keyboard archive with the requested version and build;
-   - all three archived products retain the shared App Group entitlement;
+   - all three archived products retain the shared App Group entitlement, and the app retains `iCloud.com.justspeaktoit.ios`;
    - export and upload to App Store Connect succeed.
 5. Wait for Apple processing to finish. Confirm the exact version and build are visible in App Store Connect and assign the build to the intended internal TestFlight group.
 6. Update the app from TestFlight on a physical iPhone. Confirm the installed version/build, enable the keyboard, and run the device checks below.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ open "Just Speak to It.xcworkspace"
 
 ## Versioning
 
-`VERSION` stores the semantic version and `BUILD` tracks the monotonically increasing build number. `scripts/version.sh` keeps them in sync and updates `Config/AppInfo.plist` when present.
+`VERSION` is a repository hint and `BUILD` tracks the monotonically increasing build number. `scripts/version.sh` keeps them in sync and updates `Config/AppInfo.plist` when present. For TestFlight, the release workflow requires an explicit iOS version; check App Store Connect rather than relying on `VERSION`. See [the iOS TestFlight release runbook](Docs/ios-testflight-release.md).
 
 Examples:
 

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -146,6 +146,21 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertFalse(profileBootstrap.contains("profiles.each do |stale_profile|"))
     }
 
+    func testIOSReleaseWorkflowRequiresAnExplicitSemanticVersion() throws {
+        let workflow = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-ios.yml"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(workflow.contains("required: true"))
+        XCTAssertTrue(workflow.contains("INPUT_VERSION: ${{ inputs.version }}"))
+        XCTAssertTrue(workflow.contains("iOS release version is required"))
+        XCTAssertTrue(workflow.contains("VERSION is not authoritative for TestFlight"))
+        XCTAssertTrue(workflow.contains("must be semantic version text"))
+        XCTAssertFalse(workflow.contains("leave empty to use VERSION file"))
+        XCTAssertFalse(workflow.contains("VERSION=$(cat VERSION)"))
+    }
+
     func testIOSApp_declaresRequiredBackgroundModes() throws {
         let manifest = try String(
             contentsOf: repositoryRoot.appendingPathComponent("Project.swift"),

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -132,6 +132,9 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(workflow.contains("KEYBOARD_PROFILE_UUID_PLACEHOLDER"))
         XCTAssertTrue(workflow.contains("JustSpeakKeyboard.appex"))
         XCTAssertTrue(workflow.contains("keyboard-entitlements.plist"))
+        XCTAssertTrue(workflow.contains("APP_ICLOUD_CONTAINER"))
+        XCTAssertTrue(workflow.contains("iCloud container mismatch"))
+        XCTAssertTrue(workflow.contains("iCloud.com.justspeaktoit.ios"))
 
         let profileBootstrap = try String(
             contentsOf: repositoryRoot.appendingPathComponent("scripts/create-ios-app-store-profile.rb"),
@@ -152,11 +155,36 @@ final class DistributionBuildIdentityTests: XCTestCase {
             encoding: .utf8
         )
 
-        XCTAssertTrue(workflow.contains("required: true"))
-        XCTAssertTrue(workflow.contains("INPUT_VERSION: ${{ inputs.version }}"))
-        XCTAssertTrue(workflow.contains("iOS release version is required"))
-        XCTAssertTrue(workflow.contains("VERSION is not authoritative for TestFlight"))
-        XCTAssertTrue(workflow.contains("must be semantic version text"))
+        let versionInputStart = try XCTUnwrap(workflow.range(of: "      version:\n")?.lowerBound)
+        let buildInputStart = try XCTUnwrap(workflow.range(of: "      build_number:\n")?.lowerBound)
+        let versionInput = workflow[versionInputStart..<buildInputStart]
+        XCTAssertTrue(versionInput.contains("required: true"))
+        XCTAssertTrue(versionInput.contains("type: string"))
+
+        let validationStart = try XCTUnwrap(workflow.range(of: "      - name: Determine Version\n")?.lowerBound)
+        let buildNumberStart = try XCTUnwrap(workflow.range(of: "      - name: Determine Build Number\n")?.lowerBound)
+        let validation = workflow[validationStart..<buildNumberStart]
+        XCTAssertTrue(validation.contains("INPUT_VERSION: ${{ inputs.version }}"))
+        XCTAssertTrue(validation.contains("iOS release version is required"))
+        XCTAssertTrue(validation.contains("VERSION is not authoritative for TestFlight"))
+        XCTAssertTrue(validation.contains("must be semantic version text"))
+
+        let patternPrefix = "VERSION_PATTERN='"
+        let patternStart = try XCTUnwrap(validation.range(of: patternPrefix)?.upperBound)
+        let patternEnd = try XCTUnwrap(validation[patternStart...].firstIndex(of: "'"))
+        let pattern = String(validation[patternStart..<patternEnd])
+        let regex = try NSRegularExpression(pattern: pattern)
+        func isAccepted(_ value: String) -> Bool {
+            let range = NSRange(value.startIndex..<value.endIndex, in: value)
+            return regex.firstMatch(in: value, range: range)?.range == range
+        }
+        XCTAssertTrue(isAccepted("2.29.2"))
+        XCTAssertTrue(isAccepted("0.0.0"))
+        XCTAssertFalse(isAccepted(""))
+        XCTAssertFalse(isAccepted("01.2.3"))
+        XCTAssertFalse(isAccepted("2.00.3"))
+        XCTAssertFalse(isAccepted("v2.29.2"))
+        XCTAssertFalse(isAccepted("2.29"))
         XCTAssertFalse(workflow.contains("leave empty to use VERSION file"))
         XCTAssertFalse(workflow.contains("VERSION=$(cat VERSION)"))
     }


### PR DESCRIPTION
## Motivation

The keyboard TestFlight repair exposed a release-contract gap: the repository guidance said to verify the iOS version in App Store Connect, while the workflow still accepted an empty version and silently fell back to the stale `VERSION` file. It also left the Apple Developer portal repair and physical-device completion gates undocumented.

## What changed

- add a durable iOS TestFlight/signing runbook covering App Group association, profile regeneration, entitlement-only validation, upload/processing/tester assignment, and device verification
- link the runbook from `AGENTS.md` and `README.md`, and align those documents with the existing automatic iOS dispatch plus manual iOS-only releases
- require an explicit semantic iOS version in `release-ios.yml`; remove the `VERSION` fallback and fail fast on missing or malformed input
- add a distribution contract test so the fallback cannot return unnoticed
- record the operational lesson in Beads under `ios-testflight-signing-release`

## Things we learnt that changed the direction

- enabling `APP_GROUPS` through the API does not reliably associate `group.com.justspeaktoit.ios` with the keyboard identifier; the portal association and profile regeneration are distinct gates
- converting an entire provisioning profile to JSON is unreliable because embedded certificates are binary; extracting the Entitlements plist is the dependable check
- a successful upload is not shipment: processing, tester assignment, installation, and physical microphone/keyboard handoff remain separate evidence
- `VERSION` can lag the actual iOS version, so a manual release must never derive its version from that file

## How to test

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-ios.yml")'`
- `swift test --disable-sandbox --filter DistributionBuildIdentityTests`
- `swift test --disable-sandbox` — 710 tests executed, 11 skipped, 0 failures
- `git diff --check`

## Confidence

High. The change is narrow, fail-closed, covered by the focused distribution contract test, and the full Swift test suite is green. The next real iOS release will provide end-to-end workflow evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * iOS releases now require an explicit App Store Connect version in `major.minor.patch` format.
  * Invalid or missing versions are rejected before release.
  * iOS releases no longer use the repository `VERSION` value as a fallback.

* **Documentation**
  * Added an iOS TestFlight release and signing guide.
  * Clarified versioning guidance, release requirements, provisioning, and validation steps.

* **Tests**
  * Added coverage for iOS version validation and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->