### PR TITLE
fix(ios): disable keyboard behind feature flag

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -10,9 +10,17 @@ on:
       build_number:
         description: 'Build number (auto-increments if empty)'
         required: false
+      include_keyboard:
+        description: 'Internal only: include the experimental custom keyboard extension'
+        required: false
+        default: false
+        type: boolean
 
 env:
   APP_STORE_CONNECT_KEY_ID: S747NJ9DZY
+  # Off by default. Auto Release dispatches only `version`, so production
+  # TestFlight archives omit the experimental keyboard unless explicitly opted in.
+  TUIST_IOS_KEYBOARD: ${{ inputs.include_keyboard && '1' || '0' }}
 
 jobs:
   build-and-upload:
@@ -79,30 +87,32 @@ jobs:
             echo "WIDGET_PROFILE_UUID=$WIDGET_PROFILE_UUID" >> $GITHUB_ENV
             echo "WIDGET_PROFILE_NAME=$WIDGET_PROFILE_NAME" >> $GITHUB_ENV
           fi
-          KEYBOARD_PROFILE_PATH=~/Library/MobileDevice/Provisioning\ Profiles/ios-keyboard-appstore.provisionprofile
-          if [ -n "$IOS_KEYBOARD_APPSTORE_PROFILE" ]; then
-            echo -n "$IOS_KEYBOARD_APPSTORE_PROFILE" | base64 --decode -o "$KEYBOARD_PROFILE_PATH"
-          else
-            APP_STORE_CONNECT_KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8 \
-              ruby scripts/create-ios-app-store-profile.rb \
-                --bundle-id com.justspeaktoit.ios.keyboard \
-                --bundle-name "JustSpeakToIt Keyboard" \
-                --capability APP_GROUPS \
-                --certificate-serial "$IOS_DISTRIBUTION_CERT_SERIAL" \
-                --profile-name "JustSpeakToIt Keyboard App Store" \
-                --output "$KEYBOARD_PROFILE_PATH"
+          if [ "$TUIST_IOS_KEYBOARD" = "1" ]; then
+            KEYBOARD_PROFILE_PATH=~/Library/MobileDevice/Provisioning\ Profiles/ios-keyboard-appstore.provisionprofile
+            if [ -n "$IOS_KEYBOARD_APPSTORE_PROFILE" ]; then
+              echo -n "$IOS_KEYBOARD_APPSTORE_PROFILE" | base64 --decode -o "$KEYBOARD_PROFILE_PATH"
+            else
+              APP_STORE_CONNECT_KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8 \
+                ruby scripts/create-ios-app-store-profile.rb \
+                  --bundle-id com.justspeaktoit.ios.keyboard \
+                  --bundle-name "JustSpeakToIt Keyboard" \
+                  --capability APP_GROUPS \
+                  --certificate-serial "$IOS_DISTRIBUTION_CERT_SERIAL" \
+                  --profile-name "JustSpeakToIt Keyboard App Store" \
+                  --output "$KEYBOARD_PROFILE_PATH"
+            fi
+            KEYBOARD_PROFILE_PLIST=$RUNNER_TEMP/ios-keyboard-appstore.plist
+            security cms -D -i "$KEYBOARD_PROFILE_PATH" > "$KEYBOARD_PROFILE_PLIST"
+            plutil -extract Entitlements xml1 -o - "$KEYBOARD_PROFILE_PLIST" \
+              | grep -Fq '<string>group.com.justspeaktoit.ios</string>' || {
+              echo "::error::Keyboard provisioning profile does not authorize group.com.justspeaktoit.ios. Associate that App Group with com.justspeaktoit.ios.keyboard in the Apple Developer portal, then rerun this workflow."
+              exit 1
+            }
+            KEYBOARD_PROFILE_UUID=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract UUID raw -)
+            KEYBOARD_PROFILE_NAME=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract Name raw -)
+            echo "KEYBOARD_PROFILE_UUID=$KEYBOARD_PROFILE_UUID" >> $GITHUB_ENV
+            echo "KEYBOARD_PROFILE_NAME=$KEYBOARD_PROFILE_NAME" >> $GITHUB_ENV
           fi
