### PR TITLE
test(sync): cover CloudKit key state machine

### DIFF
--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -312,13 +312,17 @@ private enum KeySyncMetadataRecordMapper {
         CKRecord.ID(recordName: recordName, zoneID: SyncConfiguration.zoneID)
     }
 
-    static func record(from metadata: KeySyncMetadata, existingRecord: CKRecord? = nil) -> CKRecord {
+    static func record(
+        from metadata: KeySyncMetadata,
+        updatedAt: Date,
+        existingRecord: CKRecord? = nil
+    ) -> CKRecord {
         let record = existingRecord ?? CKRecord(recordType: recordType, recordID: recordID)
         record[FieldKey.salt] = metadata.salt
         record[FieldKey.verifierNonce] = metadata.verifierNonce
         record[FieldKey.verifierCiphertext] = metadata.verifierCiphertext
         record[FieldKey.verifierTag] = metadata.verifierTag
-        record[FieldKey.updatedAt] = Date()
+        record[FieldKey.updatedAt] = updatedAt
         return record
     }
 
@@ -339,11 +343,15 @@ private enum KeySyncMetadataRecordMapper {
     }
 }
 
-private struct KeySyncFetchResult {
+struct KeySyncFetchResult {
     var records: [CKRecord]
     var deletedIDs: [CKRecord.ID]
-    var serverChangeToken: CKServerChangeToken?
+    var serverChangeTokenData: Data?
     var moreComing: Bool
+}
+
+struct CloudKitKeySyncDatabase {
+    let live: CKDatabase?
 }
 
 struct PendingKeySyncMutation: Codable, Equatable, Sendable {
@@ -356,6 +364,56 @@ struct PendingKeySyncMutation: Codable, Equatable, Sendable {
     let identifier: String
     let updatedAt: Date
     let kind: Kind
+}
+
+protocol CloudKitKeySyncSecretStoring: Sendable {
+    func storeSecret(_ value: String, identifier: String) async throws
+    func secret(identifier: String) async throws -> String
+    func removeSecret(identifier: String) async throws
+}
+
+extension SecureStorage: CloudKitKeySyncSecretStoring {}
+
+struct CloudKitKeySyncDependencies {
+    let defaults: UserDefaults
+    let notificationCenter: NotificationCenter
+    let now: () -> Date
+    let sleep: (UInt64) async throws -> Void
+    let hasCloudKitEntitlement: () -> Bool
+    let privateDatabase: () -> CloudKitKeySyncDatabase?
+    let accountStatus: () async throws -> CKAccountStatus
+    let accountRecordName: () async throws -> String
+    let setupInfrastructure: ((CloudKitKeySyncDatabase) async throws -> Void)?
+    let fetchRecord: ((CKRecord.ID, CloudKitKeySyncDatabase) async throws -> CKRecord?)?
+    let saveRecord: ((CKRecord, CloudKitKeySyncDatabase) async throws -> CKRecord)?
+    let fetchChanges: ((CloudKitKeySyncDatabase, Data?) async throws -> KeySyncFetchResult)?
+
+    static let live = CloudKitKeySyncDependencies(
+        defaults: .standard,
+        notificationCenter: .default,
+        now: Date.init,
+        sleep: { try await Task.sleep(nanoseconds: $0) },
+        hasCloudKitEntitlement: { SyncConfiguration.hasCloudKitEntitlement },
+        privateDatabase: {
+            SyncConfiguration.privateDatabase.map { CloudKitKeySyncDatabase(live: $0) }
+        },
+        accountStatus: {
+            guard let container = SyncConfiguration.container else {
+                return .couldNotDetermine
+            }
+            return try await container.accountStatus()
+        },
+        accountRecordName: {
+            guard let container = SyncConfiguration.container else {
+                throw CloudKitKeySyncError.cloudUnavailable
+            }
+            return try await container.userRecordID().recordName
+        },
+        setupInfrastructure: nil,
+        fetchRecord: nil,
+        saveRecord: nil,
+        fetchChanges: nil
+    )
 }
 
 private final class KeySyncFetchAccumulator: @unchecked Sendable {
@@ -394,7 +452,7 @@ private final class KeySyncFetchAccumulator: @unchecked Sendable {
                 KeySyncFetchResult(
                     records: records,
                     deletedIDs: deletedIDs,
-                    serverChangeToken: serverChangeToken,
+                    serverChangeTokenData: serverChangeToken.flatMap(Self.archive),
                     moreComing: moreComing
                 )
             )
@@ -403,6 +461,10 @@ private final class KeySyncFetchAccumulator: @unchecked Sendable {
             throw error
         }
         return snapshot.1
+    }
+
+    private static func archive(_ token: CKServerChangeToken) -> Data? {
+        try? NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true)
     }
 }
 
@@ -455,9 +517,10 @@ public final class CloudKitKeySync: ObservableObject {
     }
 
     private let log = Logger(subsystem: "com.justspeaktoit", category: "CloudKitKeySync")
-    private let stateStorage: SecureStorage
-    private var secureStorage: SecureStorage
-    private var isConfigured = false
+    private let stateStorage: any CloudKitKeySyncSecretStoring
+    private var secureStorage: any CloudKitKeySyncSecretStoring
+    private let dependencies: CloudKitKeySyncDependencies
+    private var isConfigured: Bool
     private var symmetricKey: SymmetricKey?
     private var observer: NSObjectProtocol?
     private var accountObserver: NSObjectProtocol?
