### PR TITLE
fix: unify Deepgram TTS voice catalogues

### DIFF
--- a/Sources/SpeakApp/TextToSpeech/TTSProtocol.swift
+++ b/Sources/SpeakApp/TextToSpeech/TTSProtocol.swift
@@ -1,6 +1,9 @@
 import SpeakCore
 import Foundation
 
+// This file intentionally keeps the provider protocol and static voice catalogue together.
+// swiftlint:disable file_length
+
 enum TTSProvider: String, Codable, CaseIterable, Identifiable {
   case elevenlabs
   case openai
@@ -131,6 +134,8 @@ struct TTSVoice: Identifiable, Hashable, Codable {
     case american
     case british
     case australian
+    case filipino
+    case irish
     case professional
     case casual
     case deep
@@ -216,6 +221,8 @@ protocol TextToSpeechClient {
   func validateAPIKey(_ key: String) async -> APIKeyValidationResult
 }
 
+// The provider lists form one static catalogue and are easier to audit as a single type.
+// swiftlint:disable:next type_body_length
 struct VoiceCatalog {
   static let elevenlabsVoices: [TTSVoice] = [
     // Recommended voices
@@ -440,93 +447,16 @@ struct VoiceCatalog {
     ),
   ]
 
-  // Deepgram Aura voices - ultra-low latency (~250ms first byte)
-  static let deepgramVoices: [TTSVoice] = [
+  // Both platform pickers project from the canonical SpeakCore Deepgram catalogue.
+  static let deepgramVoices: [TTSVoice] = DeepgramTTSCatalog.voices.map { voice in
     TTSVoice(
-      id: "deepgram/aura-asteria-en",
-      name: "Asteria",
+      id: voice.providerVoiceID,
+      name: "\(voice.name) · \(voice.model.displayName)",
       provider: .deepgram,
-      traits: [.female, .american, .professional, .lowLatency],
+      traits: deepgramTraits(for: voice),
       previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-luna-en",
-      name: "Luna",
-      provider: .deepgram,
-      traits: [.female, .american, .warm, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-stella-en",
-      name: "Stella",
-      provider: .deepgram,
-      traits: [.female, .american, .professional, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-athena-en",
-      name: "Athena",
-      provider: .deepgram,
-      traits: [.female, .british, .professional, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-hera-en",
-      name: "Hera",
-      provider: .deepgram,
-      traits: [.female, .american, .clear, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-orion-en",
-      name: "Orion",
-      provider: .deepgram,
-      traits: [.male, .american, .deep, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-arcas-en",
-      name: "Arcas",
-      provider: .deepgram,
-      traits: [.male, .american, .professional, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-perseus-en",
-      name: "Perseus",
-      provider: .deepgram,
-      traits: [.male, .american, .energetic, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-angus-en",
-      name: "Angus",
-      provider: .deepgram,
-      traits: [.male, .british, .professional, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-orpheus-en",
-      name: "Orpheus",
-      provider: .deepgram,
-      traits: [.male, .american, .warm, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-helios-en",
-      name: "Helios",
-      provider: .deepgram,
-      traits: [.male, .british, .deep, .lowLatency],
-      previewURL: nil
-    ),
-    TTSVoice(
-      id: "deepgram/aura-zeus-en",
-      name: "Zeus",
-      provider: .deepgram,
-      traits: [.male, .american, .deep, .lowLatency],
-      previewURL: nil
-    ),
-  ]
+    )
+  }
 
   static let allVoices: [TTSVoice] =
     elevenlabsVoices + openaiVoices + azureVoices + deepgramVoices + systemVoices
@@ -560,5 +490,20 @@ struct VoiceCatalog {
       "elevenlabs/bella": "elevenlabs/EXAVITQu4vr4xnSDxMaL",
     ]
     return legacyMappings[id] ?? id
+  }
+
+  private static func deepgramTraits(for voice: DeepgramTTSVoice) -> [TTSVoice.VoiceTrait] {
+    let gender: TTSVoice.VoiceTrait = voice.gender == .female ? .female : .male
+    let accent: TTSVoice.VoiceTrait
+    switch voice.accent {
+    case .american: accent = .american
+    case .australian: accent = .australian
+    case .british: accent = .british
+    case .filipino: accent = .filipino
+    case .irish: accent = .irish
+    }
+
+    let style = TTSVoice.VoiceTrait(rawValue: voice.style.rawValue) ?? .professional
+    return [gender, accent, style, .lowLatency]
   }
 }

--- a/Sources/SpeakApp/TextToSpeech/TTSProtocol.swift
+++ b/Sources/SpeakApp/TextToSpeech/TTSProtocol.swift
@@ -494,16 +494,27 @@ struct VoiceCatalog {
 
   private static func deepgramTraits(for voice: DeepgramTTSVoice) -> [TTSVoice.VoiceTrait] {
     let gender: TTSVoice.VoiceTrait = voice.gender == .female ? .female : .male
-    let accent: TTSVoice.VoiceTrait
-    switch voice.accent {
-    case .american: accent = .american
-    case .australian: accent = .australian
-    case .british: accent = .british
-    case .filipino: accent = .filipino
-    case .irish: accent = .irish
-    }
+    return [gender, deepgramAccent(voice.accent), deepgramStyle(voice.style), .lowLatency]
+  }
 
-    let style = TTSVoice.VoiceTrait(rawValue: voice.style.rawValue) ?? .professional
-    return [gender, accent, style, .lowLatency]
+  private static func deepgramAccent(_ accent: DeepgramTTSVoiceAccent) -> TTSVoice.VoiceTrait {
+    switch accent {
+    case .american: .american
+    case .australian: .australian
+    case .british: .british
+    case .filipino: .filipino
+    case .irish: .irish
+    }
+  }
+
+  private static func deepgramStyle(_ style: DeepgramTTSVoiceStyle) -> TTSVoice.VoiceTrait {
+    switch style {
+    case .casual: .casual
+    case .clear: .clear
+    case .deep: .deep
+    case .energetic: .energetic
+    case .professional: .professional
+    case .warm: .warm
+    }
   }
 }

--- a/Sources/SpeakCore/DeepgramTTSCatalog.swift
+++ b/Sources/SpeakCore/DeepgramTTSCatalog.swift
@@ -112,32 +112,35 @@ public enum DeepgramTTSCatalog {
         modelID: String?,
         voiceID: String?
     ) -> DeepgramTTSSelection {
-        let normalizedVoiceID = voiceID.map(normalizedVoiceID)
-        let exactVoice = normalizedVoiceID.flatMap { normalizedID in
+        let requestedVoiceID = voiceID.map(normalizedVoiceID)
+        let exactVoice = requestedVoiceID.flatMap { normalizedID in
             voices.first { $0.id == normalizedID }
         }
-        let model = model(forLegacyID: modelID) ?? exactVoice?.model ?? defaultModel
+        let resolvedModel = model(forLegacyID: modelID) ?? exactVoice?.model ?? defaultModel
 
-        if let exactVoice, exactVoice.model == model {
-            return DeepgramTTSSelection(model: model, voice: exactVoice)
+        if let exactVoice, exactVoice.model == resolvedModel {
+            return DeepgramTTSSelection(model: resolvedModel, voice: exactVoice)
         }
 
         let legacyName = exactVoice?.name.lowercased()
-            ?? normalizedVoiceID?.lowercased()
+            ?? requestedVoiceID?.lowercased()
         if let legacyName,
-           let compatibleVoice = voices(for: model).first(where: {
+           let compatibleVoice = voices(for: resolvedModel).first(where: {
                $0.name.lowercased() == legacyName
            }) {
-            return DeepgramTTSSelection(model: model, voice: compatibleVoice)
+            return DeepgramTTSSelection(model: resolvedModel, voice: compatibleVoice)
         }
 
-        return DeepgramTTSSelection(model: model, voice: defaultVoice(for: model))
+        return DeepgramTTSSelection(
+            model: resolvedModel,
+            voice: defaultVoice(for: resolvedModel)
+        )
     }
 
     private static func normalizedVoiceID(_ id: String) -> String {
-        id.trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-            .replacingOccurrences(of: "deepgram/", with: "")
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard trimmed.hasPrefix("deepgram/") else { return trimmed }
+        return String(trimmed.dropFirst("deepgram/".count))
     }
 
     // English voice metadata verified against Deepgram's Aura voice catalogue.

--- a/Sources/SpeakCore/DeepgramTTSCatalog.swift
+++ b/Sources/SpeakCore/DeepgramTTSCatalog.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+/// Deepgram Aura model families exposed by the shared voice catalogue.
+public enum DeepgramTTSModel: String, CaseIterable, Codable, Hashable, Identifiable, Sendable {
+    case aura2 = "aura-2"
+    case aura1 = "aura"
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .aura2: "Aura 2 (English)"
+        case .aura1: "Aura 1 (English)"
+        }
+    }
+}
+
+public enum DeepgramTTSVoiceGender: String, Codable, Hashable, Sendable {
+    case female
+    case male
+
+    public var displayName: String { rawValue.capitalized }
+}
+
+public enum DeepgramTTSVoiceAccent: String, Codable, Hashable, Sendable {
+    case american
+    case australian
+    case british
+    case filipino
+    case irish
+
+    public var displayName: String { rawValue.capitalized }
+
+    public var localeIdentifier: String {
+        switch self {
+        case .american: "en-US"
+        case .australian: "en-AU"
+        case .british: "en-GB"
+        case .filipino: "en-PH"
+        case .irish: "en-IE"
+        }
+    }
+}
+
+public enum DeepgramTTSVoiceStyle: String, Codable, Hashable, Sendable {
+    case casual
+    case clear
+    case deep
+    case energetic
+    case professional
+    case warm
+}
+
+/// A complete Deepgram API voice identifier and its picker metadata.
+public struct DeepgramTTSVoice: Identifiable, Codable, Hashable, Sendable {
+    public let id: String
+    public let name: String
+    public let model: DeepgramTTSModel
+    public let gender: DeepgramTTSVoiceGender
+    public let accent: DeepgramTTSVoiceAccent
+    public let style: DeepgramTTSVoiceStyle
+
+    public var providerVoiceID: String { "deepgram/\(id)" }
+
+    public var displayName: String {
+        "\(name) (\(accent.displayName), \(gender.displayName))"
+    }
+}
+
+public struct DeepgramTTSSelection: Equatable, Sendable {
+    public let model: DeepgramTTSModel
+    public let voice: DeepgramTTSVoice
+}
+
+/// Canonical Deepgram Aura catalogue, defaults, compatibility, and legacy migrations.
+public enum DeepgramTTSCatalog {
+    public static let defaultModel: DeepgramTTSModel = .aura2
+    public static let models = DeepgramTTSModel.allCases
+    public static let voices = aura2EnglishVoices + aura1EnglishVoices
+
+    public static func model(forLegacyID id: String?) -> DeepgramTTSModel? {
+        switch id?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "aura-2", "aura2", "aura_2": .aura2
+        case "aura", "aura-1", "aura1", "aura_1": .aura1
+        default: nil
+        }
+    }
+
+    public static func voices(for model: DeepgramTTSModel) -> [DeepgramTTSVoice] {
+        voices.filter { $0.model == model }
+    }
+
+    public static func voices(forModelID modelID: String) -> [DeepgramTTSVoice] {
+        voices(for: model(forLegacyID: modelID) ?? defaultModel)
+    }
+
+    public static func voice(forID id: String) -> DeepgramTTSVoice? {
+        let normalized = normalizedVoiceID(id)
+        return voices.first { $0.id == normalized }
+    }
+
+    public static func defaultVoice(for model: DeepgramTTSModel) -> DeepgramTTSVoice {
+        let defaultID = model == .aura2 ? "aura-2-asteria-en" : "aura-asteria-en"
+        guard let fallback = voices(for: model).first else {
+            preconditionFailure("Deepgram catalogue model must contain at least one voice")
+        }
+        return voices.first { $0.id == defaultID } ?? fallback
+    }
+
+    /// Normalizes old model prefixes, short voice names, provider-prefixed IDs, and invalid pairs.
+    public static func resolvedSelection(
+        modelID: String?,
+        voiceID: String?
+    ) -> DeepgramTTSSelection {
+        let normalizedVoiceID = voiceID.map(normalizedVoiceID)
+        let exactVoice = normalizedVoiceID.flatMap { normalizedID in
+            voices.first { $0.id == normalizedID }
+        }
+        let model = model(forLegacyID: modelID) ?? exactVoice?.model ?? defaultModel
+
+        if let exactVoice, exactVoice.model == model {
+            return DeepgramTTSSelection(model: model, voice: exactVoice)
+        }
+
+        let legacyName = exactVoice?.name.lowercased()
+            ?? normalizedVoiceID?.lowercased()
+        if let legacyName,
+           let compatibleVoice = voices(for: model).first(where: {
+               $0.name.lowercased() == legacyName
+           }) {
+            return DeepgramTTSSelection(model: model, voice: compatibleVoice)
+        }
+
+        return DeepgramTTSSelection(model: model, voice: defaultVoice(for: model))
+    }
+
+    private static func normalizedVoiceID(_ id: String) -> String {
+        id.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "deepgram/", with: "")
+    }
+
+    // English voice metadata verified against Deepgram's Aura voice catalogue.
+    private static let aura2EnglishVoices: [DeepgramTTSVoice] = [
+        voice("aura-2-amalthea-en", "Amalthea", .aura2, .female, .filipino, .energetic),
+        voice("aura-2-andromeda-en", "Andromeda", .aura2, .female, .american, .casual),
+        voice("aura-2-apollo-en", "Apollo", .aura2, .male, .american, .casual),
+        voice("aura-2-arcas-en", "Arcas", .aura2, .male, .american, .clear),
+        voice("aura-2-aries-en", "Aries", .aura2, .male, .american, .warm),
+        voice("aura-2-asteria-en", "Asteria", .aura2, .female, .american, .clear),
+        voice("aura-2-athena-en", "Athena", .aura2, .female, .american, .professional),
+        voice("aura-2-atlas-en", "Atlas", .aura2, .male, .american, .energetic),
+        voice("aura-2-aurora-en", "Aurora", .aura2, .female, .american, .energetic),
+        voice("aura-2-callista-en", "Callista", .aura2, .female, .american, .professional),
+        voice("aura-2-cora-en", "Cora", .aura2, .female, .american, .warm),
+        voice("aura-2-cordelia-en", "Cordelia", .aura2, .female, .american, .warm),
+        voice("aura-2-delia-en", "Delia", .aura2, .female, .american, .casual),
+        voice("aura-2-draco-en", "Draco", .aura2, .male, .british, .deep),
+        voice("aura-2-electra-en", "Electra", .aura2, .female, .american, .professional),
+        voice("aura-2-harmonia-en", "Harmonia", .aura2, .female, .american, .clear),
+        voice("aura-2-helena-en", "Helena", .aura2, .female, .american, .warm),
+        voice("aura-2-hera-en", "Hera", .aura2, .female, .american, .professional),
+        voice("aura-2-hermes-en", "Hermes", .aura2, .male, .american, .professional),
+        voice("aura-2-hyperion-en", "Hyperion", .aura2, .male, .australian, .warm),
+        voice("aura-2-iris-en", "Iris", .aura2, .female, .american, .energetic),
+        voice("aura-2-janus-en", "Janus", .aura2, .female, .american, .professional),
+        voice("aura-2-juno-en", "Juno", .aura2, .female, .american, .casual),
+        voice("aura-2-jupiter-en", "Jupiter", .aura2, .male, .american, .deep),
+        voice("aura-2-luna-en", "Luna", .aura2, .female, .american, .warm),
+        voice("aura-2-mars-en", "Mars", .aura2, .male, .american, .deep),
+        voice("aura-2-minerva-en", "Minerva", .aura2, .female, .american, .warm),
+        voice("aura-2-neptune-en", "Neptune", .aura2, .male, .american, .professional),
+        voice("aura-2-odysseus-en", "Odysseus", .aura2, .male, .american, .professional),
+        voice("aura-2-ophelia-en", "Ophelia", .aura2, .female, .american, .energetic),
+        voice("aura-2-orion-en", "Orion", .aura2, .male, .american, .casual),
+        voice("aura-2-orpheus-en", "Orpheus", .aura2, .male, .american, .professional),
+        voice("aura-2-pandora-en", "Pandora", .aura2, .female, .british, .warm),
+        voice("aura-2-phoebe-en", "Phoebe", .aura2, .female, .american, .energetic),
+        voice("aura-2-pluto-en", "Pluto", .aura2, .male, .american, .deep),
+        voice("aura-2-saturn-en", "Saturn", .aura2, .male, .american, .deep),
+        voice("aura-2-selene-en", "Selene", .aura2, .female, .american, .energetic),
+        voice("aura-2-thalia-en", "Thalia", .aura2, .female, .american, .clear),
+        voice("aura-2-theia-en", "Theia", .aura2, .female, .australian, .professional),
+        voice("aura-2-vesta-en", "Vesta", .aura2, .female, .american, .warm),
+        voice("aura-2-zeus-en", "Zeus", .aura2, .male, .american, .deep)
+    ]
+
+    private static let aura1EnglishVoices: [DeepgramTTSVoice] = [
+        voice("aura-asteria-en", "Asteria", .aura1, .female, .american, .clear),
+        voice("aura-luna-en", "Luna", .aura1, .female, .american, .warm),
+        voice("aura-stella-en", "Stella", .aura1, .female, .american, .professional),
+        voice("aura-athena-en", "Athena", .aura1, .female, .british, .professional),
+        voice("aura-hera-en", "Hera", .aura1, .female, .american, .professional),
+        voice("aura-orion-en", "Orion", .aura1, .male, .american, .casual),
+        voice("aura-arcas-en", "Arcas", .aura1, .male, .american, .clear),
+        voice("aura-perseus-en", "Perseus", .aura1, .male, .american, .professional),
+        voice("aura-angus-en", "Angus", .aura1, .male, .irish, .warm),
+        voice("aura-orpheus-en", "Orpheus", .aura1, .male, .american, .professional),
+        voice("aura-helios-en", "Helios", .aura1, .male, .british, .professional),
+        voice("aura-zeus-en", "Zeus", .aura1, .male, .american, .deep)
+    ]
+
+    // The catalogue reads like a compact table; keeping all six fields here makes drift obvious.
+    // swiftlint:disable:next function_parameter_count
+    private static func voice(
+        _ id: String,
+        _ name: String,
+        _ model: DeepgramTTSModel,
+        _ gender: DeepgramTTSVoiceGender,
+        _ accent: DeepgramTTSVoiceAccent,
+        _ style: DeepgramTTSVoiceStyle
+    ) -> DeepgramTTSVoice {
+        DeepgramTTSVoice(
+            id: id,
+            name: name,
+            model: model,
+            gender: gender,
+            accent: accent,
+            style: style
+        )
+    }
+}

--- a/Sources/SpeakiOS/Services/DeepgramTTSClient.swift
+++ b/Sources/SpeakiOS/Services/DeepgramTTSClient.swift
@@ -22,7 +22,8 @@ public final class DeepgramTTSClient: ObservableObject {
     // MARK: - Configuration
 
     public var model: String = DeepgramTTSCatalog.defaultModel.id
-    public var voice: String = DeepgramTTSCatalog.defaultVoice(for: .aura2).id
+    public var voice: String =
+        DeepgramTTSCatalog.defaultVoice(for: DeepgramTTSCatalog.defaultModel).id
     public var speed: Double = 1.0
 
     // MARK: - Init

--- a/Sources/SpeakiOS/Services/DeepgramTTSClient.swift
+++ b/Sources/SpeakiOS/Services/DeepgramTTSClient.swift
@@ -2,6 +2,7 @@
 import AVFoundation
 import Foundation
 import os.log
+import SpeakCore
 
 /// Deepgram Aura TTS client for iOS.
 /// Converts text to speech using Deepgram's Aura API.
@@ -20,8 +21,8 @@ public final class DeepgramTTSClient: ObservableObject {
 
     // MARK: - Configuration
 
-    public var model: String = "aura-2"
-    public var voice: String = "asteria"
+    public var model: String = DeepgramTTSCatalog.defaultModel.id
+    public var voice: String = DeepgramTTSCatalog.defaultVoice(for: .aura2).id
     public var speed: Double = 1.0
 
     // MARK: - Init
@@ -51,8 +52,10 @@ public final class DeepgramTTSClient: ObservableObject {
             throw DeepgramTTSError.missingAPIKey
         }
 
-        // Deepgram model format: aura-2-{voice}-en or aura-{voice}-en
-        let modelParam = "\(model)-\(voice)-en"
+        let modelParam = DeepgramTTSCatalog.resolvedSelection(
+            modelID: model,
+            voiceID: voice
+        ).voice.id
         let url = URL(string: "https://api.deepgram.com/v1/speak?model=\(modelParam)")!
 
         var request = URLRequest(url: url)

--- a/Sources/SpeakiOS/Services/OpenClawSettings.swift
+++ b/Sources/SpeakiOS/Services/OpenClawSettings.swift
@@ -72,65 +72,14 @@ public final class OpenClawSettings: ObservableObject {
         didSet { UserDefaults.standard.set(lowLatencySpeech, forKey: "openclaw.lowLatencySpeech") }
     }
 
-    // MARK: - Available Voices & Models
-
-    /// Deepgram Aura-2 voices (from official docs).
-    public static let aura2Voices: [(id: String, label: String)] = [
-        ("andromeda", "Andromeda (American, Female)"),
-        ("apollo", "Apollo (American, Male)"),
-        ("arcas", "Arcas (American, Male)"),
-        ("aries", "Aries (American, Male)"),
-        ("asteria", "Asteria (American, Female)"),
-        ("athena", "Athena (American, Female)"),
-        ("aurora", "Aurora (American, Female)"),
-        ("callista", "Callista (American, Female)"),
-        ("cora", "Cora (American, Female)"),
-        ("draco", "Draco (British, Male)"),
-        ("electra", "Electra (American, Female)"),
-        ("helena", "Helena (American, Female)"),
-        ("hera", "Hera (American, Female)"),
-        ("hermes", "Hermes (American, Male)"),
-        ("luna", "Luna (American, Female)"),
-        ("orion", "Orion (American, Male)"),
-        ("orpheus", "Orpheus (American, Male)"),
-        ("pandora", "Pandora (British, Female)"),
-        ("thalia", "Thalia (American, Female)")
-    ]
-
-    /// Deepgram Aura-1 voices.
-    public static let aura1Voices: [(id: String, label: String)] = [
-        ("asteria", "Asteria (American, Female)"),
-        ("luna", "Luna (American, Female)"),
-        ("stella", "Stella (American, Female)"),
-        ("athena", "Athena (British, Female)"),
-        ("hera", "Hera (American, Female)"),
-        ("orion", "Orion (American, Male)"),
-        ("arcas", "Arcas (American, Male)"),
-        ("perseus", "Perseus (American, Male)"),
-        ("angus", "Angus (Irish, Male)"),
-        ("orpheus", "Orpheus (American, Male)"),
-        ("helios", "Helios (British, Male)"),
-        ("zeus", "Zeus (American, Male)")
-    ]
-
-    /// Returns voices available for the given model.
-    public static func voices(for model: String) -> [(id: String, label: String)] {
-        model.hasPrefix("aura-2") ? aura2Voices : aura1Voices
-    }
-
-    /// Deepgram TTS models — the id is used as a prefix before the voice name.
-    public static let availableModels: [(id: String, label: String)] = [
-        ("aura-2", "Aura 2 (English)"),
-        ("aura", "Aura 1 (English)")
-    ]
-
-    /// Validate that the current voice is compatible with the current model,
-    /// falling back to the first available voice if not.
+    /// Migrates legacy selections and keeps the selected voice compatible with its model.
     public func validateVoiceModelCombination() {
-        let validVoices = Self.voices(for: ttsModel)
-        if !validVoices.contains(where: { $0.id == ttsVoice }) {
-            ttsVoice = validVoices.first?.id ?? "asteria"
-        }
+        let selection = DeepgramTTSCatalog.resolvedSelection(
+            modelID: ttsModel,
+            voiceID: ttsVoice
+        )
+        if ttsModel != selection.model.id { ttsModel = selection.model.id }
+        if ttsVoice != selection.voice.id { ttsVoice = selection.voice.id }
     }
 
     public var isConfigured: Bool {
@@ -143,8 +92,12 @@ public final class OpenClawSettings: ObservableObject {
         self.enabled = UserDefaults.standard.bool(forKey: "openclaw.enabled")
         self.ttsEnabled = UserDefaults.standard.object(forKey: "openclaw.ttsEnabled") as? Bool ?? true
         self.summariseResponses = UserDefaults.standard.object(forKey: "openclaw.summarise") as? Bool ?? true
-        self.ttsVoice = UserDefaults.standard.string(forKey: "openclaw.ttsVoice") ?? "asteria"
-        self.ttsModel = UserDefaults.standard.string(forKey: "openclaw.ttsModel") ?? "aura-2"
+        let ttsSelection = DeepgramTTSCatalog.resolvedSelection(
+            modelID: UserDefaults.standard.string(forKey: "openclaw.ttsModel"),
+            voiceID: UserDefaults.standard.string(forKey: "openclaw.ttsVoice")
+        )
+        self.ttsVoice = ttsSelection.voice.id
+        self.ttsModel = ttsSelection.model.id
         self.ttsSpeed = UserDefaults.standard.object(forKey: "openclaw.ttsSpeed") as? Double ?? 1.0
         self.conversationModeEnabled =
             UserDefaults.standard.object(forKey: "openclaw.conversationModeEnabled") as? Bool ?? false
@@ -157,8 +110,8 @@ public final class OpenClawSettings: ObservableObject {
             UserDefaults.standard.string(forKey: "openclaw.keywordAcknowledgePhrase") ?? "over"
         self.lowLatencySpeech = UserDefaults.standard.object(forKey: "openclaw.lowLatencySpeech") as? Bool ?? false
 
-        // Validate saved voice is compatible with saved model
-        validateVoiceModelCombination()
+        UserDefaults.standard.set(ttsVoice, forKey: "openclaw.ttsVoice")
+        UserDefaults.standard.set(ttsModel, forKey: "openclaw.ttsModel")
     }
 
     // MARK: - Keychain

--- a/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
+++ b/Sources/SpeakiOS/Views/OpenClawSettingsView.swift
@@ -102,11 +102,11 @@ public struct OpenClawSettingsView: View {
                 if settings.ttsEnabled {
                     Picker("Voice", selection: $settings.ttsVoice) {
                         ForEach(
-                            OpenClawSettings.voices(for: settings.ttsModel),
+                            DeepgramTTSCatalog.voices(forModelID: settings.ttsModel),
                             id: \.id
                         ) { voice in
                             HStack {
-                                Text(voice.label)
+                                Text(voice.displayName)
                                 Spacer()
                                 IOSModelCredentialStatusView(
                                     availability: ModelCredentialResolver.availability(
@@ -122,20 +122,20 @@ public struct OpenClawSettingsView: View {
                     }
 
                     Picker("Model", selection: $settings.ttsModel) {
-                        ForEach(OpenClawSettings.availableModels, id: \.id) { mdl in
+                        ForEach(DeepgramTTSCatalog.models) { model in
                             HStack {
-                                Text(mdl.label)
+                                Text(model.displayName)
                                 Spacer()
                                 IOSModelCredentialStatusView(
                                     availability: ModelCredentialResolver.availability(
-                                        for: mdl.id,
+                                        for: model.id,
                                         purpose: .voiceOutput,
                                         storedAPIKeyIdentifiers: appSettings.storedAPIKeyIdentifiers
                                     )
                                 )
                             }
                             .accessibilityElement(children: .combine)
-                            .tag(mdl.id)
+                            .tag(model.id)
                         }
                     }
                     .onChange(of: settings.ttsModel) { _ in

--- a/Tests/SpeakAppTests/DeepgramTTSCatalogParityTests.swift
+++ b/Tests/SpeakAppTests/DeepgramTTSCatalogParityTests.swift
@@ -1,0 +1,24 @@
+import SpeakCore
+import XCTest
+@testable import SpeakApp
+
+final class DeepgramTTSCatalogParityTests: XCTestCase {
+    func testMacVoiceProjection_MatchesEverySharedDeepgramVoice() {
+        XCTAssertEqual(
+            Set(VoiceCatalog.deepgramVoices.map(\.id)),
+            Set(DeepgramTTSCatalog.voices.map(\.providerVoiceID))
+        )
+    }
+
+    func testMacVoiceProjection_PreservesSharedMetadata() throws {
+        let shared = try XCTUnwrap(DeepgramTTSCatalog.voice(forID: "aura-2-amalthea-en"))
+        let projected = try XCTUnwrap(
+            VoiceCatalog.deepgramVoices.first { $0.id == shared.providerVoiceID }
+        )
+
+        XCTAssertTrue(projected.name.contains(shared.name))
+        XCTAssertTrue(projected.traits.contains(.female))
+        XCTAssertTrue(projected.traits.contains(.filipino))
+        XCTAssertTrue(projected.traits.contains(.lowLatency))
+    }
+}

--- a/Tests/SpeakCoreTests/DeepgramTTSCatalogTests.swift
+++ b/Tests/SpeakCoreTests/DeepgramTTSCatalogTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import SpeakCore
+
+final class DeepgramTTSCatalogTests: XCTestCase {
+    func testVoiceIdentifiers_AreUniqueAndProviderScoped() {
+        let voices = DeepgramTTSCatalog.voices
+
+        XCTAssertEqual(Set(voices.map(\.id)).count, voices.count)
+        XCTAssertEqual(Set(voices.map(\.providerVoiceID)).count, voices.count)
+        XCTAssertTrue(voices.allSatisfy { $0.providerVoiceID == "deepgram/\($0.id)" })
+    }
+
+    func testModels_ExposeCompatibleVoicesAndDefaults() {
+        for model in DeepgramTTSCatalog.models {
+            let voices = DeepgramTTSCatalog.voices(for: model)
+            XCTAssertFalse(voices.isEmpty)
+            XCTAssertTrue(voices.allSatisfy { $0.model == model })
+            XCTAssertEqual(DeepgramTTSCatalog.defaultVoice(for: model).model, model)
+        }
+    }
+
+    func testAura2Catalogue_ContainsCurrentEnglishAndLegacySharedVoices() {
+        let aura2IDs = Set(DeepgramTTSCatalog.voices(for: .aura2).map(\.id))
+
+        XCTAssertEqual(aura2IDs.count, 41)
+        XCTAssertEqual(DeepgramTTSCatalog.voices(for: .aura1).count, 12)
+        XCTAssertTrue(aura2IDs.contains("aura-2-thalia-en"))
+        XCTAssertTrue(aura2IDs.contains("aura-2-amalthea-en"))
+        XCTAssertTrue(aura2IDs.contains("aura-2-hyperion-en"))
+        XCTAssertTrue(aura2IDs.contains("aura-2-zeus-en"))
+    }
+
+    func testLegacyShortVoice_MigratesWithinSelectedModel() {
+        let aura2 = DeepgramTTSCatalog.resolvedSelection(
+            modelID: "aura-2",
+            voiceID: "asteria"
+        )
+        let aura1 = DeepgramTTSCatalog.resolvedSelection(
+            modelID: "aura-1",
+            voiceID: "athena"
+        )
+
+        XCTAssertEqual(aura2.model, .aura2)
+        XCTAssertEqual(aura2.voice.id, "aura-2-asteria-en")
+        XCTAssertEqual(aura1.model, .aura1)
+        XCTAssertEqual(aura1.voice.id, "aura-athena-en")
+    }
+
+    func testProviderPrefixedVoice_InfersModelWhenLegacyModelIsMissing() {
+        let selection = DeepgramTTSCatalog.resolvedSelection(
+            modelID: nil,
+            voiceID: "deepgram/aura-zeus-en"
+        )
+
+        XCTAssertEqual(selection.model, .aura1)
+        XCTAssertEqual(selection.voice.id, "aura-zeus-en")
+    }
+
+    func testIncompatibleVoice_MigratesByNameThenFallsBackSafely() {
+        let migratedByName = DeepgramTTSCatalog.resolvedSelection(
+            modelID: "aura-2",
+            voiceID: "deepgram/aura-luna-en"
+        )
+        let fallback = DeepgramTTSCatalog.resolvedSelection(
+            modelID: "aura",
+            voiceID: "retired-voice"
+        )
+
+        XCTAssertEqual(migratedByName.voice.id, "aura-2-luna-en")
+        XCTAssertEqual(fallback.voice, DeepgramTTSCatalog.defaultVoice(for: .aura1))
+    }
+}

--- a/Tests/SpeakCoreTests/DeepgramTTSCatalogTests.swift
+++ b/Tests/SpeakCoreTests/DeepgramTTSCatalogTests.swift
@@ -56,6 +56,21 @@ final class DeepgramTTSCatalogTests: XCTestCase {
         XCTAssertEqual(selection.voice.id, "aura-zeus-en")
     }
 
+    func testMissingOrBlankSelection_ResolvesToCatalogueDefaults() {
+        for voiceID in [nil, "", "   "] as [String?] {
+            let selection = DeepgramTTSCatalog.resolvedSelection(
+                modelID: nil,
+                voiceID: voiceID
+            )
+
+            XCTAssertEqual(selection.model, DeepgramTTSCatalog.defaultModel)
+            XCTAssertEqual(
+                selection.voice,
+                DeepgramTTSCatalog.defaultVoice(for: DeepgramTTSCatalog.defaultModel)
+            )
+        }
+    }
+
     func testIncompatibleVoice_MigratesByNameThenFallsBackSafely() {
         let migratedByName = DeepgramTTSCatalog.resolvedSelection(
             modelID: "aura-2",


### PR DESCRIPTION
## Summary
- move Deepgram Aura model, voice, metadata, defaults, and compatibility rules into one SpeakCore catalogue
- drive both the Mac and iOS voice pickers from that catalogue
- update Aura-2 to the current 41-voice English catalogue while retaining all 12 Aura-1 voices
- migrate legacy short names, model aliases, provider-prefixed IDs, and incompatible saved selections safely

## Verification
- `swift test` — 747 tests passed, 11 skipped
- focused Deepgram catalogue tests — 8 passed
- `swift build --target SpeakiOSLib`
- strict SwiftLint — 0 violations
- voice identifiers and metadata verified against the [official Deepgram TTS model catalogue](https://developers.deepgram.com/docs/tts-models)

Closes #511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Deepgram Aura voice catalog coverage, including models, accents, genders, styles, and low-latency metadata.
  * Updated voice and model selection to show readable names and support more available voices.
  * Added automatic migration and fallback for legacy, unavailable, or incompatible selections.

* **Bug Fixes**
  * Improved synthesis configuration to consistently use valid model and voice combinations.

* **Tests**
  * Added coverage for catalog completeness, compatibility, defaults, migration, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->