### PR TITLE
feat(mac): enable Parakeet and WhisperKit streaming in App Store build

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -35,7 +35,7 @@ if ProcessInfo.processInfo.environment["SHOW_OPENCLAW_TAB"] != nil {
 // two flavours: Developer ID / direct download (default) and Mac App Store. Generate
 // with `TUIST_APP_STORE=1 tuist generate` to produce a sandboxed App Store build: it
 // defines the `APP_STORE` Swift active compilation condition (gates Sparkle self-update
-// and the downloaded local-model runtimes — see Sources/SpeakCore/DistributionChannel.swift)
+// and external executable model runtimes — see Sources/SpeakCore/DistributionChannel.swift)
 // and selects the sandboxed entitlements file.
 //
 // NOTE: the env var MUST be `TUIST_`-prefixed. Tuist only forwards environment variables
@@ -109,11 +109,11 @@ if isAppStoreBuild {
 var projectPackages: [Package] = [
     .package(path: .relativeToRoot(".")),
     .remote(url: "https://github.com/getsentry/sentry-cocoa.git", requirement: .upToNextMajor(from: "9.3.0")),
-    .remote(url: "https://github.com/argmaxinc/argmax-oss-swift.git", requirement: .upToNextMajor(from: "0.9.0"))
+    .remote(url: "https://github.com/argmaxinc/argmax-oss-swift.git", requirement: .upToNextMajor(from: "0.9.0")),
+    .remote(url: "https://github.com/FluidInference/FluidAudio.git", requirement: .exact("0.15.5"))
 ]
 if !isAppStoreBuild {
     projectPackages += [
-        .remote(url: "https://github.com/FluidInference/FluidAudio.git", requirement: .exact("0.15.5")),
         .remote(url: "https://github.com/sparkle-project/Sparkle.git", requirement: .upToNextMajor(from: "2.6.0"))
     ]
 }
@@ -123,11 +123,11 @@ var macAppDependencies: [TargetDependency] = [
     .package(product: "SpeakSync"),
     .package(product: "SpeakHotKeys"),
     .package(product: "WhisperKit"),
+    .package(product: "FluidAudio"),
     .package(product: "Sentry")
 ]
 if !isAppStoreBuild {
     macAppDependencies += [
-        .package(product: "FluidAudio"),
         .package(product: "Sparkle")
     ]
 }

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -387,12 +387,10 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
 
   @Published var localTranscriptionMode: LocalTranscriptionMode {
     didSet {
-      #if APP_STORE
-      if !DistributionChannel.current.supportsExternalLocalModelRuntime, localTranscriptionMode == .streaming {
+      if !DistributionChannel.current.supportsInProcessLocalStreaming, localTranscriptionMode == .streaming {
         localTranscriptionMode = .batch
         return
       }
-      #endif
       store(localTranscriptionMode.rawValue, key: .localTranscriptionMode)
     }
   }
@@ -863,27 +861,24 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       rawValue: defaults.string(forKey: DefaultsKey.localTranscriptionMode.rawValue)
         ?? LocalTranscriptionMode.batch.rawValue
     ) ?? .batch
-    #if APP_STORE
-    localTranscriptionMode = DistributionChannel.current.supportsExternalLocalModelRuntime
+    localTranscriptionMode = DistributionChannel.current.supportsInProcessLocalStreaming
       ? loadedLocalTranscriptionMode
       : .batch
-    #else
-    localTranscriptionMode = loadedLocalTranscriptionMode
-    #endif
     let storedLocalStreamingSource = defaults.string(forKey: DefaultsKey.localStreamingModelSource.rawValue)
-    #if APP_STORE
-    let defaultLocalStreamingSource = ""
-    let supportedLocalStreamingIDs: Set<String> = []
-    #else
+    let whisperKitStreamingIDs = LocalModelManager.shared.availableModels
+      .filter(\.supportsLiveStreaming)
+      .map(WhisperKitStreamingModel.id(for:))
     let defaultLocalStreamingSource = FluidAudioModelManager.supportsCurrentHardware
       ? FluidAudioParakeetModel.id
-      : LocalModelManager.recommendedStreamingModelSources.first?.id ?? ""
+      : whisperKitStreamingIDs.first ?? ""
     let fluidAudioStreamingIDs = FluidAudioModelManager.supportsCurrentHardware
       ? [FluidAudioParakeetModel.id]
       : []
-    let supportedLocalStreamingIDs = Set(LocalModelManager.recommendedStreamingModelSources.map(\.id))
-      .union(LocalModelManager.shared.streamingModelSources.map(\.id))
+    var supportedLocalStreamingIDs = Set(whisperKitStreamingIDs)
       .union(fluidAudioStreamingIDs)
+    #if !APP_STORE
+    supportedLocalStreamingIDs.formUnion(LocalModelManager.recommendedStreamingModelSources.map(\.id))
+    supportedLocalStreamingIDs.formUnion(LocalModelManager.shared.streamingModelSources.map(\.id))
     #endif
     localStreamingModelSource =
       supportedLocalStreamingIDs.contains(storedLocalStreamingSource ?? "")

--- a/Sources/SpeakApp/FluidAudioModelManager.swift
+++ b/Sources/SpeakApp/FluidAudioModelManager.swift
@@ -1,4 +1,3 @@
-#if !APP_STORE
 @preconcurrency import CoreML
 import FluidAudio
 import Foundation
@@ -189,4 +188,3 @@ final class FluidAudioModelManager: ObservableObject {
     return configuration
   }
 }
-#endif

--- a/Sources/SpeakApp/FluidAudioParakeetLiveController.swift
+++ b/Sources/SpeakApp/FluidAudioParakeetLiveController.swift
@@ -1,4 +1,3 @@
-#if !APP_STORE
 @preconcurrency import AVFoundation
 import FluidAudio
 import Foundation
@@ -371,4 +370,3 @@ private final class FluidAudioBufferPump: @unchecked Sendable {
     return copy
   }
 }
-#endif

--- a/Sources/SpeakApp/LocalModelManager.swift
+++ b/Sources/SpeakApp/LocalModelManager.swift
@@ -304,6 +304,16 @@ final class LocalModelManager: ObservableObject {
     )
   }
 
