### PR TITLE
feat(ios): enable prepared keyboard quick dictation

### DIFF
--- a/Docs/ios-keyboard-mvp-verification.md
+++ b/Docs/ios-keyboard-mvp-verification.md
@@ -136,13 +136,12 @@ inspect or transmit surrounding text.
 2. Disable network connectivity.
 3. Open Notes or another standard text editor and focus a normal text field.
 4. Hold the globe key and choose Just Speak.
-5. Tap **Prepare Transcription**, then manually open Just Speak from the Home
-   Screen or App Switcher. Confirm the pending capture opens and requests
-   microphone/speech permission only there.
-6. Speak, tap **Finish & Transcribe**, and wait for **Ready to Insert**.
-7. Return to Notes using the app switcher or Back gesture where available,
-   choose Just Speak again if iOS changed keyboards, and confirm the text is
-   inserted once at the cursor or over the current selection.
+5. Open Just Speak once, enable the five-minute Quick Dictation session, then
+   return to the focused Notes field and choose the Just Speak keyboard.
+6. Tap **Speak** and confirm recording starts while Notes remains visible.
+7. Speak, tap **Finish & Transcribe** in the keyboard, and confirm the matching
+   text is inserted once at the cursor or over the current selection without an
+   app switch.
 8. Confirm the completed transcript is present in Just Speak History while the
    temporary App Group result cannot be inserted again.
 9. Select a word in Notes, choose **Replace Selection by Voice**, complete a
@@ -150,8 +149,8 @@ inspect or transmit surrounding text.
 10. Verify safe undo succeeds immediately after insertion but refuses to delete
     text if the cursor moved or the host text changed.
 
-iOS does not provide a public API that returns an extension directly to the
-originating third-party app, so the UI truthfully asks the user to return.
+After the prepared session expires or the containing app is terminated, confirm
+the keyboard truthfully asks the user to open Just Speak and prepare a new one.
 
 ### Cloud-model happy path
 

--- a/Docs/ios-keyboard-mvp-verification.md
+++ b/Docs/ios-keyboard-mvp-verification.md
@@ -1,5 +1,8 @@
 # iOS Custom Keyboard MVP Verification
 
+For the prepared background-microphone architecture and its additional device
+matrix, also follow [iOS Keyboard Quick Dictation](ios-keyboard-quick-dictation.md).
+
 ## Scope and architecture
 
 The Just Speak keyboard is intentionally transcription-first. It does not
@@ -10,22 +13,28 @@ control uses `UIInputViewController.handleInputModeList(from:with:)` so a user
 can return to a system keyboard for full typing.
 
 Apple does not allow a custom keyboard extension to access the microphone. The
-supported handoff is therefore:
+primary prepared-session handoff is therefore:
 
-1. The keyboard creates a short-lived, nonce-scoped request in
-   `group.com.justspeaktoit.ios`.
-2. The user opens Just Speak from the Home Screen or App Switcher. Custom
-   keyboard extensions are not one of the iOS extension points for which Apple
-   documents `NSExtensionContext.open` support, so the keyboard must not claim
-   it can launch the containing app automatically.
-3. When the containing app becomes active, it detects the pending nonce,
-   validates it, and records through the existing
+1. The user explicitly starts a five-minute Quick Dictation session in Just
+   Speak, then returns to the original text field. Idle audio buffers are
+   discarded locally while the system microphone indicator remains visible.
+2. The keyboard creates a short-lived, nonce-scoped request in
+   `group.com.justspeaktoit.ios` and posts a payload-free Darwin notification.
+3. The already-running containing app validates the nonce and records through
+   the existing
    `TranscriptionRecordingService` using the selected local or remote model.
-4. The app saves the completed transcript to History and writes one temporary
+4. The user finishes from the keyboard. The app saves the completed transcript
+   to History and writes one temporary
    final transcript to the matching versioned App Group record.
-5. After the user returns to the originating app, the keyboard inserts the
-   matching result with `textDocumentProxy.insertText` and deletes the App
-   Group copy. History remains available in Just Speak.
+5. The keyboard inserts the matching result with
+   `textDocumentProxy.insertText` and deletes the App Group copy. History
+   remains available in Just Speak.
+
+If the containing app has been suspended, force-quit, interrupted, or the
+prepared session expired, the heartbeat becomes stale and the keyboard asks the
+user to open Just Speak. Custom keyboard extensions are not one of the iOS
+extension points for which Apple documents `NSExtensionContext.open` support,
+so the keyboard must not claim it can cold-launch the containing app.
 
 Requests expire after three minutes, transcription finalisation after 90
 seconds, and completed App Group results after 60 seconds. A mismatched nonce

