### PR TITLE
fix: stream Mistral uploads from disk

### DIFF
--- a/Sources/SpeakApp/MistralTranscriptionProvider.swift
+++ b/Sources/SpeakApp/MistralTranscriptionProvider.swift
@@ -13,13 +13,16 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
 
   private let baseURL: URL
   private let session: URLSession
+  private let multipartDirectory: URL
 
   init(
     session: URLSession = .shared,
-    baseURL: URL = URL(string: "https://api.mistral.ai/v1")!
+    baseURL: URL = URL(string: "https://api.mistral.ai/v1")!,
+    multipartDirectory: URL = FileManager.default.temporaryDirectory
   ) {
     self.session = session
     self.baseURL = baseURL
+    self.multipartDirectory = multipartDirectory
   }
 
   func transcribeFile(
@@ -41,25 +44,17 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
     request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
     request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
 
-    let audioData = try Data(contentsOf: url)
-    var body = Data()
-
     let modelName = modelID(from: model)
-    body.appendFormField(named: "model", value: modelName, boundary: boundary)
-    if let languageCode = languageCode(from: language) {
-      body.appendFormField(named: "language", value: languageCode, boundary: boundary)
-    }
-    body.appendFileField(
-      named: "file",
-      filename: url.lastPathComponent,
-      mimeType: "audio/m4a",
-      fileData: audioData,
-      boundary: boundary
+    let uploadBodyURL = try Self.makeMultipartUploadBody(
+      sourceURL: url,
+      destinationDirectory: multipartDirectory,
+      boundary: boundary,
+      model: modelName,
+      language: languageCode(from: language)
     )
-    body.appendString("--\(boundary)--\r\n")
-    request.httpBody = body
+    defer { try? FileManager.default.removeItem(at: uploadBodyURL) }
 
-    let (data, response) = try await session.data(for: request)
+    let (data, response) = try await session.upload(for: request, fromFile: uploadBodyURL)
     guard let http = response as? HTTPURLResponse else {
       throw TranscriptionProviderError.invalidResponse
     }
@@ -131,6 +126,65 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
       .replacingOccurrences(of: "_", with: "-")
     guard let code = normalized.split(separator: "-").first, !code.isEmpty else { return nil }
     return String(code).lowercased()
+  }
+
+  nonisolated static func makeMultipartUploadBody(
+    sourceURL: URL,
+    destinationDirectory: URL,
+    boundary: String,
+    model: String,
+    language: String?
+  ) throws -> URL {
+    let destinationURL = destinationDirectory
+      .appendingPathComponent("mistral-upload-\(UUID().uuidString).multipart")
+    try FileManager.default.createDirectory(
+      at: destinationDirectory,
+      withIntermediateDirectories: true
+    )
+
+    do {
+      guard FileManager.default.createFile(atPath: destinationURL.path, contents: nil) else {
+        throw CocoaError(.fileWriteUnknown)
+      }
+      let output = try FileHandle(forWritingTo: destinationURL)
+      defer { try? output.close() }
+
+      try output.write(contentsOf: Data(Self.formField(named: "model", value: model, boundary: boundary).utf8))
+      if let language {
+        try output.write(
+          contentsOf: Data(Self.formField(named: "language", value: language, boundary: boundary).utf8)
+        )
+      }
+      let fileHeader =
+        "--\(boundary)\r\n"
+        + "Content-Disposition: form-data; name=\"file\"; filename=\"\(sourceURL.lastPathComponent)\"\r\n"
+        + "Content-Type: audio/m4a\r\n\r\n"
+      try output.write(contentsOf: Data(fileHeader.utf8))
+
+      let input = try FileHandle(forReadingFrom: sourceURL)
+      defer { try? input.close() }
+      while true {
+        let chunk = try input.read(upToCount: 1024 * 1024) ?? Data()
+        guard !chunk.isEmpty else { break }
+        try output.write(contentsOf: chunk)
+      }
+      try output.write(contentsOf: Data("\r\n--\(boundary)--\r\n".utf8))
+      return destinationURL
+    } catch {
+      try? FileManager.default.removeItem(at: destinationURL)
+      throw error
+    }
+  }
+
+  private nonisolated static func formField(
+    named name: String,
+    value: String,
+    boundary: String
+  ) -> String {
+    "--\(boundary)\r\n"
+      + "Content-Disposition: form-data; name=\"\(name)\"\r\n"
+      + "\r\n"
+      + "\(value)\r\n"
   }
 
   private func buildTranscriptionResult(

--- a/Sources/SpeakApp/MistralTranscriptionProvider.swift
+++ b/Sources/SpeakApp/MistralTranscriptionProvider.swift
@@ -155,9 +155,10 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
           contentsOf: Data(Self.formField(named: "language", value: language, boundary: boundary).utf8)
         )
       }
