### PR TITLE
fix(mac): improve compact HUD design and local-model labels

### DIFF
--- a/Sources/SpeakApp/HUDView.swift
+++ b/Sources/SpeakApp/HUDView.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SpeakCore
 import SwiftUI
 
 // swiftlint:disable type_body_length
@@ -141,29 +142,30 @@ struct HUDOverlay: View {
     let confidence = manager.snapshot.liveTextConfidence
 
     HStack(spacing: 6) {
-      if shouldUseLegacyRendering {
+      ZStack(alignment: .top) {
+        // Invisible two-line template reserves a fixed height so the HUD
+        // doesn't reflow every time streamed text wraps from one line to two.
+        Text(verbatim: " \n ")
+          .font(.callout)
+          .hidden()
         Text(text)
           .font(isFinal ? .callout : .callout.italic())
           .fontWeight(isFinal ? .regular : .light)
           .foregroundStyle(isFinal ? .primary : .secondary)
+          .multilineTextAlignment(.center)
           .lineLimit(2)
           .truncationMode(.head)
-          .accessibilityLabel(isFinal ? "Transcript: \(text)" : "Partial transcript: \(text)")
-      } else {
-        Text(text)
-          .font(isFinal ? .callout : .callout.italic())
-          .fontWeight(isFinal ? .regular : .light)
-          .foregroundStyle(isFinal ? .primary : .secondary)
-          .lineLimit(2)
-          .truncationMode(.head)
-          .animation(.easeInOut(duration: 0.2), value: isFinal)
+          .animation(
+            shouldUseLegacyRendering ? nil : .easeInOut(duration: 0.2),
+            value: isFinal
+          )
           .accessibilityLabel(isFinal ? "Transcript: \(text)" : "Partial transcript: \(text)")
       }
 
       if let confidence, confidence > 0 {
         Text("\(Int(confidence * 100))%")
           .font(.caption2.monospacedDigit())
-          .foregroundStyle(.tertiary)
+          .foregroundStyle(.secondary)
           .padding(.horizontal, 4)
           .padding(.vertical, 2)
           .background(
@@ -173,7 +175,6 @@ struct HUDOverlay: View {
           .accessibilityLabel("Confidence: \(Int(confidence * 100)) percent")
       }
     }
-    .frame(maxWidth: 300)
   }
 
   @ViewBuilder
@@ -183,7 +184,6 @@ struct HUDOverlay: View {
       // Show the live transcript inline (no disclosure/expand UI).
       liveTranscriptionView(text: transcriptText)
         .padding(.top, 4)
-        .accessibilityHint("Press Command-R to retry the operation")
     }
   }
 
@@ -207,30 +207,41 @@ struct HUDOverlay: View {
     }()
     let micIcon = micWarning ? "mic.slash.fill" : "mic.fill"
     let deviceLabel = health.noInputDevicesAvailable ? "No microphone connected" : health.inputDeviceName
-    HStack(spacing: 8) {
-      Image(systemName: micIcon)
-        .font(.system(size: 10, weight: .semibold))
-        .foregroundStyle(micColor)
-        .accessibilityLabel("Microphone: \(microphonePermissionLabel)")
+    HStack(spacing: 6) {
+      HStack(spacing: 4) {
+        Image(systemName: micIcon)
+          .font(.system(size: 9, weight: .semibold))
+          .foregroundStyle(micColor)
+          .accessibilityLabel("Microphone: \(microphonePermissionLabel)")
 
-      Text(deviceLabel)
-        .font(.caption2)
-        .foregroundStyle(health.noInputDevicesAvailable ? micColor : .secondary)
-        .lineLimit(1)
-        .truncationMode(.tail)
-        .help(deviceLabel)
-        .accessibilityLabel("Input device: \(deviceLabel)")
+        Text(deviceLabel)
+          .font(.caption2)
+          .foregroundStyle(health.noInputDevicesAvailable ? micColor : .secondary)
+          .lineLimit(1)
+          .truncationMode(.tail)
+          .help(deviceLabel)
+          .accessibilityLabel("Input device: \(deviceLabel)")
+      }
+
+      Text(verbatim: "·")
+        .font(.caption2.weight(.semibold))
+        .foregroundStyle(.tertiary)
+        .accessibilityHidden(true)
 
       Text(health.providerLabel)
-        .font(.caption2)
-        .foregroundStyle(.tertiary)
+        .font(.caption2.weight(.medium))
+        .foregroundStyle(.secondary)
         .lineLimit(1)
-        .truncationMode(.tail)
+        .truncationMode(.middle)
+        .layoutPriority(1)
+        .help(health.providerLabel)
         .accessibilityLabel("Transcription provider: \(health.providerLabel)")
 
-      LatencyBadgeCompact(tier: health.latencyTier)
+      LatencyBadgeCompact(tier: health.latencyTier, emphasized: true)
+        .layoutPriority(2)
         .accessibilityLabel("Latency: \(health.latencyTier.displayName)")
     }
+    .frame(height: 18)
     .accessibilityElement(children: .combine)
   }
 
@@ -355,39 +366,6 @@ struct HUDOverlay: View {
 }
 // swiftlint:enable type_body_length
 
-struct HUDOverlay_Previews: PreviewProvider {
-  static var previews: some View {
-    Group {
-      // Compact preview
-      HUDOverlay(manager: previewManager)
-        .frame(width: 600, height: 400)
-        .previewDisplayName("Compact")
-
-      // Expanded with transcript
-      HUDOverlay(manager: expandedPreviewManager)
-        .frame(width: 600, height: 500)
-        .previewDisplayName("Expanded with Transcript")
-    }
-  }
-
-  private static var previewManager: HUDManager {
-    let manager = HUDManager(appSettings: AppSettings())
-    manager.beginRecording()
-    return manager
-  }
-
-  private static var expandedPreviewManager: HUDManager {
-    let manager = HUDManager(appSettings: AppSettings())
-    manager.beginRecording()
-    manager.updateLiveTranscription(
-      text: "Hello, this is a test of the live transcription feature. It should scroll and show the text properly. And this is still being spoken...",
-      isFinal: false,
-      confidence: 0.92
-    )
-    manager.isExpanded = true
-    return manager
-  }
-}
 // @Implement: This is the view that shows a floating indicator at the bottom middle of the screen. This view should float on top of all windows in the system but only show when recording is in progress. This should be a minimal view but must be engaging and informative to the users. It should have a cool animated graphic for each phase.
 // - Recording: Show in red and how long recording is for with a cool icon as well as animation
 // - Transcribing: If the operation is a batch request, this is the transcribing phase waiting for the raw transcription to return

--- a/Sources/SpeakApp/HUDViewPreviews.swift
+++ b/Sources/SpeakApp/HUDViewPreviews.swift
@@ -1,0 +1,121 @@
+import SpeakCore
+import SwiftUI
+
+struct HUDOverlay_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      // Compact preview
+      preview(previewManager, name: "Compact")
+
+      // Compact with a long local-model label (worst case for the metadata row)
+      preview(localModelPreviewManager, name: "Compact – Long Local Model")
+
+      // Same content squeezed into a narrow window
+      preview(localModelPreviewManager, name: "Compact – Narrow", width: 360)
+
+      // Dark appearance
+      preview(localModelPreviewManager, name: "Compact – Dark")
+        .preferredColorScheme(.dark)
+
+      // Failure state with capture-health row
+      preview(failurePreviewManager, name: "Failure")
+
+      // Expanded with transcript
+      preview(expandedPreviewManager, name: "Expanded with Transcript", height: 500)
+    }
+  }
+
+  private static func preview(
+    _ manager: HUDManager,
+    name: String,
+    width: CGFloat = 600,
+    height: CGFloat = 400
+  ) -> some View {
+    HUDOverlay(manager: manager)
+      .environmentObject(AppSettings())
+      .frame(width: width, height: height)
+      .previewDisplayName(name)
+  }
+
+  private static var previewManager: HUDManager {
+    let manager = HUDManager(appSettings: AppSettings())
+    manager.beginRecording()
+    manager.updateCaptureHealth(
+      CaptureHealthSnapshot(
+        microphonePermission: .granted,
+        noInputDevicesAvailable: false,
+        inputDeviceName: "MacBook Pro Microphone",
+        providerLabel: "Deepgram Nova-3 (Streaming)",
+        latencyTier: .fast
+      )
+    )
+    manager.updateLiveTranscription(
+      text: "Testing the compact heads-up display with a short partial transcript",
+      isFinal: false,
+      confidence: 0.94
+    )
+    return manager
+  }
+
+  private static var localModelPreviewManager: HUDManager {
+    let manager = HUDManager(appSettings: AppSettings())
+    manager.beginRecording()
+    manager.updateCaptureHealth(
+      CaptureHealthSnapshot(
+        microphonePermission: .granted,
+        noInputDevicesAvailable: false,
+        inputDeviceName: "External USB Interface Microphone",
+        providerLabel: "Sherpa Onnx Streaming Zipformer En 2023 06 26",
+        latencyTier: .instant
+      )
+    )
+    manager.updateLiveTranscription(
+      text: "The quick brown fox jumps over the lazy dog while the local model keeps streaming new words in",
+      isFinal: false,
+      confidence: 0.87
+    )
+    return manager
+  }
+
+  private static var failurePreviewManager: HUDManager {
+    let manager = HUDManager(appSettings: AppSettings())
+    manager.updateCaptureHealth(
+      CaptureHealthSnapshot(
+        microphonePermission: .granted,
+        noInputDevicesAvailable: true,
+        inputDeviceName: "Unknown",
+        providerLabel: "Whisper Large v3 Turbo (Streaming)",
+        latencyTier: .medium
+      )
+    )
+    manager.finishFailure(
+      headline: "Something went wrong",
+      message: "No audio was captured from the microphone",
+      showRetryHint: true,
+      displayDuration: 0
+    )
+    return manager
+  }
+
+  private static var expandedPreviewManager: HUDManager {
+    let manager = HUDManager(appSettings: AppSettings())
+    manager.beginRecording()
+    manager.updateCaptureHealth(
+      CaptureHealthSnapshot(
+        microphonePermission: .granted,
+        noInputDevicesAvailable: false,
+        inputDeviceName: "MacBook Pro Microphone",
+        providerLabel: "Distil-Whisper Large v3 Turbo (Streaming)",
+        latencyTier: .fast
+      )
+    )
+    manager.updateLiveTranscription(
+      text: "Hello, this is a test of the live transcription feature. It should scroll and show "
+        + "the text properly. And this is still being spoken...",
+      isFinal: false,
+      confidence: 0.92
+    )
+    manager.isExpanded = true
+    return manager
+  }
+}