--- a/Docs/ios-keyboard-quick-dictation.md
+++ b/Docs/ios-keyboard-quick-dictation.md
@@ -1,0 +1,84 @@
+# iOS Keyboard Quick Dictation
+
+## Decision
+
+Just Speak uses a foreground-started, five-minute **Quick Dictation** session in
+the containing app. While that session is alive, the keyboard can start and
+finish transcription without leaving the current text field.
+
+The keyboard extension does not and cannot own microphone capture. Apple states
+that custom keyboards have no device-microphone access. A fully cold keyboard
+therefore cannot start recording after iOS has suspended or terminated the
+containing app.
+
+This is the same product boundary visible in Wispr Flow's public documentation:
+its iOS experience has a time-limited background session (five minutes by
+default), and its keyboard may need to take the user to the app when that session
+is no longer available.
+
+Sources:
+
+- [Apple Custom Keyboard Programming Guide](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html)
+- [Apple App Review Guidelines 2.5.14 and 4.4.1](https://developer.apple.com/app-store/review/guidelines/)
+- [Apple App Groups](https://developer.apple.com/documentation/Xcode/configuring-app-groups)
+- [Apple background recording category guidance](https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct/record)
+- [Wispr Flow iPhone keyboard setup](https://docs.wisprflow.ai/articles/7453988911-set-up-the-flow-keyboard-on-iphone)
+- [Wispr Flow audio-device and session timeout](https://docs.wisprflow.ai/articles/8884408990-connect-and-set-up-external-audio-devices)
+
+## Architecture
+
+1. The user explicitly enables Quick Dictation from Just Speak's keyboard
+   settings. This starts microphone permission and audio from the foreground.
+2. The containing app keeps a bounded recording-capable audio session alive.
+   Idle buffers are discarded immediately on device; they are never saved,
+   transcribed, transmitted, or placed in the App Group.
+3. The App Group holds only a short liveness heartbeat plus the existing
+   nonce-scoped handoff record.
+4. Tapping **Speak** creates a request and posts a payload-free Darwin
+   notification. The live containing app validates the nonce and starts the
+   selected transcriber.
+5. Tapping **Finish & Transcribe** changes the nonce-scoped request to
+   `finishRequested`. The containing app stops, saves to History, and writes the
+   final result to the short-lived handoff record.
+6. The keyboard consumes that exact result once and inserts it through
+   `textDocumentProxy`.
+7. A fresh heartbeat is required. If iOS kills the app, an interruption ends the
+   audio engine, or the five-minute window expires, the keyboard stops promising
+   inline recording and tells the user to prepare a new session.
+
+## Privacy and review posture
+
+- Starting the ready window is an explicit user action.
+- The system orange microphone indicator remains visible for the ready window.
+- The setup screen explains that idle audio is discarded locally.
+- The window is bounded and has an immediate **End Quick Dictation** action.
+- No surrounding host-app text is read or shared.
+- Full Access is still required for the App Group/networked keyboard path, but
+  correction controls and the globe key remain functional without transcription.
+- Do not add silent playback solely to evade suspension. The app's background
+  audio use is the user-requested microphone/dictation feature itself.
+
+## Physical-device release gate
+
+Run these cases on a real iPhone; Simulator cannot prove extension selection or
+background microphone behavior:
+
+- Start Quick Dictation in Just Speak, return to Notes, and confirm **Speak**
+  reaches **Recording** without changing apps.
+- Finish from the keyboard and confirm one insertion plus one History item.
+- Repeat in Safari and Messages during the same five-minute window.
+- Confirm the orange microphone indicator is present for the ready window and
+  clears immediately after **End Quick Dictation** or expiry.
+- Confirm idle audio produces no files, History items, provider traffic, or
+  transcripts.
+- Force-quit Just Speak and confirm the keyboard reports that preparation is
+  required within the heartbeat timeout.
+- Test expiry while idle and while actively recording. Active recording may
+  finish; readiness must not restart after the expired recording completes.
+- Test phone call, Siri, route removal, Bluetooth changes, screen lock, Low Power
+  Mode, and microphone permission revocation.
+- Test selection replacement, safe undo, Space, Backspace, cursor movement,
+  secure fields, cancellation, and globe-key switching.
+
+Do not describe the feature as fully verified until this matrix passes in the
+signed/TestFlight build.

--- a/JustSpeakKeyboard/KeyboardViewController.swift
+++ b/JustSpeakKeyboard/KeyboardViewController.swift
@@ -550,7 +550,10 @@ private struct KeyboardRootView: View {
 
     private var title: String {
         switch model.presentation {
-        case .idle: return model.quickSessionExpiresAt == nil ? "Quick Dictation needs preparation" : "Quick Dictation ready"
+        case .idle:
+            return model.quickSessionExpiresAt == nil
+                ? "Quick Dictation needs preparation"
+                : "Quick Dictation ready"
         case .starting: return "Starting in the keyboard"
         case .waitingForApp: return "Open Just Speak"
         case .recording: return "Recording in Just Speak"
@@ -624,7 +627,6 @@ private struct KeyboardRootView: View {
 
     private var progressLabel: String {
         switch model.presentation {
-        case .recording: return "Recording"
         case .transcribing: return "Transcribing"
         default: return "Waiting"
         }

--- a/JustSpeakKeyboard/KeyboardViewController.swift
+++ b/JustSpeakKeyboard/KeyboardViewController.swift
@@ -131,6 +131,7 @@ final class KeyboardViewController: UIInputViewController {
 final class KeyboardViewModel: ObservableObject {
     enum Presentation: Equatable {
         case idle
+        case starting
         case waitingForApp
         case recording
         case transcribing
@@ -145,8 +146,10 @@ final class KeyboardViewModel: ObservableObject {
     @Published private(set) var presentation: Presentation = .idle
     @Published private(set) var hasFullAccess = false
     @Published private(set) var hasSelectedText = false
+    @Published private(set) var quickSessionExpiresAt: Date?
 
     private let store: KeyboardHandoffStore
+    private let quickSessionStore: KeyboardQuickDictationStore
     private let consumer: KeyboardHandoffConsumer
     private var requestID: UUID?
     private var pollTask: Task<Void, Never>?
@@ -157,8 +160,12 @@ final class KeyboardViewModel: ObservableObject {
         lastInsertedText != nil
     }
 
-    init(store: KeyboardHandoffStore = .shared) {
+    init(
+        store: KeyboardHandoffStore = .shared,
+        quickSessionStore: KeyboardQuickDictationStore = .shared
+    ) {
         self.store = store
+        self.quickSessionStore = quickSessionStore
         self.consumer = KeyboardHandoffConsumer(store: store)
     }
 
@@ -177,6 +184,7 @@ final class KeyboardViewModel: ObservableObject {
         if requestID == nil {
             requestID = store.activeRecord()?.requestID
         }
+        refreshQuickSession()
         refresh()
         startPolling()
     }
@@ -203,7 +211,8 @@ final class KeyboardViewModel: ObservableObject {
         do {
             let request = try store.createRequest()
             requestID = request.requestID
-            presentation = .waitingForApp
+            presentation = quickSessionExpiresAt == nil ? .waitingForApp : .starting
+            KeyboardHandoffSignal.postRequestChanged()
         } catch {
             presentation = .unavailable
         }
@@ -215,8 +224,20 @@ final class KeyboardViewModel: ObservableObject {
             return
         }
         _ = try? store.cancel(requestID: requestID)
+        KeyboardHandoffSignal.postRequestChanged()
         self.requestID = nil
         presentation = .cancelled
+    }
+
+    func finish() {
+        guard let requestID else { return }
+        do {
+            try store.requestFinish(requestID: requestID)
+            presentation = .transcribing
+            KeyboardHandoffSignal.postRequestChanged()
+        } catch {
+            presentation = .error(.invalidRequest)
+        }
     }
 
     func retry(insertText: @escaping (String) -> Void) {
@@ -245,6 +266,7 @@ final class KeyboardViewModel: ObservableObject {
 
     // swiftlint:disable:next cyclomatic_complexity
     private func refresh() {
+        refreshQuickSession()
         guard hasFullAccess else {
             presentation = .missingFullAccess
             return
@@ -263,9 +285,11 @@ final class KeyboardViewModel: ObservableObject {
 
         switch record.phase {
         case .requested:
-            presentation = .waitingForApp
+            presentation = quickSessionExpiresAt == nil ? .waitingForApp : .starting
         case .recording:
             presentation = .recording
+        case .finishRequested:
+            presentation = .transcribing
         case .transcribing:
             presentation = .transcribing
         case .completed:
@@ -285,6 +309,10 @@ final class KeyboardViewModel: ObservableObject {
             self.requestID = nil
             presentation = .error(record.failureCode ?? .unknown)
         }
+    }
+
+    private func refreshQuickSession() {
+        quickSessionExpiresAt = quickSessionStore.activeSession()?.expiresAt
     }
 }
 
@@ -361,13 +389,34 @@ private struct KeyboardRootView: View {
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: 330, minHeight: 44)
 
+        case .starting:
+            HStack(spacing: 10) {
+                ProgressView()
+                Text("Starting microphone")
+                    .font(.headline)
+            }
+            .frame(maxWidth: 330, minHeight: 52)
+            .accessibilityElement(children: .combine)
+
         case .waitingForApp:
             Label("Open Just Speak manually", systemImage: "arrow.up.forward.app")
                 .font(.headline)
                 .frame(maxWidth: 330, minHeight: 52)
                 .accessibilityIdentifier("keyboardOpenAppInstruction")
 
-        case .recording, .transcribing:
+        case .recording:
+            Button {
+                model.finish()
+            } label: {
+                Label("Finish & Transcribe", systemImage: "stop.fill")
+                    .font(.headline)
+                    .frame(maxWidth: 330, minHeight: 52)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+            .accessibilityIdentifier("keyboardFinishRecordingButton")
+
+        case .transcribing:
             HStack(spacing: 10) {
                 ProgressView()
                 Text(progressLabel)
@@ -471,7 +520,7 @@ private struct KeyboardRootView: View {
 
     private var canCancel: Bool {
         switch model.presentation {
-        case .waitingForApp, .recording, .transcribing:
+        case .starting, .waitingForApp, .recording, .transcribing:
             return true
         default:
             return false
@@ -495,13 +544,14 @@ private struct KeyboardRootView: View {
         case .inserted:
             return "Speak Again"
         default:
-            return "Prepare Transcription"
+            return model.quickSessionExpiresAt == nil ? "Prepare Quick Dictation" : "Speak"
         }
     }
 
     private var title: String {
         switch model.presentation {
-        case .idle: return "Ready to transcribe"
+        case .idle: return model.quickSessionExpiresAt == nil ? "Quick Dictation needs preparation" : "Quick Dictation ready"
+        case .starting: return "Starting in the keyboard"
         case .waitingForApp: return "Open Just Speak"
         case .recording: return "Recording in Just Speak"
         case .transcribing: return "Finishing transcript"
@@ -518,13 +568,19 @@ private struct KeyboardRootView: View {
         switch model.presentation {
         case .idle:
             if model.hasSelectedText {
-                return "The next transcript replaces the selected text. Open Just Speak manually when prompted."
+                return model.quickSessionExpiresAt == nil
+                    ? "The next transcript replaces the selection. Open Just Speak once to start a five-minute session."
+                    : "The next transcript replaces the selection without leaving this app."
             }
-            return "Prepare a private request, then open Just Speak manually to record."
+            return model.quickSessionExpiresAt == nil
+                ? "Open Just Speak once to start a private five-minute microphone session."
+                : "Tap Speak and stay here. Idle audio is discarded until you start."
+        case .starting:
+            return "Stay here. Just Speak is starting the microphone in the background."
         case .waitingForApp:
-            return "Open Just Speak from the Home Screen or App Switcher. Recording starts there."
+            return "Open Just Speak from the Home Screen or App Switcher and enable Quick Dictation."
         case .recording:
-            return "Speak in the app. This keyboard never receives microphone audio."
+            return "Speak now, then finish here. The containing app owns the microphone."
         case .transcribing:
             return "Your selected JustSpeakToIt model is producing the final text."
         case .inserted:
@@ -545,6 +601,7 @@ private struct KeyboardRootView: View {
     private var statusSymbol: String {
         switch model.presentation {
         case .idle: return "waveform"
+        case .starting: return "mic.badge.plus"
         case .waitingForApp: return "arrow.up.forward.app"
         case .recording: return "record.circle"
         case .transcribing: return "ellipsis.bubble"

--- a/Sources/SpeakCore/KeyboardHandoff.swift
+++ b/Sources/SpeakCore/KeyboardHandoff.swift
@@ -12,6 +12,7 @@ public struct KeyboardHandoffRecord: Codable, Equatable, Sendable {
     public enum Phase: String, Codable, Equatable, Hashable, Sendable {
         case requested
         case recording
+        case finishRequested
         case transcribing
         case completed
         case cancelled
@@ -163,8 +164,19 @@ public final class KeyboardHandoffStore {
     public func markTranscribing(requestID: UUID, now: Date = Date()) throws -> KeyboardHandoffRecord {
         try transition(
             requestID: requestID,
-            allowedFrom: [.recording],
+            allowedFrom: [.recording, .finishRequested],
             to: .transcribing,
+            now: now,
+            lifetime: Self.transcriptionLifetime
+        )
+    }
+
+    @discardableResult
+    public func requestFinish(requestID: UUID, now: Date = Date()) throws -> KeyboardHandoffRecord {
+        try transition(
+            requestID: requestID,
+            allowedFrom: [.recording],
+            to: .finishRequested,
             now: now,
             lifetime: Self.transcriptionLifetime
         )
@@ -192,7 +204,7 @@ public final class KeyboardHandoffStore {
     public func cancel(requestID: UUID, now: Date = Date()) throws -> KeyboardHandoffRecord {
         try transition(
             requestID: requestID,
-            allowedFrom: [.requested, .recording, .transcribing],
+            allowedFrom: [.requested, .recording, .finishRequested, .transcribing],
             to: .cancelled,
             now: now,
             lifetime: Self.resultLifetime
@@ -207,7 +219,7 @@ public final class KeyboardHandoffStore {
     ) throws -> KeyboardHandoffRecord {
         try transition(
             requestID: requestID,
-            allowedFrom: [.requested, .recording, .transcribing],
+            allowedFrom: [.requested, .recording, .finishRequested, .transcribing],
             to: .failed,
             failureCode: code,
             now: now,

--- a/Sources/SpeakCore/KeyboardHandoff.swift
+++ b/Sources/SpeakCore/KeyboardHandoff.swift
@@ -395,11 +395,3 @@ public struct KeyboardHandoffConsumer {
         return true
     }
 }
-
-private extension NSLock {
-    func withLock<T>(_ operation: () throws -> T) rethrows -> T {
-        lock()
-        defer { unlock() }
-        return try operation()
-    }
-}

--- a/Sources/SpeakCore/KeyboardQuickDictation.swift
+++ b/Sources/SpeakCore/KeyboardQuickDictation.swift
@@ -1,0 +1,206 @@
+import CoreFoundation
+import Foundation
+
+/// A short, explicitly-started window in which the containing iOS app is
+/// alive and ready to service microphone commands from the keyboard.
+///
+/// The keyboard never records audio. It only reads this liveness record and
+/// writes nonce-scoped handoff commands. The containing app refreshes the
+/// heartbeat while its foreground-started audio session is alive, preventing a
+/// stale `expiresAt` value from making the keyboard promise a microphone that
+/// iOS has already suspended.
+public struct KeyboardQuickDictationSession: Codable, Equatable, Sendable {
+    public static let schemaVersion = 1
+
+    public enum Phase: String, Codable, Equatable, Sendable {
+        case ready
+        case recording
+    }
+
+    public let schemaVersion: Int
+    public let startedAt: Date
+    public let expiresAt: Date
+    public let lastHeartbeatAt: Date
+    public let phase: Phase
+
+    public init(
+        schemaVersion: Int = Self.schemaVersion,
+        startedAt: Date,
+        expiresAt: Date,
+        lastHeartbeatAt: Date,
+        phase: Phase
+    ) {
+        self.schemaVersion = schemaVersion
+        self.startedAt = startedAt
+        self.expiresAt = expiresAt
+        self.lastHeartbeatAt = lastHeartbeatAt
+        self.phase = phase
+    }
+}
+
+/// App Group-backed liveness state for the containing app's prepared audio
+/// session. Audio and transcript content never enter this store.
+public final class KeyboardQuickDictationStore {
+    public static let shared = KeyboardQuickDictationStore()
+    public static let defaultDuration: TimeInterval = 5 * 60
+    public static let heartbeatLifetime: TimeInterval = 4
+
+    private static let sessionKey = "keyboardQuickDictation.session.v1"
+
+    private let defaults: UserDefaults?
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private let lock = NSLock()
+
+    public convenience init() {
+        self.init(defaults: UserDefaults(suiteName: KeyboardHandoffStore.appGroupIdentifier))
+    }
+
+    public init(defaults: UserDefaults?) {
+        self.defaults = defaults
+    }
+
+    @discardableResult
+    public func start(
+        now: Date = Date(),
+        duration: TimeInterval = defaultDuration
+    ) -> KeyboardQuickDictationSession? {
+        lock.withKeyboardQuickDictationLock {
+            guard duration > 0 else { return nil }
+            let session = KeyboardQuickDictationSession(
+                startedAt: now,
+                expiresAt: now.addingTimeInterval(duration),
+                lastHeartbeatAt: now,
+                phase: .ready
+            )
+            return writeUnlocked(session) ? session : nil
+        }
+    }
+
+    @discardableResult
+    public func heartbeat(
+        phase: KeyboardQuickDictationSession.Phase? = nil,
+        now: Date = Date()
+    ) -> KeyboardQuickDictationSession? {
+        lock.withKeyboardQuickDictationLock {
+            guard let current = readUnlocked(),
+                  current.phase == .recording || current.expiresAt > now else {
+                clearUnlocked()
+                return nil
+            }
+            let updated = KeyboardQuickDictationSession(
+                startedAt: current.startedAt,
+                expiresAt: current.expiresAt,
+                lastHeartbeatAt: now,
+                phase: phase ?? current.phase
+            )
+            return writeUnlocked(updated) ? updated : nil
+        }
+    }
+
+    public func activeSession(now: Date = Date()) -> KeyboardQuickDictationSession? {
+        lock.withKeyboardQuickDictationLock {
+            guard let session = readUnlocked() else { return nil }
+            let heartbeatIsFresh = now.timeIntervalSince(session.lastHeartbeatAt) <= Self.heartbeatLifetime
+            let readinessWindowIsOpen = session.phase == .recording || session.expiresAt > now
+            guard heartbeatIsFresh, readinessWindowIsOpen else {
+                clearUnlocked()
+                return nil
+            }
+            return session
+        }
+    }
+
+    public func end() {
+        lock.withKeyboardQuickDictationLock {
+            clearUnlocked()
+        }
+    }
+
+    private func writeUnlocked(_ session: KeyboardQuickDictationSession) -> Bool {
+        guard let defaults, let data = try? encoder.encode(session) else { return false }
+        defaults.set(data, forKey: Self.sessionKey)
+        defaults.synchronize()
+        return true
+    }
+
+    private func readUnlocked() -> KeyboardQuickDictationSession? {
+        guard let data = defaults?.data(forKey: Self.sessionKey),
+              let session = try? decoder.decode(KeyboardQuickDictationSession.self, from: data),
+              session.schemaVersion == KeyboardQuickDictationSession.schemaVersion else {
+            return nil
+        }
+        return session
+    }
+
+    private func clearUnlocked() {
+        defaults?.removeObject(forKey: Self.sessionKey)
+        defaults?.synchronize()
+    }
+}
+
+/// A payload-free Darwin notification used only as a wake-up hint. The actual
+/// command and nonce remain in the App Group record and are validated there.
+public enum KeyboardHandoffSignal {
+    private static let requestChangedName = "com.justspeaktoit.keyboardHandoff.requestChanged" as CFString
+
+    public static func postRequestChanged() {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(requestChangedName),
+            nil,
+            nil,
+            true
+        )
+    }
+
+    public static func observeRequestChanges(
+        _ handler: @escaping @Sendable () -> Void
+    ) -> KeyboardHandoffSignalObservation {
+        KeyboardHandoffSignalObservation(name: requestChangedName, handler: handler)
+    }
+}
+
+public final class KeyboardHandoffSignalObservation: @unchecked Sendable {
+    private let name: CFString
+    private let handler: @Sendable () -> Void
+
+    fileprivate init(name: CFString, handler: @escaping @Sendable () -> Void) {
+        self.name = name
+        self.handler = handler
+        let pointer = Unmanaged.passUnretained(self).toOpaque()
+        CFNotificationCenterAddObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            pointer,
+            { _, observer, _, _, _ in
+                guard let observer else { return }
+                let observation = Unmanaged<KeyboardHandoffSignalObservation>
+                    .fromOpaque(observer)
+                    .takeUnretainedValue()
+                DispatchQueue.main.async {
+                    observation.handler()
+                }
+            },
+            name,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    deinit {
+        CFNotificationCenterRemoveObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            Unmanaged.passUnretained(self).toOpaque(),
+            CFNotificationName(name),
+            nil
+        )
+    }
+}
+
+private extension NSLock {
+    func withKeyboardQuickDictationLock<T>(_ operation: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return operation()
+    }
+}

--- a/Sources/SpeakCore/KeyboardQuickDictation.swift
+++ b/Sources/SpeakCore/KeyboardQuickDictation.swift
@@ -98,13 +98,18 @@ public final class KeyboardQuickDictationStore {
         }
     }
 
-    public func activeSession(now: Date = Date()) -> KeyboardQuickDictationSession? {
+    public func activeSession(
+        now: Date = Date(),
+        clearingStaleRecord: Bool = false
+    ) -> KeyboardQuickDictationSession? {
         lock.withLock {
             guard let session = readUnlocked() else { return nil }
             let heartbeatIsFresh = now.timeIntervalSince(session.lastHeartbeatAt) <= Self.heartbeatLifetime
             let readinessWindowIsOpen = session.phase == .recording || session.expiresAt > now
             guard heartbeatIsFresh, readinessWindowIsOpen else {
-                clearUnlocked()
+                if clearingStaleRecord {
+                    clearUnlocked()
+                }
                 return nil
             }
             return session
@@ -194,13 +199,5 @@ public final class KeyboardHandoffSignalObservation: @unchecked Sendable {
             CFNotificationName(name),
             nil
         )
-    }
-}
-
-extension NSLock {
-    func withLock<T>(_ operation: () throws -> T) rethrows -> T {
-        lock()
-        defer { unlock() }
-        return try operation()
     }
 }

--- a/Sources/SpeakCore/KeyboardQuickDictation.swift
+++ b/Sources/SpeakCore/KeyboardQuickDictation.swift
@@ -65,7 +65,7 @@ public final class KeyboardQuickDictationStore {
         now: Date = Date(),
         duration: TimeInterval = defaultDuration
     ) -> KeyboardQuickDictationSession? {
-        lock.withKeyboardQuickDictationLock {
+        lock.withLock {
             guard duration > 0 else { return nil }
             let session = KeyboardQuickDictationSession(
                 startedAt: now,
@@ -82,7 +82,7 @@ public final class KeyboardQuickDictationStore {
         phase: KeyboardQuickDictationSession.Phase? = nil,
         now: Date = Date()
     ) -> KeyboardQuickDictationSession? {
-        lock.withKeyboardQuickDictationLock {
+        lock.withLock {
             guard let current = readUnlocked(),
                   current.phase == .recording || current.expiresAt > now else {
                 clearUnlocked()
@@ -99,7 +99,7 @@ public final class KeyboardQuickDictationStore {
     }
 
     public func activeSession(now: Date = Date()) -> KeyboardQuickDictationSession? {
-        lock.withKeyboardQuickDictationLock {
+        lock.withLock {
             guard let session = readUnlocked() else { return nil }
             let heartbeatIsFresh = now.timeIntervalSince(session.lastHeartbeatAt) <= Self.heartbeatLifetime
             let readinessWindowIsOpen = session.phase == .recording || session.expiresAt > now
@@ -112,7 +112,7 @@ public final class KeyboardQuickDictationStore {
     }
 
     public func end() {
-        lock.withKeyboardQuickDictationLock {
+        lock.withLock {
             clearUnlocked()
         }
     }
@@ -197,10 +197,10 @@ public final class KeyboardHandoffSignalObservation: @unchecked Sendable {
     }
 }
 
-private extension NSLock {
-    func withKeyboardQuickDictationLock<T>(_ operation: () -> T) -> T {
+extension NSLock {
+    func withLock<T>(_ operation: () throws -> T) rethrows -> T {
         lock()
         defer { unlock() }
-        return operation()
+        return try operation()
     }
 }

--- a/Sources/SpeakCore/TranscriptionActivityAttributes.swift
+++ b/Sources/SpeakCore/TranscriptionActivityAttributes.swift
@@ -177,7 +177,12 @@ public final class TranscriptionActivityManager: ObservableObject {
 
     /// Marks the activity as completed. Headless recordings keep it primed so
     /// the next Action Button invocation can start entirely in the background.
-    public func completeActivity(finalWordCount: Int, duration: Int, keepPrimed: Bool = false) {
+    public func completeActivity(
+        finalWordCount: Int,
+        duration: Int,
+        keepPrimed: Bool = false,
+        primedMessage: String = "Ready for the Action Button"
+    ) {
         guard let activity = currentActivity else { return }
 
         let finalState = TranscriptionActivityAttributes.ContentState(
@@ -195,7 +200,7 @@ public final class TranscriptionActivityManager: ObservableObject {
                 guard !Task.isCancelled, activity.activityState == .active else { return }
                 let idleState = TranscriptionActivityAttributes.ContentState(
                     status: .idle,
-                    lastSnippet: "Ready for the Action Button",
+                    lastSnippet: primedMessage,
                     provider: finalState.provider
                 )
                 await activity.update(.init(state: idleState, staleDate: nil))

--- a/Sources/SpeakiOS/Services/KeyboardQuickDictationCoordinator.swift
+++ b/Sources/SpeakiOS/Services/KeyboardQuickDictationCoordinator.swift
@@ -1,0 +1,298 @@
+#if os(iOS)
+import AVFoundation
+import Foundation
+import SpeakCore
+import UIKit
+
+/// Owns the containing app's foreground-started, time-limited microphone
+/// session that makes keyboard-only start/stop commands possible while the app
+/// remains alive in the background.
+///
+/// Idle buffers are discarded immediately. They are never persisted, sent to a
+/// transcription provider, or placed in the App Group. Actual transcription
+/// starts only after the keyboard creates a nonce-scoped handoff request.
+@MainActor
+public final class KeyboardQuickDictationCoordinator: ObservableObject {
+    public static let shared = KeyboardQuickDictationCoordinator()
+
+    @Published public private(set) var session: KeyboardQuickDictationSession?
+    @Published public private(set) var errorMessage: String?
+
+    private let sessionStore = KeyboardQuickDictationStore.shared
+    private let handoffStore = KeyboardHandoffStore.shared
+    private let recordingService = TranscriptionRecordingService.shared
+    private let readinessAudio = KeyboardReadinessAudioSession()
+    private let activityManager = TranscriptionActivityManager.shared
+
+    private var signalObservation: KeyboardHandoffSignalObservation?
+    private var heartbeatTask: Task<Void, Never>?
+    private var requestTask: Task<Void, Never>?
+    private var activeRequestID: UUID?
+
+    private init() {}
+
+    public var isReady: Bool {
+        session?.phase == .ready && sessionStore.activeSession() != nil
+    }
+
+    public var isRecording: Bool {
+        session?.phase == .recording
+    }
+
+    public func activate() {
+        guard signalObservation == nil else { return }
+        signalObservation = KeyboardHandoffSignal.observeRequestChanges { [weak self] in
+            Task { @MainActor in
+                self?.handleRequestChange()
+            }
+        }
+        session = sessionStore.activeSession()
+    }
+
+    /// Starts a bounded session only from the foreground, after an explicit
+    /// user action. This is the supported boundary: a keyboard extension cannot
+    /// cold-start microphone capture after iOS has suspended the app.
+    public func startSession(duration: TimeInterval = KeyboardQuickDictationStore.defaultDuration) async {
+        activate()
+        errorMessage = nil
+
+        guard UIApplication.shared.applicationState == .active else {
+            errorMessage = "Open Just Speak to start Quick Dictation."
+            return
+        }
+        guard !recordingService.isRunning else {
+            errorMessage = "Finish the current recording before starting Quick Dictation."
+            return
+        }
+
+        let audioSessionManager = AudioSessionManager()
+        var hasMicrophonePermission = audioSessionManager.hasMicrophonePermission()
+        if !hasMicrophonePermission {
+            hasMicrophonePermission = await audioSessionManager.requestMicrophonePermission()
+        }
+        guard hasMicrophonePermission else {
+            errorMessage = "Microphone access is required for Quick Dictation."
+            return
+        }
+
+        do {
+            try readinessAudio.start()
+            guard let started = sessionStore.start(duration: duration) else {
+                readinessAudio.stop(deactivateAudioSession: true)
+                errorMessage = "Quick Dictation could not access the shared keyboard container."
+                return
+            }
+            session = started
+            _ = activityManager.startActivity(provider: "Keyboard Quick Dictation")
+            startHeartbeat()
+            handleRequestChange()
+        } catch {
+            readinessAudio.stop(deactivateAudioSession: true)
+            sessionStore.end()
+            session = nil
+            errorMessage = "Quick Dictation could not start the microphone: \(error.localizedDescription)"
+        }
+    }
+
+    public func endSession() {
+        requestTask?.cancel()
+        requestTask = nil
+        if recordingService.isRunning {
+            recordingService.cancelRecording()
+        }
+        if let activeRequestID {
+            _ = try? handoffStore.cancel(requestID: activeRequestID)
+        }
+        activeRequestID = nil
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        readinessAudio.stop(deactivateAudioSession: true)
+        sessionStore.end()
+        session = nil
+        activityManager.endActivity()
+    }
+
+    private func startHeartbeat() {
+        heartbeatTask?.cancel()
+        heartbeatTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                guard let updated = self.sessionStore.heartbeat() else {
+                    if !self.recordingService.isRunning {
+                        self.endSession()
+                    }
+                    return
+                }
+                guard updated.phase == .recording || self.readinessAudio.isRunning else {
+                    self.errorMessage = "Quick Dictation ended after an audio interruption."
+                    self.endSession()
+                    return
+                }
+                self.session = updated
+                try? await Task.sleep(for: .seconds(1))
+            }
+        }
+    }
+
+    private func handleRequestChange() {
+        guard requestTask == nil else { return }
+        guard sessionStore.activeSession() != nil,
+              let record = handoffStore.activeRecord() else { return }
+
+        switch record.phase {
+        case .requested:
+            requestTask = Task { [weak self] in
+                await self?.beginRecording(for: record.requestID)
+                self?.requestTask = nil
+                self?.handleRequestChange()
+            }
+        case .finishRequested:
+            requestTask = Task { [weak self] in
+                await self?.finishRecording(for: record.requestID)
+                self?.requestTask = nil
+                self?.handleRequestChange()
+            }
+        case .cancelled:
+            cancelRecording(for: record.requestID)
+        case .recording, .transcribing, .completed, .failed:
+            break
+        }
+    }
+
+    private func beginRecording(for requestID: UUID) async {
+        guard activeRequestID == nil, !recordingService.isRunning else {
+            _ = try? handoffStore.fail(requestID: requestID, code: .recordingUnavailable)
+            return
+        }
+
+        readinessAudio.stop(deactivateAudioSession: false)
+        do {
+            try await recordingService.startRecording(
+                retainBatchRecording: false,
+                sharesLiveTranscript: false
+            )
+            try handoffStore.markRecording(requestID: requestID)
+            activeRequestID = requestID
+            session = sessionStore.heartbeat(phase: .recording)
+        } catch {
+            recordingService.cancelRecording()
+            _ = try? handoffStore.fail(requestID: requestID, code: .recordingUnavailable)
+            await resumeReadinessAfterRequest()
+        }
+    }
+
+    private func finishRecording(for requestID: UUID) async {
+        guard activeRequestID == requestID, recordingService.isRunning else {
+            _ = try? handoffStore.fail(requestID: requestID, code: .invalidRequest)
+            return
+        }
+
+        do {
+            try handoffStore.markTranscribing(requestID: requestID)
+        } catch {
+            recordingService.cancelRecording()
+            _ = try? handoffStore.fail(requestID: requestID, code: .invalidRequest)
+            activeRequestID = nil
+            await resumeReadinessAfterRequest()
+            return
+        }
+
+        let result = await recordingService.stopRecording(
+            destination: .historyOnly,
+            saveToHistory: true,
+            primedActivityMessage: "Keyboard ready"
+        )
+        activeRequestID = nil
+        let transcript = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if transcript.isEmpty {
+            _ = try? handoffStore.fail(requestID: requestID, code: .noSpeech)
+        } else {
+            _ = try? handoffStore.complete(requestID: requestID, transcript: transcript)
+        }
+        await resumeReadinessAfterRequest()
+    }
+
+    private func cancelRecording(for requestID: UUID) {
+        guard activeRequestID == requestID else { return }
+        if recordingService.isRunning {
+            recordingService.cancelRecording()
+        }
+        activeRequestID = nil
+        Task {
+            await resumeReadinessAfterRequest()
+        }
+    }
+
+    private func resumeReadinessAfterRequest() async {
+        guard let current = sessionStore.activeSession(), current.expiresAt > Date() else {
+            endSession()
+            return
+        }
+        do {
+            try readinessAudio.start()
+            session = sessionStore.heartbeat(phase: .ready)
+            _ = activityManager.startActivity(provider: "Keyboard Quick Dictation")
+        } catch {
+            errorMessage = "Quick Dictation ended because the microphone could not be reactivated."
+            endSession()
+        }
+    }
+}
+
+/// Holds an explicit foreground-started recording session open while discarding
+/// idle buffers. This keeps iOS from suspending the containing app during the
+/// user's short Quick Dictation window without sending or saving idle audio.
+@MainActor
+private final class KeyboardReadinessAudioSession {
+    private let engine = AVAudioEngine()
+    private var tapInstalled = false
+
+    var isRunning: Bool {
+        engine.isRunning
+    }
+
+    func start() throws {
+        guard !engine.isRunning else { return }
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(
+            .playAndRecord,
+            mode: .measurement,
+            options: [.mixWithOthers, .allowBluetoothHFP]
+        )
+        try session.setActive(true)
+
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        guard format.channelCount > 0 else {
+            throw KeyboardReadinessAudioError.noInput
+        }
+        if !tapInstalled {
+            input.installTap(onBus: 0, bufferSize: 4_096, format: format) { _, _ in
+                // Deliberately discard idle audio. No persistence or network IO.
+            }
+            tapInstalled = true
+        }
+        engine.prepare()
+        try engine.start()
+    }
+
+    func stop(deactivateAudioSession: Bool) {
+        engine.stop()
+        if tapInstalled {
+            engine.inputNode.removeTap(onBus: 0)
+            tapInstalled = false
+        }
+        if deactivateAudioSession {
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        }
+    }
+}
+
+private enum KeyboardReadinessAudioError: LocalizedError {
+    case noInput
+
+    var errorDescription: String? {
+        "No microphone input is available."
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Services/KeyboardQuickDictationCoordinator.swift
+++ b/Sources/SpeakiOS/Services/KeyboardQuickDictationCoordinator.swift
@@ -32,7 +32,7 @@ public final class KeyboardQuickDictationCoordinator: ObservableObject {
     private init() {}
 
     public var isReady: Bool {
-        session?.phase == .ready && sessionStore.activeSession() != nil
+        session?.phase == .ready && sessionStore.activeSession(clearingStaleRecord: true) != nil
     }
 
     public var isRecording: Bool {
@@ -46,7 +46,7 @@ public final class KeyboardQuickDictationCoordinator: ObservableObject {
                 self?.handleRequestChange()
             }
         }
-        session = sessionStore.activeSession()
+        session = sessionStore.activeSession(clearingStaleRecord: true)
     }
 
     /// Starts a bounded session only from the foreground, after an explicit
@@ -118,9 +118,8 @@ public final class KeyboardQuickDictationCoordinator: ObservableObject {
             while !Task.isCancelled {
                 guard let self else { return }
                 guard let updated = self.sessionStore.heartbeat() else {
-                    if !self.recordingService.isRunning {
-                        self.endSession()
-                    }
+                    self.errorMessage = "Quick Dictation ended because its session state was unavailable."
+                    self.endSession()
                     return
                 }
                 guard updated.phase == .recording || self.readinessAudio.isRunning else {
@@ -136,7 +135,7 @@ public final class KeyboardQuickDictationCoordinator: ObservableObject {
 
     private func handleRequestChange() {
         guard requestTask == nil else { return }
-        guard sessionStore.activeSession() != nil,
+        guard sessionStore.activeSession(clearingStaleRecord: true) != nil,
               let record = handoffStore.activeRecord() else { return }
 
         switch record.phase {
@@ -224,7 +223,8 @@ public final class KeyboardQuickDictationCoordinator: ObservableObject {
     }
 
     private func resumeReadinessAfterRequest() async {
-        guard let current = sessionStore.activeSession(), current.expiresAt > Date() else {
+        guard let current = sessionStore.activeSession(clearingStaleRecord: true),
+              current.expiresAt > Date() else {
             endSession()
             return
         }
@@ -264,6 +264,7 @@ private final class KeyboardReadinessAudioSession {
         let input = engine.inputNode
         let format = input.outputFormat(forBus: 0)
         guard format.channelCount > 0 else {
+            stop(deactivateAudioSession: true)
             throw KeyboardReadinessAudioError.noInput
         }
         if !tapInstalled {
@@ -273,7 +274,12 @@ private final class KeyboardReadinessAudioSession {
             tapInstalled = true
         }
         engine.prepare()
-        try engine.start()
+        do {
+            try engine.start()
+        } catch {
+            stop(deactivateAudioSession: true)
+            throw error
+        }
     }
 
     func stop(deactivateAudioSession: Bool) {

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -254,7 +254,8 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     @discardableResult
     public func stopRecording(
         destination: HardwareTriggerDestination? = nil,
-        saveToHistory: Bool = true
+        saveToHistory: Bool = true,
+        primedActivityMessage: String = "Ready for the Action Button"
     ) async -> TranscriptionResult {
         isRunning = false
         let duration = elapsedSeconds
@@ -303,7 +304,12 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         sharesLiveTranscript = true
 
         // Complete Live Activity with clipboard confirmation
-        activityManager.completeActivity(finalWordCount: wordCount, duration: duration, keepPrimed: true)
+        activityManager.completeActivity(
+            finalWordCount: wordCount,
+            duration: duration,
+            keepPrimed: true,
+            primedMessage: primedActivityMessage
+        )
 
         // Kick off background post-processing if the chosen destination + user
         // settings call for it. The polished clipboard write must also survive

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -304,12 +304,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         sharesLiveTranscript = true
 
         // Complete Live Activity with clipboard confirmation
-        activityManager.completeActivity(
-            finalWordCount: wordCount,
-            duration: duration,
-            keepPrimed: true,
-            primedMessage: primedActivityMessage
-        )
+        completeRecordingActivity(duration: duration, primedMessage: primedActivityMessage)
 
         // Kick off background post-processing if the chosen destination + user
         // settings call for it. The polished clipboard write must also survive
@@ -333,6 +328,15 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         }
 
         return result
+    }
+
+    private func completeRecordingActivity(duration: Int, primedMessage: String) {
+        activityManager.completeActivity(
+            finalWordCount: wordCount,
+            duration: duration,
+            keepPrimed: true,
+            primedMessage: primedMessage
+        )
     }
 
     /// Cancels recording without saving.

--- a/Sources/SpeakiOS/Views/KeyboardCaptureView.swift
+++ b/Sources/SpeakiOS/Views/KeyboardCaptureView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public struct KeyboardCaptureView: View {
     @StateObject private var coordinator: KeyboardHandoffCaptureCoordinator
     @ObservedObject private var settings = AppSettings.shared
+    @ObservedObject private var quickDictation = KeyboardQuickDictationCoordinator.shared
     @Environment(\.dismiss) private var dismiss
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -145,15 +146,37 @@ public struct KeyboardCaptureView: View {
                 .accessibilityIdentifier("keyboardTranscribingProgress")
 
         case .ready:
-            Button {
-                dismiss()
-            } label: {
-                Label("Done", systemImage: "checkmark")
-                    .font(.headline)
-                    .frame(maxWidth: .infinity, minHeight: 54)
+            VStack(spacing: 12) {
+                Button {
+                    dismiss()
+                } label: {
+                    Label("Done", systemImage: "checkmark")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, minHeight: 54)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("keyboardResultReadyButton")
+
+                if !quickDictation.isReady {
+                    Button {
+                        Task {
+                            await quickDictation.startSession()
+                        }
+                    } label: {
+                        Label("Keep Keyboard Ready for 5 Minutes", systemImage: "keyboard.badge.ellipsis")
+                            .frame(maxWidth: .infinity, minHeight: 48)
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("enableQuickDictationAfterHandoffButton")
+                }
+
+                if let error = quickDictation.errorMessage {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.center)
+                }
             }
-            .buttonStyle(.borderedProminent)
-            .accessibilityIdentifier("keyboardResultReadyButton")
 
         case .cancelled, .error:
             Button("Return to Just Speak") {

--- a/Sources/SpeakiOS/Views/KeyboardSetupView.swift
+++ b/Sources/SpeakiOS/Views/KeyboardSetupView.swift
@@ -166,7 +166,8 @@ public struct KeyboardSetupView: View {
     }
 
     private var quickDictationStatus: String {
-        guard let session = quickDictation.session else { return "Not enabled" }
+        guard let session = quickDictation.session,
+              quickDictation.isReady || quickDictation.isRecording else { return "Not enabled" }
         if session.phase == .recording { return "Recording" }
         return "Ready until \(session.expiresAt.formatted(date: .omitted, time: .shortened))"
     }

--- a/Sources/SpeakiOS/Views/KeyboardSetupView.swift
+++ b/Sources/SpeakiOS/Views/KeyboardSetupView.swift
@@ -7,6 +7,7 @@ public struct KeyboardSetupView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
     @State private var observation: KeyboardExtensionObservation?
+    @ObservedObject private var quickDictation = KeyboardQuickDictationCoordinator.shared
 
     public init() {}
 
@@ -77,13 +78,55 @@ public struct KeyboardSetupView: View {
                 .foregroundStyle(.secondary)
             }
 
+            Section("Quick Dictation") {
+                statusRow(
+                    title: "Keyboard microphone",
+                    isReady: quickDictation.isReady || quickDictation.isRecording,
+                    readyText: quickDictationStatus
+                )
+
+                Button {
+                    if quickDictation.session == nil {
+                        Task {
+                            await quickDictation.startSession()
+                        }
+                    } else {
+                        quickDictation.endSession()
+                    }
+                } label: {
+                    Label(
+                        quickDictation.session == nil ? "Enable for 5 Minutes" : "End Quick Dictation",
+                        systemImage: quickDictation.session == nil ? "mic.badge.plus" : "stop.circle"
+                    )
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(quickDictation.session == nil ? .accentColor : .red)
+                .accessibilityIdentifier("keyboardQuickDictationButton")
+
+                Text(
+                    "Start once, return to your text field, then use Speak and Finish directly in the keyboard. "
+                        + "The orange microphone indicator stays visible during this short session. "
+                        + "Idle audio is discarded immediately on device and is never saved or sent."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                if let errorMessage = quickDictation.errorMessage {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
+
             Section("Why Full Access?") {
-                Label("Open the Just Speak app for microphone capture", systemImage: "arrow.up.forward.app")
+                Label("Control a prepared microphone session from the keyboard", systemImage: "mic.fill")
                 Label("Exchange one nonce-scoped result through the App Group", systemImage: "lock.shield")
                 Label("Use cloud transcription only when your selected model requires it", systemImage: "network")
                 Text(
-                    "The keyboard itself cannot use the microphone. It does not read, persist, "
-                        + "or transmit surrounding text, and shared results expire quickly."
+                    "iOS does not give keyboard extensions microphone access. Just Speak owns the explicit, "
+                        + "time-limited audio session while the keyboard sends only nonce-scoped commands. "
+                        + "It does not read, persist, or transmit surrounding text."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -97,8 +140,8 @@ public struct KeyboardSetupView: View {
 
             Section("What to Expect") {
                 Text(
-                    "Tap Speak in the keyboard, record in Just Speak, finish transcription, "
-                        + "then return to the original app. Just Speak inserts only the matching result."
+                    "Enable Quick Dictation here once, return to the original app, then start and finish "
+                        + "future dictations inside the keyboard until the five-minute session expires."
                 )
                 Text(
                     "Local Apple Speech can work offline after its language resources are available. "
@@ -120,6 +163,12 @@ public struct KeyboardSetupView: View {
     private var fullAccessStatus: String {
         guard let observation else { return "Open the keyboard to check" }
         return observation.hadFullAccess ? "Observed on" : "Observed off"
+    }
+
+    private var quickDictationStatus: String {
+        guard let session = quickDictation.session else { return "Not enabled" }
+        if session.phase == .recording { return "Recording" }
+        return "Ready until \(session.expiresAt.formatted(date: .omitted, time: .shortened))"
     }
 
     private func setupStep(number: Int, title: String, detail: String) -> some View {

--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -66,6 +66,7 @@ final class SpeakiOSAppDelegate: NSObject, UIApplicationDelegate {
 struct SpeakiOSApp: App {
     @UIApplicationDelegateAdaptor(SpeakiOSAppDelegate.self) private var appDelegate
     @ObservedObject private var deepLinkRouter = DeepLinkRouter.shared
+    @ObservedObject private var keyboardQuickDictation = KeyboardQuickDictationCoordinator.shared
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
@@ -78,6 +79,7 @@ struct SpeakiOSApp: App {
                     deepLinkRouter.handle(url)
                 }
                 .task {
+                    keyboardQuickDictation.activate()
                     #if DEBUG && targetEnvironment(simulator)
                     if ProcessInfo.processInfo.arguments.contains("--keyboard-handoff-demo"),
                        deepLinkRouter.keyboardCaptureRequest == nil {

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -113,7 +113,7 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(infoPlist.contains("$(PRODUCT_MODULE_NAME).KeyboardViewController"))
     }
 
-    func testIOSKeyboardUsesManualSupportedHandoffAndRetainsHistory() throws {
+    func testIOSKeyboardUsesSupportedPreparedSessionAndRetainsHistory() throws {
         let keyboard = try String(
             contentsOf: repositoryRoot.appendingPathComponent("JustSpeakKeyboard/KeyboardViewController.swift"),
             encoding: .utf8
@@ -124,12 +124,23 @@ final class DistributionBuildIdentityTests: XCTestCase {
             ),
             encoding: .utf8
         )
+        let quickCoordinator = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(
+                "Sources/SpeakiOS/Services/KeyboardQuickDictationCoordinator.swift"
+            ),
+            encoding: .utf8
+        )
 
         XCTAssertFalse(keyboard.contains("extensionContext.open"))
         XCTAssertTrue(keyboard.contains("Open Just Speak manually"))
+        XCTAssertTrue(keyboard.contains("KeyboardHandoffSignal.postRequestChanged"))
+        XCTAssertTrue(keyboard.contains("Finish & Transcribe"))
         XCTAssertTrue(keyboard.contains("transcripts remain in History"))
         XCTAssertFalse(keyboard.contains("Results are deleted after insertion"))
         XCTAssertTrue(captureCoordinator.contains("saveToHistory: true"))
+        XCTAssertTrue(quickCoordinator.contains("Idle buffers are discarded immediately"))
+        XCTAssertTrue(quickCoordinator.contains("saveToHistory: true"))
+        XCTAssertFalse(quickCoordinator.contains("extensionContext.open"))
     }
 
     func testIOSReleaseWorkflowSignsAndValidatesKeyboardExtension() throws {

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -138,9 +138,10 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(keyboard.contains("transcripts remain in History"))
         XCTAssertFalse(keyboard.contains("Results are deleted after insertion"))
         XCTAssertTrue(captureCoordinator.contains("saveToHistory: true"))
-        XCTAssertTrue(quickCoordinator.contains("Idle buffers are discarded immediately"))
+        XCTAssertTrue(quickCoordinator.contains("input.installTap"))
+        XCTAssertFalse(quickCoordinator.contains(".write("))
+        XCTAssertFalse(quickCoordinator.contains(".upload("))
         XCTAssertTrue(quickCoordinator.contains("saveToHistory: true"))
-        XCTAssertFalse(quickCoordinator.contains("extensionContext.open"))
     }
 
     func testIOSReleaseWorkflowSignsAndValidatesKeyboardExtension() throws {

--- a/Tests/SpeakCoreTests/KeyboardHandoffTests.swift
+++ b/Tests/SpeakCoreTests/KeyboardHandoffTests.swift
@@ -59,6 +59,20 @@ final class KeyboardHandoffTests: XCTestCase {
                 now: now.addingTimeInterval(KeyboardQuickDictationStore.heartbeatLifetime + 1)
             )
         )
+        XCTAssertNotNil(
+            quickStore.heartbeat(
+                now: now.addingTimeInterval(KeyboardQuickDictationStore.heartbeatLifetime + 1)
+            )
+        )
+    }
+
+    func testQuickDictationOwnerCanClearStaleSession() {
+        let now = Date(timeIntervalSince1970: 4_500)
+        _ = quickStore.start(now: now, duration: 300)
+        let staleTime = now.addingTimeInterval(KeyboardQuickDictationStore.heartbeatLifetime + 1)
+
+        XCTAssertNil(quickStore.activeSession(now: staleTime, clearingStaleRecord: true))
+        XCTAssertNil(quickStore.heartbeat(now: staleTime))
     }
 
     func testQuickDictationRecordingCanFinishAfterReadinessWindowExpires() {

--- a/Tests/SpeakCoreTests/KeyboardHandoffTests.swift
+++ b/Tests/SpeakCoreTests/KeyboardHandoffTests.swift
@@ -6,6 +6,7 @@ final class KeyboardHandoffTests: XCTestCase {
     private var suiteName: String!
     private var defaults: UserDefaults!
     private var store: KeyboardHandoffStore!
+    private var quickStore: KeyboardQuickDictationStore!
 
     override func setUp() {
         super.setUp()
@@ -13,11 +14,13 @@ final class KeyboardHandoffTests: XCTestCase {
         defaults = UserDefaults(suiteName: suiteName)
         defaults.removePersistentDomain(forName: suiteName)
         store = KeyboardHandoffStore(defaults: defaults)
+        quickStore = KeyboardQuickDictationStore(defaults: defaults)
     }
 
     override func tearDown() {
         defaults.removePersistentDomain(forName: suiteName)
         store = nil
+        quickStore = nil
         defaults = nil
         suiteName = nil
         super.tearDown()
@@ -35,6 +38,41 @@ final class KeyboardHandoffTests: XCTestCase {
 
         XCTAssertEqual(store.consumeResult(requestID: request.requestID), "Insert this text.")
         XCTAssertNil(store.activeRecord())
+    }
+
+    func testKeyboardCanRequestFinishBeforeContainingAppTranscribes() throws {
+        let request = try store.createRequest()
+        try store.markRecording(requestID: request.requestID)
+
+        XCTAssertEqual(try store.requestFinish(requestID: request.requestID).phase, .finishRequested)
+        XCTAssertEqual(try store.markTranscribing(requestID: request.requestID).phase, .transcribing)
+    }
+
+    func testQuickDictationRequiresFreshHeartbeatInsideReadinessWindow() {
+        let now = Date(timeIntervalSince1970: 4_000)
+        let session = quickStore.start(now: now, duration: 300)
+
+        XCTAssertEqual(session?.phase, .ready)
+        XCTAssertNotNil(quickStore.activeSession(now: now.addingTimeInterval(3)))
+        XCTAssertNil(
+            quickStore.activeSession(
+                now: now.addingTimeInterval(KeyboardQuickDictationStore.heartbeatLifetime + 1)
+            )
+        )
+    }
+
+    func testQuickDictationRecordingCanFinishAfterReadinessWindowExpires() {
+        let now = Date(timeIntervalSince1970: 5_000)
+        _ = quickStore.start(now: now, duration: 1)
+        let recording = quickStore.heartbeat(phase: .recording, now: now.addingTimeInterval(0.5))
+
+        XCTAssertEqual(recording?.phase, .recording)
+        XCTAssertNotNil(quickStore.activeSession(now: now.addingTimeInterval(2)))
+        XCTAssertEqual(
+            quickStore.heartbeat(phase: .ready, now: now.addingTimeInterval(2))?.phase,
+            .ready
+        )
+        XCTAssertNil(quickStore.activeSession(now: now.addingTimeInterval(2)))
     }
 
     func testMismatchedNonceCannotReadOrClearResult() throws {


### PR DESCRIPTION
## Motivation

The keyboard currently requires an app switch for every dictation because iOS custom keyboard extensions cannot access the microphone. Wispr Flow's public behavior uses a different supported boundary: the containing app starts a short audio session from the foreground, then the keyboard controls that already-live session.

This PR implements that prepared-session model without claiming unsupported cold-start microphone access.

## What changed

- Adds an explicit five-minute **Quick Dictation** session owned by the iOS app.
- Keeps a fresh App Group heartbeat so the keyboard only promises inline recording while the containing app is genuinely alive.
- Uses payload-free Darwin notifications as wake hints; nonce-scoped commands and final results remain in the App Group.
- Lets the keyboard start, finish, cancel, and insert a transcript without leaving the host app while the session is ready.
- Discards idle audio buffers immediately on device; idle audio is not saved, transcribed, or sent.
- Preserves completed transcripts in app History.
- Adds clear ready/recording/expired UI, orange microphone-indicator copy, immediate session stop, and an honest manual fallback when the app is no longer alive.
- Adds a one-tap **Keep Keyboard Ready for 5 Minutes** option after the existing fallback handoff.
- Documents the architecture, review posture, and signed physical-device test matrix.

## What research changed the direction

Apple explicitly states that custom keyboards have no microphone access, and guideline 4.4.1 prevents treating the extension like an app launcher. A cold keyboard therefore cannot safely promise recording after iOS suspends or terminates the containing app.

Wispr Flow's public documentation describes a time-limited background session (five minutes by default) and acknowledges that users may need to return to the app after that session is unavailable. The implementation follows that proven boundary rather than trying to make the extension record directly.

Sources:
- https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html
- https://developer.apple.com/app-store/review/guidelines/
- https://developer.apple.com/documentation/Xcode/configuring-app-groups
- https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct/record
- https://docs.wisprflow.ai/articles/7453988911-set-up-the-flow-keyboard-on-iphone
- https://docs.wisprflow.ai/articles/8884408990-connect-and-set-up-external-audio-devices

## How to test

Completed:
- `swift test --filter KeyboardHandoffTests` — 12 tests passed.
- SpeakiOS simulator build — passed.
- JustSpeakKeyboard simulator build — passed.
- SpeakiOS build-for-testing — passed.
- `git diff --check` — clean.

Required before ready/merge/TestFlight:
- Run the complete matrix in `Docs/ios-keyboard-quick-dictation.md` on a signed physical iPhone.
- Confirm Notes, Safari, and Messages can start/finish from the keyboard during the prepared window.
- Confirm idle audio creates no History item, file, provider traffic, or transcript.
- Confirm force-quit, expiry, interruptions, Bluetooth/route changes, lock, and permission revocation fall back honestly.

## Review confidence

The API boundary, state machine, privacy copy, and both build targets have focused coverage and compile successfully. Keep this draft for deep review around audio-session lifecycle and physical background behavior; those cannot be proven by compile-only or Simulator checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Quick Dictation with five-minute, app-managed microphone sessions started from the keyboard.
  * Added “Finish & Transcribe” controls, cancellation during startup, automatic transcript insertion, and no app switching during insertion.
  * Added session status, expiration recovery, microphone readiness checks, and user-facing error messages.
  * Updated keyboard setup guidance and Live Activity messaging.

* **Documentation**
  * Added Quick Dictation usage, privacy, lifecycle, permissions, and device testing guidance.

* **Tests**
  * Expanded coverage for handoff, expiration, finishing, transcript retention, and keyboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->