### PR TITLE
fix(ios): improve keyboard handoff and corrections

### DIFF
--- a/Docs/ios-keyboard-mvp-verification.md
+++ b/Docs/ios-keyboard-mvp-verification.md
@@ -3,28 +3,61 @@
 ## Scope and architecture
 
 The Just Speak keyboard is intentionally transcription-first. It does not
-implement ordinary typing, autocorrection, or an Apple-keyboard clone. The
-globe control uses `UIInputViewController.handleInputModeList(from:with:)` so a
-user can return to a system keyboard for typing.
+implement autocorrection or attempt an Apple-keyboard clone. It provides a
+small correction row (safe undo, cursor movement, space, and backspace), and a
+selected range can be replaced by the next voice transcription. The globe
+control uses `UIInputViewController.handleInputModeList(from:with:)` so a user
+can return to a system keyboard for full typing.
 
 Apple does not allow a custom keyboard extension to access the microphone. The
 supported handoff is therefore:
 
 1. The keyboard creates a short-lived, nonce-scoped request in
    `group.com.justspeaktoit.ios`.
-2. The keyboard opens `justspeaktoit://keyboard?request=<uuid>` through its
-   extension context.
-3. The containing app validates the nonce and records through the existing
+2. The user opens Just Speak from the Home Screen or App Switcher. Custom
+   keyboard extensions are not one of the iOS extension points for which Apple
+   documents `NSExtensionContext.open` support, so the keyboard must not claim
+   it can launch the containing app automatically.
+3. When the containing app becomes active, it detects the pending nonce,
+   validates it, and records through the existing
    `TranscriptionRecordingService` using the selected local or remote model.
-4. The app writes one final transcript to the matching versioned record.
+4. The app saves the completed transcript to History and writes one temporary
+   final transcript to the matching versioned App Group record.
 5. After the user returns to the originating app, the keyboard inserts the
-   matching result with `textDocumentProxy.insertText` and deletes it.
+   matching result with `textDocumentProxy.insertText` and deletes the App
+   Group copy. History remains available in Just Speak.
 
 Requests expire after three minutes, transcription finalisation after 90