-          KEYBOARD_PROFILE_PLIST=$RUNNER_TEMP/ios-keyboard-appstore.plist
-          security cms -D -i "$KEYBOARD_PROFILE_PATH" > "$KEYBOARD_PROFILE_PLIST"
-          plutil -extract Entitlements xml1 -o - "$KEYBOARD_PROFILE_PLIST" \
-            | grep -Fq '<string>group.com.justspeaktoit.ios</string>' || {
-            echo "::error::Keyboard provisioning profile does not authorize group.com.justspeaktoit.ios. Associate that App Group with com.justspeaktoit.ios.keyboard in the Apple Developer portal, then rerun this workflow."
-            exit 1
-          }
-          KEYBOARD_PROFILE_UUID=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract UUID raw -)
-          KEYBOARD_PROFILE_NAME=$(security cms -D -i "$KEYBOARD_PROFILE_PATH" | plutil -extract Name raw -)
-          echo "KEYBOARD_PROFILE_UUID=$KEYBOARD_PROFILE_UUID" >> $GITHUB_ENV
-          echo "KEYBOARD_PROFILE_NAME=$KEYBOARD_PROFILE_NAME" >> $GITHUB_ENV
 
       - name: Generate Xcode Project
         run: tuist generate --no-open
@@ -123,9 +133,12 @@ jobs:
           widget_profile = os.environ.get("WIDGET_PROFILE_NAME", "")
           keyboard_profile = os.environ.get("KEYBOARD_PROFILE_NAME", "")
           team_id = os.environ.get("APPLE_TEAM_ID", "")
+          include_keyboard = os.environ.get("TUIST_IOS_KEYBOARD", "0") == "1"
 
-          if not app_profile or not widget_profile or not keyboard_profile:
-              raise SystemExit("Missing app/widget/keyboard provisioning profile names")
+          if not app_profile or not widget_profile:
+              raise SystemExit("Missing app/widget provisioning profile names")
+          if include_keyboard and not keyboard_profile:
+              raise SystemExit("Keyboard feature enabled without a keyboard provisioning profile name")
 
           pbx_path = Path("Just Speak to It.xcodeproj/project.pbxproj")
           text = pbx_path.read_text()
@@ -162,7 +175,7 @@ jobs:
                   settings = match.group("settings")
                   if "PRODUCT_BUNDLE_IDENTIFIER = com.justspeaktoit.ios.JustSpeakToItWidgetExtension;" in settings:
                       settings = patch_release_block(settings, widget_profile)
-                  elif "PRODUCT_BUNDLE_IDENTIFIER = com.justspeaktoit.ios.keyboard;" in settings:
+                  elif include_keyboard and "PRODUCT_BUNDLE_IDENTIFIER = com.justspeaktoit.ios.keyboard;" in settings:
                       settings = patch_release_block(settings, keyboard_profile)
                   elif "PRODUCT_BUNDLE_IDENTIFIER = com.justspeaktoit.ios;" in settings:
                       settings = patch_release_block(settings, app_profile)
@@ -251,30 +264,34 @@ jobs:
 
           APP_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_PATH/Info.plist")
           WIDGET_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$WIDGET_PATH/Info.plist")
-          KEYBOARD_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$KEYBOARD_PATH/Info.plist")
           APP_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_PATH/Info.plist")
           WIDGET_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$WIDGET_PATH/Info.plist")
-          KEYBOARD_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$KEYBOARD_PATH/Info.plist")
 
           [ "$APP_VERSION" = "$VERSION" ] || { echo "App version mismatch: expected '$VERSION', got '$APP_VERSION'"; exit 1; }
           [ "$WIDGET_VERSION" = "$VERSION" ] || { echo "Widget version mismatch: expected '$VERSION', got '$WIDGET_VERSION'"; exit 1; }
-          [ "$KEYBOARD_VERSION" = "$VERSION" ] || { echo "Keyboard version mismatch: expected '$VERSION', got '$KEYBOARD_VERSION'"; exit 1; }
           [ "$APP_BUILD" = "$BUILD_NUMBER" ] || { echo "App build mismatch: expected '$BUILD_NUMBER', got '$APP_BUILD'"; exit 1; }
           [ "$WIDGET_BUILD" = "$BUILD_NUMBER" ] || { echo "Widget build mismatch: expected '$BUILD_NUMBER', got '$WIDGET_BUILD'"; exit 1; }