--- a/Sources/SpeakApp/LatencyBadge.swift
+++ b/Sources/SpeakApp/LatencyBadge.swift
@@ -62,15 +62,20 @@ struct LatencyBadge: View {
 struct LatencyBadgeCompact: View {
   let tier: LatencyTier
   let estimatedMs: Int?
+  /// Adds a tinted capsule behind the glyph for legibility on translucent
+  /// backdrops (used by the HUD capture-health row).
+  let emphasized: Bool
 
-  init(tier: LatencyTier, estimatedMs: Int? = nil) {
+  init(tier: LatencyTier, estimatedMs: Int? = nil, emphasized: Bool = false) {
     self.tier = tier
     self.estimatedMs = estimatedMs
+    self.emphasized = emphasized
   }
 
-  init(option: ModelCatalog.Option) {
+  init(option: ModelCatalog.Option, emphasized: Bool = false) {
     self.tier = option.latencyTier
     self.estimatedMs = option.estimatedLatencyMs
+    self.emphasized = emphasized
   }
 
   private var badgeColor: Color {
@@ -100,10 +105,25 @@ struct LatencyBadgeCompact: View {
   }
 
   var body: some View {
+    if emphasized {
+      glyph
+        .padding(.horizontal, 5)
+        .padding(.vertical, 3)
+        .background(
+          Capsule()
+            .fill(badgeColor.opacity(0.16))
+        )
+        .help(tooltipText)
+    } else {
+      glyph
+        .help(tooltipText)
+    }
+  }
+
+  private var glyph: some View {
     Image(systemName: iconName)
       .font(.system(size: 10, weight: .semibold))
       .foregroundStyle(badgeColor)
-      .help(tooltipText)
   }
 }
 
@@ -125,6 +145,14 @@ struct LatencyBadgeCompact: View {
       LatencyBadgeCompact(tier: .fast, estimatedMs: 500)
       LatencyBadgeCompact(tier: .medium, estimatedMs: 1500)
       LatencyBadgeCompact(tier: .slow, estimatedMs: 3000)
+    }
+
+    Text("Compact Badges (Emphasized)").font(.headline)
+    HStack(spacing: 12) {
+      LatencyBadgeCompact(tier: .instant, estimatedMs: 50, emphasized: true)
+      LatencyBadgeCompact(tier: .fast, estimatedMs: 500, emphasized: true)
+      LatencyBadgeCompact(tier: .medium, estimatedMs: 1500, emphasized: true)
+      LatencyBadgeCompact(tier: .slow, estimatedMs: 3000, emphasized: true)
     }
   }
   .padding()

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -440,9 +440,10 @@ final class MainManager: ObservableObject {
         return FluidAudioParakeetModel.displayName
       }
       #if !APP_STORE
-      let source = LocalModelManager.shared.streamingModelSources.first { $0.id == modelID }
-        ?? LocalModelManager.recommendedStreamingModelSources.first { $0.id == modelID }
-      return source?.modelName ?? "Local Streaming"
+      // Use the catalogue's cleaned-up name rather than the raw source ID
+      // (e.g. "sherpa-onnx-streaming-zipformer-en-2023-06-26") so the HUD
+      // capture-health label stays readable.
+      return ModelCatalog.friendlyName(for: modelID)
       #else
       return "Local Streaming"
       #endif


### PR DESCRIPTION
## Problem
The compact HUD's metadata row under the live transcript looked poor for local models: raw source IDs like `sherpa-onnx-streaming-zipformer-en-2023-06-26`, low-contrast tertiary text running into the device name, arbitrary tail truncation at compact width, a bare latency glyph, and the whole HUD reflowed each time streamed text wrapped to a second line.

## Changes
- Local streaming labels now go through `ModelCatalog.friendlyName` — the HUD never shows raw IDs (diagnostics keep the raw ID via the separate `transcriptionModel` field).
- Metadata row redesigned for density with hierarchy: mic+device cluster · middle-dot separator · medium-weight model label (middle truncation, layout priority, full-name tooltip) · latency badge, on a fixed-height 18pt row.
- `LatencyBadgeCompact` gains an opt-in `emphasized` tinted capsule for legibility on the translucent HUD; Settings usage unchanged.
- Transcript reserves a fixed two-line height (no more streaming reflow), drops the 300pt cap that starved expanded mode, and gets a higher-contrast confidence chip; removed a copy-pasted retry accessibility hint.
- Previews now inject the required `AppSettings` (previously crashed at preview time) and cover long-local-model, narrow, dark, and failure variants (moved to `HUDViewPreviews.swift`).

Information density is preserved — same fields, better hierarchy and truncation behavior.

## Testing
No behavioural changes to recording; `swift build`, all 763 tests, and SwiftLint strict (baseline) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)