+  func makeReadyPipeline(modelID: String) async throws -> WhisperKit {
+    guard let model = model(for: modelID) else {
+      throw LocalModelError.unknownModel(modelID)
+    }
+    guard isInstalled(model.id) else {
+      throw LocalModelError.notInstalled(model.displayName)
+    }
+    return try await pipeline(for: model)
+  }
+
   private func pipeline(for model: LocalTranscriptionModel) async throws -> WhisperKit {
     if let existing = activePipelines[model.id] {
       return existing

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -745,7 +745,11 @@ final class MainManager: ObservableObject {
           } else if WhisperKitStreamingModel.matches(result.modelIdentifier) {
             localRuntime = "whisperkit"
           } else {
+            #if APP_STORE
+            localRuntime = "unknown-local"
+            #else
             localRuntime = "sherpa-onnx"
+            #endif
           }
           let localURL = URL(string: "local://\(localRuntime)")!
             .appendingPathComponent(result.modelIdentifier)

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -37,12 +37,8 @@ final class MainManager: ObservableObject {
   }
 
   private var isStreamingTranscriptionMode: Bool {
-    #if APP_STORE
-    appSettings.transcriptionMode == .liveNative
-    #else
     appSettings.transcriptionMode == .liveNative
       || (appSettings.transcriptionMode == .localModel && appSettings.localTranscriptionMode == .streaming)
-    #endif
   }
 
   private var cachedRetryData: RetryData?
@@ -363,13 +359,9 @@ final class MainManager: ObservableObject {
     case .batchRemote:
       activeModel = appSettings.batchTranscriptionModel
     case .localModel:
-      #if APP_STORE
-      activeModel = appSettings.localTranscriptionModel
-      #else
       activeModel = appSettings.localTranscriptionMode == .streaming
         ? appSettings.localStreamingModelSource
         : appSettings.localTranscriptionModel
-      #endif
     }
     let providerLabel = captureHealthProviderLabel(for: activeModel)
     let latencyTier = ModelCatalog.allOptions.first(where: { $0.id == activeModel })?.latencyTier ?? .medium
@@ -390,13 +382,9 @@ final class MainManager: ObservableObject {
     case .batchRemote:
       return appSettings.batchTranscriptionModel
     case .localModel:
-      #if APP_STORE
-      return appSettings.localTranscriptionModel
-      #else
       return appSettings.localTranscriptionMode == .streaming
         ? appSettings.localStreamingModelSource
         : appSettings.localTranscriptionModel
-      #endif
     }
   }
 
@@ -443,13 +431,22 @@ final class MainManager: ObservableObject {
     guard appSettings.transcriptionMode == .localModel else {
       return ModelCatalog.friendlyName(for: modelID)
     }
-    #if !APP_STORE
     if appSettings.localTranscriptionMode == .streaming {
+      if let batchModelID = WhisperKitStreamingModel.batchModelID(from: modelID),
+        let model = LocalModelManager.shared.model(for: batchModelID) {
+        return shortLocalModelDisplayName(model.displayName) + " (Streaming)"
+      }
+      if FluidAudioParakeetModel.matches(modelID) {
+        return FluidAudioParakeetModel.displayName
+      }
+      #if !APP_STORE
       let source = LocalModelManager.shared.streamingModelSources.first { $0.id == modelID }
         ?? LocalModelManager.recommendedStreamingModelSources.first { $0.id == modelID }
       return source?.modelName ?? "Local Streaming"
+      #else
+      return "Local Streaming"
+      #endif
     }
-    #endif
     guard let localModel = LocalModelManager.shared.model(for: modelID) else {
       return ModelCatalog.friendlyName(for: modelID)
     }
@@ -741,11 +738,15 @@ final class MainManager: ObservableObject {
         // Log network exchange for live transcription
         let durationStr = String(format: "%.1f", result.duration)
         var didRecordLiveExchange = false
-        #if !APP_STORE
         if result.modelIdentifier.hasPrefix("local/streaming/") {
-          let localRuntime = FluidAudioParakeetModel.matches(result.modelIdentifier)
-            ? "fluidaudio"
-            : "sherpa-onnx"
+          let localRuntime: String
+          if FluidAudioParakeetModel.matches(result.modelIdentifier) {
+            localRuntime = "fluidaudio"
+          } else if WhisperKitStreamingModel.matches(result.modelIdentifier) {
+            localRuntime = "whisperkit"
+          } else {
+            localRuntime = "sherpa-onnx"
+          }
           let localURL = URL(string: "local://\(localRuntime)")!
             .appendingPathComponent(result.modelIdentifier)
           session.networkExchanges.append(
@@ -764,7 +765,6 @@ final class MainManager: ObservableObject {
           )
           didRecordLiveExchange = true
         }
-        #endif
         if !didRecordLiveExchange, result.modelIdentifier.contains("deepgram") {
           session.networkExchanges.append(
             HistoryNetworkExchange(

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -1406,7 +1406,7 @@ struct SettingsView: View {
             .accessibilityLabel("Local transcription source picker")
 
             if settings.transcriptionMode == .localModel {
-              if DistributionChannel.current.supportsExternalLocalModelRuntime {
+              if DistributionChannel.current.supportsInProcessLocalStreaming {
                 Picker(
                   "Downloaded transcription type",
                   selection: settingsBinding(\AppSettings.localTranscriptionMode)
@@ -2112,7 +2112,7 @@ struct SettingsView: View {
       localStreamingRuntimeControls
 
       localStreamingSetupSection(
-        title: "2. Add an optional sherpa-onnx model",
+        title: "3. Add an optional sherpa-onnx model",
         subtitle: "Pick one of the compatible external-runtime models we know how to download and run locally.",
         systemImage: "checklist",
         tint: .orange
@@ -2143,7 +2143,7 @@ struct SettingsView: View {
       }
 
       localStreamingSetupSection(
-        title: "3. Browse for more local streaming models",
+        title: "4. Browse for more local streaming models",
         subtitle: """
         Open Hugging Face search for sherpa-onnx streaming ASR models. \
         Only compatible sources can be added here.
@@ -2159,7 +2159,7 @@ struct SettingsView: View {
       }
 
       localStreamingSetupSection(
-        title: "4. Add a source manually",
+        title: "5. Add a source manually",
         subtitle: """
         Use this when you already know the Hugging Face repo and model name. \
         The model still stays local-only.
@@ -2375,6 +2375,7 @@ struct SettingsView: View {
                 if let fallback = firstInstalledStreamingSourceID(excluding: streamingID) {
                   settings.localStreamingModelSource = fallback
                 } else {
+                  settings.localStreamingModelSource = ""
                   settings.localTranscriptionMode = .batch
                 }
               }

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -70,8 +70,8 @@ struct SettingsView: View {
   @EnvironmentObject private var audioDevices: AudioInputDeviceManager
   @ObservedObject private var updaterManager = UpdaterManager.shared
   @ObservedObject private var localModels = LocalModelManager.shared
-  #if !APP_STORE
   @ObservedObject private var fluidAudioModels = FluidAudioModelManager.shared
+  #if !APP_STORE
   @ObservedObject private var sherpaRuntime = SherpaOnnxRuntimeManager.shared
   #endif
   @ObservedObject private var localPostProcessingModels = LocalPostProcessingModelManager.shared
@@ -177,7 +177,7 @@ struct SettingsView: View {
   }
 
   private let orderedLocalTranscriptionModes: [AppSettings.LocalTranscriptionMode] = {
-    DistributionChannel.current.supportsExternalLocalModelRuntime ? [.streaming, .batch] : [.batch]
+    DistributionChannel.current.supportsInProcessLocalStreaming ? [.streaming, .batch] : [.batch]
   }()
   private let orderedRemoteTranscriptionModes: [RemoteTranscriptionMode] = [.streaming, .batch]
 
@@ -1832,15 +1832,11 @@ struct SettingsView: View {
               selectedLocalModelCallout
             }
 
-            #if APP_STORE
-            huggingFaceModelImport
-            #else
             if settings.localTranscriptionMode == .batch {
               huggingFaceModelImport
             } else {
               localStreamingStatus
             }
-            #endif
 
             if settings.localTranscriptionMode == .batch {
               if localTranscriptionOptions.isEmpty {
@@ -1963,18 +1959,6 @@ struct SettingsView: View {
         title: "Choose Local mode",
         detail: "This switches recordings away from cloud providers."
       )
-      #if APP_STORE
-      localModelStep(
-        number: "2",
-        title: "Download a local batch model",
-        detail: "WhisperKit/Core ML models run locally after recording stops."
-      )
-      localModelStep(
-        number: "3",
-        title: "Record normally",
-        detail: "Speak transcribes after recording stops, offline on this Mac."
-      )
-      #else
       localModelStep(
         number: "2",
         title: settings.localTranscriptionMode == .batch
@@ -1982,16 +1966,15 @@ struct SettingsView: View {
           : "Download a local streaming model",
         detail: settings.localTranscriptionMode == .batch
           ? "WhisperKit/Core ML models run locally after recording stops."
-          : "Parakeet runs in-process with FluidAudio/Core ML; sherpa-onnx models remain available as alternatives."
+          : "Choose Parakeet or an installed WhisperKit model; both run in-process with Core ML."
       )
       localModelStep(
         number: "3",
         title: "Record normally",
         detail: settings.localTranscriptionMode == .batch
           ? "Speak transcribes after recording stops, offline on this Mac."
-          : "Once a compatible streaming runtime is connected, Speak will stream partial text locally."
+          : "Speak streams partial text locally while you record."
       )
-      #endif
     }
     .padding(12)
     .background(
@@ -2002,7 +1985,8 @@ struct SettingsView: View {
 
   private var localRuntimeUnavailableNote: some View {
     channelAvailabilityNote(
-      "Downloaded local runtimes are not available in this build. Local Batch and built-in cleanup remain available."
+      "External executable runtimes are unavailable in this build. "
+        + "Bundled Parakeet and WhisperKit/Core ML streaming remain available."
     )
   }
 
@@ -2093,7 +2077,6 @@ struct SettingsView: View {
     )
   }
 
-  #if !APP_STORE
   private var localStreamingStatus: some View {
     VStack(alignment: .leading, spacing: 12) {
       HStack(alignment: .top, spacing: 10) {
@@ -2106,8 +2089,7 @@ struct SettingsView: View {
           Text(
             """
             These are local-only streaming candidates, not cloud providers. \
-            Parakeet runs in-process with FluidAudio/Core ML. Optional sherpa-onnx models \
-            use a separately installed local runtime.
+            Parakeet and WhisperKit run in-process with bundled Core ML runtimes.
             """
           )
           .font(.caption)
@@ -2124,6 +2106,9 @@ struct SettingsView: View {
 
       fluidAudioStreamingRow
 
+      whisperKitStreamingRows
+
+      #if !APP_STORE
       localStreamingRuntimeControls
 
       localStreamingSetupSection(
@@ -2224,6 +2209,7 @@ struct SettingsView: View {
           }
         }
       }
+      #endif
     }
     .padding(12)
     .background(
@@ -2293,8 +2279,7 @@ struct SettingsView: View {
                   if let fallback = firstInstalledStreamingSourceID(excluding: FluidAudioParakeetModel.id) {
                     settings.localStreamingModelSource = fallback
                   } else {
-                    settings.localStreamingModelSource =
-                      LocalModelManager.recommendedStreamingModelSources.first?.id ?? ""
+                    settings.localStreamingModelSource = ""
                     settings.localTranscriptionMode = .batch
                   }
                 }
@@ -2332,6 +2317,82 @@ struct SettingsView: View {
     }
   }
 
+  private var whisperKitStreamingRows: some View {
+    localStreamingSetupSection(
+      title: "2. WhisperKit streaming",
+      subtitle: "Use any downloaded WhisperKit/Core ML model for multilingual live transcription.",
+      systemImage: "waveform",
+      tint: .blue
+    ) {
+      VStack(spacing: 10) {
+        ForEach(localStreamingModels) { model in
+          whisperKitStreamingRow(model)
+        }
+      }
+    }
+  }
+
+  // swiftlint:disable:next function_body_length
+  private func whisperKitStreamingRow(_ model: LocalTranscriptionModel) -> some View {
+    let state = localModels.installState(for: model.id)
+    let streamingID = WhisperKitStreamingModel.id(for: model)
+    let isSelected = state == .installed && settings.localStreamingModelSource == streamingID
+    return localModelRowContainer(isSelected: isSelected, tint: .blue) {
+      HStack(alignment: .top, spacing: 12) {
+        Image(systemName: localModelIcon(for: state))
+          .foregroundStyle(localModelTint(for: state))
+          .frame(width: 24)
+        VStack(alignment: .leading, spacing: 4) {
+          HStack(spacing: 8) {
+            Text(model.displayName)
+              .font(.subheadline.weight(.semibold))
+            if isSelected {
+              localModelBadge("Selected", tint: .blue)
+            }
+            localModelBadge("Streaming", tint: .blue)
+          }
+          Text(model.description)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+          Text("WhisperKit / Core ML · \(localModelSizeLabel(for: model))")
+            .font(.caption2.monospacedDigit())
+            .foregroundStyle(.tertiary)
+        }
+        Spacer()
+        VStack(alignment: .trailing, spacing: 8) {
+          switch state {
+          case .installed:
+            if isSelected {
+              selectedModelBadge(tint: .blue)
+            } else {
+              Button("Use") {
+                settings.localStreamingModelSource = streamingID
+              }
+            }
+            Button("Delete") {
+              localModels.delete(model)
+              if isSelected {
+                if let fallback = firstInstalledStreamingSourceID(excluding: streamingID) {
+                  settings.localStreamingModelSource = fallback
+                } else {
+                  settings.localTranscriptionMode = .batch
+                }
+              }
+            }
+          case .installing:
+            ProgressView()
+              .controlSize(.small)
+          case .notInstalled, .failed:
+            Button("Download") {
+              Task { await localModels.install(model) }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  #if !APP_STORE
   // swiftlint:disable:next function_body_length
   private func localStreamingSourceRow(_ source: LocalStreamingModelSource) -> some View {
     let state = sherpaRuntime.modelStates[source.id] ?? .notInstalled
@@ -2415,6 +2476,8 @@ struct SettingsView: View {
     }
   }
 
+  #endif
+
   private func localStreamingSetupSection<Content: View>(
     title: String,
     subtitle: String,
@@ -2448,6 +2511,7 @@ struct SettingsView: View {
     )
   }
 
+  #if !APP_STORE
   private var localStreamingRuntimeControls: some View {
     HStack(alignment: .center, spacing: 10) {
       Image(systemName: sherpaRuntimeIcon)
@@ -2719,16 +2783,26 @@ struct SettingsView: View {
       streamingHuggingFaceImportError = error.localizedDescription
     }
   }
+  #endif
 
   private func firstInstalledStreamingSourceID(excluding excludedID: String? = nil) -> String? {
     if FluidAudioParakeetModel.id != excludedID, fluidAudioModels.installState == .installed {
       return FluidAudioParakeetModel.id
     }
+    if let whisperKitModel = localStreamingModels.first(where: {
+      let streamingID = WhisperKitStreamingModel.id(for: $0)
+      return streamingID != excludedID && localModels.isInstalled($0.id)
+    }) {
+      return WhisperKitStreamingModel.id(for: whisperKitModel)
+    }
+    #if !APP_STORE
     return localModels.streamingModelSources.first {
       $0.id != excludedID && (sherpaRuntime.modelStates[$0.id] ?? .notInstalled) == .installed
     }?.id
+    #else
+    return nil
+    #endif
   }
-  #endif
 
   private func firstInstalledLocalTranscriptionModelID(excluding excludedID: String? = nil) -> String? {
     localModels.availableModels.first {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -24,6 +24,7 @@ enum TranscriptionManagerError: LocalizedError, Equatable {
   case permissionsMissing
   case microphonePermissionMissing
   case localLiveStreamingUnsupported
+  case localLiveStreamingStartupTimedOut
   case invalidLocalStreamingSource(String)
   case noUsableAudioInput
 
@@ -40,7 +41,10 @@ enum TranscriptionManagerError: LocalizedError, Equatable {
     case .microphonePermissionMissing:
       return "Microphone permission is missing. Grant microphone access in System Settings and try again."
     case .localLiveStreamingUnsupported:
-      return "Downloaded local models are offline-only in this prerelease. Use Local Batch after recording."
+      return "The selected downloaded model does not support Local Streaming. Choose another model or use Local Batch."
+    case .localLiveStreamingStartupTimedOut:
+      return "The local streaming model did not start receiving microphone audio in time. " +
+        "Try reconnecting the input device."
     case .invalidLocalStreamingSource(let sourceID):
       return "Local streaming source is not available: \(sourceID). " +
         "Choose or download a local streaming model in Settings."
@@ -284,6 +288,7 @@ final class TranscriptionManager: ObservableObject {
     var availableStreamingSourceIDs = Set(
       LocalModelManager.shared.availableModels
         .filter(\.supportsLiveStreaming)
+        .filter { LocalModelManager.shared.isInstalled($0.id) }
         .map(WhisperKitStreamingModel.id(for:))
     )
     if FluidAudioModelManager.supportsCurrentHardware {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -281,16 +281,17 @@ final class TranscriptionManager: ObservableObject {
   }
 
   private func liveTranscriptionModelForCurrentMode() throws -> String {
-    #if APP_STORE
-    let availableStreamingSourceIDs: Set<String> = []
-    #else
     var availableStreamingSourceIDs = Set(
-      LocalModelManager.recommendedStreamingModelSources.map(\.id)
-        + LocalModelManager.shared.streamingModelSources.map(\.id)
+      LocalModelManager.shared.availableModels
+        .filter(\.supportsLiveStreaming)
+        .map(WhisperKitStreamingModel.id(for:))
     )
     if FluidAudioModelManager.supportsCurrentHardware {
       availableStreamingSourceIDs.insert(FluidAudioParakeetModel.id)
     }
+    #if !APP_STORE
+    availableStreamingSourceIDs.formUnion(LocalModelManager.recommendedStreamingModelSources.map(\.id))
+    availableStreamingSourceIDs.formUnion(LocalModelManager.shared.streamingModelSources.map(\.id))
     #endif
     return try Self.resolvedLiveTranscriptionModel(
       transcriptionMode: appSettings.transcriptionMode,
@@ -308,11 +309,6 @@ final class TranscriptionManager: ObservableObject {
     liveTranscriptionModel: String,
     availableStreamingSourceIDs: Set<String>
   ) throws -> String {
-    #if APP_STORE
-    if transcriptionMode == .localModel, localTranscriptionMode == .streaming {
-      return liveTranscriptionModel
-    }
-    #endif
     guard transcriptionMode == .localModel, localTranscriptionMode == .streaming else {
       return liveTranscriptionModel
     }
@@ -3974,8 +3970,9 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private var gladiaController: GladiaLiveController
   private var openAIRealtimeController: OpenAIRealtimeLiveController
   private var sharedClientController: SharedClientLiveController
-  #if !APP_STORE
   private var fluidAudioController: FluidAudioParakeetLiveController
+  private var whisperKitController: WhisperKitLiveController
+  #if !APP_STORE
   private var sherpaOnnxController: SherpaOnnxLiveController
   #endif
   private var unsupportedLocalLiveController: UnsupportedLocalLiveTranscriber
@@ -4068,13 +4065,18 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       audioDeviceManager: audioDeviceManager,
       secureStorage: secureStorage
     )
-    #if !APP_STORE
     fluidAudioController = FluidAudioParakeetLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
       modelManager: FluidAudioModelManager.shared
     )
+    whisperKitController = WhisperKitLiveController(
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      modelManager: LocalModelManager.shared
+    )
+    #if !APP_STORE
     sherpaOnnxController = SherpaOnnxLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
@@ -4161,8 +4163,9 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     // OpenAI's only live transcription transport is the Realtime WebSocket
     // API. So any openai/* live model is handled by openAIRealtimeController.
     if model.hasPrefix("openai/") { return openAIRealtimeController }
-    #if !APP_STORE
     if FluidAudioParakeetModel.matches(model) { return fluidAudioController }
+    if WhisperKitStreamingModel.matches(model) { return whisperKitController }
+    #if !APP_STORE
     if model.hasPrefix("local/streaming/") { return sherpaOnnxController }
     #else
     if model.hasPrefix("local/streaming/") { return unsupportedLocalLiveController }
@@ -4201,9 +4204,10 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       sharedClientController,
       unsupportedLocalLiveController
     ]
+    controllers.insert(whisperKitController, at: controllers.count - 1)
+    controllers.insert(fluidAudioController, at: controllers.count - 1)
     #if !APP_STORE
     controllers.insert(sherpaOnnxController, at: controllers.count - 1)
-    controllers.insert(fluidAudioController, at: controllers.count - 1)
     #endif
     let model = currentModel ?? appSettings.liveTranscriptionModel
     for controller in controllers {
@@ -4292,13 +4296,18 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
       audioDeviceManager: audioDeviceManager,
       secureStorage: secureStorage
     )
-    #if !APP_STORE
     fluidAudioController = FluidAudioParakeetLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
       audioDeviceManager: audioDeviceManager,
       modelManager: FluidAudioModelManager.shared
     )
+    whisperKitController = WhisperKitLiveController(
+      permissionsManager: permissionsManager,
+      audioDeviceManager: audioDeviceManager,
+      modelManager: LocalModelManager.shared
+    )
+    #if !APP_STORE
     sherpaOnnxController = SherpaOnnxLiveController(
       appSettings: appSettings,
       permissionsManager: permissionsManager,

--- a/Sources/SpeakApp/WhisperKitLiveController.swift
+++ b/Sources/SpeakApp/WhisperKitLiveController.swift
@@ -4,200 +4,236 @@ import WhisperKit
 
 @MainActor
 final class WhisperKitLiveController: LiveTranscriptionController {
-  weak var delegate: LiveTranscriptionSessionDelegate?
-  private(set) var isRunning = false
+    weak var delegate: LiveTranscriptionSessionDelegate?
+    private(set) var isRunning = false
 
-  private let permissionsManager: PermissionsManager
-  private let audioDeviceManager: AudioInputDeviceManager
-  private let modelManager: LocalModelManager
-  private var transcriber: AudioStreamTranscriber?
-  private var streamTask: Task<Void, Never>?
-  private var startupTask: Task<Void, Never>?
-  private var startupContinuation: CheckedContinuation<Void, Error>?
-  private var activeInputSession: AudioInputDeviceManager.SessionContext?
-  private var currentLanguage: String?
-  private var currentModel = WhisperKitStreamingModel.prefix + "tiny"
-  private var latestText = ""
-  private var startedAt: Date?
-  private var isStopping = false
+    private let permissionsManager: PermissionsManager
+    private let audioDeviceManager: AudioInputDeviceManager
+    private let modelManager: LocalModelManager
+    private var transcriber: AudioStreamTranscriber?
+    private var streamTask: Task<Void, Never>?
+    private var startupTask: Task<Void, Never>?
+    private var startupContinuation: CheckedContinuation<Void, Error>?
+    private var activeInputSession: AudioInputDeviceManager.SessionContext?
+    private var currentLanguage: String?
+    private var currentModel = WhisperKitStreamingModel.prefix + "tiny"
+    private var latestText = ""
+    private var startedAt: Date?
+    private var isStopping = false
 
-  init(
-    permissionsManager: PermissionsManager,
-    audioDeviceManager: AudioInputDeviceManager,
-    modelManager: LocalModelManager
-  ) {
-    self.permissionsManager = permissionsManager
-    self.audioDeviceManager = audioDeviceManager
-    self.modelManager = modelManager
-  }
-
-  func configure(language: String?, model: String) {
-    currentLanguage = language
-    currentModel = model
-  }
-
-  // swiftlint:disable:next function_body_length
-  func start() async throws {
-    guard !isRunning, streamTask == nil, !isStopping else {
-      throw TranscriptionManagerError.liveSessionAlreadyRunning
-    }
-    guard await permissionsManager.ensureGranted(.microphone).isGranted else {
-      throw TranscriptionManagerError.microphonePermissionMissing
-    }
-    guard let batchModelID = WhisperKitStreamingModel.batchModelID(from: currentModel) else {
-      throw TranscriptionManagerError.invalidLocalStreamingSource(currentModel)
+    init(
+        permissionsManager: PermissionsManager,
+        audioDeviceManager: AudioInputDeviceManager,
+        modelManager: LocalModelManager
+    ) {
+        self.permissionsManager = permissionsManager
+        self.audioDeviceManager = audioDeviceManager
+        self.modelManager = modelManager
     }
 
-    let pipeline = try await modelManager.makeReadyPipeline(modelID: batchModelID)
-    guard let tokenizer = pipeline.tokenizer else {
-      throw TranscriptionManagerError.localLiveStreamingUnsupported
+    func configure(language: String?, model: String) {
+        currentLanguage = language
+        currentModel = model
     }
 
-    activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
-    latestText = ""
-    startedAt = Date()
+    // swiftlint:disable:next function_body_length
+    func start() async throws {
+        guard !isRunning, streamTask == nil, !isStopping else {
+            throw TranscriptionManagerError.liveSessionAlreadyRunning
+        }
+        guard await permissionsManager.ensureGranted(.microphone).isGranted else {
+            throw TranscriptionManagerError.microphonePermissionMissing
+        }
+        guard let batchModelID = WhisperKitStreamingModel.batchModelID(from: currentModel) else {
+            throw TranscriptionManagerError.invalidLocalStreamingSource(currentModel)
+        }
 
-    let language = currentLanguage?
-      .split(whereSeparator: { $0 == "_" || $0 == "-" })
-      .first
-      .map(String.init)
-      .map { $0.lowercased() }
-    let options = DecodingOptions(
-      task: .transcribe,
-      language: language,
-      usePrefillPrompt: language != nil,
-      skipSpecialTokens: true,
-      wordTimestamps: true
-    )
-    let transcriber = AudioStreamTranscriber(
-      audioEncoder: pipeline.audioEncoder,
-      featureExtractor: pipeline.featureExtractor,
-      segmentSeeker: pipeline.segmentSeeker,
-      textDecoder: pipeline.textDecoder,
-      tokenizer: tokenizer,
-      audioProcessor: pipeline.audioProcessor,
-      decodingOptions: options,
-      stateChangeCallback: { [weak self] oldState, newState in
+        let pipeline = try await modelManager.makeReadyPipeline(modelID: batchModelID)
+        guard let tokenizer = pipeline.tokenizer else {
+            throw TranscriptionManagerError.localLiveStreamingUnsupported
+        }
+
+        activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+        latestText = ""
+        startedAt = Date()
+
+        let language = currentLanguage?
+            .split(whereSeparator: { $0 == "_" || $0 == "-" })
+            .first
+            .map(String.init)
+            .map { $0.lowercased() }
+        let options = DecodingOptions(
+            task: .transcribe,
+            language: language,
+            usePrefillPrompt: language != nil,
+            skipSpecialTokens: true,
+            wordTimestamps: true
+        )
+        let transcriber = AudioStreamTranscriber(
+            audioEncoder: pipeline.audioEncoder,
+            featureExtractor: pipeline.featureExtractor,
+            segmentSeeker: pipeline.segmentSeeker,
+            textDecoder: pipeline.textDecoder,
+            tokenizer: tokenizer,
+            audioProcessor: pipeline.audioProcessor,
+            decodingOptions: options,
+            stateChangeCallback: { [weak self] oldState, newState in
+                Task { @MainActor [weak self] in
+                    self?.handleStateChange(from: oldState, to: newState)
+                }
+            }
+        )
+        self.transcriber = transcriber
+
+        try await withCheckedThrowingContinuation { continuation in
+            startupContinuation = continuation
+            streamTask = Task { [weak self, transcriber] in
+                do {
+                    try await transcriber.startStreamTranscription()
+                    await self?.streamEnded(error: nil)
+                } catch {
+                    await self?.streamEnded(error: error)
+                }
+            }
+            startupTask = Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(for: .seconds(10))
+                } catch {
+                    return
+                }
+                guard let self, let continuation = self.startupContinuation else { return }
+                let activeStreamTask = self.streamTask
+                self.startupContinuation = nil
+                self.isStopping = true
+                continuation.resume(throwing: TranscriptionManagerError.localLiveStreamingStartupTimedOut)
+                await self.cleanupAfterFailedStart()
+                await activeStreamTask?.value
+                self.isStopping = false
+            }
+        }
+    }
+
+    func stop() async {
+        guard isRunning || streamTask != nil else { return }
+        isStopping = true
+        startupTask?.cancel()
+        startupTask = nil
+        if let continuation = startupContinuation {
+            startupContinuation = nil
+            continuation.resume(throwing: TranscriptionManagerError.liveSessionNotRunning)
+        }
+
+        if let transcriber {
+            await transcriber.stopStreamTranscription()
+        }
+        await streamTask?.value
+        streamTask = nil
+        transcriber = nil
+        isRunning = false
+
+        if let activeInputSession {
+            await audioDeviceManager.endUsingPreferredInput(session: activeInputSession)
+            self.activeInputSession = nil
+        }
+
+        let duration = startedAt.map { Date().timeIntervalSince($0) } ?? 0
+        startedAt = nil
+        isStopping = false
+        delegate?.liveTranscriber(
+            self,
+            didFinishWith: TranscriptionResult(
+                text: latestText,
+                segments: [],
+                confidence: nil,
+                duration: duration,
+                modelIdentifier: currentModel,
+                cost: nil,
+                rawPayload: nil,
+                debugInfo: nil
+            )
+        )
+    }
+
+    private func handleStateChange(
+        from oldState: AudioStreamTranscriber.State,
+        to newState: AudioStreamTranscriber.State
+    ) {
+        let beganProcessingAudio = newState.isRecording
+            && (oldState.currentText != newState.currentText
+                || oldState.bufferEnergy != newState.bufferEnergy
+                || oldState.lastBufferSize != newState.lastBufferSize)
+        if beganProcessingAudio, let continuation = startupContinuation {
+            startupTask?.cancel()
+            startupTask = nil
+            startupContinuation = nil
+            isRunning = true
+            continuation.resume()
+        }
+
         guard oldState.currentText != newState.currentText
-          || oldState.confirmedSegments != newState.confirmedSegments
-          || oldState.unconfirmedSegments != newState.unconfirmedSegments
+            || oldState.confirmedSegments != newState.confirmedSegments
+            || oldState.unconfirmedSegments != newState.unconfirmedSegments
         else { return }
-        Task { @MainActor [weak self] in
-          self?.handleState(newState)
+        handleState(newState)
+    }
+
+    private func handleState(_ state: AudioStreamTranscriber.State) {
+        let segmentText = (state.confirmedSegments + state.unconfirmedSegments)
+            .map(\.text)
+            .joined(separator: " ")
+        let currentText = state.currentText == "Waiting for speech..." ? "" : state.currentText
+        let text = clean([segmentText, currentText].joined(separator: " "))
+        guard text != latestText else { return }
+        latestText = text
+        delegate?.liveTranscriber(self, didUpdatePartial: text)
+    }
+
+    private func streamEnded(error: Error?) async {
+        startupTask?.cancel()
+        startupTask = nil
+        if let continuation = startupContinuation {
+            startupContinuation = nil
+            continuation.resume(throwing: error ?? TranscriptionManagerError.liveSessionNotRunning)
+            await cleanupAfterFailedStart()
+            return
         }
-      }
-    )
-    self.transcriber = transcriber
-
-    try await withCheckedThrowingContinuation { continuation in
-      startupContinuation = continuation
-      streamTask = Task { [weak self, transcriber] in
-        do {
-          try await transcriber.startStreamTranscription()
-          await self?.streamEnded(error: nil)
-        } catch {
-          await self?.streamEnded(error: error)
+        guard !isStopping else { return }
+        isRunning = false
+        streamTask = nil
+        if let transcriber {
+            await transcriber.stopStreamTranscription()
         }
-      }
-      startupTask = Task { @MainActor [weak self] in
-        try? await Task.sleep(for: .milliseconds(250))
-        guard let self, let continuation = self.startupContinuation else { return }
-        self.startupContinuation = nil
-        self.isRunning = true
-        continuation.resume()
-      }
-    }
-  }
-
-  func stop() async {
-    guard isRunning || streamTask != nil else { return }
-    isStopping = true
-    startupTask?.cancel()
-    startupTask = nil
-    if let continuation = startupContinuation {
-      startupContinuation = nil
-      continuation.resume(throwing: TranscriptionManagerError.liveSessionNotRunning)
+        transcriber = nil
+        startedAt = nil
+        await cleanupInputSession()
+        delegate?.liveTranscriber(
+            self,
+            didFail: error ?? TranscriptionManagerError.liveSessionNotRunning
+        )
     }
 
-    if let transcriber {
-      await transcriber.stopStreamTranscription()
-    }
-    await streamTask?.value
-    streamTask = nil
-    transcriber = nil
-    isRunning = false
-
-    if let activeInputSession {
-      await audioDeviceManager.endUsingPreferredInput(session: activeInputSession)
-      self.activeInputSession = nil
+    private func cleanupAfterFailedStart() async {
+        streamTask = nil
+        if let transcriber {
+            await transcriber.stopStreamTranscription()
+        }
+        transcriber = nil
+        startedAt = nil
+        isRunning = false
+        await cleanupInputSession()
     }
 
-    let duration = startedAt.map { Date().timeIntervalSince($0) } ?? 0
-    startedAt = nil
-    isStopping = false
-    delegate?.liveTranscriber(
-      self,
-      didFinishWith: TranscriptionResult(
-        text: latestText,
-        segments: [],
-        confidence: nil,
-        duration: duration,
-        modelIdentifier: currentModel,
-        cost: nil,
-        rawPayload: nil,
-        debugInfo: nil
-      )
-    )
-  }
-
-  private func handleState(_ state: AudioStreamTranscriber.State) {
-    let segmentText = (state.confirmedSegments + state.unconfirmedSegments)
-      .map(\.text)
-      .joined(separator: " ")
-    let currentText = state.currentText == "Waiting for speech..." ? "" : state.currentText
-    let text = clean([segmentText, currentText].joined(separator: " "))
-    guard text != latestText else { return }
-    latestText = text
-    delegate?.liveTranscriber(self, didUpdatePartial: text)
-  }
-
-  private func streamEnded(error: Error?) async {
-    startupTask?.cancel()
-    startupTask = nil
-    if let continuation = startupContinuation {
-      startupContinuation = nil
-      continuation.resume(throwing: error ?? TranscriptionManagerError.liveSessionNotRunning)
-      await cleanupAfterFailedStart()
-      return
+    private func cleanupInputSession() async {
+        if let activeInputSession {
+            await audioDeviceManager.endUsingPreferredInput(session: activeInputSession)
+            self.activeInputSession = nil
+        }
     }
-    guard !isStopping else { return }
-    isRunning = false
-    await cleanupInputSession()
-    delegate?.liveTranscriber(
-      self,
-      didFail: error ?? TranscriptionManagerError.liveSessionNotRunning
-    )
-  }
 
-  private func cleanupAfterFailedStart() async {
-    streamTask = nil
-    transcriber = nil
-    startedAt = nil
-    isRunning = false
-    await cleanupInputSession()
-  }
-
-  private func cleanupInputSession() async {
-    if let activeInputSession {
-      await audioDeviceManager.endUsingPreferredInput(session: activeInputSession)
-      self.activeInputSession = nil
+    private func clean(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "[BLANK_AUDIO]", with: "", options: .caseInsensitive)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
-  }
-
-  private func clean(_ text: String) -> String {
-    text
-      .replacingOccurrences(of: "[BLANK_AUDIO]", with: "", options: .caseInsensitive)
-      .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-  }
 }

--- a/Sources/SpeakApp/WhisperKitLiveController.swift
+++ b/Sources/SpeakApp/WhisperKitLiveController.swift
@@ -1,0 +1,203 @@
+import Foundation
+import SpeakCore
+import WhisperKit
+
+@MainActor
+final class WhisperKitLiveController: LiveTranscriptionController {
+  weak var delegate: LiveTranscriptionSessionDelegate?
+  private(set) var isRunning = false
+
+  private let permissionsManager: PermissionsManager
+  private let audioDeviceManager: AudioInputDeviceManager
+  private let modelManager: LocalModelManager
+  private var transcriber: AudioStreamTranscriber?
+  private var streamTask: Task<Void, Never>?
+  private var startupTask: Task<Void, Never>?
+  private var startupContinuation: CheckedContinuation<Void, Error>?
+  private var activeInputSession: AudioInputDeviceManager.SessionContext?
+  private var currentLanguage: String?
+  private var currentModel = WhisperKitStreamingModel.prefix + "tiny"
+  private var latestText = ""
+  private var startedAt: Date?
+  private var isStopping = false
+
+  init(
+    permissionsManager: PermissionsManager,
+    audioDeviceManager: AudioInputDeviceManager,
+    modelManager: LocalModelManager
+  ) {
+    self.permissionsManager = permissionsManager
+    self.audioDeviceManager = audioDeviceManager
+    self.modelManager = modelManager
+  }
+
+  func configure(language: String?, model: String) {
+    currentLanguage = language
+    currentModel = model
+  }
+
+  // swiftlint:disable:next function_body_length
+  func start() async throws {
+    guard !isRunning, streamTask == nil, !isStopping else {
+      throw TranscriptionManagerError.liveSessionAlreadyRunning
+    }
+    guard await permissionsManager.ensureGranted(.microphone).isGranted else {
+      throw TranscriptionManagerError.microphonePermissionMissing
+    }
+    guard let batchModelID = WhisperKitStreamingModel.batchModelID(from: currentModel) else {
+      throw TranscriptionManagerError.invalidLocalStreamingSource(currentModel)
+    }
+
+    let pipeline = try await modelManager.makeReadyPipeline(modelID: batchModelID)
+    guard let tokenizer = pipeline.tokenizer else {
+      throw TranscriptionManagerError.localLiveStreamingUnsupported
+    }
+
+    activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    latestText = ""
+    startedAt = Date()
+
+    let language = currentLanguage?
+      .split(whereSeparator: { $0 == "_" || $0 == "-" })
+      .first
+      .map(String.init)
+      .map { $0.lowercased() }
+    let options = DecodingOptions(
+      task: .transcribe,
+      language: language,
+      usePrefillPrompt: language != nil,
+      skipSpecialTokens: true,
+      wordTimestamps: true
+    )
+    let transcriber = AudioStreamTranscriber(
+      audioEncoder: pipeline.audioEncoder,
+      featureExtractor: pipeline.featureExtractor,
+      segmentSeeker: pipeline.segmentSeeker,
+      textDecoder: pipeline.textDecoder,
+      tokenizer: tokenizer,
+      audioProcessor: pipeline.audioProcessor,
+      decodingOptions: options,
+      stateChangeCallback: { [weak self] oldState, newState in
+        guard oldState.currentText != newState.currentText
+          || oldState.confirmedSegments != newState.confirmedSegments
+          || oldState.unconfirmedSegments != newState.unconfirmedSegments
+        else { return }
+        Task { @MainActor [weak self] in
+          self?.handleState(newState)
+        }
+      }
+    )
+    self.transcriber = transcriber
+
+    try await withCheckedThrowingContinuation { continuation in
+      startupContinuation = continuation
+      streamTask = Task { [weak self, transcriber] in
+        do {
+          try await transcriber.startStreamTranscription()
+          await self?.streamEnded(error: nil)
+        } catch {
+          await self?.streamEnded(error: error)
+        }
+      }
+      startupTask = Task { @MainActor [weak self] in
+        try? await Task.sleep(for: .milliseconds(250))
+        guard let self, let continuation = self.startupContinuation else { return }
+        self.startupContinuation = nil
+        self.isRunning = true
+        continuation.resume()
+      }
+    }
+  }
+
+  func stop() async {
+    guard isRunning || streamTask != nil else { return }
+    isStopping = true
+    startupTask?.cancel()
+    startupTask = nil
+    if let continuation = startupContinuation {
+      startupContinuation = nil
+      continuation.resume(throwing: TranscriptionManagerError.liveSessionNotRunning)
+    }
+
+    if let transcriber {
+      await transcriber.stopStreamTranscription()
+    }
+    await streamTask?.value
+    streamTask = nil
+    transcriber = nil
+    isRunning = false
+
+    if let activeInputSession {
+      await audioDeviceManager.endUsingPreferredInput(session: activeInputSession)
+      self.activeInputSession = nil
+    }
+
+    let duration = startedAt.map { Date().timeIntervalSince($0) } ?? 0
+    startedAt = nil
+    isStopping = false
+    delegate?.liveTranscriber(
+      self,
+      didFinishWith: TranscriptionResult(
+        text: latestText,
+        segments: [],
+        confidence: nil,
+        duration: duration,
+        modelIdentifier: currentModel,
+        cost: nil,
+        rawPayload: nil,
+        debugInfo: nil
+      )
+    )
+  }
+
+  private func handleState(_ state: AudioStreamTranscriber.State) {
+    let segmentText = (state.confirmedSegments + state.unconfirmedSegments)
+      .map(\.text)
+      .joined(separator: " ")
+    let currentText = state.currentText == "Waiting for speech..." ? "" : state.currentText
+    let text = clean([segmentText, currentText].joined(separator: " "))
+    guard text != latestText else { return }
+    latestText = text
+    delegate?.liveTranscriber(self, didUpdatePartial: text)
+  }
+
+  private func streamEnded(error: Error?) async {
+    startupTask?.cancel()
+    startupTask = nil
+    if let continuation = startupContinuation {
+      startupContinuation = nil
+      continuation.resume(throwing: error ?? TranscriptionManagerError.liveSessionNotRunning)
+      await cleanupAfterFailedStart()
+      return
+    }
+    guard !isStopping else { return }
+    isRunning = false
+    await cleanupInputSession()
+    delegate?.liveTranscriber(
+      self,
+      didFail: error ?? TranscriptionManagerError.liveSessionNotRunning
+    )
+  }
+
+  private func cleanupAfterFailedStart() async {
+    streamTask = nil
+    transcriber = nil
+    startedAt = nil
+    isRunning = false
+    await cleanupInputSession()
+  }
+
+  private func cleanupInputSession() async {
+    if let activeInputSession {
+      await audioDeviceManager.endUsingPreferredInput(session: activeInputSession)
+      self.activeInputSession = nil
+    }
+  }
+
+  private func clean(_ text: String) -> String {
+    text
+      .replacingOccurrences(of: "[BLANK_AUDIO]", with: "", options: .caseInsensitive)
+      .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}

--- a/Sources/SpeakApp/WhisperKitStreamingModel.swift
+++ b/Sources/SpeakApp/WhisperKitStreamingModel.swift
@@ -1,24 +1,24 @@
 import SpeakCore
 
 enum WhisperKitStreamingModel {
-  static let prefix = "local/streaming/whisperkit/"
-  private static let batchPrefix = "local/whisperkit/"
+    static let prefix = "local/streaming/whisperkit/"
+    private static let batchPrefix = "local/whisperkit/"
 
-  static func id(for model: LocalTranscriptionModel) -> String {
-    id(forBatchModelID: model.id)
-  }
+    static func id(for model: LocalTranscriptionModel) -> String {
+        id(forBatchModelID: model.id)
+    }
 
-  static func id(forBatchModelID modelID: String) -> String {
-    guard modelID.hasPrefix(batchPrefix) else { return prefix + modelID }
-    return prefix + modelID.dropFirst(batchPrefix.count)
-  }
+    static func id(forBatchModelID modelID: String) -> String {
+        guard modelID.hasPrefix(batchPrefix) else { return prefix + modelID }
+        return prefix + modelID.dropFirst(batchPrefix.count)
+    }
 
-  static func batchModelID(from streamingID: String) -> String? {
-    guard streamingID.hasPrefix(prefix) else { return nil }
-    return batchPrefix + streamingID.dropFirst(prefix.count)
-  }
+    static func batchModelID(from streamingID: String) -> String? {
+        guard streamingID.hasPrefix(prefix) else { return nil }
+        return batchPrefix + streamingID.dropFirst(prefix.count)
+    }
 
-  static func matches(_ modelID: String) -> Bool {
-    batchModelID(from: modelID) != nil
-  }
+    static func matches(_ modelID: String) -> Bool {
+        batchModelID(from: modelID) != nil
+    }
 }

--- a/Sources/SpeakApp/WhisperKitStreamingModel.swift
+++ b/Sources/SpeakApp/WhisperKitStreamingModel.swift
@@ -1,0 +1,24 @@
+import SpeakCore
+
+enum WhisperKitStreamingModel {
+  static let prefix = "local/streaming/whisperkit/"
+  private static let batchPrefix = "local/whisperkit/"
+
+  static func id(for model: LocalTranscriptionModel) -> String {
+    id(forBatchModelID: model.id)
+  }
+
+  static func id(forBatchModelID modelID: String) -> String {
+    guard modelID.hasPrefix(batchPrefix) else { return prefix + modelID }
+    return prefix + modelID.dropFirst(batchPrefix.count)
+  }
+
+  static func batchModelID(from streamingID: String) -> String? {
+    guard streamingID.hasPrefix(prefix) else { return nil }
+    return batchPrefix + streamingID.dropFirst(prefix.count)
+  }
+
+  static func matches(_ modelID: String) -> Bool {
+    batchModelID(from: modelID) != nil
+  }
+}

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -77,6 +77,8 @@ public enum ChannelFeature: String, Sendable, CaseIterable {
     case selfUpdate
     /// Downloaded Core ML model data used by a runtime already bundled in the app.
     case downloadedCoreMLModels
+    /// Live transcription performed by a bundled, in-process Core ML runtime.
+    case inProcessLocalStreaming
     /// External runtimes (llama.cpp / sherpa-onnx) that install or spawn executable
     /// code and therefore cannot be offered in the App Store sandbox.
     case externalLocalModelRuntime
@@ -115,7 +117,7 @@ public extension DistributionChannel {
             // iOS and Mac App Store builds carry the managed iCloud entitlements.
             // Direct Mac keeps API keys solely in its local Keychain vault.
             return self == .appStore
-        case .downloadedCoreMLModels, .localNetworkTransport:
+        case .downloadedCoreMLModels, .inProcessLocalStreaming, .localNetworkTransport:
             return true
         }
     }
@@ -125,6 +127,9 @@ public extension DistributionChannel {
 
     /// Downloadable WhisperKit/Core ML model data (both channels).
     var supportsDownloadedCoreMLModels: Bool { supports(.downloadedCoreMLModels) }
+
+    /// In-process local streaming through bundled Core ML runtimes (both channels).
+    var supportsInProcessLocalStreaming: Bool { supports(.inProcessLocalStreaming) }
 
     /// Installable executable local runtimes such as sherpa-onnx and llama.cpp (direct only).
     var supportsExternalLocalModelRuntime: Bool { supports(.externalLocalModelRuntime) }

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -554,8 +554,9 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             modelName: "tiny",
             engine: .whisperKit,
             approximateSizeMB: 75,
-            description: "Small downloadable Core ML Whisper model for fast offline transcription testing.",
-            tags: [.fast, .cheap]
+            description: "Small downloadable Core ML Whisper model for fast batch or live transcription testing.",
+            tags: [.fast, .cheap],
+            supportsLiveStreaming: true
         ),
         LocalTranscriptionModel(
             id: "local/whisperkit/base",
@@ -563,8 +564,9 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             modelName: "base",
             engine: .whisperKit,
             approximateSizeMB: 145,
-            description: "Balanced downloaded Whisper model for private offline transcription.",
-            tags: [.fast]
+            description: "Balanced downloaded Whisper model for private batch or live transcription.",
+            tags: [.fast],
+            supportsLiveStreaming: true
         ),
         LocalTranscriptionModel(
             id: "local/whisperkit/small",
@@ -572,8 +574,9 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             modelName: "small",
             engine: .whisperKit,
             approximateSizeMB: 465,
-            description: "Higher quality local Whisper model for longer recordings on Apple silicon.",
-            tags: [.quality]
+            description: "Higher quality local Whisper model for batch and live transcription on Apple silicon.",
+            tags: [.quality],
+            supportsLiveStreaming: true
         ),
         LocalTranscriptionModel(
             id: "local/whisperkit/large-v3-turbo",
@@ -582,8 +585,9 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             engine: .whisperKit,
             approximateSizeMB: 632,
             description: "Whisper Large v3 Turbo — near-Large quality with ≈4× real-time speed on "
-                + "Apple silicon. Recommended for high-accuracy offline transcription.",
-            tags: [.quality, .fast]
+                + "Apple silicon. Recommended for high-accuracy batch or live transcription.",
+            tags: [.quality, .fast],
+            supportsLiveStreaming: true
         ),
         LocalTranscriptionModel(
             id: "local/whisperkit/distil-large-v3",
@@ -593,7 +597,8 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             approximateSizeMB: 594,
             description: "Distilled Whisper Large v3 — English-optimised, faster and lighter than "
                 + "the full Large model with minimal accuracy loss.",
-            tags: [.fast, .quality]
+            tags: [.fast, .quality],
+            supportsLiveStreaming: true
         ),
         LocalTranscriptionModel(
             id: "local/whisperkit/distil-large-v3-turbo",
@@ -602,8 +607,9 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             engine: .whisperKit,
             approximateSizeMB: 600,
             description: "Distilled, turbo-optimised Whisper Large v3 — fastest high-quality "
-                + "English-only offline option on Apple silicon.",
-            tags: [.fast, .quality]
+                + "English-only batch or live option on Apple silicon.",
+            tags: [.fast, .quality],
+            supportsLiveStreaming: true
         )
     ]
 

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -122,16 +122,14 @@ final class AppSettingsDefaultsTests: XCTestCase {
         XCTAssertEqual(settings.recordingSoundVolume, 0.7, accuracy: 0.001)
     }
 
-    #if !APP_STORE
     @MainActor
     func testLocalStreamingDefaults_matchHardwareSupport() {
         let settings = AppSettings(defaults: defaults)
         let expected = FluidAudioModelManager.supportsCurrentHardware
           ? FluidAudioParakeetModel.id
-          : LocalModelManager.recommendedStreamingModelSources.first?.id ?? ""
+          : WhisperKitStreamingModel.id(for: LocalModelManager.shared.availableModels[0])
         XCTAssertEqual(settings.localStreamingModelSource, expected)
     }
-    #endif
 
     @MainActor
     func testRecordingDefaults_hotKeyActivationStyleIsHoldAndDoubleTap() {

--- a/Tests/SpeakAppTests/FluidAudioModelManagerTests.swift
+++ b/Tests/SpeakAppTests/FluidAudioModelManagerTests.swift
@@ -1,4 +1,3 @@
-#if !APP_STORE
 import FluidAudio
 import Foundation
 import XCTest
@@ -77,4 +76,3 @@ final class FluidAudioModelManagerTests: XCTestCase {
     }
   }
 }
-#endif

--- a/Tests/SpeakAppTests/TranscriptionManagerRoutingTests.swift
+++ b/Tests/SpeakAppTests/TranscriptionManagerRoutingTests.swift
@@ -28,7 +28,6 @@ final class TranscriptionManagerRoutingTests: XCTestCase {
     XCTAssertEqual(model, sourceID)
   }
 
-  #if !APP_STORE
   @MainActor
   func testSwitchingLiveTranscriber_routesFluidAudioParakeetToDedicatedController() {
     let settings = AppSettings()
@@ -50,7 +49,28 @@ final class TranscriptionManagerRoutingTests: XCTestCase {
       transcriber.controller(for: FluidAudioParakeetModel.id) is FluidAudioParakeetLiveController
     )
   }
-  #endif
+
+  @MainActor
+  func testSwitchingLiveTranscriber_routesWhisperKitStreamingToDedicatedController() {
+    let settings = AppSettings()
+    let permissions = PermissionsManager()
+    let audioDevices = AudioInputDeviceManager(appSettings: settings)
+    let secureStorage = SecureAppStorage(
+      permissionsManager: permissions,
+      appSettings: settings,
+      keychainService: "com.justspeaktoit.tests.whisperkit.routing.\(UUID().uuidString)"
+    )
+    let transcriber = SwitchingLiveTranscriber(
+      appSettings: settings,
+      permissionsManager: permissions,
+      audioDeviceManager: audioDevices,
+      secureStorage: secureStorage
+    )
+
+    XCTAssertTrue(
+      transcriber.controller(for: "local/streaming/whisperkit/tiny") is WhisperKitLiveController
+    )
+  }
 
   func testResolvedLiveTranscriptionModel_rejectsInvalidLocalStreamingSource() {
     XCTAssertThrowsError(

--- a/Tests/SpeakAppTests/TranscriptionManagerRoutingTests.swift
+++ b/Tests/SpeakAppTests/TranscriptionManagerRoutingTests.swift
@@ -52,6 +52,11 @@ final class TranscriptionManagerRoutingTests: XCTestCase {
 
   @MainActor
   func testSwitchingLiveTranscriber_routesWhisperKitStreamingToDedicatedController() {
+    XCTAssertEqual(
+      WhisperKitStreamingModel.id(forBatchModelID: "local/whisperkit/tiny"),
+      "local/streaming/whisperkit/tiny"
+    )
+
     let settings = AppSettings()
     let permissions = PermissionsManager()
     let audioDevices = AudioInputDeviceManager(appSettings: settings)

--- a/Tests/SpeakAppTests/WhisperKitStreamingModelTests.swift
+++ b/Tests/SpeakAppTests/WhisperKitStreamingModelTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+@testable import SpeakApp
+
+final class WhisperKitStreamingModelTests: XCTestCase {
+  func testIdentifierRoundTrip_preservesBuiltInModel() {
+    let streamingID = WhisperKitStreamingModel.id(forBatchModelID: "local/whisperkit/tiny")
+
+    XCTAssertEqual(streamingID, "local/streaming/whisperkit/tiny")
+    XCTAssertEqual(
+      WhisperKitStreamingModel.batchModelID(from: streamingID),
+      "local/whisperkit/tiny"
+    )
+  }
+
+  func testBatchModelID_rejectsOtherStreamingRuntimes() {
+    XCTAssertNil(
+      WhisperKitStreamingModel.batchModelID(
+        from: "local/streaming/fluidaudio/parakeet-realtime-eou-120m"
+      )
+    )
+  }
+}

--- a/Tests/SpeakAppTests/WhisperKitStreamingModelTests.swift
+++ b/Tests/SpeakAppTests/WhisperKitStreamingModelTests.swift
@@ -3,21 +3,21 @@ import XCTest
 @testable import SpeakApp
 
 final class WhisperKitStreamingModelTests: XCTestCase {
-  func testIdentifierRoundTrip_preservesBuiltInModel() {
-    let streamingID = WhisperKitStreamingModel.id(forBatchModelID: "local/whisperkit/tiny")
+    func testIdentifierRoundTrip_preservesBuiltInModel() {
+        let streamingID = WhisperKitStreamingModel.id(forBatchModelID: "local/whisperkit/tiny")
 
-    XCTAssertEqual(streamingID, "local/streaming/whisperkit/tiny")
-    XCTAssertEqual(
-      WhisperKitStreamingModel.batchModelID(from: streamingID),
-      "local/whisperkit/tiny"
-    )
-  }
+        XCTAssertEqual(streamingID, "local/streaming/whisperkit/tiny")
+        XCTAssertEqual(
+            WhisperKitStreamingModel.batchModelID(from: streamingID),
+            "local/whisperkit/tiny"
+        )
+    }
 
-  func testBatchModelID_rejectsOtherStreamingRuntimes() {
-    XCTAssertNil(
-      WhisperKitStreamingModel.batchModelID(
-        from: "local/streaming/fluidaudio/parakeet-realtime-eou-120m"
-      )
-    )
-  }
+    func testBatchModelID_rejectsOtherStreamingRuntimes() {
+        XCTAssertNil(
+            WhisperKitStreamingModel.batchModelID(
+                from: "local/streaming/fluidaudio/parakeet-realtime-eou-120m"
+            )
+        )
+    }
 }

--- a/Tests/SpeakCoreTests/DistributionChannelTests.swift
+++ b/Tests/SpeakCoreTests/DistributionChannelTests.swift
@@ -16,6 +16,7 @@ final class DistributionChannelTests: XCTestCase {
         // Act & Assert
         XCTAssertTrue(channel.supportsSelfUpdate)
         XCTAssertTrue(channel.supportsDownloadedCoreMLModels)
+        XCTAssertTrue(channel.supportsInProcessLocalStreaming)
         XCTAssertTrue(channel.supportsExternalLocalModelRuntime)
         XCTAssertFalse(channel.supportsEncryptedCloudKitKeySync)
         XCTAssertFalse(channel.supportsICloudSync)
@@ -36,6 +37,8 @@ final class DistributionChannelTests: XCTestCase {
             "App Store builds update through the store, not Sparkle")
         XCTAssertTrue(channel.supportsDownloadedCoreMLModels,
             "WhisperKit/Core ML model data can run through the bundled in-process runtime")
+        XCTAssertTrue(channel.supportsInProcessLocalStreaming,
+            "Bundled Core ML streaming runtimes are compatible with the App Store sandbox")
         XCTAssertFalse(channel.supportsExternalLocalModelRuntime,
             "Executable local-model runtimes cannot run in the App Store sandbox")
         XCTAssertTrue(channel.supportsEncryptedCloudKitKeySync)
@@ -57,6 +60,7 @@ final class DistributionChannelTests: XCTestCase {
         for channel in DistributionChannel.allCases {
             XCTAssertEqual(channel.supports(.selfUpdate), channel.supportsSelfUpdate)
             XCTAssertEqual(channel.supports(.downloadedCoreMLModels), channel.supportsDownloadedCoreMLModels)
+            XCTAssertEqual(channel.supports(.inProcessLocalStreaming), channel.supportsInProcessLocalStreaming)
             XCTAssertEqual(channel.supports(.externalLocalModelRuntime), channel.supportsExternalLocalModelRuntime)
             XCTAssertEqual(channel.supports(.automaticAccessibilityPrompt),
                            channel.supportsAutomaticAccessibilityPrompt)

--- a/Tests/SpeakCoreTests/ModelCatalogTests.swift
+++ b/Tests/SpeakCoreTests/ModelCatalogTests.swift
@@ -124,7 +124,15 @@ final class ModelCatalogTests: XCTestCase {
         for model in ModelCatalog.localTranscription {
             XCTAssertTrue(model.id.hasPrefix("local/"), "\(model.id) should use the downloaded local namespace")
             XCTAssertFalse(model.id.hasPrefix("apple/local/"), "\(model.id) should not be grouped with Apple Speech")
-            XCTAssertFalse(model.supportsLiveStreaming, "\(model.id) should be explicit about offline-only support")
+        }
+    }
+
+    func testWhisperKitLocalTranscription_advertisesLiveStreamingSupport() {
+        let whisperKitModels = ModelCatalog.localTranscription.filter { $0.engine == .whisperKit }
+
+        XCTAssertFalse(whisperKitModels.isEmpty)
+        for model in whisperKitModels {
+            XCTAssertTrue(model.supportsLiveStreaming, "\(model.id) should advertise its in-process live path")
         }
     }
 


### PR DESCRIPTION
## Motivation

The Mac App Store build previously forced downloaded local transcription into batch mode even though FluidAudio and WhisperKit are bundled, in-process Core ML runtimes that are compatible with the sandbox. Users should be able to use local live transcription without enabling the direct build-only executable runtimes.

## What changed

- include FluidAudio in both macOS distribution targets
- expose Parakeet Realtime EOU and downloaded WhisperKit models in Local > Streaming
- add an in-process WhisperKit live controller based on WhisperKit AudioStreamTranscriber
- keep sherpa-onnx and other spawned executable runtimes direct-build only
- route, label, and record local streaming sessions consistently in History
- cover channel gates, settings defaults, routing, and model-ID conversion

## Things we learnt that changed the direction

WhisperKit already ships an official in-process AudioStreamTranscriber. The safe App Store boundary is therefore not batch versus streaming; it is bundled in-process Core ML versus downloaded or spawned executable runtimes. The channel capability now expresses that distinction directly.

## How to test

- `swift test --disable-index-store --filter "DistributionChannelTests|WhisperKitStreamingModelTests|TranscriptionManagerRoutingTests|AppSettingsDefaultsTests"`
- repeat with `-Xswiftc -DAPP_STORE`
- `swiftlint lint --strict --config .swiftlint.yml --baseline .swiftlint-baseline.json`
- `TUIST_APP_STORE=1 tuist generate`
- `xcodebuild -workspace "Just Speak to It.xcworkspace" -scheme SpeakApp -configuration Release -destination "platform=macOS,arch=arm64" CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=YES ARCHS=arm64 build`

Observed locally: both focused suites passed (55 tests each), lint passed, Tuist generation passed, and the arm64 App Store Release build succeeded. The resulting App Store binary contains both streaming controllers and uses the sandbox/audio-input entitlement set.

## Review confidence

High confidence in build gating, routing, and UI availability. Please deeply review the new WhisperKit live-session lifecycle; physical microphone transcription in the signed App Store container remains the final release gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live local transcription with bundled WhisperKit/Core ML models across supported distribution channels.
  * Expanded FluidAudio Parakeet support with automatic model discovery and hardware-aware defaults.
  * Added streaming model selection, setup guidance, status indicators, and management controls.
  * Improved routing and provider labels across local transcription engines.

* **Bug Fixes**
  * Improved model validation, fallback selection, startup handling, and error reporting.
  * Updated model descriptions to distinguish batch and live transcription support.

* **Tests**
  * Expanded coverage for model selection, routing, distribution capabilities, and streaming identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->