-          [ "$KEYBOARD_BUILD" = "$BUILD_NUMBER" ] || { echo "Keyboard build mismatch: expected '$BUILD_NUMBER', got '$KEYBOARD_BUILD'"; exit 1; }
+
+          if [ "$TUIST_IOS_KEYBOARD" = "1" ]; then
+            KEYBOARD_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$KEYBOARD_PATH/Info.plist")
+            KEYBOARD_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$KEYBOARD_PATH/Info.plist")
+            [ "$KEYBOARD_VERSION" = "$VERSION" ] || { echo "Keyboard version mismatch: expected '$VERSION', got '$KEYBOARD_VERSION'"; exit 1; }
+            [ "$KEYBOARD_BUILD" = "$BUILD_NUMBER" ] || { echo "Keyboard build mismatch: expected '$BUILD_NUMBER', got '$KEYBOARD_BUILD'"; exit 1; }
+          else
+            [ ! -e "$KEYBOARD_PATH" ] || {
+              echo "::error::Keyboard feature is off, but JustSpeakKeyboard.appex was embedded in the archive."
+              exit 1
+            }
+          fi
 
           codesign -d --entitlements - --xml "$APP_PATH" > "$RUNNER_TEMP/app-entitlements.plist"
           codesign -d --entitlements - --xml "$WIDGET_PATH" > "$RUNNER_TEMP/widget-entitlements.plist"
-          codesign -d --entitlements - --xml "$KEYBOARD_PATH" > "$RUNNER_TEMP/keyboard-entitlements.plist"
           APP_GROUP=$(/usr/libexec/PlistBuddy \
             -c 'Print :com.apple.security.application-groups:0' \
             "$RUNNER_TEMP/app-entitlements.plist" 2>/dev/null || true)
           WIDGET_GROUP=$(/usr/libexec/PlistBuddy \
             -c 'Print :com.apple.security.application-groups:0' \
             "$RUNNER_TEMP/widget-entitlements.plist" 2>/dev/null || true)
-          KEYBOARD_GROUP=$(/usr/libexec/PlistBuddy \
-            -c 'Print :com.apple.security.application-groups:0' \
-            "$RUNNER_TEMP/keyboard-entitlements.plist" 2>/dev/null || true)
           APP_ICLOUD_CONTAINER=$(/usr/libexec/PlistBuddy \
             -c 'Print :com.apple.developer.icloud-container-identifiers:0' \
             "$RUNNER_TEMP/app-entitlements.plist" 2>/dev/null || true)
@@ -283,8 +300,14 @@ jobs:
             || { echo "App group mismatch: expected 'group.com.justspeaktoit.ios', got '${APP_GROUP:-missing}'"; exit 1; }
           [ "$WIDGET_GROUP" = "group.com.justspeaktoit.ios" ] \
             || { echo "Widget group mismatch: expected 'group.com.justspeaktoit.ios', got '${WIDGET_GROUP:-missing}'"; exit 1; }
-          [ "$KEYBOARD_GROUP" = "group.com.justspeaktoit.ios" ] \
-            || { echo "Keyboard group mismatch: expected 'group.com.justspeaktoit.ios', got '${KEYBOARD_GROUP:-missing}'"; exit 1; }
+          if [ "$TUIST_IOS_KEYBOARD" = "1" ]; then
+            codesign -d --entitlements - --xml "$KEYBOARD_PATH" > "$RUNNER_TEMP/keyboard-entitlements.plist"
+            KEYBOARD_GROUP=$(/usr/libexec/PlistBuddy \
+              -c 'Print :com.apple.security.application-groups:0' \
+              "$RUNNER_TEMP/keyboard-entitlements.plist" 2>/dev/null || true)
+            [ "$KEYBOARD_GROUP" = "group.com.justspeaktoit.ios" ] \
+              || { echo "Keyboard group mismatch: expected 'group.com.justspeaktoit.ios', got '${KEYBOARD_GROUP:-missing}'"; exit 1; }
+          fi
           [ "$APP_ICLOUD_CONTAINER" = "iCloud.com.justspeaktoit.ios" ] \
             || { echo "iCloud container mismatch: expected 'iCloud.com.justspeaktoit.ios', got '${APP_ICLOUD_CONTAINER:-missing}'"; exit 1; }
 
