### PR TITLE
feat(mac): simplify local model setup

### DIFF
--- a/Sources/SpeakApp/LocalTranscriptionStarterPreset.swift
+++ b/Sources/SpeakApp/LocalTranscriptionStarterPreset.swift
@@ -1,0 +1,100 @@
+import SpeakCore
+
+struct LocalTranscriptionStarterPreset: Identifiable, Equatable {
+  enum PresetID: String, Hashable {
+    case parakeetStreaming
+    case whisperKitStreaming
+    case whisperKitBatch
+  }
+
+  enum Engine: Equatable {
+    case parakeet
+    case whisperKit(LocalTranscriptionModel)
+  }
+
+  let id: PresetID
+  let mode: AppSettings.LocalTranscriptionMode
+  let engine: Engine
+  let recommendation: String
+  let detail: String
+  let runtime: String
+  let approximateSizeMB: Int
+
+  var displayName: String {
+    switch engine {
+    case .parakeet:
+      return FluidAudioParakeetModel.displayName
+    case .whisperKit(let model):
+      return model.displayName
+    }
+  }
+
+  static func recommended(
+    for mode: AppSettings.LocalTranscriptionMode,
+    availableModels: [LocalTranscriptionModel],
+    supportsParakeet: Bool
+  ) -> [Self] {
+    let whisperKitModel = preferredWhisperKitModel(
+      from: availableModels,
+      requiresStreaming: mode == .streaming
+    )
+
+    switch mode {
+    case .streaming:
+      var presets: [Self] = []
+      if supportsParakeet {
+        presets.append(
+          Self(
+            id: .parakeetStreaming,
+            mode: .streaming,
+            engine: .parakeet,
+            recommendation: "Fastest for English",
+            detail: FluidAudioParakeetModel.description,
+            runtime: FluidAudioParakeetModel.runtimeName,
+            approximateSizeMB: FluidAudioParakeetModel.approximateSizeMB
+          )
+        )
+      }
+      if let whisperKitModel {
+        presets.append(
+          Self(
+            id: .whisperKitStreaming,
+            mode: .streaming,
+            engine: .whisperKit(whisperKitModel),
+            recommendation: "Best for multilingual dictation",
+            detail: whisperKitModel.description,
+            runtime: "WhisperKit / Core ML",
+            approximateSizeMB: whisperKitModel.approximateSizeMB
+          )
+        )
+      }
+      return presets
+    case .batch:
+      guard let whisperKitModel else { return [] }
+      return [
+        Self(
+          id: .whisperKitBatch,
+          mode: .batch,
+          engine: .whisperKit(whisperKitModel),
+          recommendation: "Best quality for finished recordings",
+          detail: whisperKitModel.description,
+          runtime: "WhisperKit / Core ML",
+          approximateSizeMB: whisperKitModel.approximateSizeMB
+        )
+      ]
+    }
+  }
+
+  static func preferredWhisperKitModel(
+    from availableModels: [LocalTranscriptionModel],
+    requiresStreaming: Bool
+  ) -> LocalTranscriptionModel? {
+    let candidates = availableModels.filter { model in
+      model.engine == .whisperKit && (!requiresStreaming || model.supportsLiveStreaming)
+    }
+    return candidates.first { $0.tags.contains(.leading) }
+      ?? candidates.first { $0.tags.contains(.quality) && $0.tags.contains(.fast) }
+      ?? candidates.first { $0.tags.contains(.quality) }
+      ?? candidates.first
+  }
+}

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -117,6 +117,7 @@ struct SettingsView: View {
   @State private var huggingFaceRepoID: String = "argmaxinc/whisperkit-coreml"
   @State private var huggingFaceModelName: String = "tiny"
   @State private var huggingFaceImportError: String?
+  @State private var isLocalTranscriptionAdvancedExpanded = false
   #if !APP_STORE
   @State private var streamingHuggingFaceRepoID: String =
     "csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26"
@@ -174,6 +175,13 @@ struct SettingsView: View {
       case .downloaded: return "Downloaded Model"
       }
     }