@@ -471,30 +534,36 @@ public final class CloudKitKeySync: ObservableObject {
     private var lifecycleIsLocked = false
     private var lifecycleWaiters: [CheckedContinuation<Void, Never>] = []
 
-    private init(
-        secureStorage: SecureStorage = SecureStorage(),
-        stateStorage: SecureStorage = SecureStorage(
+    init(
+        secureStorage: any CloudKitKeySyncSecretStoring = SecureStorage(),
+        stateStorage: any CloudKitKeySyncSecretStoring = SecureStorage(
             configuration: SecureStorageConfiguration(
                 service: "com.justspeaktoit.keysync-state",
                 masterAccount: "cloudkit-key-sync-state",
                 accessGroup: nil,
                 synchronizable: false
             )
-        )
+        ),
+        dependencies: CloudKitKeySyncDependencies = .live,
+        isConfigured: Bool = false,
+        symmetricKey: SymmetricKey? = nil
     ) {
         self.secureStorage = secureStorage
         self.stateStorage = stateStorage
-        self.pendingMutations = Self.loadPersistedPendingMutations()
+        self.dependencies = dependencies
+        self.isConfigured = isConfigured
+        self.symmetricKey = symmetricKey
+        self.pendingMutations = Self.loadPersistedPendingMutations(defaults: dependencies.defaults)
         observeLocalKeyChanges()
         observeCloudKitAccountChanges()
     }
 
     deinit {
         if let observer {
-            NotificationCenter.default.removeObserver(observer)
+            dependencies.notificationCenter.removeObserver(observer)
         }
         if let accountObserver {
-            NotificationCenter.default.removeObserver(accountObserver)
+            dependencies.notificationCenter.removeObserver(accountObserver)
         }
     }
 
@@ -504,22 +573,22 @@ public final class CloudKitKeySync: ObservableObject {
     }
 
     public func isAvailable() async -> Bool {
-        guard SyncConfiguration.hasCloudKitEntitlement,
-              let container = SyncConfiguration.container else {
+        guard dependencies.hasCloudKitEntitlement(),
+              dependencies.privateDatabase() != nil else {
             status.isCloudAvailable = false
             return false
         }
 
         do {
-            let accountStatus = try await container.accountStatus()
+            let accountStatus = try await dependencies.accountStatus()
             guard accountStatus == .available else {
                 status.isCloudAvailable = false
                 return false
             }
-            try await validateCurrentAccount(container: container)
+            try await validateCurrentAccount()
             status.isCloudAvailable = true
             status.lastErrorDescription = nil
-            status.isEnabled = UserDefaults.standard.bool(forKey: Self.enabledKey)
+            status.isEnabled = dependencies.defaults.bool(forKey: Self.enabledKey)
             if status.isEnabled, isConfigured {
                 await restoreSavedKeyIfNeeded()
                 restorePendingMutationTasks()
@@ -537,7 +606,7 @@ public final class CloudKitKeySync: ObservableObject {
         let trimmed = passphrase.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { throw CloudKitKeySyncError.missingPassphrase }
         try EncryptedSecretCrypto.validatePassphrase(trimmed)
-        guard await isAvailable(), let database = SyncConfiguration.privateDatabase else {
+        guard await isAvailable(), let database = dependencies.privateDatabase() else {
             throw CloudKitKeySyncError.cloudUnavailable
         }
 
@@ -556,7 +625,7 @@ public final class CloudKitKeySync: ObservableObject {
             try ensureGenerationIsCurrent(generation)
             try await seedPendingMutationsForExistingSecrets()
             try ensureGenerationIsCurrent(generation)
-            UserDefaults.standard.set(true, forKey: Self.enabledKey)
+            dependencies.defaults.set(true, forKey: Self.enabledKey)
             status.isEnabled = true
             status.lastErrorDescription = nil
             restorePendingMutationTasks()
@@ -580,7 +649,7 @@ public final class CloudKitKeySync: ObservableObject {
         activeSync = nil
         localUploadTasks.removeAll()
         localUploadTaskIDs.removeAll()
-        UserDefaults.standard.set(false, forKey: Self.enabledKey)
+        dependencies.defaults.set(false, forKey: Self.enabledKey)
         symmetricKey = nil
         status.isEnabled = false
         status.isSyncing = false
@@ -600,7 +669,7 @@ public final class CloudKitKeySync: ObservableObject {
 
         retryAttempts.removeAll()
         pendingMutations.removeAll()
-        Self.clearPersistedPendingMutations()
+        Self.clearPersistedPendingMutations(defaults: dependencies.defaults)
         do {
             try await stateStorage.removeSecret(identifier: Self.localDerivedKeyIdentifier)
         } catch {
@@ -617,11 +686,11 @@ public final class CloudKitKeySync: ObservableObject {
             try await activeSync.task.value
             return
         }
-        guard UserDefaults.standard.bool(forKey: Self.enabledKey) else { return }
-        guard await isAvailable(), let database = SyncConfiguration.privateDatabase else {
+        guard dependencies.defaults.bool(forKey: Self.enabledKey) else { return }
+        guard await isAvailable(), let database = dependencies.privateDatabase() else {
             throw CloudKitKeySyncError.cloudUnavailable
         }
-        guard UserDefaults.standard.bool(forKey: Self.enabledKey) else { return }
+        guard dependencies.defaults.bool(forKey: Self.enabledKey) else { return }
         await restoreSavedKeyIfNeeded()
         guard let key = symmetricKey else { throw CloudKitKeySyncError.missingPassphrase }
 
@@ -658,7 +727,7 @@ public final class CloudKitKeySync: ObservableObject {
     }
 
     private func performSync(
-        database: CKDatabase,
+        database: CloudKitKeySyncDatabase,
         key: SymmetricKey,
         generation: UInt64
     ) async throws {
@@ -679,7 +748,7 @@ public final class CloudKitKeySync: ObservableObject {
             try ensureSyncIsActive(generation: generation)
             try await uploadLocalSecrets(database: database, key: key, generation: generation)
             try ensureSyncIsActive(generation: generation)
-            status.lastSyncTime = Date()
+            status.lastSyncTime = dependencies.now()
         } catch is CancellationError {
             throw CancellationError()
         } catch {
@@ -691,7 +760,7 @@ public final class CloudKitKeySync: ObservableObject {
     }
 
     private func observeLocalKeyChanges() {
-        observer = NotificationCenter.default.addObserver(
+        observer = dependencies.notificationCenter.addObserver(
             forName: SecureStorage.didChangeSecretNotification,
             object: nil,
             queue: nil
@@ -705,11 +774,12 @@ public final class CloudKitKeySync: ObservableObject {
 
             Task { @MainActor in
                 guard !self.applyingRemoteIdentifiers.contains(identifier),
-                      UserDefaults.standard.bool(forKey: Self.enabledKey) else {
+                      self.dependencies.defaults.bool(forKey: Self.enabledKey) else {
                     return
                 }
                 let updatedAt = notification
-                    .userInfo?[SecureStorage.NotificationUserInfoKey.updatedAt] as? Date ?? Date()
+                    .userInfo?[SecureStorage.NotificationUserInfoKey.updatedAt] as? Date
+                    ?? self.dependencies.now()
                 let operation = notification
                     .userInfo?[SecureStorage.NotificationUserInfoKey.operation] as? String
                 let mutation = PendingKeySyncMutation(
@@ -718,7 +788,7 @@ public final class CloudKitKeySync: ObservableObject {
                     updatedAt: updatedAt,
                     kind: operation == "remove" ? .deletion : .update
                 )
-                Self.persistPendingMutation(mutation)
+                Self.persistPendingMutation(mutation, defaults: self.dependencies.defaults)
                 self.pendingMutations[identifier] = mutation
                 self.scheduleLocalUpload(identifier: identifier)
             }
@@ -726,7 +796,7 @@ public final class CloudKitKeySync: ObservableObject {
     }
 
     private func observeCloudKitAccountChanges() {
-        accountObserver = NotificationCenter.default.addObserver(
+        accountObserver = dependencies.notificationCenter.addObserver(
             forName: .CKAccountChanged,
             object: nil,
             queue: nil
@@ -763,7 +833,7 @@ public final class CloudKitKeySync: ObservableObject {
                 }
 
                 do {
-                    try await Task.sleep(nanoseconds: Self.localUploadDebounceNanoseconds)
+                    try await self.dependencies.sleep(Self.localUploadDebounceNanoseconds)
                 } catch {
                     return
                 }
@@ -775,7 +845,7 @@ public final class CloudKitKeySync: ObservableObject {
                     continue
                 }
                 guard let key = self.symmetricKey,
-                      let database = SyncConfiguration.privateDatabase else {
+                      let database = self.dependencies.privateDatabase() else {
                     return
                 }
 
@@ -806,7 +876,7 @@ public final class CloudKitKeySync: ObservableObject {
                         Self.localUploadMaximumRetryNanoseconds
                     )
                     do {
-                        try await Task.sleep(nanoseconds: delay)
+                        try await self.dependencies.sleep(delay)
                     } catch {
                         return
                     }
@@ -821,7 +891,7 @@ public final class CloudKitKeySync: ObservableObject {
 
     private func restoreSavedKeyIfNeeded() async {
         guard symmetricKey == nil,
-              UserDefaults.standard.bool(forKey: Self.enabledKey),
+              dependencies.defaults.bool(forKey: Self.enabledKey),
               let stored = try? await stateStorage.secret(identifier: Self.localDerivedKeyIdentifier),
               let data = Data(base64Encoded: stored) else {
             return
@@ -830,7 +900,7 @@ public final class CloudKitKeySync: ObservableObject {
     }
 
     private func restorePendingMutationTasks() {
-        pendingMutations = Self.loadPersistedPendingMutations()
+        pendingMutations = Self.loadPersistedPendingMutations(defaults: dependencies.defaults)
         for identifier in pendingMutations.keys {
             scheduleLocalUpload(identifier: identifier)
         }
@@ -844,7 +914,7 @@ public final class CloudKitKeySync: ObservableObject {
                 mutationsToPersist.append(PendingKeySyncMutation(
                     operationID: UUID(),
                     identifier: identifier,
-                    updatedAt: Date(),
+                    updatedAt: dependencies.now(),
                     kind: .update
                 ))
             } catch SecureStorageError.valueNotFound {
@@ -855,51 +925,57 @@ public final class CloudKitKeySync: ObservableObject {
             }
         }
         for mutation in mutationsToPersist {
-            Self.persistPendingMutation(mutation)
+            Self.persistPendingMutation(mutation, defaults: dependencies.defaults)
             pendingMutations[mutation.identifier] = mutation
         }
     }
 
     private func clearPendingMutation(ifMatching mutation: PendingKeySyncMutation) {
         guard pendingMutations[mutation.identifier]?.operationID == mutation.operationID,
-              Self.loadPersistedPendingMutation(identifier: mutation.identifier)?.operationID
+              Self.loadPersistedPendingMutation(
+                identifier: mutation.identifier,
+                defaults: dependencies.defaults
+              )?.operationID
                 == mutation.operationID else {
             return
         }
         pendingMutations[mutation.identifier] = nil
-        UserDefaults.standard.removeObject(forKey: Self.pendingMutationKey(identifier: mutation.identifier))
+        dependencies.defaults.removeObject(forKey: Self.pendingMutationKey(identifier: mutation.identifier))
     }
 
     private static func pendingMutationKey(identifier: String) -> String {
         pendingMutationPrefix + identifier
     }
 
-    private static func persistPendingMutation(_ mutation: PendingKeySyncMutation) {
+    private static func persistPendingMutation(_ mutation: PendingKeySyncMutation, defaults: UserDefaults) {
         guard let data = try? JSONEncoder().encode(mutation) else { return }
-        UserDefaults.standard.set(data, forKey: pendingMutationKey(identifier: mutation.identifier))
+        defaults.set(data, forKey: pendingMutationKey(identifier: mutation.identifier))
     }
 
-    private static func loadPersistedPendingMutation(identifier: String) -> PendingKeySyncMutation? {
-        guard let data = UserDefaults.standard.data(forKey: pendingMutationKey(identifier: identifier)) else {
+    private static func loadPersistedPendingMutation(
+        identifier: String,
+        defaults: UserDefaults
+    ) -> PendingKeySyncMutation? {
+        guard let data = defaults.data(forKey: pendingMutationKey(identifier: identifier)) else {
             return nil
         }
         return try? JSONDecoder().decode(PendingKeySyncMutation.self, from: data)
     }
 
-    private static func loadPersistedPendingMutations() -> [String: PendingKeySyncMutation] {
+    private static func loadPersistedPendingMutations(defaults: UserDefaults) -> [String: PendingKeySyncMutation] {
         syncableIdentifiers.reduce(into: [:]) { mutations, identifier in
-            mutations[identifier] = loadPersistedPendingMutation(identifier: identifier)
+            mutations[identifier] = loadPersistedPendingMutation(identifier: identifier, defaults: defaults)
         }
     }
 
-    private static func clearPersistedPendingMutations() {
+    private static func clearPersistedPendingMutations(defaults: UserDefaults) {
         for identifier in syncableIdentifiers {
-            UserDefaults.standard.removeObject(forKey: pendingMutationKey(identifier: identifier))
+            defaults.removeObject(forKey: pendingMutationKey(identifier: identifier))
         }
     }
 
-    private func validateCurrentAccount(container: CKContainer) async throws {
-        let recordName = try await container.userRecordID().recordName
+    private func validateCurrentAccount() async throws {
+        let recordName = try await dependencies.accountRecordName()
         let fingerprint = SHA256.hash(data: Data(recordName.utf8))
             .map { String(format: "%02x", $0) }
             .joined()
@@ -920,18 +996,18 @@ public final class CloudKitKeySync: ObservableObject {
     private func resetAccountBoundState(ifNeededFor fingerprint: String) async throws {
         await acquireLifecycleLock()
         defer { releaseLifecycleLock() }
-        guard UserDefaults.standard.string(forKey: Self.accountIdentifierKey) != fingerprint else {
+        guard dependencies.defaults.string(forKey: Self.accountIdentifierKey) != fingerprint else {
             return
         }
         let suspendedWork = suspendActiveWork()
         await waitForSuspendedWork(suspendedWork)
         pendingMutations.removeAll()
         retryAttempts.removeAll()
-        Self.clearPersistedPendingMutations()
-        UserDefaults.standard.removeObject(forKey: Self.enabledKey)
-        UserDefaults.standard.removeObject(forKey: Self.syncTokenKey)
-        UserDefaults.standard.removeObject(forKey: Self.zoneCreatedKey)
-        UserDefaults.standard.removeObject(forKey: Self.subscriptionCreatedKey)
+        Self.clearPersistedPendingMutations(defaults: dependencies.defaults)
+        dependencies.defaults.removeObject(forKey: Self.enabledKey)
+        dependencies.defaults.removeObject(forKey: Self.syncTokenKey)
+        dependencies.defaults.removeObject(forKey: Self.zoneCreatedKey)
+        dependencies.defaults.removeObject(forKey: Self.subscriptionCreatedKey)
         try await stateStorage.removeSecret(identifier: Self.localDerivedKeyIdentifier)
         for identifier in Self.syncableIdentifiers {
             try await stateStorage.removeSecret(identifier: Self.localUpdatedPrefix + identifier)
@@ -941,7 +1017,7 @@ public final class CloudKitKeySync: ObservableObject {
         status.isSyncing = false
         status.lastSyncTime = nil
         status.lastErrorDescription = nil
-        UserDefaults.standard.set(fingerprint, forKey: Self.accountIdentifierKey)
+        dependencies.defaults.set(fingerprint, forKey: Self.accountIdentifierKey)
     }
 
     private func suspendActiveWork() -> SuspendedWork {
@@ -995,7 +1071,7 @@ public final class CloudKitKeySync: ObservableObject {
 
     private func ensureSyncIsActive(generation: UInt64) throws {
         try ensureGenerationIsCurrent(generation)
-        guard UserDefaults.standard.bool(forKey: Self.enabledKey),
+        guard dependencies.defaults.bool(forKey: Self.enabledKey),
               status.isEnabled else {
             throw CancellationError()
         }
@@ -1008,31 +1084,42 @@ public final class CloudKitKeySync: ObservableObject {
         }
     }
 
-    private func setupCloudKitInfrastructure(database: CKDatabase) async throws {
-        if !UserDefaults.standard.bool(forKey: Self.zoneCreatedKey) {
+    private func setupCloudKitInfrastructure(database: CloudKitKeySyncDatabase) async throws {
+        if let setupInfrastructure = dependencies.setupInfrastructure {
+            try await setupInfrastructure(database)
+            return
+        }
+        guard let liveDatabase = database.live else {
+            throw CloudKitKeySyncError.cloudUnavailable
+        }
+
+        if !dependencies.defaults.bool(forKey: Self.zoneCreatedKey) {
             do {
-                _ = try await database.save(SyncConfiguration.recordZone)
-                UserDefaults.standard.set(true, forKey: Self.zoneCreatedKey)
+                _ = try await liveDatabase.save(SyncConfiguration.recordZone)
+                dependencies.defaults.set(true, forKey: Self.zoneCreatedKey)
             } catch let error as CKError where error.code == .serverRecordChanged {
-                UserDefaults.standard.set(true, forKey: Self.zoneCreatedKey)
+                dependencies.defaults.set(true, forKey: Self.zoneCreatedKey)
             }
         }
 
-        if !UserDefaults.standard.bool(forKey: Self.subscriptionCreatedKey) {
+        if !dependencies.defaults.bool(forKey: Self.subscriptionCreatedKey) {
             let subscription = CKDatabaseSubscription(subscriptionID: Self.subscriptionID)
             let info = CKSubscription.NotificationInfo()
             info.shouldSendContentAvailable = true
             subscription.notificationInfo = info
             do {
-                _ = try await database.save(subscription)
-                UserDefaults.standard.set(true, forKey: Self.subscriptionCreatedKey)
+                _ = try await liveDatabase.save(subscription)
+                dependencies.defaults.set(true, forKey: Self.subscriptionCreatedKey)
             } catch let error as CKError where error.code == .serverRejectedRequest {
                 log.warning("Key sync subscription unavailable: \(error.localizedDescription)")
             }
         }
     }
 
-    private func loadOrCreateMetadataKey(passphrase: String, database: CKDatabase) async throws -> SymmetricKey {
+    private func loadOrCreateMetadataKey(
+        passphrase: String,
+        database: CloudKitKeySyncDatabase
+    ) async throws -> SymmetricKey {
         if let record = try await fetchRecord(id: KeySyncMetadataRecordMapper.recordID, database: database) {
             guard let metadata = KeySyncMetadataRecordMapper.metadata(from: record) else {
                 throw CloudKitKeySyncError.malformedRecord
@@ -1061,12 +1148,15 @@ public final class CloudKitKeySync: ObservableObject {
             verifierCiphertext: token.ciphertext,
             verifierTag: token.tag
         )
-        _ = try await database.save(KeySyncMetadataRecordMapper.record(from: metadata))
+        _ = try await saveRecord(
+            KeySyncMetadataRecordMapper.record(from: metadata, updatedAt: dependencies.now()),
+            database: database
+        )
         return key
     }
 
     private func fetchRemoteChanges(
-        database: CKDatabase,
+        database: CloudKitKeySyncDatabase,
         key: SymmetricKey,
         generation: UInt64
     ) async throws {
@@ -1092,9 +1182,9 @@ public final class CloudKitKeySync: ObservableObject {
 
     // swiftlint:disable:next cyclomatic_complexity
     private func fetchAndApplyRemoteChanges(
-        database: CKDatabase,
+        database: CloudKitKeySyncDatabase,
         key: SymmetricKey,
-        changeToken: CKServerChangeToken?,
+        changeToken: Data?,
         generation: UInt64
     ) async throws {
         let result = try await executeFetchOperation(database: database, changeToken: changeToken)
@@ -1126,7 +1216,11 @@ public final class CloudKitKeySync: ObservableObject {
             guard let identifier = identifierFromRecordName(recordID.recordName) else { continue }
 
             do {
-                try await applyRemoteDeletion(identifier: identifier, updatedAt: Date(), generation: generation)
+                try await applyRemoteDeletion(
+                    identifier: identifier,
+                    updatedAt: dependencies.now(),
+                    generation: generation
+                )
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
@@ -1139,7 +1233,7 @@ public final class CloudKitKeySync: ObservableObject {
             throw firstError
         }
         try ensureSyncIsActive(generation: generation)
-        if let token = result.serverChangeToken {
+        if let token = result.serverChangeTokenData {
             saveChangeToken(token)
         }
     }
@@ -1151,7 +1245,10 @@ public final class CloudKitKeySync: ObservableObject {
     ) async throws {
         guard Self.syncableIdentifiers.contains(secret.identifier) else { return }
         let pendingMutation = pendingMutations[secret.identifier]
-            ?? Self.loadPersistedPendingMutation(identifier: secret.identifier)
+            ?? Self.loadPersistedPendingMutation(
+                identifier: secret.identifier,
+                defaults: dependencies.defaults
+            )
         let localUpdatedAt = try await effectiveLocalUpdatedAt(identifier: secret.identifier)
         guard localUpdatedAt == nil || secret.updatedAt > (localUpdatedAt ?? .distantPast) else { return }
         try ensureSyncIsActive(generation: generation)
@@ -1175,7 +1272,10 @@ public final class CloudKitKeySync: ObservableObject {
     private func applyRemoteDeletion(identifier: String, updatedAt: Date, generation: UInt64) async throws {
         guard Self.syncableIdentifiers.contains(identifier) else { return }
         guard pendingMutations[identifier] == nil,
-              Self.loadPersistedPendingMutation(identifier: identifier) == nil else {
+              Self.loadPersistedPendingMutation(
+                identifier: identifier,
+                defaults: dependencies.defaults
+              ) == nil else {
             return
         }
         try ensureSyncIsActive(generation: generation)
@@ -1187,7 +1287,7 @@ public final class CloudKitKeySync: ObservableObject {
     }
 
     private func uploadLocalSecrets(
-        database: CKDatabase,
+        database: CloudKitKeySyncDatabase,
         key: SymmetricKey,
         generation: UInt64
     ) async throws {
@@ -1195,7 +1295,10 @@ public final class CloudKitKeySync: ObservableObject {
         let mutations = Self.syncableIdentifiers
             .compactMap { identifier in
                 pendingMutations[identifier]
-                    ?? Self.loadPersistedPendingMutation(identifier: identifier)
+                    ?? Self.loadPersistedPendingMutation(
+                        identifier: identifier,
+                        defaults: dependencies.defaults
+                    )
             }
             .sorted { $0.identifier < $1.identifier }
             .prefix(SyncConfiguration.batchSize)
@@ -1234,7 +1337,7 @@ public final class CloudKitKeySync: ObservableObject {
     private func uploadSecret(
         identifier: String,
         updatedAt: Date,
-        database: CKDatabase,
+        database: CloudKitKeySyncDatabase,
         key: SymmetricKey,
         isDeletion: Bool,
         generation: UInt64
@@ -1269,17 +1372,29 @@ public final class CloudKitKeySync: ObservableObject {
             }
         }
         let record = EncryptedSecretRecordMapper.record(from: secret, existingRecord: existing)
-        _ = try await database.save(record)
+        _ = try await saveRecord(record, database: database)
         try ensureSyncIsActive(generation: generation)
         return .uploaded
     }
 
+    // swiftlint:disable:next function_body_length
     private func executeFetchOperation(
-        database: CKDatabase,
-        changeToken: CKServerChangeToken?
+        database: CloudKitKeySyncDatabase,
+        changeToken: Data?
     ) async throws -> KeySyncFetchResult {
+        if let fetchChanges = dependencies.fetchChanges {
+            return try await fetchChanges(database, changeToken)
+        }
+        guard let liveDatabase = database.live else {
+            throw CloudKitKeySyncError.cloudUnavailable
+        }
         let config = CKFetchRecordZoneChangesOperation.ZoneConfiguration()
-        config.previousServerChangeToken = changeToken
+        if let changeToken {
+            config.previousServerChangeToken = try? NSKeyedUnarchiver.unarchivedObject(
+                ofClass: CKServerChangeToken.self,
+                from: changeToken
+            )
+        }
         let operation = CKFetchRecordZoneChangesOperation(
             recordZoneIDs: [SyncConfiguration.zoneID],
             configurationsByRecordZoneID: [SyncConfiguration.zoneID: config]
@@ -1323,33 +1438,52 @@ public final class CloudKitKeySync: ObservableObject {
                     continuation.resume(throwing: error)
                 }
             }
-            database.add(operation)
+            liveDatabase.add(operation)
         }
 
         return try accumulator.result()
     }
 
-    private func fetchRecord(id: CKRecord.ID, database: CKDatabase) async throws -> CKRecord? {
+    private func fetchRecord(
+        id: CKRecord.ID,
+        database: CloudKitKeySyncDatabase
+    ) async throws -> CKRecord? {
+        if let fetchRecord = dependencies.fetchRecord {
+            return try await fetchRecord(id, database)
+        }
+        guard let liveDatabase = database.live else {
+            throw CloudKitKeySyncError.cloudUnavailable
+        }
         do {
-            return try await database.record(for: id)
+            return try await liveDatabase.record(for: id)
         } catch let error as CKError where error.code == .unknownItem {
             return nil
         }
     }
 
-    private func loadChangeToken() -> CKServerChangeToken? {
-        guard let data = UserDefaults.standard.data(forKey: Self.syncTokenKey) else { return nil }
-        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: CKServerChangeToken.self, from: data)
+    private func saveRecord(
+        _ record: CKRecord,
+        database: CloudKitKeySyncDatabase
+    ) async throws -> CKRecord {
+        if let saveRecord = dependencies.saveRecord {
+            return try await saveRecord(record, database)
+        }
+        guard let liveDatabase = database.live else {
+            throw CloudKitKeySyncError.cloudUnavailable
+        }
+        return try await liveDatabase.save(record)
     }
 
-    private func saveChangeToken(_ token: CKServerChangeToken) {
-        if let data = try? NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true) {
-            UserDefaults.standard.set(data, forKey: Self.syncTokenKey)
-        }
+    private func loadChangeToken() -> Data? {
+        dependencies.defaults.data(forKey: Self.syncTokenKey)
+    }
+
+    private func saveChangeToken(_ token: Data) {
+        dependencies.defaults.set(token, forKey: Self.syncTokenKey)
     }
 
     private func clearChangeToken() {
-        UserDefaults.standard.removeObject(forKey: Self.syncTokenKey)
+        dependencies.defaults.removeObject(forKey: Self.syncTokenKey)
     }
 
     private static func isChangeTokenExpired(_ error: Error) -> Bool {
@@ -1385,7 +1519,7 @@ public final class CloudKitKeySync: ObservableObject {
     private func effectiveLocalUpdatedAt(identifier: String) async throws -> Date? {
         let committed = try await loadLocalUpdatedAt(identifier: identifier)
         let pending = pendingMutations[identifier]
-            ?? Self.loadPersistedPendingMutation(identifier: identifier)
+            ?? Self.loadPersistedPendingMutation(identifier: identifier, defaults: dependencies.defaults)
         guard let pending else { return committed }
         return max(committed ?? .distantPast, pending.updatedAt)
     }

--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -75,6 +75,7 @@ public enum CloudKitKeySyncError: LocalizedError, Equatable {
     case incorrectPassphrase
     case encryptionFailed
     case malformedRecord
+    case invalidChangeToken
     case passphraseTooShort(minimumLength: Int)
     case randomGenerationFailed
     case notConfigured
@@ -91,6 +92,8 @@ public enum CloudKitKeySyncError: LocalizedError, Equatable {
             return "Failed to encrypt or decrypt the API key."
         case .malformedRecord:
             return "CloudKit returned an invalid encrypted key record."
+        case .invalidChangeToken:
+            return "CloudKit returned an invalid synchronization token."
         case .passphraseTooShort(let minimumLength):
             return "Use an API-key sync passphrase with at least \(minimumLength) characters."
         case .randomGenerationFailed:
@@ -449,22 +452,24 @@ private final class KeySyncFetchAccumulator: @unchecked Sendable {
         let snapshot = lock.withLock {
             (
                 errors.first,
-                KeySyncFetchResult(
-                    records: records,
-                    deletedIDs: deletedIDs,
-                    serverChangeTokenData: serverChangeToken.flatMap(Self.archive),
-                    moreComing: moreComing
-                )
+                records,
+                deletedIDs,
+                serverChangeToken,
+                moreComing
             )
         }
         if let error = snapshot.0 {
             throw error
         }
-        return snapshot.1
-    }
-
-    private static func archive(_ token: CKServerChangeToken) -> Data? {
-        try? NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true)
+        let tokenData = try snapshot.3.map {
+            try NSKeyedArchiver.archivedData(withRootObject: $0, requiringSecureCoding: true)
+        }
+        return KeySyncFetchResult(
+            records: snapshot.1,
+            deletedIDs: snapshot.2,
+            serverChangeTokenData: tokenData,
+            moreComing: snapshot.4
+        )
     }
 }
 
@@ -488,11 +493,11 @@ public final class CloudKitKeySync: ObservableObject {
 
     @Published public private(set) var status = CloudKitKeySyncStatus()
 
-    private static let enabledKey = "speak.keysync.enabled"
-    private static let syncTokenKey = "speak.keysync.serverChangeToken"
+    static let enabledKey = "speak.keysync.enabled"
+    static let syncTokenKey = "speak.keysync.serverChangeToken"
     private static let subscriptionCreatedKey = "speak.keysync.subscriptionCreated"
     private static let zoneCreatedKey = "speak.keysync.zoneCreated"
-    private static let accountIdentifierKey = "speak.keysync.accountIdentifier"
+    static let accountIdentifierKey = "speak.keysync.accountIdentifier"
     private static let pendingMutationPrefix = "speak.keysync.pending."
     private static let localDerivedKeyIdentifier = "cloudkitKeySync.derivedKey"
     private static let localUpdatedPrefix = "speak.keysync.localUpdatedAt."
@@ -943,7 +948,7 @@ public final class CloudKitKeySync: ObservableObject {
         dependencies.defaults.removeObject(forKey: Self.pendingMutationKey(identifier: mutation.identifier))
     }
 
-    private static func pendingMutationKey(identifier: String) -> String {
+    static func pendingMutationKey(identifier: String) -> String {
         pendingMutationPrefix + identifier
     }
 
@@ -1180,14 +1185,30 @@ public final class CloudKitKeySync: ObservableObject {
         }
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     private func fetchAndApplyRemoteChanges(
         database: CloudKitKeySyncDatabase,
         key: SymmetricKey,
         changeToken: Data?,
         generation: UInt64
     ) async throws {
-        let result = try await executeFetchOperation(database: database, changeToken: changeToken)
+        var nextChangeToken = changeToken
+        while true {
+            let result = try await executeFetchOperation(database: database, changeToken: nextChangeToken)
+            try await applyFetchedChanges(result, key: key, generation: generation)
+            guard result.moreComing else { return }
+            guard let token = result.serverChangeTokenData else {
+                throw CloudKitKeySyncError.invalidChangeToken
+            }
+            nextChangeToken = token
+        }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func applyFetchedChanges(
+        _ result: KeySyncFetchResult,
+        key: SymmetricKey,
+        generation: UInt64
+    ) async throws {
         try ensureSyncIsActive(generation: generation)
         var firstError: Error?
 
@@ -1377,7 +1398,7 @@ public final class CloudKitKeySync: ObservableObject {
         return .uploaded
     }
 
-    // swiftlint:disable:next function_body_length
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func executeFetchOperation(
         database: CloudKitKeySyncDatabase,
         changeToken: Data?
@@ -1390,10 +1411,15 @@ public final class CloudKitKeySync: ObservableObject {
         }
         let config = CKFetchRecordZoneChangesOperation.ZoneConfiguration()
         if let changeToken {
-            config.previousServerChangeToken = try? NSKeyedUnarchiver.unarchivedObject(
-                ofClass: CKServerChangeToken.self,
-                from: changeToken
-            )
+            do {
+                config.previousServerChangeToken = try NSKeyedUnarchiver.unarchivedObject(
+                    ofClass: CKServerChangeToken.self,
+                    from: changeToken
+                )
+            } catch {
+                log.error("Discarding unreadable CloudKit change token: \(error.localizedDescription)")
+                clearChangeToken()
+            }
         }
         let operation = CKFetchRecordZoneChangesOperation(
             recordZoneIDs: [SyncConfiguration.zoneID],

--- a/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
+++ b/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
@@ -1,8 +1,14 @@
 import CloudKit
 import CryptoKit
+import SpeakCore
 import XCTest
 @testable import SpeakSync
 
+// The behavioral scenarios share one deterministic harness so their race ordering stays explicit.
+// swiftlint:disable file_length
+
+@MainActor
+// swiftlint:disable:next type_body_length
 final class CloudKitKeySyncTests: XCTestCase {
     func testSyncableIdentifiers_containsXAI() {
         XCTAssertTrue(CloudKitKeySync.syncableIdentifiers.contains("xai.apiKey"))
@@ -102,5 +108,493 @@ final class CloudKitKeySyncTests: XCTestCase {
             derived.map { String(format: "%02x", $0) }.joined(),
             "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a"
         )
+    }
+
+    func testRepeatedLocalChangesCoalesceIntoOneUpload() async throws {
+        let harness = makeHarness()
+        let isAvailable = await harness.sync.isAvailable()
+        XCTAssertTrue(isAvailable)
+        let firstDate = Date(timeIntervalSince1970: 1_720_100_001)
+        let secondDate = Date(timeIntervalSince1970: 1_720_100_002)
+        await harness.secrets.set("latest", identifier: "openai.apiKey")
+
+        postLocalChange(harness, identifier: "openai.apiKey", updatedAt: firstDate)
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        postLocalChange(harness, identifier: "openai.apiKey", updatedAt: secondDate)
+        await harness.sleeper.resumeNext()
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        await harness.sleeper.resumeNext()
+
+        try await eventually { harness.cloud.savedRecords.count == 1 }
+        let saved = try XCTUnwrap(EncryptedSecretRecordMapper.secret(from: harness.cloud.savedRecords[0]))
+        XCTAssertEqual(saved.updatedAt, secondDate)
+        XCTAssertEqual(try EncryptedSecretCrypto.decryptSecret(saved, key: harness.key), "latest")
+        let journalKey = pendingKey("openai.apiKey")
+        try await eventually { harness.defaults.data(forKey: journalKey) == nil }
+        XCTAssertNil(harness.defaults.data(forKey: journalKey))
+    }
+
+    func testFailedDeletionRemainsJournaledAndRetries() async throws {
+        let harness = makeHarness()
+        let isAvailable = await harness.sync.isAvailable()
+        XCTAssertTrue(isAvailable)
+        harness.cloud.saveFailuresRemaining = 1
+        let updatedAt = Date(timeIntervalSince1970: 1_720_100_003)
+
+        postLocalChange(
+            harness,
+            identifier: "deepgram.apiKey",
+            operation: "remove",
+            updatedAt: updatedAt
+        )
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        await harness.sleeper.resumeNext()
+        try await eventually { harness.cloud.saveAttempts == 1 }
+        XCTAssertNotNil(harness.defaults.data(forKey: pendingKey("deepgram.apiKey")))
+
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        await harness.sleeper.resumeNext()
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        await harness.sleeper.resumeNext()
+
+        try await eventually { harness.cloud.savedRecords.count == 1 }
+        let saved = try XCTUnwrap(EncryptedSecretRecordMapper.secret(from: harness.cloud.savedRecords[0]))
+        XCTAssertTrue(saved.isDeleted)
+        XCTAssertEqual(saved.updatedAt, updatedAt)
+        let journalKey = pendingKey("deepgram.apiKey")
+        try await eventually { harness.defaults.data(forKey: journalKey) == nil }
+        XCTAssertNil(harness.defaults.data(forKey: journalKey))
+    }
+
+    func testFailedUpdateRemainsJournaledAndRetries() async throws {
+        let harness = makeHarness()
+        let isAvailable = await harness.sync.isAvailable()
+        XCTAssertTrue(isAvailable)
+        harness.cloud.saveFailuresRemaining = 1
+        await harness.secrets.set("retry-value", identifier: "openai.apiKey")
+
+        postLocalChange(
+            harness,
+            identifier: "openai.apiKey",
+            updatedAt: Date(timeIntervalSince1970: 1_720_100_003.5)
+        )
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        await harness.sleeper.resumeNext()
+        try await eventually { harness.cloud.saveAttempts == 1 }
+        let journalKey = pendingKey("openai.apiKey")
+        XCTAssertNotNil(harness.defaults.data(forKey: journalKey))
+
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        await harness.sleeper.resumeNext()
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        await harness.sleeper.resumeNext()
+
+        try await eventually { harness.cloud.savedRecords.count == 1 }
+        let saved = try XCTUnwrap(EncryptedSecretRecordMapper.secret(from: harness.cloud.savedRecords[0]))
+        XCTAssertFalse(saved.isDeleted)
+        XCTAssertEqual(try EncryptedSecretCrypto.decryptSecret(saved, key: harness.key), "retry-value")
+        try await eventually { harness.defaults.data(forKey: journalKey) == nil }
+    }
+
+    func testNewerMutationSurvivesOlderUploadCompletion() async throws {
+        let harness = makeHarness()
+        let isAvailable = await harness.sync.isAvailable()
+        XCTAssertTrue(isAvailable)
+        let saveGate = TestGate()
+        harness.cloud.saveGate = saveGate
+        await harness.secrets.set("first", identifier: "openai.apiKey")
+        let firstDate = Date(timeIntervalSince1970: 1_720_100_004)
+        let secondDate = Date(timeIntervalSince1970: 1_720_100_005)
+
+        postLocalChange(harness, identifier: "openai.apiKey", updatedAt: firstDate)
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        await harness.sleeper.resumeNext()
+        try await eventually { await saveGate.waiterCount == 1 }
+
+        await harness.secrets.set("second", identifier: "openai.apiKey")
+        postLocalChange(harness, identifier: "openai.apiKey", updatedAt: secondDate)
+        await saveGate.open()
+        try await eventually { await harness.sleeper.waiterCount == 1 }
+        XCTAssertNotNil(harness.defaults.data(forKey: pendingKey("openai.apiKey")))
+        harness.cloud.saveGate = nil
+        await harness.sleeper.resumeNext()
+
+        try await eventually { harness.cloud.savedRecords.count == 2 }
+        let saved = try XCTUnwrap(EncryptedSecretRecordMapper.secret(from: harness.cloud.savedRecords[1]))
+        XCTAssertEqual(saved.updatedAt, secondDate)
+        XCTAssertEqual(try EncryptedSecretCrypto.decryptSecret(saved, key: harness.key), "second")
+        let journalKey = pendingKey("openai.apiKey")
+        try await eventually { harness.defaults.data(forKey: journalKey) == nil }
+        XCTAssertNil(harness.defaults.data(forKey: journalKey))
+    }
+
+    func testRemoteApplyFailureDoesNotAdvanceChangeToken() async throws {
+        let harness = makeHarness()
+        let oldToken = Data("old-token".utf8)
+        let newToken = Data("new-token".utf8)
+        harness.defaults.set(oldToken, forKey: "speak.keysync.serverChangeToken")
+        await harness.secrets.failNextStore()
+        harness.cloud.fetchResults = [.success(KeySyncFetchResult(
+            records: [try remoteRecord(
+                identifier: "openai.apiKey",
+                value: "remote",
+                updatedAt: Date(timeIntervalSince1970: 1_720_100_006),
+                key: harness.key
+            )],
+            deletedIDs: [],
+            serverChangeTokenData: newToken,
+            moreComing: false
+        ))]
+
+        await XCTAssertThrowsErrorAsync { try await harness.sync.syncNow() }
+        XCTAssertEqual(harness.defaults.data(forKey: "speak.keysync.serverChangeToken"), oldToken)
+    }
+
+    func testExpiredChangeTokenRetriesExactlyOnceWithoutToken() async throws {
+        let harness = makeHarness()
+        let oldToken = Data("expired-token".utf8)
+        let newToken = Data("replacement-token".utf8)
+        harness.defaults.set(oldToken, forKey: "speak.keysync.serverChangeToken")
+        harness.cloud.fetchResults = [
+            .failure(CKError(.changeTokenExpired)),
+            .success(KeySyncFetchResult(
+                records: [],
+                deletedIDs: [],
+                serverChangeTokenData: newToken,
+                moreComing: false
+            ))
+        ]
+
+        try await harness.sync.syncNow()
+
+        XCTAssertEqual(harness.cloud.fetchTokens, [oldToken, nil])
+        XCTAssertEqual(harness.defaults.data(forKey: "speak.keysync.serverChangeToken"), newToken)
+    }
+
+    func testDisableCancelsInFlightFetchBeforeWritesOrTokenCommit() async throws {
+        let harness = makeHarness()
+        let fetchGate = TestGate()
+        harness.cloud.fetchGate = fetchGate
+        let token = Data("must-not-commit".utf8)
+        harness.cloud.fetchResults = [.success(KeySyncFetchResult(
+            records: [try remoteRecord(
+                identifier: "openai.apiKey",
+                value: "remote",
+                updatedAt: Date(timeIntervalSince1970: 1_720_100_007),
+                key: harness.key
+            )],
+            deletedIDs: [],
+            serverChangeTokenData: token,
+            moreComing: false
+        ))]
+
+        let syncTask = Task { try await harness.sync.syncNow() }
+        try await eventually { await fetchGate.waiterCount == 1 }
+        let disableTask = Task { await harness.sync.disable() }
+        await fetchGate.open()
+        _ = try? await syncTask.value
+        await disableTask.value
+
+        XCTAssertFalse(harness.defaults.bool(forKey: "speak.keysync.enabled"))
+        XCTAssertNil(harness.defaults.data(forKey: "speak.keysync.serverChangeToken"))
+        let storedValue = try? await harness.secrets.secret(identifier: "openai.apiKey")
+        XCTAssertNil(storedValue)
+    }
+
+    func testAccountChangeClearsAccountStateAndCancelsInFlightSync() async throws {
+        let harness = makeHarness(accountName: "first-account")
+        let fetchGate = TestGate()
+        harness.cloud.fetchGate = fetchGate
+        harness.cloud.fetchResults = [.success(KeySyncFetchResult(
+            records: [],
+            deletedIDs: [],
+            serverChangeTokenData: Data("stale-token".utf8),
+            moreComing: false
+        ))]
+        harness.defaults.set(Data("pending".utf8), forKey: pendingKey("openai.apiKey"))
+
+        let syncTask = Task { try await harness.sync.syncNow() }
+        try await eventually { await fetchGate.waiterCount == 1 }
+        harness.cloud.accountName = "second-account"
+        harness.notifications.post(name: .CKAccountChanged, object: nil)
+        await fetchGate.open()
+        _ = try? await syncTask.value
+
+        try await eventually {
+            harness.defaults.string(forKey: "speak.keysync.accountIdentifier")
+                == accountFingerprint("second-account")
+        }
+        XCTAssertFalse(harness.defaults.bool(forKey: "speak.keysync.enabled"))
+        XCTAssertNil(harness.defaults.data(forKey: pendingKey("openai.apiKey")))
+        XCTAssertNil(harness.defaults.data(forKey: "speak.keysync.serverChangeToken"))
+    }
+
+    func testNewerRemoteSecretSupersedesPendingLocalMutation() async throws {
+        let harness = makeHarness()
+        let localDate = Date(timeIntervalSince1970: 1_720_100_008)
+        let remoteDate = Date(timeIntervalSince1970: 1_720_100_009)
+        let mutation = PendingKeySyncMutation(
+            operationID: UUID(),
+            identifier: "openai.apiKey",
+            updatedAt: localDate,
+            kind: .update
+        )
+        harness.defaults.set(try JSONEncoder().encode(mutation), forKey: pendingKey("openai.apiKey"))
+        await harness.secrets.set("local", identifier: "openai.apiKey")
+        harness.cloud.fetchResults = [.success(KeySyncFetchResult(
+            records: [try remoteRecord(
+                identifier: "openai.apiKey",
+                value: "remote",
+                updatedAt: remoteDate,
+                key: harness.key
+            )],
+            deletedIDs: [],
+            serverChangeTokenData: Data("new-token".utf8),
+            moreComing: false
+        ))]
+
+        try await harness.sync.syncNow()
+
+        let storedValue = try await harness.secrets.secret(identifier: "openai.apiKey")
+        XCTAssertEqual(storedValue, "remote")
+        XCTAssertTrue(harness.cloud.savedRecords.isEmpty)
+        XCTAssertNil(harness.defaults.data(forKey: pendingKey("openai.apiKey")))
+    }
+}
+
+private extension CloudKitKeySyncTests {
+    struct Harness {
+        let sync: CloudKitKeySync
+        let secrets: MemorySecretStorage
+        let state: MemorySecretStorage
+        let defaults: UserDefaults
+        let notifications: NotificationCenter
+        let cloud: FakeKeySyncCloud
+        let sleeper: TestSleeper
+        let key: SymmetricKey
+    }
+
+    func makeHarness(accountName: String = "test-account") -> Harness {
+        let suiteName = "CloudKitKeySyncTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(true, forKey: "speak.keysync.enabled")
+        defaults.set(accountFingerprint(accountName), forKey: "speak.keysync.accountIdentifier")
+        let notifications = NotificationCenter()
+        let cloud = FakeKeySyncCloud(accountName: accountName)
+        let sleeper = TestSleeper()
+        let secrets = MemorySecretStorage()
+        let state = MemorySecretStorage()
+        let key = SymmetricKey(data: Data(repeating: 7, count: 32))
+        let dependencies = CloudKitKeySyncDependencies(
+            defaults: defaults,
+            notificationCenter: notifications,
+            now: { Date(timeIntervalSince1970: 1_720_199_999) },
+            sleep: { try await sleeper.sleep($0) },
+            hasCloudKitEntitlement: { true },
+            privateDatabase: { cloud.database },
+            accountStatus: { .available },
+            accountRecordName: { cloud.accountName },
+            setupInfrastructure: { _ in },
+            fetchRecord: { id, _ in cloud.records[id.recordName] },
+            saveRecord: { record, _ in try await cloud.save(record) },
+            fetchChanges: { _, token in try await cloud.fetch(token: token) }
+        )
+        let sync = CloudKitKeySync(
+            secureStorage: secrets,
+            stateStorage: state,
+            dependencies: dependencies,
+            isConfigured: true,
+            symmetricKey: key
+        )
+        return Harness(
+            sync: sync,
+            secrets: secrets,
+            state: state,
+            defaults: defaults,
+            notifications: notifications,
+            cloud: cloud,
+            sleeper: sleeper,
+            key: key
+        )
+    }
+
+    func postLocalChange(
+        _ harness: Harness,
+        identifier: String,
+        operation: String = "store",
+        updatedAt: Date
+    ) {
+        harness.notifications.post(
+            name: SecureStorage.didChangeSecretNotification,
+            object: nil,
+            userInfo: [
+                SecureStorage.NotificationUserInfoKey.identifier: identifier,
+                SecureStorage.NotificationUserInfoKey.operation: operation,
+                SecureStorage.NotificationUserInfoKey.updatedAt: updatedAt
+            ]
+        )
+    }
+
+    func pendingKey(_ identifier: String) -> String {
+        "speak.keysync.pending.\(identifier)"
+    }
+
+    func remoteRecord(
+        identifier: String,
+        value: String,
+        updatedAt: Date,
+        key: SymmetricKey
+    ) throws -> CKRecord {
+        EncryptedSecretRecordMapper.record(from: try EncryptedSecretCrypto.encryptSecret(
+            identifier: identifier,
+            value: value,
+            updatedAt: updatedAt,
+            key: key
+        ))
+    }
+
+    func eventually(
+        attempts: Int = 2_000,
+        condition: @escaping @MainActor () async -> Bool
+    ) async throws {
+        for _ in 0..<attempts {
+            if await condition() { return }
+            await Task.yield()
+        }
+        XCTFail("Condition was not satisfied")
+        throw TestFailure.timedOut
+    }
+}
+
+private enum TestFailure: Error {
+    case injected
+    case timedOut
+}
+
+private actor MemorySecretStorage: CloudKitKeySyncSecretStoring {
+    private var values: [String: String] = [:]
+    private var shouldFailNextStore = false
+
+    func set(_ value: String, identifier: String) {
+        values[identifier] = value
+    }
+
+    func failNextStore() {
+        shouldFailNextStore = true
+    }
+
+    func storeSecret(_ value: String, identifier: String) async throws {
+        if shouldFailNextStore {
+            shouldFailNextStore = false
+            throw TestFailure.injected
+        }
+        values[identifier] = value
+    }
+
+    func secret(identifier: String) async throws -> String {
+        guard let value = values[identifier] else { throw SecureStorageError.valueNotFound }
+        return value
+    }
+
+    func removeSecret(identifier: String) async throws {
+        values[identifier] = nil
+    }
+}
+
+@MainActor
+private final class FakeKeySyncCloud {
+    let database = CloudKitKeySyncDatabase(live: nil)
+    var accountName: String
+    var records: [String: CKRecord] = [:]
+    var fetchResults: [Result<KeySyncFetchResult, Error>] = []
+    var fetchTokens: [Data?] = []
+    var savedRecords: [CKRecord] = []
+    var saveAttempts = 0
+    var saveFailuresRemaining = 0
+    var saveGate: TestGate?
+    var fetchGate: TestGate?
+
+    init(accountName: String) {
+        self.accountName = accountName
+    }
+
+    func save(_ record: CKRecord) async throws -> CKRecord {
+        saveAttempts += 1
+        if let saveGate { await saveGate.wait() }
+        if saveFailuresRemaining > 0 {
+            saveFailuresRemaining -= 1
+            throw TestFailure.injected
+        }
+        savedRecords.append(record)
+        records[record.recordID.recordName] = record
+        return record
+    }
+
+    func fetch(token: Data?) async throws -> KeySyncFetchResult {
+        fetchTokens.append(token)
+        if let fetchGate { await fetchGate.wait() }
+        guard !fetchResults.isEmpty else {
+            return KeySyncFetchResult(
+                records: [],
+                deletedIDs: [],
+                serverChangeTokenData: token,
+                moreComing: false
+            )
+        }
+        return try fetchResults.removeFirst().get()
+    }
+}
+
+private actor TestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    var waiterCount: Int { waiters.count }
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+private actor TestSleeper {
+    private var waiters: [CheckedContinuation<Void, Error>] = []
+
+    var waiterCount: Int { waiters.count }
+
+    func sleep(_ nanoseconds: UInt64) async throws {
+        try await withCheckedThrowingContinuation { waiters.append($0) }
+    }
+
+    func resumeNext() {
+        guard !waiters.isEmpty else { return }
+        waiters.removeFirst().resume()
+    }
+}
+
+private func accountFingerprint(_ accountName: String) -> String {
+    SHA256.hash(data: Data(accountName.utf8))
+        .map { String(format: "%02x", $0) }
+        .joined()
+}
+
+private func XCTAssertThrowsErrorAsync(
+    _ expression: () async throws -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        try await expression()
+        XCTFail("Expected expression to throw", file: file, line: line)
+    } catch {
+        // Expected.
     }
 }

--- a/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
+++ b/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
@@ -110,7 +110,7 @@ final class CloudKitKeySyncTests: XCTestCase {
         )
     }
 
-    func testRepeatedLocalChangesCoalesceIntoOneUpload() async throws {
+    func testRepeatedLocalChanges_CoalesceIntoOneUpload() async throws {
         let harness = makeHarness()
         let isAvailable = await harness.sync.isAvailable()
         XCTAssertTrue(isAvailable)
@@ -134,7 +134,7 @@ final class CloudKitKeySyncTests: XCTestCase {
         XCTAssertNil(harness.defaults.data(forKey: journalKey))
     }
 
-    func testFailedDeletionRemainsJournaledAndRetries() async throws {
+    func testFailedDeletion_RemainsJournaledAndRetries() async throws {
         let harness = makeHarness()
         let isAvailable = await harness.sync.isAvailable()
         XCTAssertTrue(isAvailable)
@@ -166,7 +166,7 @@ final class CloudKitKeySyncTests: XCTestCase {
         XCTAssertNil(harness.defaults.data(forKey: journalKey))
     }
 
-    func testFailedUpdateRemainsJournaledAndRetries() async throws {
+    func testFailedUpdate_RemainsJournaledAndRetries() async throws {
         let harness = makeHarness()
         let isAvailable = await harness.sync.isAvailable()
         XCTAssertTrue(isAvailable)
@@ -196,7 +196,7 @@ final class CloudKitKeySyncTests: XCTestCase {
         try await eventually { harness.defaults.data(forKey: journalKey) == nil }
     }
 
-    func testNewerMutationSurvivesOlderUploadCompletion() async throws {
+    func testNewerMutation_SurvivesOlderUploadCompletion() async throws {
         let harness = makeHarness()
         let isAvailable = await harness.sync.isAvailable()
         XCTAssertTrue(isAvailable)
@@ -228,11 +228,11 @@ final class CloudKitKeySyncTests: XCTestCase {
         XCTAssertNil(harness.defaults.data(forKey: journalKey))
     }
 
-    func testRemoteApplyFailureDoesNotAdvanceChangeToken() async throws {
+    func testRemoteApplyFailure_DoesNotAdvanceChangeToken() async throws {
         let harness = makeHarness()
         let oldToken = Data("old-token".utf8)
         let newToken = Data("new-token".utf8)
-        harness.defaults.set(oldToken, forKey: "speak.keysync.serverChangeToken")
+        harness.defaults.set(oldToken, forKey: CloudKitKeySync.syncTokenKey)
         await harness.secrets.failNextStore()
         harness.cloud.fetchResults = [.success(KeySyncFetchResult(
             records: [try remoteRecord(
@@ -247,14 +247,14 @@ final class CloudKitKeySyncTests: XCTestCase {
         ))]
 
         await XCTAssertThrowsErrorAsync { try await harness.sync.syncNow() }
-        XCTAssertEqual(harness.defaults.data(forKey: "speak.keysync.serverChangeToken"), oldToken)
+        XCTAssertEqual(harness.defaults.data(forKey: CloudKitKeySync.syncTokenKey), oldToken)
     }
 
-    func testExpiredChangeTokenRetriesExactlyOnceWithoutToken() async throws {
+    func testExpiredChangeToken_RetriesExactlyOnceWithoutToken() async throws {
         let harness = makeHarness()
         let oldToken = Data("expired-token".utf8)
         let newToken = Data("replacement-token".utf8)
-        harness.defaults.set(oldToken, forKey: "speak.keysync.serverChangeToken")
+        harness.defaults.set(oldToken, forKey: CloudKitKeySync.syncTokenKey)
         harness.cloud.fetchResults = [
             .failure(CKError(.changeTokenExpired)),
             .success(KeySyncFetchResult(
@@ -268,10 +268,10 @@ final class CloudKitKeySyncTests: XCTestCase {
         try await harness.sync.syncNow()
 
         XCTAssertEqual(harness.cloud.fetchTokens, [oldToken, nil])
-        XCTAssertEqual(harness.defaults.data(forKey: "speak.keysync.serverChangeToken"), newToken)
+        XCTAssertEqual(harness.defaults.data(forKey: CloudKitKeySync.syncTokenKey), newToken)
     }
 
-    func testDisableCancelsInFlightFetchBeforeWritesOrTokenCommit() async throws {
+    func testDisable_CancelsInFlightFetchBeforeWritesOrTokenCommit() async throws {
         let harness = makeHarness()
         let fetchGate = TestGate()
         harness.cloud.fetchGate = fetchGate
@@ -295,13 +295,13 @@ final class CloudKitKeySyncTests: XCTestCase {
         _ = try? await syncTask.value
         await disableTask.value
 
-        XCTAssertFalse(harness.defaults.bool(forKey: "speak.keysync.enabled"))
-        XCTAssertNil(harness.defaults.data(forKey: "speak.keysync.serverChangeToken"))
+        XCTAssertFalse(harness.defaults.bool(forKey: CloudKitKeySync.enabledKey))
+        XCTAssertNil(harness.defaults.data(forKey: CloudKitKeySync.syncTokenKey))
         let storedValue = try? await harness.secrets.secret(identifier: "openai.apiKey")
         XCTAssertNil(storedValue)
     }
 
-    func testAccountChangeClearsAccountStateAndCancelsInFlightSync() async throws {
+    func testAccountChange_ClearsAccountStateAndCancelsInFlightSync() async throws {
         let harness = makeHarness(accountName: "first-account")
         let fetchGate = TestGate()
         harness.cloud.fetchGate = fetchGate
@@ -311,7 +311,16 @@ final class CloudKitKeySyncTests: XCTestCase {
             serverChangeTokenData: Data("stale-token".utf8),
             moreComing: false
         ))]
-        harness.defaults.set(Data("pending".utf8), forKey: pendingKey("openai.apiKey"))
+        let pending = PendingKeySyncMutation(
+            operationID: UUID(),
+            identifier: "openai.apiKey",
+            updatedAt: Date(timeIntervalSince1970: 1_720_100_010),
+            kind: .update
+        )
+        harness.defaults.set(
+            try JSONEncoder().encode(pending),
+            forKey: CloudKitKeySync.pendingMutationKey(identifier: "openai.apiKey")
+        )
 
         let syncTask = Task { try await harness.sync.syncNow() }
         try await eventually { await fetchGate.waiterCount == 1 }
@@ -321,15 +330,15 @@ final class CloudKitKeySyncTests: XCTestCase {
         _ = try? await syncTask.value
 
         try await eventually {
-            harness.defaults.string(forKey: "speak.keysync.accountIdentifier")
+            harness.defaults.string(forKey: CloudKitKeySync.accountIdentifierKey)
                 == accountFingerprint("second-account")
         }
-        XCTAssertFalse(harness.defaults.bool(forKey: "speak.keysync.enabled"))
-        XCTAssertNil(harness.defaults.data(forKey: pendingKey("openai.apiKey")))
-        XCTAssertNil(harness.defaults.data(forKey: "speak.keysync.serverChangeToken"))
+        XCTAssertFalse(harness.defaults.bool(forKey: CloudKitKeySync.enabledKey))
+        XCTAssertNil(harness.defaults.data(forKey: CloudKitKeySync.pendingMutationKey(identifier: "openai.apiKey")))
+        XCTAssertNil(harness.defaults.data(forKey: CloudKitKeySync.syncTokenKey))
     }
 
-    func testNewerRemoteSecretSupersedesPendingLocalMutation() async throws {
+    func testNewerRemoteSecret_SupersedesPendingLocalMutation() async throws {
         let harness = makeHarness()
         let localDate = Date(timeIntervalSince1970: 1_720_100_008)
         let remoteDate = Date(timeIntervalSince1970: 1_720_100_009)
@@ -360,6 +369,63 @@ final class CloudKitKeySyncTests: XCTestCase {
         XCTAssertTrue(harness.cloud.savedRecords.isEmpty)
         XCTAssertNil(harness.defaults.data(forKey: pendingKey("openai.apiKey")))
     }
+
+    func testPagedRemoteChanges_AppliesEveryPageAndAdvancesTokens() async throws {
+        let harness = makeHarness()
+        let firstToken = Data("first-page-token".utf8)
+        let finalToken = Data("final-page-token".utf8)
+        harness.cloud.fetchResults = [
+            .success(KeySyncFetchResult(
+                records: [try remoteRecord(
+                    identifier: "openai.apiKey",
+                    value: "first-page",
+                    updatedAt: Date(timeIntervalSince1970: 1_720_100_011),
+                    key: harness.key
+                )],
+                deletedIDs: [],
+                serverChangeTokenData: firstToken,
+                moreComing: true
+            )),
+            .success(KeySyncFetchResult(
+                records: [try remoteRecord(
+                    identifier: "deepgram.apiKey",
+                    value: "second-page",
+                    updatedAt: Date(timeIntervalSince1970: 1_720_100_012),
+                    key: harness.key
+                )],
+                deletedIDs: [],
+                serverChangeTokenData: finalToken,
+                moreComing: false
+            ))
+        ]
+
+        try await harness.sync.syncNow()
+
+        XCTAssertEqual(harness.cloud.fetchTokens, [nil, firstToken])
+        let firstValue = try await harness.secrets.secret(identifier: "openai.apiKey")
+        let secondValue = try await harness.secrets.secret(identifier: "deepgram.apiKey")
+        XCTAssertEqual(firstValue, "first-page")
+        XCTAssertEqual(secondValue, "second-page")
+        XCTAssertEqual(harness.defaults.data(forKey: CloudKitKeySync.syncTokenKey), finalToken)
+    }
+
+    func testSleeperCancellation_ResumesTheMatchingWaiter() async throws {
+        let sleeper = TestSleeper()
+        let sleepTask = Task { try await sleeper.sleep(123) }
+        try await eventually { await sleeper.waiterCount == 1 }
+
+        sleepTask.cancel()
+
+        do {
+            try await sleepTask.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+        try await eventually { await sleeper.waiterCount == 0 }
+        let requestedNanoseconds = await sleeper.requestedNanoseconds
+        XCTAssertEqual(requestedNanoseconds, [123])
+    }
 }
 
 private extension CloudKitKeySyncTests {
@@ -378,8 +444,8 @@ private extension CloudKitKeySyncTests {
         let suiteName = "CloudKitKeySyncTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
-        defaults.set(true, forKey: "speak.keysync.enabled")
-        defaults.set(accountFingerprint(accountName), forKey: "speak.keysync.accountIdentifier")
+        defaults.set(true, forKey: CloudKitKeySync.enabledKey)
+        defaults.set(accountFingerprint(accountName), forKey: CloudKitKeySync.accountIdentifierKey)
         let notifications = NotificationCenter()
         let cloud = FakeKeySyncCloud(accountName: accountName)
         let sleeper = TestSleeper()
@@ -437,7 +503,7 @@ private extension CloudKitKeySyncTests {
     }
 
     func pendingKey(_ identifier: String) -> String {
-        "speak.keysync.pending.\(identifier)"
+        CloudKitKeySync.pendingMutationKey(identifier: identifier)
     }
 
     func remoteRecord(
@@ -456,13 +522,15 @@ private extension CloudKitKeySyncTests {
 
     func eventually(
         attempts: Int = 2_000,
+        file: StaticString = #filePath,
+        line: UInt = #line,
         condition: @escaping @MainActor () async -> Bool
     ) async throws {
         for _ in 0..<attempts {
             if await condition() { return }
             await Task.yield()
         }
-        XCTFail("Condition was not satisfied")
+        XCTFail("Condition was not satisfied after \(attempts) attempts", file: file, line: line)
         throw TestFailure.timedOut
     }
 }
@@ -566,17 +634,41 @@ private actor TestGate {
 }
 
 private actor TestSleeper {
-    private var waiters: [CheckedContinuation<Void, Error>] = []
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private var waiters: [Waiter] = []
+    private(set) var requestedNanoseconds: [UInt64] = []
 
     var waiterCount: Int { waiters.count }
 
     func sleep(_ nanoseconds: UInt64) async throws {
-        try await withCheckedThrowingContinuation { waiters.append($0) }
+        try Task.checkCancellation()
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            try await withCheckedThrowingContinuation { continuation in
+                requestedNanoseconds.append(nanoseconds)
+                waiters.append(Waiter(id: id, continuation: continuation))
+                if Task.isCancelled {
+                    cancelWaiter(id: id)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: id) }
+        }
     }
 
     func resumeNext() {
         guard !waiters.isEmpty else { return }
-        waiters.removeFirst().resume()
+        waiters.removeFirst().continuation.resume()
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        waiters.remove(at: index).continuation.resume(throwing: CancellationError())
     }
 }
 


### PR DESCRIPTION
## Summary
- inject CloudKit operations, account identity, time, sleep, notifications, defaults, and secret storage behind the production key-sync boundary
- exercise local mutation coalescing, durable update/deletion retries, overlapping upload races, remote-apply failures, token expiry recovery, account changes, disable cancellation, and server timestamp precedence
- keep every scenario deterministic and independent of entitlements, network access, or an iCloud account

## Verification
- `swift test`
- `swift package --disable-dependency-cache plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json`

Closes #507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CloudKit synchronization reliability during retries, account changes, cancellations, and remote updates.
  * Improved recovery from expired synchronization state and failed uploads.
  * Reduced the risk of local changes being lost or overwritten during concurrent updates.

* **Tests**
  * Expanded coverage for synchronization failures, retries, cancellations, and conflicting local and remote changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->