@@ -295,7 +318,6 @@ jobs:
         run: |
           APP_PROFILE_UUID=$(security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/ios-appstore.provisionprofile" | plutil -extract UUID raw -)
           WIDGET_PROFILE_UUID=$(security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/ios-widget-appstore.provisionprofile" | plutil -extract UUID raw -)
-          KEYBOARD_PROFILE_UUID=$(security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/ios-keyboard-appstore.provisionprofile" | plutil -extract UUID raw -)
           cat > ExportOptions.plist << 'PLIST'
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -315,8 +337,6 @@ jobs:
                   <string>APP_PROFILE_UUID_PLACEHOLDER</string>
                   <key>com.justspeaktoit.ios.JustSpeakToItWidgetExtension</key>
                   <string>WIDGET_PROFILE_UUID_PLACEHOLDER</string>
-                  <key>com.justspeaktoit.ios.keyboard</key>
-                  <string>KEYBOARD_PROFILE_UUID_PLACEHOLDER</string>
               </dict>
               <key>uploadSymbols</key>
               <true/>
@@ -329,7 +349,12 @@ jobs:
           sed -i '' "s/APPLE_TEAM_ID_PLACEHOLDER/${APPLE_TEAM_ID}/g" ExportOptions.plist
           sed -i '' "s/APP_PROFILE_UUID_PLACEHOLDER/${APP_PROFILE_UUID}/g" ExportOptions.plist
           sed -i '' "s/WIDGET_PROFILE_UUID_PLACEHOLDER/${WIDGET_PROFILE_UUID}/g" ExportOptions.plist
-          sed -i '' "s/KEYBOARD_PROFILE_UUID_PLACEHOLDER/${KEYBOARD_PROFILE_UUID}/g" ExportOptions.plist
+          if [ "$TUIST_IOS_KEYBOARD" = "1" ]; then
+            KEYBOARD_PROFILE_UUID=$(security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/ios-keyboard-appstore.provisionprofile" | plutil -extract UUID raw -)
+            /usr/libexec/PlistBuddy \
+              -c "Add :provisioningProfiles:com.justspeaktoit.ios.keyboard string $KEYBOARD_PROFILE_UUID" \
+              ExportOptions.plist
+          fi
           
           xcodebuild -exportArchive \
             -archivePath build/SpeakiOS.xcarchive \

--- a/Docs/ios-keyboard-instant-dictation.md
+++ b/Docs/ios-keyboard-instant-dictation.md
@@ -1,5 +1,12 @@
 # iOS Keyboard Instant Dictation
 
+> **Shipping status:** disabled. Default local, CI, archive, and TestFlight
+> builds do not include the custom keyboard extension or expose its setup UI.
+> Internal development requires `TUIST_IOS_KEYBOARD=1 tuist generate`; a manual
+> TestFlight run additionally requires the off-by-default `include_keyboard`
+> input. Do not enable either flag until the physical-device release matrix and
+> product-quality review pass.
+
 ## Product decision
 
 Just Speak uses an explicitly enabled, foreground-started **Instant Dictation**

--- a/Docs/ios-keyboard-mvp-verification.md
+++ b/Docs/ios-keyboard-mvp-verification.md
@@ -1,5 +1,9 @@
 # iOS Custom Keyboard MVP Verification
 
+The keyboard is currently an internal, off-by-default feature. Generate with
+`TUIST_IOS_KEYBOARD=1 tuist generate` before running this matrix. A normal
+project generation or TestFlight release must omit `JustSpeakKeyboard.appex`.
+
 For the always-ready background-microphone architecture and its additional
 device matrix, also follow [iOS Keyboard Instant Dictation](ios-keyboard-instant-dictation.md).
 

--- a/Project.swift
+++ b/Project.swift
@@ -22,13 +22,31 @@ var iosAppSettings: [String: SettingValue] = [
     "MARKETING_VERSION": "\(version)"
 ]
 
-// Build-time feature flag: the OpenClaw tab is hidden by default (App Store
-// builds ship without it). Generate the project with `SHOW_OPENCLAW_TAB=1
-// tuist generate` to bring the tab back for internal testing. Gated in code via
-// the `SHOW_OPENCLAW_TAB` Swift active compilation condition (see
-// SpeakiOSApp/FeatureFlags.swift).
+// Build-time feature flags for iOS. Both features are hidden by default.
+// `TUIST_IOS_KEYBOARD=1 tuist generate` is the only way to include the custom
+// keyboard extension in the generated project and host app. The matching Swift
+// condition gates app activation and setup UI (see SpeakiOSApp/FeatureFlags.swift).
+let iosKeyboardFlag = (ProcessInfo.processInfo.environment["TUIST_IOS_KEYBOARD"] ?? "").lowercased()
+let isIOSKeyboardEnabled = ["1", "true", "yes"].contains(iosKeyboardFlag)
+var iosActiveCompilationConditions: [String] = []
+var iosTestSettings: [String: SettingValue] = [:]
+var iosTestResourceElements: [ResourceFileElement] = [
+    "SpeakiOS.entitlements",
+    "JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtension.entitlements"
+]
+
 if ProcessInfo.processInfo.environment["SHOW_OPENCLAW_TAB"] != nil {
-    iosAppSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) SHOW_OPENCLAW_TAB"
+    iosActiveCompilationConditions.append("SHOW_OPENCLAW_TAB")
+}
+if isIOSKeyboardEnabled {
+    iosActiveCompilationConditions.append("IOS_KEYBOARD_FEATURE")
+    iosTestSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) IOS_KEYBOARD_FEATURE"
+    iosTestResourceElements.append("JustSpeakKeyboard/JustSpeakKeyboard.entitlements")
+}
+if !iosActiveCompilationConditions.isEmpty {
+    iosAppSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = .string(
+        "$(inherited) \(iosActiveCompilationConditions.joined(separator: " "))"
+    )
 }
 
 // Distribution channel selection for macOS. The app compiles from one codebase into
@@ -213,11 +231,11 @@ let project = Project(
                 .package(product: "SpeakCore"),
                 .package(product: "SpeakiOSLib"),
                 .package(product: "SpeakSync"),
-                .target(name: "JustSpeakToItWidgetExtension"),
-                .target(name: "JustSpeakKeyboard")
-            ],
+                .target(name: "JustSpeakToItWidgetExtension")
+            ] + (isIOSKeyboardEnabled ? [.target(name: "JustSpeakKeyboard")] : []),
             settings: .settings(base: iosAppSettings)
-        ),
+        )
+    ] + (isIOSKeyboardEnabled ? [
         .target(
             name: "JustSpeakKeyboard",
             destinations: .iOS,
@@ -231,7 +249,8 @@ let project = Project(
                 .package(product: "SpeakCore")
             ],
             settings: .settings(base: iosKeyboardSettings)
-        ),
+        )
+    ] : []) + [
         .target(
             name: "JustSpeakToItWidgetExtension",
             destinations: .iOS,
@@ -266,7 +285,8 @@ let project = Project(
             sources: ["Tests/SpeakiOSUITests/**"],
             dependencies: [
                 .target(name: "SpeakiOS")
-            ]
+            ],
+            settings: .settings(base: iosTestSettings)
         ),
         .target(
             name: "SpeakiOSTests",
@@ -275,16 +295,13 @@ let project = Project(
             bundleId: "com.justspeaktoit.ios.tests",
             deploymentTargets: .iOS("17.0"),
             sources: ["Tests/SpeakiOSTests/**"],
-            resources: [
-                "SpeakiOS.entitlements",
-                "JustSpeakToItWidgetExtension/JustSpeakToItWidgetExtension.entitlements",
-                "JustSpeakKeyboard/JustSpeakKeyboard.entitlements"
-            ],
+            resources: .resources(iosTestResourceElements),
             dependencies: [
                 .target(name: "SpeakiOS"),
                 .package(product: "SpeakCore"),
                 .package(product: "SpeakiOSLib")
-            ]
+            ],
+            settings: .settings(base: iosTestSettings)
         )
     ]
 )