+  }
+
+  private enum StarterPresetInstallState: Equatable {
+    case notInstalled
+    case installing
+    case installed
+    case failed(String)
   }
 
   private let orderedLocalTranscriptionModes: [AppSettings.LocalTranscriptionMode] = {
@@ -1805,65 +1813,91 @@ struct SettingsView: View {
             )
 
             Text(
-              {
-                #if APP_STORE
-                return """
-                Downloaded transcription is separate from Apple Speech and cloud providers. \
-                WhisperKit/Core ML model data runs in-process and is supported in this App Store build.
-                """
-                #else
-                return """
-                Downloaded transcription is separate from Apple Speech and cloud providers. \
-                Local Batch uses in-process WhisperKit/Core ML model data. Local Streaming can use \
-                in-process FluidAudio/Core ML or an optional external sherpa-onnx runtime.
-                """
-                #endif
-              }()
+              "Choose a ready-made setup below. Speak will select the right local mode "
+                + "and download everything it needs."
             )
             .font(.caption)
             .foregroundStyle(.secondary)
 
-            if !DistributionChannel.current.supportsExternalLocalModelRuntime {
-              localRuntimeUnavailableNote
-            }
+            localModelStarterSetup
 
-            localModelQuickStart
-            if settings.localTranscriptionMode == .batch {
-              selectedLocalModelCallout
-            }
-
-            if settings.localTranscriptionMode == .batch {
-              huggingFaceModelImport
-            } else {
-              localStreamingStatus
-            }
-
-            if settings.localTranscriptionMode == .batch {
-              if localTranscriptionOptions.isEmpty {
-                Label(
-                  "Download a local batch model before selecting it for recording.",
-                  systemImage: "arrow.down.circle"
+            DisclosureGroup(isExpanded: $isLocalTranscriptionAdvancedExpanded) {
+              VStack(alignment: .leading, spacing: 16) {
+                Text(
+                  {
+                    #if APP_STORE
+                    return """
+                    Downloaded transcription is separate from Apple Speech and cloud providers. \
+                    WhisperKit/Core ML model data runs in-process and is supported in this App Store build.
+                    """
+                    #else
+                    return """
+                    Downloaded transcription is separate from Apple Speech and cloud providers. \
+                    Local Batch uses in-process WhisperKit/Core ML model data. Local Streaming can use \
+                    in-process FluidAudio/Core ML or an optional external sherpa-onnx runtime.
+                    """
+                    #endif
+                  }()
                 )
-                  .font(.caption)
-                  .foregroundStyle(.orange)
-              } else {
-                ModelPicker(
-                  title: "Local Batch Model",
-                  help: "Used for local-only transcription after recording stops.",
-                  options: localTranscriptionOptions,
-                  value: localTranscriptionModelBinding,
-                  credentialPurpose: .batchTranscription,
-                  storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
-                  allowsCustom: false
-                )
-              }
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
-              VStack(spacing: 10) {
-                ForEach(localTranscriptionModels) { model in
-                  localModelRow(model)
+                if !DistributionChannel.current.supportsExternalLocalModelRuntime {
+                  localRuntimeUnavailableNote
+                }
+
+                localModelQuickStart
+                if settings.localTranscriptionMode == .batch {
+                  selectedLocalModelCallout
+                  huggingFaceModelImport
+                } else {
+                  localStreamingStatus
+                }
+
+                if settings.localTranscriptionMode == .batch {
+                  if localTranscriptionOptions.isEmpty {
+                    Label(
+                      "Download a local batch model before selecting it for recording.",
+                      systemImage: "arrow.down.circle"
+                    )
+                      .font(.caption)
+                      .foregroundStyle(.orange)
+                  } else {
+                    ModelPicker(
+                      title: "Local Batch Model",
+                      help: "Used for local-only transcription after recording stops.",
+                      options: localTranscriptionOptions,
+                      value: localTranscriptionModelBinding,
+                      credentialPurpose: .batchTranscription,
+                      storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
+                      allowsCustom: false
+                    )
+                  }
+
+                  VStack(spacing: 10) {
+                    ForEach(localTranscriptionModels) { model in
+                      localModelRow(model)
+                    }
+                  }
                 }
               }
+              .padding(.top, 12)
+            } label: {
+              Label("Advanced model configuration", systemImage: "slider.horizontal.3")
+                .font(.subheadline.weight(.semibold))
             }
+            .padding(12)
+            .background(
+              RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.65))
+            )
+            .overlay(
+              RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.secondary.opacity(0.16), lineWidth: 1)
+            )
+            .speakTooltip(
+              "Show every downloaded model, custom Hugging Face sources, runtime controls, and manual selection."
+            )
           }
         }
         .speakTooltip("Download and manage private local transcription models.")
