### PR TITLE
refactor(ios): unify transcription session routing

### DIFF
--- a/Sources/SpeakiOS/Services/IOSTranscriptionSession.swift
+++ b/Sources/SpeakiOS/Services/IOSTranscriptionSession.swift
@@ -1,0 +1,264 @@
+#if os(iOS)
+import Foundation
+import SpeakCore
+
+/// One factory-owned transcription session shared by foreground and hardware-trigger recording.
+/// Keeping construction and lifecycle routing here prevents the two entry points from drifting.
+@MainActor
+final class IOSTranscriptionSession {
+    enum Mode: Equatable, Sendable {
+        case streaming
+        case batch(retainRecording: Bool)
+    }
+
+    enum BackendKind: Equatable, Sendable {
+        case batch
+        case apple
+        case deepgram
+        case elevenLabs
+        case openAI
+        case shared(LiveTranscriptionProviderID)
+    }
+
+    struct Resolution: Equatable, Sendable {
+        let modelID: String
+        let backend: BackendKind
+        let route: LiveTranscriptionRoute?
+
+        var isBatch: Bool { backend == .batch }
+        var sampleRate: Int? { route?.sampleRate }
+    }
+
+    var onPartialResult: ((String, Bool) -> Void)?
+    var onError: ((Error) -> Void)?
+
+    let resolution: Resolution
+
+    var isBatch: Bool { resolution.isBatch }
+
+    var partialText: String {
+        switch backend {
+        case .batch:
+            return ""
+        case .apple(let transcriber):
+            return transcriber.partialText
+        case .deepgram(let transcriber):
+            return transcriber.partialText
+        case .elevenLabs(let transcriber):
+            return transcriber.partialText
+        case .openAI(let transcriber):
+            return transcriber.partialText
+        case .shared(let transcriber):
+            return transcriber.partialText
+        }
+    }
+
+    var confidence: Double? {
+        guard case .apple(let transcriber) = backend else { return nil }
+        return transcriber.confidence
+    }
+
+    private enum Backend {
+        case batch(IOSBatchTranscriber)
+        case apple(iOSLiveTranscriber)
+        case deepgram(DeepgramLiveTranscriber)
+        case elevenLabs(ElevenLabsLiveTranscriber)
+        case openAI(OpenAIRealtimeLiveTranscriber)
+        case shared(SharedClientLiveTranscriber)
+    }
+
+    private let backend: Backend
+
+    init(
+        modelID: String,
+        mode: Mode,
+        audioSessionManager: AudioSessionManager,
+        batchAPIKey: String,
+        liveAPIKey: (LiveTranscriptionRoute) -> String
+    ) throws {
+        let resolution = try Self.resolve(modelID: modelID, mode: mode)
+        self.resolution = resolution
+        backend = try Self.makeBackend(
+            resolution: resolution,
+            mode: mode,
+            audioSessionManager: audioSessionManager,
+            batchAPIKey: batchAPIKey,
+            liveAPIKey: liveAPIKey
+        )
+        bindCallbacks()
+    }
+
+    nonisolated static func resolve(modelID: String, mode: Mode) throws -> Resolution {
+        let trimmedModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if case .batch = mode {
+            return Resolution(modelID: trimmedModelID, backend: .batch, route: nil)
+        }
+
+        guard let route = LiveTranscriptionRouting.route(for: trimmedModelID) else {
+            throw LiveTranscriptionClientError.unknownModel(trimmedModelID)
+        }
+        let backend: BackendKind
+        switch route.provider {
+        case .apple:
+            backend = .apple
+        case .deepgram:
+            backend = .deepgram
+        case .elevenlabs:
+            backend = .elevenLabs
+        case .openai:
+            backend = .openAI
+        default:
+            guard route.provider.isSupportedOnIOS else {
+                throw LiveTranscriptionClientError.providerNotAvailable(route.provider)
+            }
+            backend = .shared(route.provider)
+        }
+        return Resolution(modelID: route.modelID, backend: backend, route: route)
+    }
+
+    private static func makeBackend(
+        resolution: Resolution,
+        mode: Mode,
+        audioSessionManager: AudioSessionManager,
+        batchAPIKey: String,
+        liveAPIKey: (LiveTranscriptionRoute) -> String
+    ) throws -> Backend {
+        switch resolution.backend {
+        case .batch:
+            let retainRecording: Bool
+            if case .batch(let shouldRetain) = mode {
+                retainRecording = shouldRetain
+            } else {
+                retainRecording = true
+            }
+            return .batch(
+                IOSBatchTranscriber(
+                    audioSessionManager: audioSessionManager,
+                    model: resolution.modelID,
+                    apiKey: batchAPIKey,
+                    retainRecording: retainRecording
+                )
+            )
+        case .apple:
+            let transcriber = iOSLiveTranscriber(audioSessionManager: audioSessionManager)
+            transcriber.modelID = resolution.modelID
+            return .apple(transcriber)
+        case .deepgram:
+            let route = try requiredRoute(for: resolution)
+            let transcriber = DeepgramLiveTranscriber(audioSessionManager: audioSessionManager)
+            transcriber.configure(apiKey: liveAPIKey(route))
+            transcriber.model = route.apiModelName
+            return .deepgram(transcriber)
+        case .elevenLabs:
+            let route = try requiredRoute(for: resolution)
+            let transcriber = ElevenLabsLiveTranscriber(audioSessionManager: audioSessionManager)
+            transcriber.configure(apiKey: liveAPIKey(route))
+            transcriber.modelID = route.apiModelName
+            return .elevenLabs(transcriber)
+        case .openAI:
+            let route = try requiredRoute(for: resolution)
+            let transcriber = OpenAIRealtimeLiveTranscriber(audioSessionManager: audioSessionManager)
+            transcriber.configure(apiKey: liveAPIKey(route))
+            transcriber.modelID = route.apiModelName
+            return .openAI(transcriber)
+        case .shared:
+            let route = try requiredRoute(for: resolution)
+            return .shared(
+                SharedClientLiveTranscriber(
+                    route: route,
+                    apiKey: liveAPIKey(route),
+                    audioSessionManager: audioSessionManager
+                )
+            )
+        }
+    }
+
+    private static func requiredRoute(for resolution: Resolution) throws -> LiveTranscriptionRoute {
+        guard let route = resolution.route else {
+            throw LiveTranscriptionClientError.unknownModel(resolution.modelID)
+        }
+        return route
+    }
+
+    func start() async throws {
+        switch backend {
+        case .batch(let transcriber):
+            try await transcriber.start()
+        case .apple(let transcriber):
+            try await transcriber.start()
+        case .deepgram(let transcriber):
+            try await transcriber.start()
+        case .elevenLabs(let transcriber):
+            try await transcriber.start()
+        case .openAI(let transcriber):
+            try await transcriber.start()
+        case .shared(let transcriber):
+            try await transcriber.start()
+        }
+    }
+
+    func stop(language: String?) async throws -> TranscriptionResult {
+        switch backend {
+        case .batch(let transcriber):
+            return try await transcriber.stop(language: language)
+        case .apple(let transcriber):
+            return await transcriber.stop()
+        case .deepgram(let transcriber):
+            return await transcriber.stop()
+        case .elevenLabs(let transcriber):
+            return await transcriber.stop()
+        case .openAI(let transcriber):
+            return await transcriber.stop()
+        case .shared(let transcriber):
+            return await transcriber.stop()
+        }
+    }
+
+    func cancel() {
+        switch backend {
+        case .batch(let transcriber):
+            transcriber.cancel()
+        case .apple(let transcriber):
+            transcriber.cancel()
+        case .deepgram(let transcriber):
+            transcriber.cancel()
+        case .elevenLabs(let transcriber):
+            transcriber.cancel()
+        case .openAI(let transcriber):
+            transcriber.cancel()
+        case .shared(let transcriber):
+            transcriber.cancel()
+        }
+    }
+
+    private func bindCallbacks() {
+        let partialHandler: (String, Bool) -> Void = { [weak self] text, isFinal in
+            guard let self else { return }
+            self.onPartialResult?(self.partialText.isEmpty ? text : self.partialText, isFinal)
+        }
+        let errorHandler: (Error) -> Void = { [weak self] error in
+            self?.onError?(error)
+        }
+
+        switch backend {
+        case .batch:
+            break
+        case .apple(let transcriber):
+            transcriber.onPartialResult = partialHandler
+            transcriber.onError = errorHandler
+        case .deepgram(let transcriber):
+            transcriber.onPartialResult = partialHandler
+            transcriber.onError = errorHandler
+        case .elevenLabs(let transcriber):
+            transcriber.onPartialResult = partialHandler
+            transcriber.onError = errorHandler
+        case .openAI(let transcriber):
+            transcriber.onPartialResult = partialHandler
+            transcriber.onError = errorHandler
+        case .shared(let transcriber):
+            transcriber.onPartialResult = partialHandler
+            transcriber.onError = errorHandler
+        }
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -8,7 +8,7 @@ import SpeakCore
 /// Headless recording coordinator for Action Button / Shortcuts / Siri.
 /// Manages the full lifecycle: start recording → live transcription → stop → clipboard → Live Activity.
 @MainActor
-public final class TranscriptionRecordingService: ObservableObject { // swiftlint:disable:this type_body_length
+public final class TranscriptionRecordingService: ObservableObject {
     public static let shared = TranscriptionRecordingService()
 
     @Published public private(set) var isRunning = false
@@ -19,12 +19,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     private let activityManager = TranscriptionActivityManager.shared
     private let sharedState = SharedTranscriptionState.shared
 
-    private var appleTranscriber: iOSLiveTranscriber?
-    private var deepgramTranscriber: DeepgramLiveTranscriber?
-    private var elevenLabsTranscriber: ElevenLabsLiveTranscriber?
-    private var openAITranscriber: OpenAIRealtimeLiveTranscriber?
-    private var sharedTranscriber: SharedClientLiveTranscriber?
-    private var batchTranscriber: IOSBatchTranscriber?
+    private var transcriptionSession: IOSTranscriptionSession?
     private var startTime: Date?
     private var currentModel: String = ""
     private var sharesLiveTranscript = true
@@ -52,7 +47,8 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
     private var modelDisplayName: String {
         ModelCatalog.transcriptionDisplayName(
             for: currentModel,
-            isBatch: batchTranscriber != nil
+            isBatch: transcriptionSession?.isBatch
+                ?? (AppSettings.shared.transcriptionMode == .batch)
         )
     }
 
@@ -109,138 +105,30 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         #endif
 
         do {
-            if settings.transcriptionMode == .batch {
-                let transcriber = IOSBatchTranscriber(
-                    audioSessionManager: audioSessionManager,
-                    model: currentModel,
-                    apiKey: settings.batchAPIKey,
-                    retainRecording: retainBatchRecording
-                )
-                batchTranscriber = transcriber
-                appleTranscriber = nil
-                deepgramTranscriber = nil
-                elevenLabsTranscriber = nil
-                openAITranscriber = nil
-                sharedTranscriber = nil
-                try await transcriber.start()
-            } else if currentModel.hasPrefix("deepgram") {
-                let transcriber = DeepgramLiveTranscriber(audioSessionManager: audioSessionManager)
-                transcriber.configure(apiKey: settings.deepgramAPIKey)
-                transcriber.model = LiveTranscriptionRouting.route(for: currentModel)?.apiModelName
-                    ?? currentModel.replacingOccurrences(of: "deepgram/", with: "")
-
-                transcriber.onPartialResult = { [weak self] text, _ in
-                    Task { @MainActor in
-                        self?.handlePartialResult(text: text)
-                    }
-                }
-                transcriber.onError = { [weak self] error in
-                    Task { @MainActor in
-                        self?.handleError(error)
-                    }
-                }
-
-                deepgramTranscriber = transcriber
-                appleTranscriber = nil
-                elevenLabsTranscriber = nil
-                try await transcriber.start()
-            } else if currentModel.hasPrefix("elevenlabs") {
-                let transcriber = ElevenLabsLiveTranscriber(audioSessionManager: audioSessionManager)
-                transcriber.configure(apiKey: settings.elevenLabsAPIKey)
-                transcriber.modelID = LiveTranscriptionRouting.route(for: currentModel)?.apiModelName
-                    ?? currentModel.replacingOccurrences(of: "elevenlabs/", with: "")
-
-                transcriber.onPartialResult = { [weak self] text, _ in
-                    Task { @MainActor in
-                        self?.handlePartialResult(text: text)
-                    }
-                }
-                transcriber.onError = { [weak self] error in
-                    Task { @MainActor in
-                        self?.handleError(error)
-                    }
-                }
-
-                elevenLabsTranscriber = transcriber
-                deepgramTranscriber = nil
-                appleTranscriber = nil
-                openAITranscriber = nil
-                try await transcriber.start()
-            } else if currentModel.hasPrefix("openai") {
-                let transcriber = OpenAIRealtimeLiveTranscriber(audioSessionManager: audioSessionManager)
-                transcriber.configure(apiKey: settings.openAIAPIKey)
-                transcriber.modelID = LiveTranscriptionRouting.route(for: currentModel)?.apiModelName
-                    ?? currentModel.replacingOccurrences(of: "openai/", with: "")
-
-                transcriber.onPartialResult = { [weak self] text, _ in
-                    Task { @MainActor in
-                        self?.handlePartialResult(text: text)
-                    }
-                }
-                transcriber.onError = { [weak self] error in
-                    Task { @MainActor in
-                        self?.handleError(error)
-                    }
-                }
-
-                openAITranscriber = transcriber
-                elevenLabsTranscriber = nil
-                deepgramTranscriber = nil
-                appleTranscriber = nil
-                sharedTranscriber = nil
-                try await transcriber.start()
-            } else if let route = LiveTranscriptionRouting.route(for: currentModel),
-                      route.provider.isSupportedOnIOS {
-                // Generic shared-client path (Cartesia, and future ported providers).
-                let transcriber = SharedClientLiveTranscriber(
-                    route: route,
-                    apiKey: settings.liveAPIKey(for: route),
-                    audioSessionManager: audioSessionManager
-                )
-                transcriber.onPartialResult = { [weak self] text, _ in
-                    Task { @MainActor in self?.handlePartialResult(text: text) }
-                }
-                transcriber.onError = { [weak self] error in
-                    Task { @MainActor in self?.handleError(error) }
-                }
-                sharedTranscriber = transcriber
-                deepgramTranscriber = nil
-                elevenLabsTranscriber = nil
-                openAITranscriber = nil
-                appleTranscriber = nil
-                try await transcriber.start()
-            } else {
-                let transcriber = iOSLiveTranscriber(audioSessionManager: audioSessionManager)
-                transcriber.modelID = currentModel
-
-                transcriber.onPartialResult = { [weak self] text, _ in
-                    Task { @MainActor in
-                        self?.handlePartialResult(text: text)
-                    }
-                }
-                transcriber.onError = { [weak self] error in
-                    Task { @MainActor in
-                        self?.handleError(error)
-                    }
-                }
-
-                appleTranscriber = transcriber
-                deepgramTranscriber = nil
-                elevenLabsTranscriber = nil
-                openAITranscriber = nil
-                sharedTranscriber = nil
-                try await transcriber.start()
+            let mode: IOSTranscriptionSession.Mode = settings.transcriptionMode == .batch
+                ? .batch(retainRecording: retainBatchRecording)
+                : .streaming
+            let session = try IOSTranscriptionSession(
+                modelID: currentModel,
+                mode: mode,
+                audioSessionManager: audioSessionManager,
+                batchAPIKey: settings.batchAPIKey,
+                liveAPIKey: settings.liveAPIKey(for:)
+            )
+            session.onPartialResult = { [weak self] text, _ in
+                self?.handlePartialResult(text: text)
             }
+            session.onError = { [weak self] error in
+                self?.handleError(error)
+            }
+            transcriptionSession = session
+            try await session.start()
 
             isRunning = true
         } catch {
+            transcriptionSession?.cancel()
             startTime = nil
-            deepgramTranscriber = nil
-            elevenLabsTranscriber = nil
-            openAITranscriber = nil
-            appleTranscriber = nil
-            sharedTranscriber = nil
-            batchTranscriber = nil
+            transcriptionSession = nil
             self.sharesLiveTranscript = true
             sharedState.clearRecordingState()
             activityManager.endActivity()
@@ -270,7 +158,7 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
         // landed, so "Copied N words" was reported but nothing arrived.
         let assertion = beginBackgroundAssertion("Finalise transcription")
 
-        if batchTranscriber != nil {
+        if transcriptionSession?.isBatch == true {
             activityManager.updateActivity(
                 status: .processing,
                 lastSnippet: "Transcribing recording…",
@@ -345,18 +233,8 @@ public final class TranscriptionRecordingService: ObservableObject { // swiftlin
 
     /// Cancels recording without saving.
     public func cancelRecording() {
-        deepgramTranscriber?.cancel()
-        elevenLabsTranscriber?.cancel()
-        openAITranscriber?.cancel()
-        appleTranscriber?.cancel()
-        sharedTranscriber?.cancel()
-        batchTranscriber?.cancel()
-        deepgramTranscriber = nil
-        elevenLabsTranscriber = nil
-        openAITranscriber = nil
-        appleTranscriber = nil
-        sharedTranscriber = nil
-        batchTranscriber = nil
+        transcriptionSession?.cancel()
+        transcriptionSession = nil
         sharesLiveTranscript = true
         isRunning = false
         startTime = nil
@@ -462,10 +340,10 @@ private extension TranscriptionRecordingService {
     /// and otherwise both calls would see the same non-nil transcriber and try
     /// to stop it twice.
     func drainActiveTranscriber(duration: Int) async -> TranscriptionResult {
-        if let batch = batchTranscriber {
-            batchTranscriber = nil
+        if let session = transcriptionSession {
+            transcriptionSession = nil
             do {
-                return try await batch.stop(language: Locale.current.identifier)
+                return try await session.stop(language: Locale.current.identifier)
             } catch {
                 handleError(error)
                 return TranscriptionResult(
@@ -479,26 +357,6 @@ private extension TranscriptionRecordingService {
                     debugInfo: nil
                 )
             }
-        }
-        if let deepgram = deepgramTranscriber {
-            deepgramTranscriber = nil
-            return await deepgram.stop()
-        }
-        if let elevenlabs = elevenLabsTranscriber {
-            elevenLabsTranscriber = nil
-            return await elevenlabs.stop()
-        }
-        if let openai = openAITranscriber {
-            openAITranscriber = nil
-            return await openai.stop()
-        }
-        if let shared = sharedTranscriber {
-            sharedTranscriber = nil
-            return await shared.stop()
-        }
-        if let apple = appleTranscriber {
-            appleTranscriber = nil
-            return await apple.stop()
         }
         return TranscriptionResult(
             text: partialText,

--- a/Sources/SpeakiOS/Views/ContentView.swift
+++ b/Sources/SpeakiOS/Views/ContentView.swift
@@ -3,10 +3,9 @@ import SwiftUI
 import SpeakCore
 
 // swiftlint:disable file_length
-/// Unified transcriber that switches between Apple Speech and Deepgram.
+/// Foreground recording coordinator backed by the shared iOS transcription factory.
 /// Integrates with Live Activity for lock screen presence.
 @MainActor
-// swiftlint:disable:next type_body_length
 final class TranscriberCoordinator: ObservableObject {
     @Published private(set) var isRunning = false
     @Published private(set) var partialText = ""
@@ -19,12 +18,7 @@ final class TranscriberCoordinator: ObservableObject {
     private let activityManager = TranscriptionActivityManager.shared
     private let sharedState = SharedTranscriptionState.shared
 
-    private var appleTranscriber: iOSLiveTranscriber?
-    private var deepgramTranscriber: DeepgramLiveTranscriber?
-    private var elevenLabsTranscriber: ElevenLabsLiveTranscriber?
-    private var openAITranscriber: OpenAIRealtimeLiveTranscriber?
-    private var sharedTranscriber: SharedClientLiveTranscriber?
-    private var batchTranscriber: IOSBatchTranscriber?
+    private var transcriptionSession: IOSTranscriptionSession?
     private var startTime: Date?
 
     init() {
@@ -34,7 +28,8 @@ final class TranscriberCoordinator: ObservableObject {
     var modelDisplayName: String {
         ModelCatalog.transcriptionDisplayName(
             for: currentModel,
-            isBatch: batchTranscriber != nil
+            isBatch: transcriptionSession?.isBatch
+                ?? (AppSettings.shared.transcriptionMode == .batch)
         )
     }
 
@@ -75,126 +70,36 @@ final class TranscriberCoordinator: ObservableObject {
         }
         #endif
 
-        if settings.transcriptionMode == .batch {
-            let transcriber = IOSBatchTranscriber(
-                audioSessionManager: audioSessionManager,
-                model: currentModel,
-                apiKey: settings.batchAPIKey
-            )
-            batchTranscriber = transcriber
-            appleTranscriber = nil
-            deepgramTranscriber = nil
-            elevenLabsTranscriber = nil
-            openAITranscriber = nil
-            sharedTranscriber = nil
-            try await transcriber.start()
-            markRecordingStarted()
-        } else if currentModel.hasPrefix("deepgram") {
-            // Use Deepgram
-            let transcriber = DeepgramLiveTranscriber(audioSessionManager: audioSessionManager)
-            transcriber.configure(apiKey: settings.deepgramAPIKey)
-            transcriber.model = LiveTranscriptionRouting.route(for: currentModel)?.apiModelName
-                ?? currentModel.replacingOccurrences(of: "deepgram/", with: "")
-
-            transcriber.onPartialResult = { [weak self] text, isFinal in
-                self?.handlePartialResult(text: self?.deepgramTranscriber?.partialText ?? text, isFinal: isFinal)
-            }
-            transcriber.onError = { [weak self] error in
-                self?.handleError(error)
-            }
-
-            deepgramTranscriber = transcriber
-            appleTranscriber = nil
-            elevenLabsTranscriber = nil
-
-            try await transcriber.start()
-            markRecordingStarted()
-        } else if currentModel.hasPrefix("elevenlabs") {
-            // Use ElevenLabs
-            let transcriber = ElevenLabsLiveTranscriber(audioSessionManager: audioSessionManager)
-            transcriber.configure(apiKey: settings.elevenLabsAPIKey)
-            transcriber.modelID = LiveTranscriptionRouting.route(for: currentModel)?.apiModelName
-                ?? currentModel.replacingOccurrences(of: "elevenlabs/", with: "")
-
-            transcriber.onPartialResult = { [weak self] text, isFinal in
-                self?.handlePartialResult(text: self?.elevenLabsTranscriber?.partialText ?? text, isFinal: isFinal)
-            }
-            transcriber.onError = { [weak self] error in
-                self?.handleError(error)
-            }
-
-            elevenLabsTranscriber = transcriber
-            deepgramTranscriber = nil
-            appleTranscriber = nil
-
-            try await transcriber.start()
-            markRecordingStarted()
-        } else if currentModel.hasPrefix("openai") {
-            // Use OpenAI Realtime
-            let transcriber = OpenAIRealtimeLiveTranscriber(audioSessionManager: audioSessionManager)
-            transcriber.configure(apiKey: settings.openAIAPIKey)
-            transcriber.modelID = LiveTranscriptionRouting.route(for: currentModel)?.apiModelName
-                ?? currentModel.replacingOccurrences(of: "openai/", with: "")
-
-            transcriber.onPartialResult = { [weak self] text, isFinal in
-                self?.handlePartialResult(text: self?.openAITranscriber?.partialText ?? text, isFinal: isFinal)
-            }
-            transcriber.onError = { [weak self] error in
-                self?.handleError(error)
-            }
-
-            openAITranscriber = transcriber
-            elevenLabsTranscriber = nil
-            deepgramTranscriber = nil
-            appleTranscriber = nil
-
-            try await transcriber.start()
-            markRecordingStarted()
-        } else if let route = LiveTranscriptionRouting.route(for: currentModel),
-                  route.provider.isSupportedOnIOS {
-            // Generic shared-client path (Cartesia, and future ported providers).
-            let transcriber = SharedClientLiveTranscriber(
-                route: route,
-                apiKey: settings.liveAPIKey(for: route),
-                audioSessionManager: audioSessionManager
-            )
-            transcriber.onPartialResult = { [weak self] text, isFinal in
-                self?.handlePartialResult(text: self?.sharedTranscriber?.partialText ?? text, isFinal: isFinal)
-            }
-            transcriber.onError = { [weak self] error in
-                self?.handleError(error)
-            }
-
-            sharedTranscriber = transcriber
-            deepgramTranscriber = nil
-            elevenLabsTranscriber = nil
-            openAITranscriber = nil
-            appleTranscriber = nil
-
-            try await transcriber.start()
-            markRecordingStarted()
-        } else {
-            // Use Apple Speech
-            let transcriber = iOSLiveTranscriber(audioSessionManager: audioSessionManager)
-            transcriber.modelID = currentModel
-
-            transcriber.onPartialResult = { [weak self] text, isFinal in
-                self?.handlePartialResult(text: self?.appleTranscriber?.partialText ?? text, isFinal: isFinal)
-                self?.confidence = self?.appleTranscriber?.confidence
-            }
-            transcriber.onError = { [weak self] error in
-                self?.handleError(error)
-            }
-
-            appleTranscriber = transcriber
-            deepgramTranscriber = nil
-            elevenLabsTranscriber = nil
-            openAITranscriber = nil
-            sharedTranscriber = nil
-
-            try await transcriber.start()
-            markRecordingStarted()
+        let mode: IOSTranscriptionSession.Mode = settings.transcriptionMode == .batch
+            ? .batch(retainRecording: true)
+            : .streaming
+        let session = try IOSTranscriptionSession(
+            modelID: currentModel,
+            mode: mode,
+            audioSessionManager: audioSessionManager,
+            batchAPIKey: settings.batchAPIKey,
+            liveAPIKey: settings.liveAPIKey(for:)
+        )
+        session.onPartialResult = { [weak self, weak session] text, isFinal in
+            self?.handlePartialResult(text: text, isFinal: isFinal)
+            self?.confidence = session?.confidence
         }
+        session.onError = { [weak self] error in
+            self?.handleError(error)
+        }
+        transcriptionSession = session
+        do {
+            try await session.start()
+        } catch {
+            session.cancel()
+            transcriptionSession = nil
+            startTime = nil
+            if settings.liveActivitiesEnabled {
+                activityManager.endActivity()
+            }
+            throw error
+        }
+        markRecordingStarted()
     }
 
     private func markRecordingStarted() {
@@ -228,7 +133,6 @@ final class TranscriberCoordinator: ObservableObject {
         }
     }
 
-    // swiftlint:disable:next function_body_length
     func stop() async -> TranscriptionResult {
         isRunning = false
         sharedState.clearRecordingState()
@@ -237,7 +141,7 @@ final class TranscriberCoordinator: ObservableObject {
         // Streaming results can complete immediately. Batch recordings remain
         // in a processing state until the upload returns.
         if AppSettings.shared.liveActivitiesEnabled {
-            if batchTranscriber != nil {
+            if transcriptionSession?.isBatch == true {
                 activityManager.updateActivity(
                     status: .processing,
                     lastSnippet: "Transcribing recording…",
@@ -249,39 +153,21 @@ final class TranscriberCoordinator: ObservableObject {
             }
         }
 
-        if let batch = batchTranscriber {
-            batchTranscriber = nil
+        if let session = transcriptionSession {
+            transcriptionSession = nil
             do {
-                let result = try await batch.stop(language: Locale.current.identifier)
-                partialText = result.text
-                wordCount = result.text.split(whereSeparator: \.isWhitespace).count
-                if AppSettings.shared.liveActivitiesEnabled {
-                    activityManager.completeActivity(finalWordCount: wordCount, duration: duration)
+                let result = try await session.stop(language: Locale.current.identifier)
+                if session.isBatch {
+                    partialText = result.text
+                    wordCount = result.text.split(whereSeparator: \.isWhitespace).count
+                    if AppSettings.shared.liveActivitiesEnabled {
+                        activityManager.completeActivity(finalWordCount: wordCount, duration: duration)
+                    }
                 }
                 return finishStop(with: result)
             } catch {
                 handleError(error)
             }
-        } else if let deepgram = deepgramTranscriber {
-            let result = await deepgram.stop()
-            deepgramTranscriber = nil
-            return finishStop(with: result)
-        } else if let elevenlabs = elevenLabsTranscriber {
-            let result = await elevenlabs.stop()
-            elevenLabsTranscriber = nil
-            return finishStop(with: result)
-        } else if let openai = openAITranscriber {
-            let result = await openai.stop()
-            openAITranscriber = nil
-            return finishStop(with: result)
-        } else if let shared = sharedTranscriber {
-            let result = await shared.stop()
-            sharedTranscriber = nil
-            return finishStop(with: result)
-        } else if let apple = appleTranscriber {
-            let result = await apple.stop()
-            appleTranscriber = nil
-            return finishStop(with: result)
         }
 
         startTime = nil
@@ -308,18 +194,8 @@ final class TranscriberCoordinator: ObservableObject {
     }
 
     func cancel() {
-        deepgramTranscriber?.cancel()
-        elevenLabsTranscriber?.cancel()
-        openAITranscriber?.cancel()
-        appleTranscriber?.cancel()
-        sharedTranscriber?.cancel()
-        batchTranscriber?.cancel()
-        deepgramTranscriber = nil
-        elevenLabsTranscriber = nil
-        openAITranscriber = nil
-        appleTranscriber = nil
-        sharedTranscriber = nil
-        batchTranscriber = nil
+        transcriptionSession?.cancel()
+        transcriptionSession = nil
         isRunning = false
         startTime = nil
         if AppSettings.shared.liveActivitiesEnabled {

--- a/Tests/SpeakiOSTests/IOSTranscriptionSessionTests.swift
+++ b/Tests/SpeakiOSTests/IOSTranscriptionSessionTests.swift
@@ -1,0 +1,86 @@
+#if os(iOS)
+import XCTest
+import SpeakCore
+
+@testable import SpeakiOSLib
+
+final class IOSTranscriptionSessionTests: XCTestCase {
+    @MainActor
+    func testEverySelectableLiveModelResolvesAndConstructsThroughSharedFactory() throws {
+        var checkedModelIDs: Set<String> = []
+
+        for model in ModelCatalog.liveTranscription {
+            guard
+                let route = LiveTranscriptionRouting.route(for: model.id),
+                route.provider.isSupportedOnIOS
+            else {
+                continue
+            }
+
+            let resolution = try IOSTranscriptionSession.resolve(
+                modelID: model.id,
+                mode: .streaming
+            )
+            XCTAssertEqual(resolution.modelID, route.modelID)
+            XCTAssertEqual(resolution.route, route)
+            XCTAssertEqual(resolution.sampleRate, route.sampleRate)
+
+            let session = try IOSTranscriptionSession(
+                modelID: model.id,
+                mode: .streaming,
+                audioSessionManager: AudioSessionManager(),
+                batchAPIKey: "",
+                liveAPIKey: { _ in "test-key" }
+            )
+            XCTAssertEqual(session.resolution, resolution)
+            checkedModelIDs.insert(model.id)
+        }
+
+        let expectedModelIDs: Set<String> = Set(
+            ModelCatalog.liveTranscription.compactMap { model in
+                guard LiveTranscriptionRouting.route(for: model.id)?.provider.isSupportedOnIOS == true else {
+                    return nil
+                }
+                return model.id
+            }
+        )
+        XCTAssertEqual(checkedModelIDs, expectedModelIDs)
+        XCTAssertFalse(checkedModelIDs.isEmpty)
+    }
+
+    func testProviderKindsUseOneCanonicalRoutingDecision() throws {
+        for route in LiveTranscriptionRouting.allRoutes where route.provider.isSupportedOnIOS {
+            let resolution = try IOSTranscriptionSession.resolve(
+                modelID: route.modelID,
+                mode: .streaming
+            )
+            let expectedBackend: IOSTranscriptionSession.BackendKind
+            switch route.provider {
+            case .apple:
+                expectedBackend = .apple
+            case .deepgram:
+                expectedBackend = .deepgram
+            case .elevenlabs:
+                expectedBackend = .elevenLabs
+            case .openai:
+                expectedBackend = .openAI
+            default:
+                expectedBackend = .shared(route.provider)
+            }
+            XCTAssertEqual(resolution.backend, expectedBackend, route.modelID)
+        }
+    }
+
+    func testBatchModeUsesSameFactoryWithoutLiveProviderRouting() throws {
+        let resolution = try IOSTranscriptionSession.resolve(
+            modelID: "openai/gpt-4o-mini-transcribe",
+            mode: .batch(retainRecording: false)
+        )
+
+        XCTAssertEqual(resolution.backend, .batch)
+        XCTAssertEqual(resolution.modelID, "openai/gpt-4o-mini-transcribe")
+        XCTAssertNil(resolution.route)
+        XCTAssertTrue(resolution.isBatch)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- introduce one factory-owned iOS transcription session shared by the foreground recorder and Action Button / Shortcuts service
- route every supported streaming provider through `LiveTranscriptionRouting`, including canonical API model names and sample rates
- consolidate batch and streaming lifecycle handling so the two entry points cannot drift
- add coverage that constructs every selectable iOS live model through the shared factory and verifies provider routing

Closes #510

## Verification
- full `SpeakiOSTests` suite passes on iPhone 17 Pro Simulator
- `SpeakiOS` Debug build passes for the generic iOS Simulator destination
- SwiftLint reports zero violations in all changed files
- `swiftc -parse` passes for all changed Swift files