--- a/Sources/SpeakiOS/Views/KeyboardVisibility.swift
+++ b/Sources/SpeakiOS/Views/KeyboardVisibility.swift
@@ -1,0 +1,19 @@
+#if os(iOS)
+import SwiftUI
+
+/// Environment flag controlling whether custom-keyboard surfaces are visible.
+///
+/// The library defaults to `false`, so a host cannot accidentally expose setup
+/// UI without deliberately enabling the matching extension build flag.
+private struct IOSKeyboardEnabledKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+public extension EnvironmentValues {
+    /// Whether the custom keyboard extension is included in this app build.
+    var iOSKeyboardEnabled: Bool {
+        get { self[IOSKeyboardEnabledKey.self] }
+        set { self[IOSKeyboardEnabledKey.self] = newValue }
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Views/SettingsView.swift
+++ b/Sources/SpeakiOS/Views/SettingsView.swift
@@ -668,6 +668,7 @@ public struct SettingsView: View {
     @StateObject private var settings = AppSettings.shared
     @Environment(\.openURL) private var openURL
     @Environment(\.openClawEnabled) private var openClawEnabled
+    @Environment(\.iOSKeyboardEnabled) private var iOSKeyboardEnabled
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var showingAPIKeys = false
     @State private var missingTranscriptionAPIKeyAlert: IOSMissingTranscriptionAPIKeyAlert?
@@ -853,23 +854,25 @@ public struct SettingsView: View {
                 }
             }
 
-            Section("Just Speak Keyboard") {
-                NavigationLink {
-                    KeyboardSetupView()
-                } label: {
-                    HStack {
-                        Label("Set Up Keyboard", systemImage: "keyboard")
-                        Spacer()
-                        Text(keyboardStatusLabel)
+            if iOSKeyboardEnabled {
+                Section("Just Speak Keyboard") {
+                    NavigationLink {
+                        KeyboardSetupView()
+                    } label: {
+                        HStack {
+                            Label("Set Up Keyboard", systemImage: "keyboard")
+                            Spacer()
+                            Text(keyboardStatusLabel)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .accessibilityIdentifier("keyboardSetupLink")
+
+                    if !usesInlineDensityLayout {
+                        Text("Transcribe into other apps through a private handoff to Just Speak.")
+                            .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                }
-                .accessibilityIdentifier("keyboardSetupLink")
-
-                if !usesInlineDensityLayout {
-                    Text("Transcribe into other apps through a private handoff to Just Speak.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                 }
             }
 

--- a/SpeakiOSApp/FeatureFlags.swift
+++ b/SpeakiOSApp/FeatureFlags.swift
@@ -11,6 +11,18 @@ import Foundation
 /// (see `Project.swift`, which maps the env var to the
 /// `SHOW_OPENCLAW_TAB` compilation condition).
 enum FeatureFlags {
+    /// Whether the custom keyboard extension and its app-owned readiness flow
+    /// are enabled. Defaults to `false`; `Project.swift` includes the extension
+    /// and defines `IOS_KEYBOARD_FEATURE` only when generated with
+    /// `TUIST_IOS_KEYBOARD=1`.
+    static var iOSKeyboardEnabled: Bool {
+        #if IOS_KEYBOARD_FEATURE
+        true
+        #else
+        false
+        #endif
+    }
+
     /// Whether the OpenClaw tab is shown in the main tab bar. Defaults to
     /// `false` (hidden) so App Store builds ship without it; set the
     /// `SHOW_OPENCLAW_TAB` build condition to bring the tab back (e.g. for

--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -75,14 +75,19 @@ struct SpeakiOSApp: App {
                 .tint(.brandAccent)
                 .environmentObject(deepLinkRouter)
                 .environment(\.openClawEnabled, FeatureFlags.openClawTabEnabled)
+                .environment(\.iOSKeyboardEnabled, FeatureFlags.iOSKeyboardEnabled)
                 .onOpenURL { url in
                     deepLinkRouter.handle(url)
                 }
                 .task {
+                    guard FeatureFlags.iOSKeyboardEnabled else {
+                        KeyboardInstantDictationStore.shared.setEnabled(false)
+                        return
+                    }
                     keyboardInstantDictation.activate()
                 }
                 .onChange(of: scenePhase) { _, newPhase in
-                    guard newPhase == .active else { return }
+                    guard FeatureFlags.iOSKeyboardEnabled, newPhase == .active else { return }
                     keyboardInstantDictation.activate()
                 }
         }

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import XCTest
 
+// swiftlint:disable:next type_body_length
 final class DistributionBuildIdentityTests: XCTestCase {
     private var repositoryRoot: URL {
         URL(fileURLWithPath: #filePath)
@@ -87,7 +88,11 @@ final class DistributionBuildIdentityTests: XCTestCase {
 
         XCTAssertTrue(iosTarget.contains("sources: [\"SpeakiOSApp/**\"]"))
         XCTAssertTrue(iosTarget.contains(".package(product: \"SpeakiOSLib\")"))
-        XCTAssertTrue(iosTarget.contains(".target(name: \"JustSpeakKeyboard\")"))
+        XCTAssertTrue(
+            iosTarget.contains(
+                "] + (isIOSKeyboardEnabled ? [.target(name: \"JustSpeakKeyboard\")] : [])"
+            )
+        )
         XCTAssertFalse(iosTarget.contains("Sources/SpeakApp"))
         XCTAssertFalse(iosTarget.contains("SpeakHotKeys"))
         XCTAssertFalse(iosTarget.contains("Sparkle"))
@@ -111,6 +116,41 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(infoPlist.contains("com.apple.keyboard-service"))
         XCTAssertTrue(infoPlist.contains("RequestsOpenAccess"))
         XCTAssertTrue(infoPlist.contains("$(PRODUCT_MODULE_NAME).KeyboardViewController"))
+    }
+
+    func testIOSKeyboardIsAnExplicitOffByDefaultBuildFeature() throws {
+        let manifest = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("Project.swift"),
+            encoding: .utf8
+        )
+        let featureFlags = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("SpeakiOSApp/FeatureFlags.swift"),
+            encoding: .utf8
+        )
+        let app = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("SpeakiOSApp/SpeakiOSApp.swift"),
+            encoding: .utf8
+        )
+        let settings = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("Sources/SpeakiOS/Views/SettingsView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(manifest.contains("environment[\"TUIST_IOS_KEYBOARD\"] ?? \"\""))
+        XCTAssertTrue(manifest.contains("let isIOSKeyboardEnabled = [\"1\", \"true\", \"yes\"]"))
+        XCTAssertTrue(manifest.contains("isIOSKeyboardEnabled ? ["))
+        XCTAssertTrue(manifest.contains("iosActiveCompilationConditions.append(\"IOS_KEYBOARD_FEATURE\")"))
+        XCTAssertTrue(manifest.contains("settings: .settings(base: iosTestSettings)"))
+        XCTAssertTrue(
+            manifest.contains(
+                "iosTestResourceElements.append(\"JustSpeakKeyboard/JustSpeakKeyboard.entitlements\")"
+            )
+        )
+        XCTAssertTrue(featureFlags.contains("#if IOS_KEYBOARD_FEATURE"))
+        XCTAssertTrue(featureFlags.contains("static var iOSKeyboardEnabled: Bool"))
+        XCTAssertTrue(app.contains("guard FeatureFlags.iOSKeyboardEnabled else"))
+        XCTAssertTrue(app.contains("KeyboardInstantDictationStore.shared.setEnabled(false)"))
+        XCTAssertTrue(settings.contains("if iOSKeyboardEnabled"))
     }
 
     func testIOSKeyboardUsesInstantSessionLivePreviewAndRetainsHistory() throws {
@@ -157,12 +197,25 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(workflow.contains("plutil -extract Entitlements xml1"))
         XCTAssertTrue(workflow.contains("<string>group.com.justspeaktoit.ios</string>"))
         XCTAssertFalse(workflow.contains("Entitlements.com.apple.security.application-groups.0"))
-        XCTAssertTrue(workflow.contains("KEYBOARD_PROFILE_UUID_PLACEHOLDER"))
+        XCTAssertFalse(workflow.contains("KEYBOARD_PROFILE_UUID_PLACEHOLDER"))
+        XCTAssertTrue(
+            workflow.contains(
+                "Add :provisioningProfiles:com.justspeaktoit.ios.keyboard string $KEYBOARD_PROFILE_UUID"
+            )
+        )
         XCTAssertTrue(workflow.contains("JustSpeakKeyboard.appex"))
         XCTAssertTrue(workflow.contains("keyboard-entitlements.plist"))
         XCTAssertTrue(workflow.contains("APP_ICLOUD_CONTAINER"))
         XCTAssertTrue(workflow.contains("iCloud container mismatch"))
         XCTAssertTrue(workflow.contains("iCloud.com.justspeaktoit.ios"))
+        XCTAssertTrue(workflow.contains("TUIST_IOS_KEYBOARD: ${{ inputs.include_keyboard && '1' || '0' }}"))
+        XCTAssertTrue(workflow.contains("Keyboard feature is off, but JustSpeakKeyboard.appex was embedded"))
+
+        let keyboardInputStart = try XCTUnwrap(workflow.range(of: "      include_keyboard:\n")?.lowerBound)
+        let environmentStart = try XCTUnwrap(workflow.range(of: "\nenv:\n")?.lowerBound)
+        let keyboardInput = workflow[keyboardInputStart..<environmentStart]
+        XCTAssertTrue(keyboardInput.contains("default: false"))
+        XCTAssertTrue(keyboardInput.contains("type: boolean"))
 
         let profileBootstrap = try String(
             contentsOf: repositoryRoot.appendingPathComponent("scripts/create-ios-app-store-profile.rb"),

--- a/Tests/SpeakiOSTests/AppGroupConfigurationTests.swift
+++ b/Tests/SpeakiOSTests/AppGroupConfigurationTests.swift
@@ -19,12 +19,14 @@ final class AppGroupConfigurationTests: XCTestCase {
         XCTAssertTrue(entitledGroups.contains(SharedTranscriptionState.appGroupIdentifier))
     }
 
+    #if IOS_KEYBOARD_FEATURE
     func testKeyboardUsesSameEntitledAppGroup() throws {
         let entitledGroups = try appGroups(inResourceNamed: "JustSpeakKeyboard")
 
         XCTAssertEqual(KeyboardHandoffStore.appGroupIdentifier, SharedTranscriptionState.appGroupIdentifier)
         XCTAssertTrue(entitledGroups.contains(KeyboardHandoffStore.appGroupIdentifier))
     }
+    #endif
 
     private func appGroups(inResourceNamed resourceName: String) throws -> [String] {
         let entitlementsURL = try XCTUnwrap(

--- a/Tests/SpeakiOSTests/PlatformFeatureVisibilityTests.swift
+++ b/Tests/SpeakiOSTests/PlatformFeatureVisibilityTests.swift
@@ -1,11 +1,16 @@
 #if os(iOS)
 import SpeakCore
+import SwiftUI
 import XCTest
 
 @testable import SpeakiOSLib
 
 @MainActor
 final class PlatformFeatureVisibilityTests: XCTestCase {
+    func testKeyboardFeatureEnvironmentDefaultsOff() {
+        XCTAssertFalse(EnvironmentValues().iOSKeyboardEnabled)
+    }
+
     func testRemoteLivePicker_omitsProvidersWithoutAnIOSImplementation() {
         let visibleModels = AppSettings.supportedLiveModels
         let visibleIDs = Set(visibleModels.map(\.id))

--- a/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
+++ b/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
@@ -65,6 +65,7 @@ final class ActionButtonSettingsUITests: XCTestCase {
         XCTAssertTrue(readyOrMissingStatus.waitForExistence(timeout: 5))
     }
 
+    #if IOS_KEYBOARD_FEATURE
     func testKeyboardOnboardingExplainsSupportedSetup() {
         app.buttons["Settings"].tap()
 
@@ -77,6 +78,13 @@ final class ActionButtonSettingsUITests: XCTestCase {
         XCTAssertTrue(scrollUpUntilExists(app.staticTexts["Why Full Access?"]))
         XCTAssertTrue(scrollUpUntilExists(app.staticTexts["Where It Won’t Appear"]))
     }
+    #else
+    func testKeyboardOnboardingIsHiddenWhenFeatureIsDisabled() {
+        app.buttons["Settings"].tap()
+
+        XCTAssertFalse(scrollUpUntilExists(app.buttons["keyboardSetupLink"]))
+    }
+    #endif
 
     private func scrollUpUntilExists(_ element: XCUIElement, maxSwipes: Int = 6) -> Bool {
         if element.waitForExistence(timeout: 1) {


### PR DESCRIPTION
## Motivation

The current custom-keyboard experience is not good enough to ship. The keyboard must be absent from normal app and TestFlight builds while we rethink the interaction model, without deleting the experimental work.

## What changed

- Added one authoritative, off-by-default `TUIST_IOS_KEYBOARD` build flag.
- Default Tuist generation omits the keyboard target, scheme, entitlement resource, host dependency, and embedded extension.
- Hid keyboard setup and stopped/cleared Instant Dictation readiness when the feature is disabled.
- Added an explicit `include_keyboard` manual TestFlight input for internal opt-in builds.
- Made signing/export/archive checks conditional and added a hard failure if a default archive unexpectedly contains `JustSpeakKeyboard.appex`.
- Documented the shipping status and preserved the physical-device matrix for future internal work.

## Things we learned that changed the direction

The supported handoff implementation does not deliver the keyboard-first, near-instant dictation experience users expect. Shipping the extension now would expose setup and lifecycle friction before the UX meets the product bar, so the safer contract is to omit it completely unless an internal build deliberately opts in.

## How to test

- `tuist generate --no-open`
  - no `JustSpeakKeyboard` scheme, target, entitlement, bundle ID, or product appears
- Default generic iOS Simulator build succeeds
  - built app contains `JustSpeakToItWidgetExtension.appex` only
- Focused Simulator tests:
  - `AppGroupConfigurationTests`
  - `PlatformFeatureVisibilityTests`
- `TUIST_IOS_KEYBOARD=1 tuist generate --no-open`
  - keyboard target and `IOS_KEYBOARD_FEATURE` return
- Release workflow YAML, keyboard plist, SwiftLint, and diff checks pass

## Review confidence

High confidence in the default-off containment path. The opt-in path was generation-verified, but the keyboard itself remains experimental and still requires the separate physical-device UX matrix before it can ship.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional iOS custom keyboard feature that can be enabled for internal builds and TestFlight releases.
  * Keyboard setup controls and instant dictation activation are available only when the feature is enabled.
  * Added safeguards to validate keyboard provisioning, signing, entitlements, and App Group configuration when enabled.

* **Bug Fixes**
  * Ensured the keyboard is disabled by default and excluded from standard builds and releases.

* **Documentation**
  * Documented the keyboard’s off-by-default shipping status and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->