@@ -1872,6 +1906,209 @@ struct SettingsView: View {
       if settings.hasSelectedModulateModel {
         modulateFeatureSettings
       }
+    }
+  }
+
+  private var localModelStarterSetup: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .top, spacing: 10) {
+        Image(systemName: "wand.and.stars")
+          .foregroundStyle(Color.green)
+          .frame(width: 24)
+        VStack(alignment: .leading, spacing: 3) {
+          Text(settings.localTranscriptionMode == .streaming ? "Quick streaming setup" : "Quick batch setup")
+            .font(.subheadline.weight(.semibold))
+          Text(
+            settings.localTranscriptionMode == .streaming
+              ? "Choose fast English streaming or high-quality multilingual streaming."
+              : "Use the recommended high-quality model after each recording finishes."
+          )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+
+      VStack(spacing: 10) {
+        ForEach(localStarterPresets) { preset in
+          localStarterPresetRow(preset)
+        }
+      }
+    }
+    .padding(12)
+    .background(
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .fill(Color.green.opacity(0.08))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .stroke(Color.green.opacity(0.2), lineWidth: 1)
+    )
+  }
+
+  private func localStarterPresetRow(_ preset: LocalTranscriptionStarterPreset) -> some View {
+    let state = starterPresetInstallState(for: preset)
+    let isSelected = isStarterPresetSelected(preset)
+    return localModelRowContainer(isSelected: isSelected, tint: .green) {
+      HStack(alignment: .top, spacing: 12) {
+        Image(systemName: starterPresetIcon(for: preset))
+          .foregroundStyle(Color.green)
+          .frame(width: 24)
+
+        VStack(alignment: .leading, spacing: 4) {
+          HStack(spacing: 8) {
+            Text(preset.displayName)
+              .font(.subheadline.weight(.semibold))
+            localModelBadge(preset.recommendation, tint: .green)
+            if isSelected {
+              localModelBadge("Selected", tint: .blue)
+            }
+          }
+          Text(preset.detail)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+          Text("\(preset.runtime) · ~\(preset.approximateSizeMB) MB")
+            .font(.caption2.monospacedDigit())
+            .foregroundStyle(.tertiary)
+          Text(starterPresetStatusText(for: state, isSelected: isSelected))
+            .font(.caption2)
+            .foregroundStyle(starterPresetStatusTint(for: state))
+        }
+
+        Spacer()
+
+        VStack(alignment: .trailing, spacing: 8) {
+          if state == .installing {
+            starterPresetProgress(for: preset)
+          } else {
+            Button(starterPresetActionTitle(for: state, isSelected: isSelected)) {
+              configureAndDownload(preset)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(state == .installed && isSelected)
+          }
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func starterPresetProgress(for preset: LocalTranscriptionStarterPreset) -> some View {
+    switch preset.engine {
+    case .parakeet:
+      ProgressView(value: fluidAudioModels.downloadProgress)
+        .frame(width: 90)
+      Text("\(Int(fluidAudioModels.downloadProgress * 100))%")
+        .font(.caption2.monospacedDigit())
+        .foregroundStyle(.secondary)
+    case .whisperKit:
+      ProgressView()
+        .controlSize(.small)
+      Text("Configuring")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+  }
+
+  private var localStarterPresets: [LocalTranscriptionStarterPreset] {
+    LocalTranscriptionStarterPreset.recommended(
+      for: settings.localTranscriptionMode,
+      availableModels: localTranscriptionModels,
+      supportsParakeet: FluidAudioModelManager.supportsCurrentHardware
+    )
+  }
+
+  private func starterPresetInstallState(
+    for preset: LocalTranscriptionStarterPreset
+  ) -> StarterPresetInstallState {
+    switch preset.engine {
+    case .parakeet:
+      switch fluidAudioModels.installState {
+      case .notInstalled: return .notInstalled
+      case .installing: return .installing
+      case .installed: return .installed
+      case .failed(let message): return .failed(message)
+      }
+    case .whisperKit(let model):
+      switch localModels.installState(for: model.id) {
+      case .notInstalled: return .notInstalled
+      case .installing: return .installing
+      case .installed: return .installed
+      case .failed(let message): return .failed(message)
+      }
+    }
+  }
+
+  private func isStarterPresetSelected(_ preset: LocalTranscriptionStarterPreset) -> Bool {
+    guard settings.transcriptionMode == .localModel,
+      settings.localTranscriptionMode == preset.mode
+    else { return false }
+
+    switch preset.engine {
+    case .parakeet:
+      return settings.localStreamingModelSource == FluidAudioParakeetModel.id
+    case .whisperKit(let model):
+      if preset.mode == .streaming {
+        return settings.localStreamingModelSource == WhisperKitStreamingModel.id(for: model)
+      }
+      return settings.localTranscriptionModel == model.id
+    }
+  }
+
+  private func configureAndDownload(_ preset: LocalTranscriptionStarterPreset) {
+    settings.transcriptionMode = .localModel
+    settings.localTranscriptionMode = preset.mode
+
+    switch preset.engine {
+    case .parakeet:
+      settings.localStreamingModelSource = FluidAudioParakeetModel.id
+      guard fluidAudioModels.installState != .installed else { return }
+      Task { await fluidAudioModels.install() }
+    case .whisperKit(let model):
+      settings.localTranscriptionModel = model.id
+      if preset.mode == .streaming {
+        settings.localStreamingModelSource = WhisperKitStreamingModel.id(for: model)
+      }
+      guard !localModels.isInstalled(model.id) else { return }
+      Task { await localModels.install(model) }
+    }
+  }
+
+  private func starterPresetIcon(for preset: LocalTranscriptionStarterPreset) -> String {
+    switch preset.engine {
+    case .parakeet: return "waveform.badge.mic"
+    case .whisperKit: return preset.mode == .streaming ? "waveform" : "doc.text.magnifyingglass"
+    }
+  }
+
+  private func starterPresetActionTitle(
+    for state: StarterPresetInstallState,
+    isSelected: Bool
+  ) -> String {
+    switch state {
+    case .installed: return isSelected ? "Configured" : "Use This Setup"
+    case .installing: return "Configuring"
+    case .notInstalled, .failed: return "Configure and Download"
+    }
+  }
+
+  private func starterPresetStatusText(
+    for state: StarterPresetInstallState,
+    isSelected: Bool
+  ) -> String {
+    switch state {
+    case .installed: return isSelected ? "Configured and ready" : "Downloaded and ready to select"
+    case .installing: return "Downloading and preparing the model"
+    case .notInstalled: return "Not downloaded"
+    case .failed(let message): return "Download failed: \(message)"
+    }
+  }
+
+  private func starterPresetStatusTint(for state: StarterPresetInstallState) -> Color {
+    switch state {
+    case .installed: return .green
+    case .installing: return .orange
+    case .notInstalled: return .secondary
+    case .failed: return .red
     }
   }
 
@@ -2028,7 +2265,7 @@ struct SettingsView: View {
           Text(
             """
             Browse WhisperKit/Core ML model repos, then paste the Hugging Face repo ID and model variant here. \
-            WhisperKit models are offline batch models in this prerelease; live local streaming is not enabled yet.
+            Compatible WhisperKit models can be used for either local batch or local streaming.
             """
           )
           .font(.caption)

--- a/Sources/SpeakCore/ModelCatalog.swift
+++ b/Sources/SpeakCore/ModelCatalog.swift
@@ -586,7 +586,7 @@ public struct ModelCatalog: Sendable { // swiftlint:disable:this type_body_lengt
             approximateSizeMB: 632,
             description: "Whisper Large v3 Turbo — near-Large quality with ≈4× real-time speed on "
                 + "Apple silicon. Recommended for high-accuracy batch or live transcription.",
-            tags: [.quality, .fast],
+            tags: [.quality, .fast, .leading],
             supportsLiveStreaming: true
         ),
         LocalTranscriptionModel(

--- a/Tests/SpeakAppTests/LocalTranscriptionStarterPresetTests.swift
+++ b/Tests/SpeakAppTests/LocalTranscriptionStarterPresetTests.swift
@@ -1,0 +1,70 @@
+import SpeakCore
+@testable import SpeakApp
+import XCTest
+
+final class LocalTranscriptionStarterPresetTests: XCTestCase {
+  func testRecommendedStreamingPresets_includeParakeetAndLeadingWhisperKitModel() {
+    let presets = LocalTranscriptionStarterPreset.recommended(
+      for: .streaming,
+      availableModels: ModelCatalog.localTranscription,
+      supportsParakeet: true
+    )
+
+    XCTAssertEqual(presets.map(\.id), [.parakeetStreaming, .whisperKitStreaming])
+    XCTAssertEqual(presets.first?.displayName, FluidAudioParakeetModel.displayName)
+    XCTAssertEqual(whisperKitModel(in: presets)?.id, "local/whisperkit/large-v3-turbo")
+  }
+
+  func testRecommendedBatchPresets_onlyIncludeLeadingWhisperKitModel() {
+    let presets = LocalTranscriptionStarterPreset.recommended(
+      for: .batch,
+      availableModels: ModelCatalog.localTranscription,
+      supportsParakeet: true
+    )
+
+    XCTAssertEqual(presets.map(\.id), [.whisperKitBatch])
+    XCTAssertEqual(whisperKitModel(in: presets)?.id, "local/whisperkit/large-v3-turbo")
+  }
+
+  func testRecommendedStreamingPresets_omitParakeetOnUnsupportedHardware() {
+    let presets = LocalTranscriptionStarterPreset.recommended(
+      for: .streaming,
+      availableModels: ModelCatalog.localTranscription,
+      supportsParakeet: false
+    )
+
+    XCTAssertEqual(presets.map(\.id), [.whisperKitStreaming])
+  }
+
+  func testPreferredWhisperKitModel_fallsBackToQualityAndFastModel() {
+    let fallback = LocalTranscriptionModel(
+      id: "local/whisperkit/future-model",
+      displayName: "Future Model",
+      modelName: "future-model",
+      engine: .whisperKit,
+      approximateSizeMB: 200,
+      description: "A future quality model.",
+      tags: [.quality, .fast],
+      supportsLiveStreaming: true
+    )
+
+    XCTAssertEqual(
+      LocalTranscriptionStarterPreset.preferredWhisperKitModel(
+        from: [fallback],
+        requiresStreaming: true
+      ),
+      fallback
+    )
+  }
+
+  private func whisperKitModel(
+    in presets: [LocalTranscriptionStarterPreset]
+  ) -> LocalTranscriptionModel? {
+    for preset in presets {
+      if case .whisperKit(let model) = preset.engine {
+        return model
+      }
+    }
+    return nil
+  }
+}


### PR DESCRIPTION
## Summary

- add a guided quick setup for downloaded local transcription
- offer Parakeet and WhisperKit presets for Streaming, and the best WhisperKit preset for Batch
- configure the selected mode and download through the existing model managers
- keep the complete catalogue, custom model sources, runtime controls, and manual selection inside a collapsed Advanced section
- select the current best WhisperKit model from model-catalog metadata

## User impact

Downloaded local transcription now starts with a small set of clear, ready-made choices and a single **Configure and Download** action. Existing saved settings remain valid, and advanced users retain every existing control.

## Validation

- complete Swift package test suite: 728 passed, 11 skipped, 0 failures
- direct macOS app build
- App Store compilation with `APP_STORE`
- SwiftFormat lint on all changed Swift files
- strict SwiftLint with the repository baseline on all changed Swift files
- isolated runtime UI validation for Batch, Streaming, and expanded Advanced controls