+      let escapedFilename = Self.escapedMultipartFilename(sourceURL.lastPathComponent)
       let fileHeader =
         "--\(boundary)\r\n"
-        + "Content-Disposition: form-data; name=\"file\"; filename=\"\(sourceURL.lastPathComponent)\"\r\n"
+        + "Content-Disposition: form-data; name=\"file\"; filename=\"\(escapedFilename)\"\r\n"
         + "Content-Type: audio/m4a\r\n\r\n"
       try output.write(contentsOf: Data(fileHeader.utf8))
 
@@ -185,6 +186,14 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
       + "Content-Disposition: form-data; name=\"\(name)\"\r\n"
       + "\r\n"
       + "\(value)\r\n"
+  }
+
+  private nonisolated static func escapedMultipartFilename(_ filename: String) -> String {
+    filename
+      .replacingOccurrences(of: "\r", with: "")
+      .replacingOccurrences(of: "\n", with: "")
+      .replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "\"", with: "\\\"")
   }
 
   private func buildTranscriptionResult(

--- a/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
@@ -91,6 +91,25 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     XCTAssertTrue(bodyText.hasSuffix("\r\n--TestBoundary--\r\n"))
   }
 
+  func testMultipartUploadBody_escapesFilenameAndRemovesHeaderBreaks() throws {
+    let audioURL = try makeAudioFile(filename: "audio\"\\\r\nX-Evil: true.m4a")
+    let directory = try makeTemporaryDirectory()
+    let bodyURL = try MistralTranscriptionProvider.makeMultipartUploadBody(
+      sourceURL: audioURL,
+      destinationDirectory: directory,
+      boundary: "TestBoundary",
+      model: "voxtral-mini-latest",
+      language: nil
+    )
+    defer { try? FileManager.default.removeItem(at: bodyURL) }
+
+    let body = try Data(contentsOf: bodyURL)
+    let bodyText = try XCTUnwrap(String(data: body, encoding: .utf8))
+
+    XCTAssertTrue(bodyText.contains(#"filename="audio\"\\X-Evil: true.m4a""#))
+    XCTAssertFalse(bodyText.contains("\r\nX-Evil: true.m4a"))
+  }
+
   func testTranscribeFile_removesMultipartFileAfterSuccessfulUpload() async throws {
     let directory = try makeTemporaryDirectory()
     MistralMockURLProtocol.requestHandler = { request in
@@ -235,26 +254,14 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     XCTAssertEqual(result.outcome, .failure(message: "API key is empty"))
   }
 
-  private func makeProvider(
-    multipartDirectory: URL = FileManager.default.temporaryDirectory
-  ) -> MistralTranscriptionProvider {
-    MistralTranscriptionProvider(
-      session: makeMockSession(),
-      multipartDirectory: multipartDirectory
-    )
-  }
-
-  private func makeMockSession() -> URLSession {
-    let configuration = URLSessionConfiguration.ephemeral
-    configuration.protocolClasses = [MistralMockURLProtocol.self]
-    return URLSession(configuration: configuration)
-  }
-
-  private func makeAudioFile(contents: Data = Data("fake-audio".utf8)) throws -> URL {
+  private func makeAudioFile(
+    contents: Data = Data("fake-audio".utf8),
+    filename: String = "mistral-transcription-\(UUID().uuidString).m4a"
+  ) throws -> URL {
     let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
     let directory = root.appendingPathComponent(".build/test-audio", isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-    let url = directory.appendingPathComponent("mistral-transcription-\(UUID().uuidString).m4a")
+    let url = directory.appendingPathComponent(filename)
     try contents.write(to: url)
     addTeardownBlock {
       try? FileManager.default.removeItem(at: url)
@@ -281,6 +288,17 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     )!
     return (response, Data(body.utf8))
   }
+}
+
+private func makeProvider(
+  multipartDirectory: URL = FileManager.default.temporaryDirectory
+) -> MistralTranscriptionProvider {
+  let configuration = URLSessionConfiguration.ephemeral
+  configuration.protocolClasses = [MistralMockURLProtocol.self]
+  return MistralTranscriptionProvider(
+    session: URLSession(configuration: configuration),
+    multipartDirectory: multipartDirectory
+  )
 }
 
 private actor MistralRequestObserver {

--- a/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
@@ -54,25 +54,80 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     )
 
     let capturedRequest = await requestObserver.capturedRequest()
-    let capturedBody = await requestObserver.capturedBodyString()
     let request = try XCTUnwrap(capturedRequest)
-    let body = try XCTUnwrap(capturedBody)
 
     XCTAssertEqual(request.httpMethod, "POST")
     XCTAssertEqual(request.url?.absoluteString, "https://api.mistral.ai/v1/audio/transcriptions")
     XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-mistral-key")
     let contentType = request.value(forHTTPHeaderField: "Content-Type")
     XCTAssertTrue(contentType?.hasPrefix("multipart/form-data; boundary=") == true)
-    XCTAssertTrue(body.contains(#"name="model""#))
-    XCTAssertTrue(body.contains("\r\nvoxtral-mini-latest\r\n"))
-    XCTAssertFalse(body.contains("\r\nmistral/voxtral-mini-latest\r\n"))
-    XCTAssertTrue(body.contains(#"name="language""#))
-    XCTAssertTrue(body.contains("\r\nen\r\n"))
-    XCTAssertTrue(body.contains(#"name="file"; filename=""#))
-    XCTAssertFalse(body.contains("response_format"))
     XCTAssertEqual(result.text, "hello world")
     XCTAssertEqual(result.duration, 1.25)
     XCTAssertEqual(result.modelIdentifier, "mistral/voxtral-mini-latest")
+  }
+
+  func testMultipartUploadBody_preservesFieldsAndStreamsAudioBytesToDisk() throws {
+    let audioURL = try makeAudioFile(contents: Data([0x00, 0x01, 0xFE, 0xFF]))
+    let directory = try makeTemporaryDirectory()
+    let bodyURL = try MistralTranscriptionProvider.makeMultipartUploadBody(
+      sourceURL: audioURL,
+      destinationDirectory: directory,
+      boundary: "TestBoundary",
+      model: "voxtral-mini-latest",
+      language: "en"
+    )
+    defer { try? FileManager.default.removeItem(at: bodyURL) }
+
+    let body = try Data(contentsOf: bodyURL)
+    let bodyText = try XCTUnwrap(String(data: body, encoding: .isoLatin1))
+
+    XCTAssertTrue(bodyText.contains(#"name="model""#))
+    XCTAssertTrue(bodyText.contains("\r\nvoxtral-mini-latest\r\n"))
+    XCTAssertTrue(bodyText.contains(#"name="language""#))
+    XCTAssertTrue(bodyText.contains("\r\nen\r\n"))
+    XCTAssertTrue(bodyText.contains(#"name="file"; filename=""#))
+    XCTAssertTrue(bodyText.contains("Content-Type: audio/m4a"))
+    XCTAssertTrue(bodyText.contains("\u{0}\u{1}þÿ"))
+    XCTAssertTrue(bodyText.hasSuffix("\r\n--TestBoundary--\r\n"))
+  }
+
+  func testTranscribeFile_removesMultipartFileAfterSuccessfulUpload() async throws {
+    let directory = try makeTemporaryDirectory()
+    MistralMockURLProtocol.requestHandler = { request in
+      try Self.makeResponse(for: request, body: #"{"text":"hello","duration":1}"#)
+    }
+    defer { MistralMockURLProtocol.requestHandler = nil }
+
+    _ = try await makeProvider(multipartDirectory: directory).transcribeFile(
+      at: try makeAudioFile(),
+      apiKey: "test-mistral-key",
+      model: "mistral/voxtral-mini-latest",
+      language: nil
+    )
+
+    XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: directory.path), [])
+  }
+
+  func testTranscribeFile_removesMultipartFileAfterFailedUpload() async throws {
+    let directory = try makeTemporaryDirectory()
+    MistralMockURLProtocol.requestHandler = { _ in
+      throw URLError(.cannotConnectToHost)
+    }
+    defer { MistralMockURLProtocol.requestHandler = nil }
+
+    do {
+      _ = try await makeProvider(multipartDirectory: directory).transcribeFile(
+        at: try makeAudioFile(),
+        apiKey: "test-mistral-key",
+        model: "mistral/voxtral-mini-latest",
+        language: nil
+      )
+      XCTFail("Expected the upload to fail")
+    } catch {
+      XCTAssertEqual((error as? URLError)?.code, .cannotConnectToHost)
+    }
+
+    XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: directory.path), [])
   }
 
   func testTranscribeFile_mapsSegments() async throws {
@@ -180,8 +235,13 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     XCTAssertEqual(result.outcome, .failure(message: "API key is empty"))
   }
 
-  private func makeProvider() -> MistralTranscriptionProvider {
-    MistralTranscriptionProvider(session: makeMockSession())
+  private func makeProvider(
+    multipartDirectory: URL = FileManager.default.temporaryDirectory
+  ) -> MistralTranscriptionProvider {
+    MistralTranscriptionProvider(
+      session: makeMockSession(),
+      multipartDirectory: multipartDirectory
+    )
   }
 
   private func makeMockSession() -> URLSession {
@@ -190,16 +250,26 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     return URLSession(configuration: configuration)
   }
 
-  private func makeAudioFile() throws -> URL {
+  private func makeAudioFile(contents: Data = Data("fake-audio".utf8)) throws -> URL {
     let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
     let directory = root.appendingPathComponent(".build/test-audio", isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     let url = directory.appendingPathComponent("mistral-transcription-\(UUID().uuidString).m4a")
-    try Data("fake-audio".utf8).write(to: url)
+    try contents.write(to: url)
     addTeardownBlock {
       try? FileManager.default.removeItem(at: url)
     }
     return url
+  }
+
+  private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("mistral-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    addTeardownBlock {
+      try? FileManager.default.removeItem(at: directory)
+    }
+    return directory
   }
 
   private static func makeResponse(for request: URLRequest, body: String) throws -> (HTTPURLResponse, Data) {
@@ -215,38 +285,15 @@ final class MistralTranscriptionProviderTests: XCTestCase {
 
 private actor MistralRequestObserver {
   private var request: URLRequest?
-  private var body: Data?
 
   func store(request: URLRequest) {
     self.request = request
-    body = request.httpBody ?? readBody(from: request.httpBodyStream)
   }
 
   func capturedRequest() -> URLRequest? {
     request
   }
 
-  func capturedBodyString() -> String? {
-    body.flatMap { String(data: $0, encoding: .utf8) }
-  }
-
-  private func readBody(from stream: InputStream?) -> Data? {
-    guard let stream else { return nil }
-    stream.open()
-    defer { stream.close() }
-
-    var data = Data()
-    let bufferSize = 4096
-    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
-    defer { buffer.deallocate() }
-
-    while stream.hasBytesAvailable {
-      let readCount = stream.read(buffer, maxLength: bufferSize)
-      if readCount <= 0 { break }
-      data.append(buffer, count: readCount)
-    }
-    return data.isEmpty ? nil : data
-  }
 }
 
 private final class MistralMockURLProtocol: URLProtocol {


### PR DESCRIPTION
## Summary

- stream Mistral Voxtral multipart uploads through a temporary file instead of loading the source audio and request body into memory
- upload the generated multipart body with URLSession's file upload API
- remove temporary multipart files after successful and failed uploads
- cover multipart fields, binary audio bytes, and cleanup paths without a live API key

## Verification

- `swift test --filter MistralTranscriptionProviderTests`
- `swift test` (756 tests, 11 skipped, 0 failures)
- strict SwiftLint (0 violations)
- `git diff --check`

Closes #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved transcription uploads by streaming multipart data, reducing memory usage for large audio files.

* **Reliability**
  * Temporary upload files are automatically cleaned up after successful or failed requests.
  * Multipart filenames are sanitized for safer uploads.

* **Testing**
  * Expanded coverage for streamed audio uploads, multipart formatting, custom upload directories, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->