-seconds, and completed results after 60 seconds. A mismatched nonce can neither
-read nor clear another request. Keyboard-originated dictation does not write to
-History or the clipboard, does not publish partial text through the legacy App
-Group keys, and deletes temporary batch audio after transcription.
+seconds, and completed App Group results after 60 seconds. A mismatched nonce
+can neither read nor clear another request. Keyboard-originated dictation does
+not write to the clipboard, does not publish partial text through the legacy
+App Group keys, and deletes temporary batch audio after transcription.
+
+## Correction UX decision
+
+Do not build a full QWERTY keyboard until product evidence justifies owning the
+complete typing experience. Apple requires custom keyboards to handle field
+traits, compact and regular widths, rotation, iPad layouts, input-mode
+switching, text context, and accessibility. Wispr Flow's public iOS notes also
+show the ongoing surface area of a production QWERTY keyboard: capitalization,
+autocorrect, shift/caps lock, double-space punctuation, multi-touch ordering,
+hit targets between keys, and language behavior.
+
+The supported Just Speak correction path is deliberately smaller:
+
+- select mistaken host-app text and choose **Replace Selection by Voice**;
+- undo the most recent insertion only when the exact inserted suffix still
+  precedes the cursor;
+- move the cursor, insert a space, or delete backward without changing
+  keyboards;
+- use the globe key for arbitrary character typing with Apple's keyboard.
+
+Primary references:
+
+- [Creating a custom keyboard](https://developer.apple.com/documentation/uikit/creating-a-custom-keyboard)
+- [Handling text interactions in custom keyboards](https://developer.apple.com/documentation/uikit/handling-text-interactions-in-custom-keyboards)
+- [`NSExtensionContext.open`](https://developer.apple.com/documentation/foundation/nsextensioncontext/open(_:completionhandler:))
+- [Wispr Flow iPhone keyboard notes](https://docs.wisprflow.ai/articles/7453988911-set-up-the-flow-keyboard-on-iphone)
 
 ## Simulator verification
 
@@ -59,7 +92,8 @@ For a deterministic containing-app capture screen, launch the Debug app with:
 JUSTSPEAKTOIT_SIMULATOR_TRANSCRIPT=Simulator keyboard result
 ```
 
-Tap **Finish & Transcribe** and confirm the screen reaches **Ready to Insert**.
+Open the app with a pending demo request, tap **Finish & Transcribe**, and
+confirm the screen reaches **Ready to Insert**.
 The nonce, transcript, API keys, and surrounding text must not appear in logs.
 
 ## Physical-device matrix
@@ -93,13 +127,19 @@ inspect or transmit surrounding text.
 2. Disable network connectivity.
 3. Open Notes or another standard text editor and focus a normal text field.
 4. Hold the globe key and choose Just Speak.
-5. Tap **Speak in Just Speak**. Confirm the containing app opens and requests
+5. Tap **Prepare Transcription**, then manually open Just Speak from the Home
+   Screen or App Switcher. Confirm the pending capture opens and requests
    microphone/speech permission only there.
 6. Speak, tap **Finish & Transcribe**, and wait for **Ready to Insert**.
 7. Return to Notes using the app switcher or Back gesture where available,
    choose Just Speak again if iOS changed keyboards, and confirm the text is
    inserted once at the cursor or over the current selection.
-8. Reopen the keyboard and confirm the result is not inserted again.
+8. Confirm the completed transcript is present in Just Speak History while the
+   temporary App Group result cannot be inserted again.
+9. Select a word in Notes, choose **Replace Selection by Voice**, complete a
+   second handoff, and confirm the selected word is replaced.
+10. Verify safe undo succeeds immediately after insertion but refuses to delete
+    text if the cursor moved or the host text changed.
 
 iOS does not provide a public API that returns an extension directly to the
 originating third-party app, so the UI truthfully asks the user to return.
@@ -114,8 +154,8 @@ remote batch model. Confirm:
 - no API key, provider response body, transcript, nonce, or surrounding text is
   emitted to device logs;
 - batch audio is removed after success and after cancellation/failure;
-- the final result is inserted once and expires if the user waits over 60
-  seconds before returning.
+- the temporary result is inserted once and expires if the user waits over 60
+  seconds before returning; the History entry remains.
 
 ### Cancellation and recovery
 
@@ -151,9 +191,9 @@ labels, Switch Control targets, and touch targets of at least 44 points.
 - The containing app's existing microphone and speech usage descriptions apply
   when capture begins.
 - Only a schema version, request UUID, timestamps, phase, safe failure enum, and
-  final transcript are shared. The final transcript is removed on insertion or
-  timeout.
+  final transcript are shared. The App Group transcript is removed on insertion
+  or timeout; the containing app's History record is not.
 - No private settings URL, responder-chain URL workaround, Apple keyboard asset,
-  or copied Apple keyboard layout is used.
-- App Review notes should describe the manual return-to-origin step and the
+  copied Apple keyboard layout, or unsupported containing-app launch is used.
+- App Review notes should describe the manual open/return steps and the
   secure-field, phone-pad, and host-app restrictions exactly as users see them.

--- a/JustSpeakKeyboard/KeyboardViewController.swift
+++ b/JustSpeakKeyboard/KeyboardViewController.swift
@@ -18,11 +18,17 @@ final class KeyboardViewController: UIInputViewController {
         let root = KeyboardRootView(
             model: model,
             showsInputModeSwitch: needsInputModeSwitchKey,
-            openContainingApp: { [weak self] url in
-                self?.openContainingApp(url)
-            },
             insertText: { [weak self] text in
                 self?.textDocumentProxy.insertText(text)
+            },
+            deleteBackward: { [weak self] in
+                self?.textDocumentProxy.deleteBackward()
+            },
+            adjustCursor: { [weak self] offset in
+                self?.textDocumentProxy.adjustTextPosition(byCharacterOffset: offset)
+            },
+            undoLastInsertion: { [weak self] text in
+                self?.undoLastInsertion(text) ?? false
             },
             showInputModeList: { [weak self] button, event in
                 self?.handleInputModeList(from: button, with: event)
@@ -47,6 +53,7 @@ final class KeyboardViewController: UIInputViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         model.activate(hasFullAccess: hasFullAccess)
+        updateDocumentContext()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -69,18 +76,29 @@ final class KeyboardViewController: UIInputViewController {
     override func textDidChange(_ textInput: UITextInput?) {
         super.textDidChange(textInput)
         model.activate(hasFullAccess: hasFullAccess)
+        updateDocumentContext()
     }
 
-    private func openContainingApp(_ url: URL) {
-        guard let extensionContext else {
-            model.appOpenCompleted(succeeded: false)
-            return
+    override func selectionDidChange(_ textInput: UITextInput?) {
+        super.selectionDidChange(textInput)
+        updateDocumentContext()
+    }
+
+    private func updateDocumentContext() {
+        model.updateDocumentContext(selectedText: textDocumentProxy.selectedText)
+    }
+
+    private func undoLastInsertion(_ text: String) -> Bool {
+        guard let count = KeyboardCorrectionPlan.undoDeletionCount(
+            insertedText: text,
+            documentContextBeforeInput: textDocumentProxy.documentContextBeforeInput
+        ) else {
+            return false
         }
-        extensionContext.open(url) { [weak model] succeeded in
-            Task { @MainActor in
-                model?.appOpenCompleted(succeeded: succeeded)
-            }
+        for _ in 0..<count {
+            textDocumentProxy.deleteBackward()
         }
+        return true
     }
 
     private func updatePreferredHeight() {
@@ -89,9 +107,9 @@ final class KeyboardViewController: UIInputViewController {
         let isPad = traitCollection.userInterfaceIdiom == .pad
         var height: CGFloat
         if isLandscape {
-            height = isPad ? 220 : 205
+            height = isPad ? 250 : 235
         } else {
-            height = isPad ? 280 : 260
+            height = isPad ? 320 : 300
         }
         if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
             height += isPad ? 80 : 60
@@ -113,10 +131,11 @@ final class KeyboardViewController: UIInputViewController {
 final class KeyboardViewModel: ObservableObject {
     enum Presentation: Equatable {
         case idle
-        case openingApp
+        case waitingForApp
         case recording
         case transcribing
         case inserted
+        case undone
         case missingFullAccess
         case unavailable
         case cancelled
@@ -125,12 +144,18 @@ final class KeyboardViewModel: ObservableObject {
 
     @Published private(set) var presentation: Presentation = .idle
     @Published private(set) var hasFullAccess = false
+    @Published private(set) var hasSelectedText = false
 
     private let store: KeyboardHandoffStore
     private let consumer: KeyboardHandoffConsumer
     private var requestID: UUID?
     private var pollTask: Task<Void, Never>?
     private var insertText: ((String) -> Void)?
+    private var lastInsertedText: String?
+
+    var canUndoLastInsertion: Bool {
+        lastInsertedText != nil
+    }
 
     init(store: KeyboardHandoffStore = .shared) {
         self.store = store
@@ -161,10 +186,11 @@ final class KeyboardViewModel: ObservableObject {
         pollTask = nil
     }
 
-    func startHandoff(
-        openContainingApp: (URL) -> Void,
-        insertText: @escaping (String) -> Void
-    ) {
+    func updateDocumentContext(selectedText: String?) {
+        hasSelectedText = !(selectedText ?? "").isEmpty
+    }
+
+    func startHandoff(insertText: @escaping (String) -> Void) {
         self.insertText = insertText
         guard KeyboardLaunchPolicy.blockReason(
             hasFullAccess: hasFullAccess,
@@ -177,29 +203,10 @@ final class KeyboardViewModel: ObservableObject {
         do {
             let request = try store.createRequest()
             requestID = request.requestID
-            presentation = .openingApp
-
-            var components = URLComponents()
-            components.scheme = "justspeaktoit"
-            components.host = "keyboard"
-            components.queryItems = [
-                URLQueryItem(name: "request", value: request.requestID.uuidString.lowercased())
-            ]
-            guard let url = components.url else {
-                _ = try? store.fail(requestID: request.requestID, code: .invalidRequest)
-                presentation = .error(.invalidRequest)
-                return
-            }
-            openContainingApp(url)
+            presentation = .waitingForApp
         } catch {
             presentation = .unavailable
         }
-    }
-
-    func appOpenCompleted(succeeded: Bool) {
-        guard !succeeded, let requestID else { return }
-        _ = try? store.fail(requestID: requestID, code: .appUnavailable)
-        presentation = .error(.appUnavailable)
     }
 
     func cancel() {
@@ -212,15 +219,18 @@ final class KeyboardViewModel: ObservableObject {
         presentation = .cancelled
     }
 
-    func retry(
-        openContainingApp: (URL) -> Void,
-        insertText: @escaping (String) -> Void
-    ) {
+    func retry(insertText: @escaping (String) -> Void) {
         if let requestID {
             store.clear(requestID: requestID)
         }
         requestID = nil
-        startHandoff(openContainingApp: openContainingApp, insertText: insertText)
+        startHandoff(insertText: insertText)
+    }
+
+    func undoLastInsertion(perform: (String) -> Bool) {
+        guard let lastInsertedText, perform(lastInsertedText) else { return }
+        self.lastInsertedText = nil
+        presentation = .undone
     }
 
     private func startPolling() {
@@ -240,7 +250,7 @@ final class KeyboardViewModel: ObservableObject {
             return
         }
         guard let requestID else {
-            if presentation != .inserted && presentation != .cancelled {
+            if presentation != .inserted && presentation != .undone && presentation != .cancelled {
                 presentation = .idle
             }
             return
@@ -253,7 +263,7 @@ final class KeyboardViewModel: ObservableObject {
 
         switch record.phase {
         case .requested:
-            presentation = .openingApp
+            presentation = .waitingForApp
         case .recording:
             presentation = .recording
         case .transcribing:
@@ -264,6 +274,7 @@ final class KeyboardViewModel: ObservableObject {
                 return
             }
             if consumer.insertReadyResult(requestID: requestID, insert: insertText) {
+                lastInsertedText = record.transcript
                 self.requestID = nil
                 presentation = .inserted
             }
@@ -280,8 +291,10 @@ final class KeyboardViewModel: ObservableObject {
 private struct KeyboardRootView: View {
     @ObservedObject var model: KeyboardViewModel
     let showsInputModeSwitch: Bool
-    let openContainingApp: (URL) -> Void
     let insertText: (String) -> Void
+    let deleteBackward: () -> Void
+    let adjustCursor: (Int) -> Void
+    let undoLastInsertion: (String) -> Bool
     let showInputModeList: (UIButton, UIEvent) -> Void
 
     var body: some View {
@@ -296,6 +309,10 @@ private struct KeyboardRootView: View {
                 } else {
                     statusCopy
                     primaryControl
+                }
+
+                if showsCorrectionControls {
+                    correctionControls
                 }
 
                 Spacer(minLength: 0)
@@ -326,11 +343,11 @@ private struct KeyboardRootView: View {
     @ViewBuilder
     private var primaryControl: some View {
         switch model.presentation {
-        case .idle, .inserted, .cancelled:
+        case .idle, .inserted, .undone, .cancelled:
             Button {
-                model.startHandoff(openContainingApp: openContainingApp, insertText: insertText)
+                model.startHandoff(insertText: insertText)
             } label: {
-                Label("Speak in Just Speak", systemImage: "mic.fill")
+                Label(primaryButtonTitle, systemImage: "mic.fill")
                     .font(.headline)
                     .frame(maxWidth: 330, minHeight: 52)
             }
@@ -344,7 +361,13 @@ private struct KeyboardRootView: View {
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: 330, minHeight: 44)
 
-        case .openingApp, .recording, .transcribing:
+        case .waitingForApp:
+            Label("Open Just Speak manually", systemImage: "arrow.up.forward.app")
+                .font(.headline)
+                .frame(maxWidth: 330, minHeight: 52)
+                .accessibilityIdentifier("keyboardOpenAppInstruction")
+
+        case .recording, .transcribing:
             HStack(spacing: 10) {
                 ProgressView()
                 Text(progressLabel)
@@ -355,7 +378,7 @@ private struct KeyboardRootView: View {
 
         case .unavailable, .error:
             Button {
-                model.retry(openContainingApp: openContainingApp, insertText: insertText)
+                model.retry(insertText: insertText)
             } label: {
                 Label("Try Again", systemImage: "arrow.clockwise")
                     .font(.headline)
@@ -364,6 +387,56 @@ private struct KeyboardRootView: View {
             .buttonStyle(.borderedProminent)
             .accessibilityIdentifier("keyboardRetryButton")
         }
+    }
+
+    private var correctionControls: some View {
+        HStack(spacing: 8) {
+            if model.canUndoLastInsertion {
+                Button {
+                    model.undoLastInsertion(perform: undoLastInsertion)
+                } label: {
+                    Label("Undo", systemImage: "arrow.uturn.backward")
+                        .labelStyle(.iconOnly)
+                        .frame(minWidth: 44, minHeight: 44)
+                }
+                .accessibilityLabel("Undo last transcript insertion")
+                .accessibilityIdentifier("keyboardUndoInsertionButton")
+            }
+
+            Button {
+                adjustCursor(-1)
+            } label: {
+                Image(systemName: "arrow.left")
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+            .accessibilityLabel("Move cursor left")
+
+            Button {
+                insertText(" ")
+            } label: {
+                Text("Space")
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+            .accessibilityIdentifier("keyboardSpaceButton")
+
+            Button {
+                adjustCursor(1)
+            } label: {
+                Image(systemName: "arrow.right")
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+            .accessibilityLabel("Move cursor right")
+
+            Button {
+                deleteBackward()
+            } label: {
+                Image(systemName: "delete.left")
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+            .accessibilityLabel("Delete backward")
+            .accessibilityIdentifier("keyboardDeleteButton")
+        }
+        .buttonStyle(.bordered)
     }
 
     private var bottomBar: some View {
@@ -375,7 +448,7 @@ private struct KeyboardRootView: View {
                     .accessibilityHint("Touch and hold to choose another keyboard")
             }
 
-            Text("Audio is captured only in Just Speak. Results are deleted after insertion.")
+            Text("Audio stays in Just Speak. Temporary handoff clears; transcripts remain in History.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity)
@@ -398,20 +471,42 @@ private struct KeyboardRootView: View {
 
     private var canCancel: Bool {
         switch model.presentation {
-        case .openingApp, .recording, .transcribing:
+        case .waitingForApp, .recording, .transcribing:
             return true
         default:
             return false
         }
     }
 
+    private var showsCorrectionControls: Bool {
+        switch model.presentation {
+        case .idle, .inserted, .undone, .cancelled:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private var primaryButtonTitle: String {
+        if model.hasSelectedText {
+            return "Replace Selection by Voice"
+        }
+        switch model.presentation {
+        case .inserted:
+            return "Speak Again"
+        default:
+            return "Prepare Transcription"
+        }
+    }
+
     private var title: String {
         switch model.presentation {
         case .idle: return "Ready to transcribe"
-        case .openingApp: return "Opening Just Speak"
+        case .waitingForApp: return "Open Just Speak"
         case .recording: return "Recording in Just Speak"
         case .transcribing: return "Finishing transcript"
         case .inserted: return "Inserted"
+        case .undone: return "Insertion removed"
         case .missingFullAccess: return "Full Access is off"
         case .unavailable: return "Just Speak is unavailable"
         case .cancelled: return "Cancelled"
@@ -422,21 +517,26 @@ private struct KeyboardRootView: View {
     private var detail: String {
         switch model.presentation {
         case .idle:
-            return "Opens the app for microphone capture, then inserts the matching result here."
-        case .openingApp:
-            return "Complete recording in the Just Speak app, then return here."
+            if model.hasSelectedText {
+                return "The next transcript replaces the selected text. Open Just Speak manually when prompted."
+            }
+            return "Prepare a private request, then open Just Speak manually to record."
+        case .waitingForApp:
+            return "Open Just Speak from the Home Screen or App Switcher. Recording starts there."
         case .recording:
             return "Speak in the app. This keyboard never receives microphone audio."
         case .transcribing:
             return "Your selected JustSpeakToIt model is producing the final text."
         case .inserted:
-            return "The one-time result was inserted and removed from shared storage."
+            return "Saved in Just Speak History. Select text above to dictate a replacement, or use the correction row."
+        case .undone:
+            return "The inserted copy was removed. The completed transcript remains in Just Speak History."
         case .missingFullAccess:
             return "Full Access is required for the App Group handoff. It never exposes surrounding text."
         case .unavailable:
             return "Open the Just Speak app once and check that the keyboard is enabled."
         case .cancelled:
-            return "No transcript was inserted or retained."
+            return "No transcript was inserted."
         case let .error(code):
             return errorDetail(for: code)
         }
@@ -445,10 +545,11 @@ private struct KeyboardRootView: View {
     private var statusSymbol: String {
         switch model.presentation {
         case .idle: return "waveform"
-        case .openingApp: return "arrow.up.forward.app"
+        case .waitingForApp: return "arrow.up.forward.app"
         case .recording: return "record.circle"
         case .transcribing: return "ellipsis.bubble"
         case .inserted: return "checkmark.circle.fill"
+        case .undone: return "arrow.uturn.backward.circle.fill"
         case .missingFullAccess: return "lock.trianglebadge.exclamationmark"
         case .unavailable, .error: return "exclamationmark.triangle.fill"
         case .cancelled: return "xmark.circle"
@@ -457,7 +558,7 @@ private struct KeyboardRootView: View {
 
     private var statusTint: Color {
         switch model.presentation {
-        case .inserted: return .green
+        case .inserted, .undone: return .green
         case .recording: return .red
         case .missingFullAccess, .unavailable, .error: return .orange
         default: return .primary
@@ -468,7 +569,7 @@ private struct KeyboardRootView: View {
         switch model.presentation {
         case .recording: return "Recording"
         case .transcribing: return "Transcribing"
-        default: return "Opening App"
+        default: return "Waiting"
         }
     }
 
@@ -477,7 +578,7 @@ private struct KeyboardRootView: View {
         case .fullAccessRequired:
             return "Turn on Full Access in Settings, then try again."
         case .appUnavailable:
-            return "The containing app could not be opened. Open Just Speak manually and retry."
+            return "Open Just Speak manually from the Home Screen or App Switcher, then retry."
         case .recordingUnavailable:
             return "Recording could not start. Check microphone permission in Just Speak."
         case .noSpeech:
@@ -487,7 +588,7 @@ private struct KeyboardRootView: View {
         case .invalidRequest:
             return "The request did not match the active keyboard session."
         case .unknown:
-            return "The handoff ended safely without retaining a transcript."
+            return "The temporary handoff ended safely. Completed recordings remain in History."
         }
     }
 }

--- a/Sources/SpeakCore/KeyboardCorrectionPlan.swift
+++ b/Sources/SpeakCore/KeyboardCorrectionPlan.swift
@@ -1,0 +1,17 @@
+public enum KeyboardCorrectionPlan {
+    /// Returns the number of user-perceived characters that can be deleted to
+    /// undo the last insertion, but only while that exact text still precedes
+    /// the cursor. This avoids deleting host-app text after the user edits or
+    /// moves the insertion point.
+    public static func undoDeletionCount(
+        insertedText: String,
+        documentContextBeforeInput: String?
+    ) -> Int? {
+        guard !insertedText.isEmpty,
+              let documentContextBeforeInput,
+              documentContextBeforeInput.hasSuffix(insertedText) else {
+            return nil
+        }
+        return insertedText.count
+    }
+}

--- a/Sources/SpeakCore/KeyboardHandoff.swift
+++ b/Sources/SpeakCore/KeyboardHandoff.swift
@@ -3,8 +3,9 @@ import Foundation
 /// The only App Group payload used by the custom keyboard handoff.
 ///
 /// Audio, API keys, surrounding text, and intermediate transcripts are never
-/// written here. The final transcript exists only until the matching keyboard
-/// consumes it or the short result timeout expires.
+/// written here. The App Group copy of the final transcript exists only until
+/// the matching keyboard consumes it or the short result timeout expires.
+/// History persistence happens separately inside the containing app.
 public struct KeyboardHandoffRecord: Codable, Equatable, Sendable {
     public static let schemaVersion = 1
 
@@ -349,6 +350,33 @@ public enum KeyboardLaunchPolicy {
             return .sharedContainerUnavailable
         }
         return nil
+    }
+
+    /// A manually opened containing app should resume only a fresh request
+    /// that has not started recording yet.
+    public static func pendingCaptureRequestID(
+        from record: KeyboardHandoffRecord?
+    ) -> UUID? {
+        guard let record, record.phase == .requested else { return nil }
+        return record.requestID
+    }
+}
+
+public enum KeyboardCorrectionPlan {
+    /// Returns the number of user-perceived characters that can be deleted to
+    /// undo the last insertion, but only while that exact text still precedes
+    /// the cursor. This avoids deleting host-app text after the user edits or
+    /// moves the insertion point.
+    public static func undoDeletionCount(
+        insertedText: String,
+        documentContextBeforeInput: String?
+    ) -> Int? {
+        guard !insertedText.isEmpty,
+              let documentContextBeforeInput,
+              documentContextBeforeInput.hasSuffix(insertedText) else {
+            return nil
+        }
+        return insertedText.count
     }
 }
 

--- a/Sources/SpeakCore/KeyboardHandoff.swift
+++ b/Sources/SpeakCore/KeyboardHandoff.swift
@@ -362,24 +362,6 @@ public enum KeyboardLaunchPolicy {
     }
 }
 
-public enum KeyboardCorrectionPlan {
-    /// Returns the number of user-perceived characters that can be deleted to
-    /// undo the last insertion, but only while that exact text still precedes
-    /// the cursor. This avoids deleting host-app text after the user edits or
-    /// moves the insertion point.
-    public static func undoDeletionCount(
-        insertedText: String,
-        documentContextBeforeInput: String?
-    ) -> Int? {
-        guard !insertedText.isEmpty,
-              let documentContextBeforeInput,
-              documentContextBeforeInput.hasSuffix(insertedText) else {
-            return nil
-        }
-        return insertedText.count
-    }
-}
-
 public struct KeyboardHandoffConsumer {
     private let store: KeyboardHandoffStore
 

--- a/Sources/SpeakiOS/Services/KeyboardHandoffCaptureCoordinator.swift
+++ b/Sources/SpeakiOS/Services/KeyboardHandoffCaptureCoordinator.swift
@@ -84,7 +84,7 @@ public final class KeyboardHandoffCaptureCoordinator: ObservableObject {
         message = "Finishing with your selected transcription model…"
         let result = await recordingService.stopRecording(
             destination: .historyOnly,
-            saveToHistory: false
+            saveToHistory: true
         )
         let transcript = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !transcript.isEmpty else {

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -284,7 +284,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         partialText = text
         wordCount = text.split(whereSeparator: \.isWhitespace).count
 
-        // Keyboard handoffs opt out so transient dictation is not persisted.
+        // Specialized callers may opt out when their result is intentionally transient.
         let historyItem = saveToHistory
             ? iOSHistoryManager.shared.recordTranscription(
                 text: text,

--- a/Sources/SpeakiOS/Views/KeyboardCaptureView.swift
+++ b/Sources/SpeakiOS/Views/KeyboardCaptureView.swift
@@ -96,7 +96,7 @@ public struct KeyboardCaptureView: View {
                 .font(.headline)
             Text(
                 "The keyboard cannot access the microphone. Just Speak records here with your selected model, "
-                    + "shares one nonce-matched final result, and deletes it after insertion or timeout."
+                    + "saves the completed transcript to History, and clears the temporary handoff after insertion or timeout."
             )
             .font(.subheadline)
             .foregroundStyle(.secondary)

--- a/Sources/SpeakiOS/Views/KeyboardCaptureView.swift
+++ b/Sources/SpeakiOS/Views/KeyboardCaptureView.swift
@@ -96,7 +96,8 @@ public struct KeyboardCaptureView: View {
                 .font(.headline)
             Text(
                 "The keyboard cannot access the microphone. Just Speak records here with your selected model, "
-                    + "saves the completed transcript to History, and clears the temporary handoff after insertion or timeout."
+                    + "saves the completed transcript to History, "
+                    + "and clears the temporary handoff after insertion or timeout."
             )
             .font(.subheadline)
             .foregroundStyle(.secondary)

--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -66,6 +66,7 @@ final class SpeakiOSAppDelegate: NSObject, UIApplicationDelegate {
 struct SpeakiOSApp: App {
     @UIApplicationDelegateAdaptor(SpeakiOSAppDelegate.self) private var appDelegate
     @ObservedObject private var deepLinkRouter = DeepLinkRouter.shared
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
@@ -78,15 +79,29 @@ struct SpeakiOSApp: App {
                 }
                 .task {
                     #if DEBUG && targetEnvironment(simulator)
-                    guard ProcessInfo.processInfo.arguments.contains("--keyboard-handoff-demo"),
-                          deepLinkRouter.keyboardCaptureRequest == nil,
-                          let request = try? KeyboardHandoffStore.shared.createRequest() else {
-                        return
+                    if ProcessInfo.processInfo.arguments.contains("--keyboard-handoff-demo"),
+                       deepLinkRouter.keyboardCaptureRequest == nil {
+                        _ = try? KeyboardHandoffStore.shared.createRequest()
                     }
-                    deepLinkRouter.keyboardCaptureRequest = KeyboardCaptureRequest(id: request.requestID)
                     #endif
+                    resumePendingKeyboardCapture()
+                }
+                .onChange(of: scenePhase) { _, newPhase in
+                    guard newPhase == .active else { return }
+                    resumePendingKeyboardCapture()
                 }
         }
+    }
+
+    private func resumePendingKeyboardCapture() {
+        guard deepLinkRouter.keyboardCaptureRequest == nil,
+              let requestID = KeyboardLaunchPolicy.pendingCaptureRequestID(
+                  from: KeyboardHandoffStore.shared.activeRecord()
+              ) else {
+            return
+        }
+        deepLinkRouter.selectedTab = 0
+        deepLinkRouter.keyboardCaptureRequest = KeyboardCaptureRequest(id: requestID)
     }
 }
 

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -113,6 +113,25 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(infoPlist.contains("$(PRODUCT_MODULE_NAME).KeyboardViewController"))
     }
 
+    func testIOSKeyboardUsesManualSupportedHandoffAndRetainsHistory() throws {
+        let keyboard = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("JustSpeakKeyboard/KeyboardViewController.swift"),
+            encoding: .utf8
+        )
+        let captureCoordinator = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(
+                "Sources/SpeakiOS/Services/KeyboardHandoffCaptureCoordinator.swift"
+            ),
+            encoding: .utf8
+        )
+
+        XCTAssertFalse(keyboard.contains("extensionContext.open"))
+        XCTAssertTrue(keyboard.contains("Open Just Speak manually"))
+        XCTAssertTrue(keyboard.contains("transcripts remain in History"))
+        XCTAssertFalse(keyboard.contains("Results are deleted after insertion"))
+        XCTAssertTrue(captureCoordinator.contains("saveToHistory: true"))
+    }
+
     func testIOSReleaseWorkflowSignsAndValidatesKeyboardExtension() throws {
         let workflow = try String(
             contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-ios.yml"),

--- a/Tests/SpeakCoreTests/KeyboardHandoffTests.swift
+++ b/Tests/SpeakCoreTests/KeyboardHandoffTests.swift
@@ -110,6 +110,41 @@ final class KeyboardHandoffTests: XCTestCase {
         XCTAssertNil(store.activeRecord())
     }
 
+    func testOnlyRequestedHandoffResumesWhenContainingAppOpens() throws {
+        let request = try store.createRequest()
+
+        XCTAssertEqual(
+            KeyboardLaunchPolicy.pendingCaptureRequestID(from: store.activeRecord()),
+            request.requestID
+        )
+
+        try store.markRecording(requestID: request.requestID)
+        XCTAssertNil(KeyboardLaunchPolicy.pendingCaptureRequestID(from: store.activeRecord()))
+        XCTAssertNil(KeyboardLaunchPolicy.pendingCaptureRequestID(from: nil))
+    }
+
+    func testUndoPlanRequiresExactInsertedSuffix() {
+        XCTAssertEqual(
+            KeyboardCorrectionPlan.undoDeletionCount(
+                insertedText: "Correct this 👋",
+                documentContextBeforeInput: "Prefix. Correct this 👋"
+            ),
+            14
+        )
+        XCTAssertNil(
+            KeyboardCorrectionPlan.undoDeletionCount(
+                insertedText: "Correct this 👋",
+                documentContextBeforeInput: "Correct this changed"
+            )
+        )
+        XCTAssertNil(
+            KeyboardCorrectionPlan.undoDeletionCount(
+                insertedText: "",
+                documentContextBeforeInput: "Prefix"
+            )
+        )
+    }
+
     private func completedRequest(transcript: String) throws -> KeyboardHandoffRecord {
         let request = try store.createRequest()
         try store.markRecording(requestID: request.requestID)


### PR DESCRIPTION
## Motivation

The iOS keyboard claimed results were deleted after insertion even though users expect completed dictations in Just Speak History. The screenshot also exposed a failed attempt to launch the containing app from a custom keyboard extension. Users need a small, dependable way to correct inserted speech without requiring us to own a full replacement typing experience.

## What changed

- Save keyboard-originated transcriptions to app History while keeping the nonce-scoped App Group result temporary.
- Replace the unsupported automatic app-launch attempt with a pending request that the containing app resumes when the user opens Just Speak.
- Add a focused correction row: safe undo, cursor left/right, space, and backspace.
- Detect selected host-app text and present “Replace Selection by Voice”; insertion uses the supported text-document proxy replacement behavior.
- Keep the globe control as the route to Apple's keyboard for arbitrary typing.
- Update the keyboard/privacy copy and the physical-device verification runbook.
- Add regression coverage for History retention, manual handoff, and context-safe undo.

## Things we learnt that changed the direction

Apple documents `NSExtensionContext.open` support as extension-point specific; custom keyboard extensions are not a supported automatic containing-app launch surface. The callback failure in the reported screenshot was therefore a product-flow problem, not a provisioning retry problem.

The existing keyboard capture path also explicitly passed `saveToHistory: false`, so the old UI wording reflected implementation but not the intended product behavior. This PR changes both the behavior and copy.

Wispr Flow's public keyboard notes make the ongoing scope of a production QWERTY replacement visible: autocorrect, capitalization, shift/caps lock, multi-touch ordering, key-edge hit targets, punctuation shortcuts, layout variants, and language behavior. We are deliberately shipping the smaller correction surface first.

## How to test

- `swift test --filter KeyboardHandoffTests --filter DistributionBuildIdentityTests` — 19 tests passed.
- `tuist generate --no-open`
- `xcodebuild -workspace "Just Speak to It.xcworkspace" -scheme SpeakiOS -destination "generic/platform=iOS Simulator" -derivedDataPath /private/tmp/jsti-ios-keyboard-derived CODE_SIGNING_ALLOWED=NO build` — succeeded, including embedded keyboard validation.
- Simulator build/install/launch with `--keyboard-handoff-demo` reached the Keyboard Transcription screen and showed the updated History/privacy copy.

Physical iPhone/TestFlight validation remains required for microphone capture, host-app return, actual third-party keyboard insertion, selection replacement, and correction controls. Follow `Docs/ios-keyboard-mvp-verification.md`; tracked as Beads issue `justspeaktoit-dv8`.

## Review confidence

The supported-API boundary, shared-state transitions, and source contracts have strong automated/build coverage. Please review the keyboard UX and app-activation resume behavior carefully; keep this draft until the physical-device matrix passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual keyboard handoff to Just Speak with recovery for pending capture requests.
  * Added voice replacement for selected text, cursor movement, spacing, deletion, and safe undo controls.
  * Completed keyboard transcripts are now saved to History.
* **Privacy**
  * Temporary handoff data is cleared after insertion or expiration, while saved History remains available.
* **Documentation**
  * Expanded verification guidance for offline use, pending requests, corrections, undo, History, and App Review evidence.
* **Accessibility**
  * Updated status messaging and control labels for the new keyboard workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->