### PR TITLE
refactor: deduplicate provider validation and snapshot boilerplate (-387 lines)

### DIFF
--- a/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/AssemblyAITranscriptionProvider.swift
@@ -187,7 +187,7 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
       self.bufferPool.returnBuffer(&returnBuffer)
 
       if let error {
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.logger.error("Failed to send audio: \(error.localizedDescription)")
         self.currentOnError()?(error)
       }
@@ -241,7 +241,7 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
       self.bufferPool.returnBuffer(&returnBuffer)
 
       if let error {
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.logger.error("Failed to send audio: \(error.localizedDescription)")
         self.currentOnError()?(error)
       }
@@ -333,7 +333,7 @@ final class AssemblyAILiveTranscriber: @unchecked Sendable {
         // We re-arm via asyncAfter (not the completion handler thread) so we
         // don't starve URLSession's delegate queue and prevent it from
         // delivering the Begin/Turn frames.
-        if self.shouldIgnoreSocketError(error) {
+        if WebSocketErrorFilter.shouldIgnore(error) {
           DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.01) { [weak self] in
             self?.receiveMessages()
           }
@@ -490,15 +490,6 @@ private extension AssemblyAILiveTranscriber {
   func currentOnTranscript() -> ((AssemblyAITurnResponse) -> Void)? {
     withStateLock { onTranscript }
   }
-
-  func shouldIgnoreSocketError(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-    if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-      return true
-    }
-    return false
-  }
 }
 
 // MARK: - AssemblyAI Transcription Provider
@@ -589,8 +580,7 @@ struct AssemblyAITranscriptionProvider: TranscriptionProvider {
     }
 
     if let language {
-      let code = extractLanguageCode(from: language)
-      body["language_code"] = code
+      body["language_code"] = language.localeLanguageCode
     } else {
       body["language_detection"] = true
     }
@@ -680,40 +670,18 @@ struct AssemblyAITranscriptionProvider: TranscriptionProvider {
   // MARK: - API Key Validation
 
   func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
-    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else {
-      return .failure(message: "API key is empty")
-    }
-
-    // Use the /v2/transcript endpoint with a lightweight GET to validate
+    // Use the /v2/transcript endpoint with a lightweight GET, limited to 1 result,
+    // just to validate auth.
     let url = baseURL.appendingPathComponent("transcript")
-    var request = URLRequest(url: url)
-    request.httpMethod = "GET"
-    request.setValue(trimmed, forHTTPHeaderField: "Authorization")
-    // Limit to 1 result just to validate auth
     var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
     components.queryItems = [URLQueryItem(name: "limit", value: "1")]
-    request.url = components.url
 
-    do {
-      let (data, response) = try await session.data(for: request)
-      guard let http = response as? HTTPURLResponse else {
-        return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
-      }
-
-      let debug = debugSnapshot(request: request, response: http, data: data)
-
-      if (200..<300).contains(http.statusCode) {
-        return .success(message: "AssemblyAI API key validated", debug: debug)
-      }
-
-      return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
-    } catch {
-      return .failure(
-        message: "Validation failed: \(error.localizedDescription)",
-        debug: debugSnapshot(request: request, error: error)
-      )
-    }
+    return await GETProbeAPIKeyValidator(
+      url: components.url ?? url,
+      headers: { ["Authorization": $0] },
+      serviceName: "AssemblyAI",
+      session: session
+    ).validate(key)
   }
 
   func requiresAPIKey(for model: String) -> Bool {
@@ -774,33 +742,6 @@ struct AssemblyAITranscriptionProvider: TranscriptionProvider {
     }
   }
 
-  private func extractLanguageCode(from locale: String) -> String {
-    let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
-    return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
-  }
-
-  private func debugSnapshot(
-    request: URLRequest,
-    response: HTTPURLResponse? = nil,
-    data: Data? = nil,
-    error: Error? = nil
-  ) -> APIKeyValidationDebugSnapshot {
-    APIKeyValidationDebugSnapshot(
-      url: request.url?.absoluteString ?? "",
-      method: request.httpMethod ?? "GET",
-      requestHeaders: request.allHTTPHeaderFields ?? [:],
-      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-      statusCode: response?.statusCode,
-      responseHeaders: response.map { headers in
-        headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
-          guard let key = entry.key as? String else { return }
-          partialResult[key] = String(describing: entry.value)
-        }
-      } ?? [:],
-      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
-      errorDescription: error?.localizedDescription
-    )
-  }
 }
 
 // MARK: - Streaming Response Models

--- a/Sources/SpeakApp/CartesiaTranscriptionProvider.swift
+++ b/Sources/SpeakApp/CartesiaTranscriptionProvider.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import Foundation
 import os.log
 import SpeakCore
@@ -110,24 +109,13 @@ struct CartesiaTranscriptionProvider: TranscriptionProvider {
     response: HTTPURLResponse,
     data: Data
   ) -> APIKeyValidationDebugSnapshot {
-    var requestHeaders = request.allHTTPHeaderFields ?? [:]
-    if requestHeaders["Authorization"] != nil {
-      requestHeaders["Authorization"] = "Bearer [REDACTED]"
+    // Blank the key out entirely rather than letting the shared redactor keep a
+    // recognisable prefix/suffix of it.
+    var redacted = request
+    if request.value(forHTTPHeaderField: "Authorization") != nil {
+      redacted.setValue("Bearer [REDACTED]", forHTTPHeaderField: "Authorization")
     }
-
-    return APIKeyValidationDebugSnapshot(
-      url: request.url?.absoluteString ?? "",
-      method: request.httpMethod ?? "GET",
-      requestHeaders: requestHeaders,
-      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-      statusCode: response.statusCode,
-      responseHeaders: response.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
-        guard let key = entry.key as? String else { return }
-        partialResult[key] = String(describing: entry.value)
-      },
-      responseBody: String(data: data, encoding: .utf8),
-      errorDescription: nil
-    )
+    return .capture(request: redacted, response: response, data: data)
   }
 }
 
@@ -193,7 +181,7 @@ final class CartesiaLiveTranscriber: @unchecked Sendable {
       defer { sendGroup.leave() }
       guard let self else { return }
       if let error {
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.currentOnError()?(self.mapConnectionError(error))
       }
     }
@@ -298,7 +286,7 @@ final class CartesiaLiveTranscriber: @unchecked Sendable {
         self.handleMessage(message)
         self.receiveMessages()
       case .failure(let error):
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.currentOnError()?(self.mapConnectionError(error))
       }
     }
@@ -331,15 +319,6 @@ final class CartesiaLiveTranscriber: @unchecked Sendable {
       return CartesiaLiveError.invalidAPIKey
     }
     return error
-  }
-
-  private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-    if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-      return true
-    }
-    return false
   }
 
   private func withStateLock<T>(_ block: () -> T) -> T {

--- a/Sources/SpeakApp/DeepgramTranscriptionProvider.swift
+++ b/Sources/SpeakApp/DeepgramTranscriptionProvider.swift
@@ -88,7 +88,7 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
             self.bufferPool.returnBuffer(&returnBuffer)
 
             if let error {
-                if self.isStopping || self.shouldIgnoreSocketError(error) {
+                if self.isStopping || WebSocketErrorFilter.shouldIgnore(error) {
                     return
                 }
                 self.logger.error("Failed to send audio: \(error.localizedDescription)")
@@ -131,7 +131,7 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
             self.bufferPool.returnBuffer(&returnBuffer)
 
             if let error {
-                if self.isStopping || self.shouldIgnoreSocketError(error) {
+                if self.isStopping || WebSocketErrorFilter.shouldIgnore(error) {
                     return
                 }
                 self.logger.error("Failed to send audio: \(error.localizedDescription)")
@@ -147,17 +147,6 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
         logger.info("Deepgram WebSocket connection closed")
-    }
-
-    private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { // ENOTCONN
-            return true
-        }
-        if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-            return true
-        }
-        return false
     }
 
     private func receiveMessages() {
@@ -176,7 +165,7 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
                 self.receiveMessages()
 
             case .failure(let error):
-                if stopping || self.shouldIgnoreSocketError(error) {
+                if stopping || WebSocketErrorFilter.shouldIgnore(error) {
                     return
                 }
                 self.logger.error("WebSocket receive error: \(error.localizedDescription)")
@@ -243,7 +232,7 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
 
         if isFlux {
             if model == "flux-general-multi", let language {
-                queryItems.append(URLQueryItem(name: "language_hint", value: extractLanguageCode(from: language)))
+                queryItems.append(URLQueryItem(name: "language_hint", value: language.localeLanguageCode))
             }
         } else {
             queryItems.append(contentsOf: [
@@ -256,7 +245,7 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
                 URLQueryItem(name: "vad_events", value: "true")
             ])
             if let language {
-                queryItems.append(URLQueryItem(name: "language", value: extractLanguageCode(from: language)))
+                queryItems.append(URLQueryItem(name: "language", value: language.localeLanguageCode))
             }
         }
 
@@ -264,10 +253,6 @@ final class DeepgramLiveTranscriber: @unchecked Sendable {
         return urlComponents.url
     }
 
-    private nonisolated static func extractLanguageCode(from locale: String) -> String {
-        let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
-        return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
-    }
 }
 
 // MARK: - Deepgram Transcription Provider
@@ -308,7 +293,7 @@ struct DeepgramTranscriptionProvider: TranscriptionProvider {
             URLQueryItem(name: "utterances", value: "true")
         ]
         if let language {
-            let languageCode = extractLanguageCode(from: language)
+            let languageCode = language.localeLanguageCode
             queryItems.append(URLQueryItem(name: "language", value: languageCode))
         }
 
@@ -346,36 +331,12 @@ struct DeepgramTranscriptionProvider: TranscriptionProvider {
     }
 
     func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
-        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return .failure(message: "API key is empty")
-        }
-
-        let url = baseURL.appendingPathComponent("projects")
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Token \(trimmed)", forHTTPHeaderField: "Authorization")
-
-        do {
-            let (data, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse else {
-                return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
-            }
-
-            let debug = debugSnapshot(request: request, response: http, data: data)
-
-            if (200..<300).contains(http.statusCode) {
-                return .success(message: "Deepgram API key validated", debug: debug)
-            }
-
-            let message = "HTTP \(http.statusCode) while validating key"
-            return .failure(message: message, debug: debug)
-        } catch {
-            return .failure(
-                message: "Validation failed: \(error.localizedDescription)",
-                debug: debugSnapshot(request: request, error: error)
-            )
-        }
+        await GETProbeAPIKeyValidator(
+            url: baseURL.appendingPathComponent("projects"),
+            headers: { ["Authorization": "Token \($0)"] },
+            serviceName: "Deepgram",
+            session: session
+        ).validate(key)
     }
 
     func requiresAPIKey(for model: String) -> Bool {
@@ -435,11 +396,6 @@ struct DeepgramTranscriptionProvider: TranscriptionProvider {
         return name
     }
 
-    private func extractLanguageCode(from locale: String) -> String {
-        let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
-        return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
-    }
-
     private func buildTranscriptionResult(
         response: DeepgramBatchResponse,
         audioURL: URL,
@@ -491,28 +447,6 @@ struct DeepgramTranscriptionProvider: TranscriptionProvider {
         )
     }
 
-    private func debugSnapshot(
-        request: URLRequest,
-        response: HTTPURLResponse? = nil,
-        data: Data? = nil,
-        error: Error? = nil
-    ) -> APIKeyValidationDebugSnapshot {
-        APIKeyValidationDebugSnapshot(
-            url: request.url?.absoluteString ?? "",
-            method: request.httpMethod ?? "GET",
-            requestHeaders: request.allHTTPHeaderFields ?? [:],
-            requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-            statusCode: response?.statusCode,
-            responseHeaders: response.map { headers in
-                headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
-                    guard let key = entry.key as? String else { return }
-                    partialResult[key] = String(describing: entry.value)
-                }
-            } ?? [:],
-            responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
-            errorDescription: error?.localizedDescription
-        )
-    }
 }
 
 // MARK: - Response Models

--- a/Sources/SpeakApp/ElevenLabsLiveTranscriber.swift
+++ b/Sources/SpeakApp/ElevenLabsLiveTranscriber.swift
@@ -159,7 +159,7 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
             defer { sendGroup.leave() }
             guard let self else { return }
             if let error {
-                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
                 self.logger.error("Failed to send audio: \(error.localizedDescription, privacy: .public)")
                 self.currentOnError()?(error)
             }
@@ -309,7 +309,7 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
                 self.receiveMessages()
             case .failure(let error):
                 if self.isStoppingState() { return }
-                if self.shouldIgnoreSocketError(error) { return }
+                if WebSocketErrorFilter.shouldIgnore(error) { return }
                 let mapped = self.mapConnectionError(error)
                 self.logger.error("WebSocket receive error: \(error.localizedDescription, privacy: .public)")
                 self.currentOnError()?(mapped)
@@ -403,15 +403,6 @@ final class ElevenLabsLiveTranscriber: @unchecked Sendable {
             return ElevenLabsLiveError.invalidAPIKeyOrMissingScribeAccess
         }
         return error
-    }
-
-    private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-        if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-            return true
-        }
-        return false
     }
 }
 

--- a/Sources/SpeakApp/ElevenLabsTranscriptionProvider.swift
+++ b/Sources/SpeakApp/ElevenLabsTranscriptionProvider.swift
@@ -46,7 +46,7 @@ struct ElevenLabsTranscriptionProvider: TranscriptionProvider {
         body.appendFormField(named: "timestamps_granularity", value: "word", boundary: boundary)
 
         if let language {
-            let languageCode = extractLanguageCode(from: language)
+            let languageCode = language.localeLanguageCode
             body.appendFormField(named: "language_code", value: languageCode, boundary: boundary)
         }
 
@@ -111,11 +111,6 @@ struct ElevenLabsTranscriptionProvider: TranscriptionProvider {
     private func extractModelID(from model: String) -> String {
         // Strip the provider prefix: "elevenlabs/scribe_v1" -> "scribe_v1"
         model.split(separator: "/").last.map(String.init) ?? model
-    }
-
-    private func extractLanguageCode(from locale: String) -> String {
-        let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
-        return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
     }
 
     private func buildTranscriptionResult(

--- a/Sources/SpeakApp/GladiaTranscriptionProvider.swift
+++ b/Sources/SpeakApp/GladiaTranscriptionProvider.swift
@@ -76,13 +76,15 @@ struct GladiaTranscriptionProvider: TranscriptionProvider {
       }
       switch http.statusCode {
       case 200..<300:
-        let debug = debugSnapshot(request: request, response: http, data: nil)
+        // The listing body echoes previous sessions' transcripts, so it is deliberately
+        // left out of the debug snapshot on success.
+        let debug = APIKeyValidationDebugSnapshot.capture(request: request, response: http)
         return .success(message: "Gladia API key validated", debug: debug)
       case 401, 403:
-        let debug = debugSnapshot(request: request, response: http, data: data)
+        let debug = APIKeyValidationDebugSnapshot.capture(request: request, response: http, data: data)
         return .failure(message: "Gladia rejected the key (HTTP \(http.statusCode))", debug: debug)
       default:
-        let debug = debugSnapshot(request: request, response: http, data: data)
+        let debug = APIKeyValidationDebugSnapshot.capture(request: request, response: http, data: data)
         return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
       }
     } catch {
@@ -120,25 +122,6 @@ struct GladiaTranscriptionProvider: TranscriptionProvider {
     )
   }
 
-  private func debugSnapshot(
-    request: URLRequest,
-    response: HTTPURLResponse,
-    data: Data?
-  ) -> APIKeyValidationDebugSnapshot {
-    APIKeyValidationDebugSnapshot(
-      url: request.url?.absoluteString ?? "",
-      method: request.httpMethod ?? "GET",
-      requestHeaders: request.allHTTPHeaderFields ?? [:],
-      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-      statusCode: response.statusCode,
-      responseHeaders: response.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
-        guard let key = entry.key as? String else { return }
-        partialResult[key] = String(describing: entry.value)
-      },
-      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
-      errorDescription: nil
-    )
-  }
 }
 
 struct GladiaTranscriptEvent: Equatable, Sendable {
@@ -227,7 +210,7 @@ final class GladiaLiveTranscriber: @unchecked Sendable {
     task.send(.string(message)) { [weak self] error in
       defer { sendGroup.leave() }
       guard let self else { return }
-      if let error, !self.isStoppingState(), !self.shouldIgnoreSocketError(error) {
+      if let error, !self.isStoppingState(), !WebSocketErrorFilter.shouldIgnore(error) {
         self.currentOnError()?(error)
       }
     }
@@ -374,7 +357,7 @@ final class GladiaLiveTranscriber: @unchecked Sendable {
       defer { sendGroup.leave() }
       guard let self else { return }
       if let error {
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.currentOnError()?(self.mapConnectionError(error))
       }
     }
@@ -389,7 +372,7 @@ final class GladiaLiveTranscriber: @unchecked Sendable {
         self.handleMessage(message)
         self.receiveMessages()
       case .failure(let error):
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.currentOnError()?(self.mapConnectionError(error))
       }
     }
@@ -436,15 +419,6 @@ final class GladiaLiveTranscriber: @unchecked Sendable {
       return GladiaLiveError.invalidAPIKey
     }
     return error
-  }
-
-  private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-    if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-      return true
-    }
-    return false
   }
 
   private func withStateLock<T>(_ block: () -> T) -> T {

--- a/Sources/SpeakApp/MistralTranscriptionProvider.swift
+++ b/Sources/SpeakApp/MistralTranscriptionProvider.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import Foundation
 import SpeakCore
 
@@ -69,34 +68,12 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
   }
 
   func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
-    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else {
-      return .failure(message: "API key is empty")
-    }
-
-    let url = baseURL.appendingPathComponent("models")
-    var request = URLRequest(url: url)
-    request.httpMethod = "GET"
-    request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-
-    do {
-      let (data, response) = try await session.data(for: request)
-      guard let http = response as? HTTPURLResponse else {
-        return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
-      }
-
-      let debug = debugSnapshot(request: request, response: http, data: data)
-      if (200..<300).contains(http.statusCode) {
-        return .success(message: "Mistral API key validated", debug: debug)
-      }
-
-      return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
-    } catch {
-      return .failure(
-        message: "Validation failed: \(error.localizedDescription)",
-        debug: debugSnapshot(request: request, error: error)
-      )
-    }
+    await GETProbeAPIKeyValidator(
+      url: baseURL.appendingPathComponent("models"),
+      headers: { ["Authorization": "Bearer \($0)"] },
+      serviceName: "Mistral",
+      session: session
+    ).validate(key)
   }
 
   func requiresAPIKey(for model: String) -> Bool {
@@ -202,7 +179,11 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
     model: String,
     payload: Data
   ) async throws -> TranscriptionResult {
-    let duration = await resolvedDuration(for: audioURL, response: response)
+    let duration = await resolvedTranscriptionDuration(
+      reported: response.duration,
+      lastSegmentEnd: response.lastSegmentEnd,
+      audioURL: audioURL
+    )
     let transcriptText = response.transcriptText
     let mappedSegments = response.transcriptionSegments(duration: duration)
     let segments = mappedSegments.isEmpty
@@ -218,43 +199,6 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
       cost: nil,
       rawPayload: String(data: payload, encoding: .utf8),
       debugInfo: nil
-    )
-  }
-
-  private func resolvedDuration(for audioURL: URL, response: MistralTranscriptionResponse) async -> TimeInterval {
-    if let duration = response.duration, duration > 0 {
-      return duration
-    }
-    if let lastSegmentEnd = response.lastSegmentEnd, lastSegmentEnd > 0 {
-      return lastSegmentEnd
-    }
-    let asset = AVURLAsset(url: audioURL)
-    guard let durationTime = try? await asset.load(.duration), durationTime.seconds.isFinite else {
-      return 0
-    }
-    return durationTime.seconds
-  }
-
-  private func debugSnapshot(
-    request: URLRequest,
-    response: HTTPURLResponse? = nil,
-    data: Data? = nil,
-    error: Error? = nil
-  ) -> APIKeyValidationDebugSnapshot {
-    APIKeyValidationDebugSnapshot(
-      url: request.url?.absoluteString ?? "",
-      method: request.httpMethod ?? "GET",
-      requestHeaders: request.allHTTPHeaderFields ?? [:],
-      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-      statusCode: response?.statusCode,
-      responseHeaders: response.map { headers in
-        headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
-          guard let key = entry.key as? String else { return }
-          partialResult[key] = String(describing: entry.value)
-        }
-      } ?? [:],
-      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
-      errorDescription: error?.localizedDescription
     )
   }
 }
@@ -350,19 +294,7 @@ private enum MistralSpeaker: Decodable {
     case .int(let value):
       return "Speaker \(value + 1)"
     case .string(let value):
-      let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else { return nil }
-      let uppercased = trimmed.uppercased()
-      if uppercased.hasPrefix("SPEAKER_") {
-        let digits = trimmed.filter(\.isNumber)
-        if let index = Int(digits) {
-          return "Speaker \(index + 1)"
-        }
-        return trimmed.replacingOccurrences(of: "_", with: " ").capitalized
-      } else if uppercased.hasPrefix("SPEAKER ") {
-        return trimmed.capitalized
-      }
-      return trimmed
+      return SpeakerLabelNormalizer.displayLabel(for: value, spacedFormIsIndexed: false)
     }
   }
 }

--- a/Sources/SpeakApp/ModulateTranscriptionProvider.swift
+++ b/Sources/SpeakApp/ModulateTranscriptionProvider.swift
@@ -161,7 +161,7 @@ final class ModulateLiveTranscriber: @unchecked Sendable {
       self.bufferPool.returnBuffer(&returnBuffer)
 
       if let error {
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.logger.error("Failed to send Modulate audio: \(error.localizedDescription)")
         self.currentOnError()?(error)
       }
@@ -183,7 +183,7 @@ final class ModulateLiveTranscriber: @unchecked Sendable {
     task.send(.string("")) { [weak self] error in
       defer { sendGroup.leave() }
       guard let self, let error else { return }
-      if self.shouldIgnoreSocketError(error) { return }
+      if WebSocketErrorFilter.shouldIgnore(error) { return }
       self.logger.error("Failed to send Modulate end-of-stream: \(error.localizedDescription)")
       self.currentOnError()?(error)
     }
@@ -222,7 +222,7 @@ final class ModulateLiveTranscriber: @unchecked Sendable {
           self.receiveMessages()
         }
       case .failure(let error):
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.logger.error("Modulate WebSocket receive error: \(error.localizedDescription)")
         self.currentOnError()?(error)
       }
@@ -274,15 +274,6 @@ final class ModulateLiveTranscriber: @unchecked Sendable {
     var components = URLComponents(string: "wss://modulate-developer-apis.com/api/velma-2-stt-streaming")!
     components.queryItems = [URLQueryItem(name: "api_key", value: apiKey)] + featureConfiguration.queryItems
     return components.url!
-  }
-
-  private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-    if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-      return true
-    }
-    return false
   }
 
   private func withStateLock<T>(_ block: () -> T) -> T {
@@ -445,10 +436,10 @@ struct ModulateTranscriptionProvider: TranscriptionProvider {
     do {
       let (data, response) = try await session.data(for: request)
       guard let http = response as? HTTPURLResponse else {
-        return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
+        return .failure(message: "Received a non-HTTP response", debug: .capture(request: request))
       }
 
-      let debug = debugSnapshot(request: request, response: http, data: data)
+      let debug = APIKeyValidationDebugSnapshot.capture(request: request, response: http, data: data)
       let detail = parseValidationDetail(from: data)
 
       switch http.statusCode {
@@ -483,7 +474,7 @@ struct ModulateTranscriptionProvider: TranscriptionProvider {
     } catch {
       return .failure(
         message: "Validation failed: \(error.localizedDescription)",
-        debug: debugSnapshot(request: request, error: error)
+        debug: .capture(request: request, error: error)
       )
     }
   }
@@ -652,29 +643,6 @@ struct ModulateTranscriptionProvider: TranscriptionProvider {
     request.httpBody = body
 
     return request
-  }
-
-  private func debugSnapshot(
-    request: URLRequest,
-    response: HTTPURLResponse? = nil,
-    data: Data? = nil,
-    error: Error? = nil
-  ) -> APIKeyValidationDebugSnapshot {
-    APIKeyValidationDebugSnapshot(
-      url: request.url?.absoluteString ?? "",
-      method: request.httpMethod ?? "GET",
-      requestHeaders: request.allHTTPHeaderFields ?? [:],
-      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-      statusCode: response?.statusCode,
-      responseHeaders: response.map { headers in
-        headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
-          guard let key = entry.key as? String else { return }
-          partialResult[key] = String(describing: entry.value)
-        }
-      } ?? [:],
-      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
-      errorDescription: error?.localizedDescription
-    )
   }
 
   private func currentDefaults() -> UserDefaults {

--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -113,7 +113,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
       transcriber = provider.createLiveTranscriber(
         apiKey: apiKey,
         model: realtimeName,
-        language: currentLanguage.map(Self.extractLanguageCode(from:)),
+        language: currentLanguage.map(\.localeLanguageCode),
         // OpenAI Realtime's transcription `prompt` is a glossary-style
         // bias — use the AssemblyAI keyterms list as a comma-joined hint.
         // We deliberately do *not* forward the post-processing system prompt
@@ -339,14 +339,6 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
   private func trimmedKeytermsPrompt() -> String? {
     let raw = appSettings.assemblyAIKeyterms.trimmingCharacters(in: .whitespacesAndNewlines)
     return raw.isEmpty ? nil : raw
-  }
-
-  /// Normalises a BCP-47 locale identifier (e.g. "en-GB", "en_US") to the
-  /// ISO-639-1 two-letter code OpenAI Realtime expects (e.g. "en"). Mirrors
-  /// the helper used by every other transcription provider.
-  static func extractLanguageCode(from locale: String) -> String {
-    let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
-    return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
   }
 
   private func openAIAPIKey() async throws -> String {

--- a/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeTranscriptionProvider.swift
@@ -282,7 +282,7 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
     task.send(.string(json)) { [weak self] error in
       defer { sendGroup.leave() }
       guard let self else { return }
-      if let error, !self.isStoppingState(), !self.shouldIgnoreSocketError(error) {
+      if let error, !self.isStoppingState(), !WebSocketErrorFilter.shouldIgnore(error) {
         self.logger.error("Failed to send audio: \(error.localizedDescription)")
         self.currentOnError()?(error)
       }
@@ -314,7 +314,7 @@ final class OpenAIRealtimeLiveTranscriber: @unchecked Sendable {
         self.receiveMessages()
       case .failure(let error):
         if self.isStoppingState() { return }
-        if self.shouldIgnoreSocketError(error) {
+        if WebSocketErrorFilter.shouldIgnore(error) {
           // ENOTCONN / "Socket is not connected" is terminal — a
           // URLSessionWebSocketTask cannot be reused for receiving once
           // disconnected. Stop the receive loop instead of spinning every
@@ -426,15 +426,6 @@ private extension OpenAIRealtimeLiveTranscriber {
 
   func isStoppingState() -> Bool {
     withStateLock { isStopping }
-  }
-
-  func shouldIgnoreSocketError(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-    if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-      return true
-    }
-    return false
   }
 }
 

--- a/Sources/SpeakApp/OpenAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/OpenAITranscriptionProvider.swift
@@ -1,5 +1,4 @@
 import SpeakCore
-import AVFoundation
 import Foundation
 
 struct OpenAITranscriptionProvider: TranscriptionProvider {
@@ -55,7 +54,7 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
         // OpenAI expects ISO-639-1 (2-letter code), not full locale (e.g., "en" not "en_GB").
         // The new GPT Transcribe family accepts plural language hints while
         // existing GPT-4o and Whisper models retain the singular field.
-        let languageCode = extractLanguageCode(from: language)
+        let languageCode = language.localeLanguageCode
         body.appendFormField(
             named: OpenAITranscriptionModels.batchLanguageFieldName(for: modelName),
             value: languageCode,
@@ -93,36 +92,12 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
   }
 
   func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
-    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else {
-      return .failure(message: "API key is empty")
-    }
-
-    let url = baseURL.appendingPathComponent("models")
-    var request = URLRequest(url: url)
-    request.httpMethod = "GET"
-    request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-
-    do {
-      let (data, response) = try await session.data(for: request)
-      guard let http = response as? HTTPURLResponse else {
-        return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
-      }
-
-      let debug = debugSnapshot(request: request, response: http, data: data)
-
-      if (200..<300).contains(http.statusCode) {
-        return .success(message: "\(validationServiceName) API key validated", debug: debug)
-      }
-
-      let message = "HTTP \(http.statusCode) while validating key"
-      return .failure(message: message, debug: debug)
-    } catch {
-      return .failure(
-        message: "Validation failed: \(error.localizedDescription)",
-        debug: debugSnapshot(request: request, error: error)
-      )
-    }
+    await GETProbeAPIKeyValidator(
+      url: baseURL.appendingPathComponent("models"),
+      headers: { ["Authorization": "Bearer \($0)"] },
+      serviceName: validationServiceName,
+      session: session
+    ).validate(key)
   }
 
   func requiresAPIKey(for model: String) -> Bool {
@@ -149,20 +124,17 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
     modelName == "gpt-4o-transcribe-diarize"
   }
 
-  private func extractLanguageCode(from locale: String) -> String {
-    // Extract just the language code from locale identifiers
-    // e.g., "en_GB" -> "en", "en-US" -> "en", "en" -> "en"
-    let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
-    return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
-  }
-
   private func buildTranscriptionResult(
     response: OpenAITranscriptionResponse,
     audioURL: URL,
     model: String,
     payload: Data
   ) async throws -> TranscriptionResult {
-    let duration = await resolvedDuration(for: audioURL, response: response)
+    let duration = await resolvedTranscriptionDuration(
+      reported: response.duration,
+      lastSegmentEnd: response.segments?.last?.end,
+      audioURL: audioURL
+    )
     let transcriptText = response.transcriptText
 
     let mappedSegments =
@@ -187,43 +159,6 @@ struct OpenAITranscriptionProvider: TranscriptionProvider {
       cost: nil,
       rawPayload: String(data: payload, encoding: .utf8),
       debugInfo: nil
-    )
-  }
-
-  private func resolvedDuration(for audioURL: URL, response: OpenAITranscriptionResponse) async -> TimeInterval {
-    if let duration = response.duration, duration > 0 {
-      return duration
-    }
-    if let lastSegmentEnd = response.segments?.last?.end, lastSegmentEnd > 0 {
-      return lastSegmentEnd
-    }
-    let asset = AVURLAsset(url: audioURL)
-    guard let durationTime = try? await asset.load(.duration), durationTime.seconds.isFinite else {
-      return 0
-    }
-    return durationTime.seconds
-  }
-
-  private func debugSnapshot(
-    request: URLRequest,
-    response: HTTPURLResponse? = nil,
-    data: Data? = nil,
-    error: Error? = nil
-  ) -> APIKeyValidationDebugSnapshot {
-    APIKeyValidationDebugSnapshot(
-      url: request.url?.absoluteString ?? "",
-      method: request.httpMethod ?? "GET",
-      requestHeaders: request.allHTTPHeaderFields ?? [:],
-      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-      statusCode: response?.statusCode,
-      responseHeaders: response.map { headers in
-        headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
-          guard let key = entry.key as? String else { return }
-          partialResult[key] = String(describing: entry.value)
-        }
-      } ?? [:],
-      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
-      errorDescription: error?.localizedDescription
     )
   }
 }
@@ -263,17 +198,6 @@ private struct OpenAITranscriptionResponse: Decodable {
   }
 
   private func speakerLabel(from value: String?) -> String? {
-    guard let raw = value?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
-      return nil
-    }
-    let uppercased = raw.uppercased()
-    if uppercased.hasPrefix("SPEAKER_") || uppercased.hasPrefix("SPEAKER ") {
-      let digits = raw.filter(\.isNumber)
-      if let index = Int(digits) {
-        return "Speaker \(index + 1)"
-      }
-      return raw.replacingOccurrences(of: "_", with: " ").capitalized
-    }
-    return raw
+    SpeakerLabelNormalizer.displayLabel(for: value, spacedFormIsIndexed: true)
   }
 }

--- a/Sources/SpeakApp/RevAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/RevAITranscriptionProvider.swift
@@ -39,36 +39,12 @@ struct RevAITranscriptionProvider: TranscriptionProvider {
   }
 
   func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
-    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else {
-      return .failure(message: "API key is empty")
-    }
-
-    let url = baseURL.appendingPathComponent("jobs")
-    var request = URLRequest(url: url)
-    request.httpMethod = "GET"
-    request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-
-    do {
-      let (data, response) = try await session.data(for: request)
-      guard let http = response as? HTTPURLResponse else {
-        return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
-      }
-
-      let debug = debugSnapshot(request: request, response: http, data: data)
-
-      if (200..<300).contains(http.statusCode) {
-        return .success(message: "Rev.ai API key validated", debug: debug)
-      }
-
-      let message = "HTTP \(http.statusCode) while validating key"
-      return .failure(message: message, debug: debug)
-    } catch {
-      return .failure(
-        message: "Validation failed: \(error.localizedDescription)",
-        debug: debugSnapshot(request: request, error: error)
-      )
-    }
+    await GETProbeAPIKeyValidator(
+      url: baseURL.appendingPathComponent("jobs"),
+      headers: { ["Authorization": "Bearer \($0)"] },
+      serviceName: "Rev.ai",
+      session: session
+    ).validate(key)
   }
 
   func requiresAPIKey(for model: String) -> Bool {
@@ -104,8 +80,7 @@ struct RevAITranscriptionProvider: TranscriptionProvider {
     if let language {
       // Rev.ai accepts language codes like "en", but also accepts locale-specific codes
       // Normalize to just language code for consistency
-      let languageCode = extractLanguageCode(from: language)
-      metadata["language"] = languageCode
+      metadata["language"] = language.localeLanguageCode
     }
     metadata["skip_diarization"] = false
     metadata["skip_punctuation"] = false
@@ -247,35 +222,6 @@ struct RevAITranscriptionProvider: TranscriptionProvider {
     )
   }
 
-  private func extractLanguageCode(from locale: String) -> String {
-    // Extract just the language code from locale identifiers
-    // e.g., "en_GB" -> "en", "en-US" -> "en", "en" -> "en"
-    let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
-    return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
-  }
-
-  private func debugSnapshot(
-    request: URLRequest,
-    response: HTTPURLResponse? = nil,
-    data: Data? = nil,
-    error: Error? = nil
-  ) -> APIKeyValidationDebugSnapshot {
-    APIKeyValidationDebugSnapshot(
-      url: request.url?.absoluteString ?? "",
-      method: request.httpMethod ?? "GET",
-      requestHeaders: request.allHTTPHeaderFields ?? [:],
-      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-      statusCode: response?.statusCode,
-      responseHeaders: response.map { headers in
-        headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
-          guard let key = entry.key as? String else { return }
-          partialResult[key] = String(describing: entry.value)
-        }
-      } ?? [:],
-      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
-      errorDescription: error?.localizedDescription
-    )
-  }
 }
 
 // MARK: - Response Models

--- a/Sources/SpeakApp/SonioxTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SonioxTranscriptionProvider.swift
@@ -229,7 +229,7 @@ struct SonioxTranscriptionProvider: TranscriptionProvider {
         let payload = SonioxCreateTranscriptionPayload(
             model: self.extractModelName(from: "soniox/stt-async-v5"),
             fileID: fileID,
-            languageHints: language.map { [self.extractLanguageCode(from: $0)] },
+            languageHints: language.map { [$0.localeLanguageCode] },
             enableSpeakerDiarization: true,
             enableLanguageIdentification: true
         )
@@ -521,11 +521,6 @@ struct SonioxTranscriptionProvider: TranscriptionProvider {
         return mimeTypes[url.pathExtension.lowercased()] ?? "application/octet-stream"
     }
 
-    private func extractLanguageCode(from locale: String) -> String {
-        let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
-        return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
-    }
-
     private func extractModelName(from model: String) -> String {
         model.split(separator: "/").last.map(String.init) ?? model
     }
@@ -656,7 +651,7 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
             defer { sendGroup.leave() }
             guard let self else { return }
             if let error {
-                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
                 self.logger.error("Failed to send audio: \(error.localizedDescription)")
                 self.currentOnError()?(error)
             }
@@ -771,7 +766,7 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
                 self.handleMessage(message)
                 self.receiveMessages()
             case .failure(let error):
-                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
                 self.logger.error("Soniox receive error: \(error.localizedDescription)")
                 self.currentOnError()?(self.mapConnectionError(error))
             }
@@ -870,15 +865,6 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
             return SonioxLiveError.invalidAPIKey
         }
         return error
-    }
-
-    private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-        if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-            return true
-        }
-        return false
     }
 
     private func withStateLock<T>(_ block: () -> T) -> T {

--- a/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
@@ -59,35 +59,13 @@ struct SpeechmaticsTranscriptionProvider: TranscriptionProvider {
   }
 
   func validateAPIKey(_ key: String) async -> APIKeyValidationResult {
-    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else {
-      return .failure(message: "API key is empty")
-    }
-
-    var request = URLRequest(url: validationURL)
-    request.httpMethod = "GET"
-    request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
-
-    do {
-      let (data, response) = try await session.data(for: request)
-      guard let http = response as? HTTPURLResponse else {
-        return .failure(message: "Received a non-HTTP response", debug: debugSnapshot(request: request))
-      }
-
-      let debug = debugSnapshot(request: request, response: http, data: data)
-      if (200..<300).contains(http.statusCode) {
-        return .success(message: "Speechmatics API key validated", debug: debug)
-      }
-      if http.statusCode == 401 || http.statusCode == 403 {
-        return .failure(message: "Speechmatics rejected the key (HTTP \(http.statusCode))", debug: debug)
-      }
-      return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
-    } catch {
-      return .failure(
-        message: "Validation failed: \(error.localizedDescription)",
-        debug: debugSnapshot(request: request, error: error)
-      )
-    }
+    await GETProbeAPIKeyValidator(
+      url: validationURL,
+      headers: { ["Authorization": "Bearer \($0)"] },
+      serviceName: "Speechmatics",
+      session: session,
+      rejectionStatusCodes: [401, 403]
+    ).validate(key)
   }
 
   func requiresAPIKey(for model: String) -> Bool {
@@ -113,7 +91,7 @@ struct SpeechmaticsTranscriptionProvider: TranscriptionProvider {
     SpeechmaticsLiveTranscriber(
       apiKey: apiKey,
       model: Self.realtimeModelName(from: model),
-      language: language.map(Self.extractLanguageCode(from:)),
+      language: language.map(\.localeLanguageCode),
       sampleRate: sampleRate
     )
   }
@@ -126,32 +104,6 @@ struct SpeechmaticsTranscriptionProvider: TranscriptionProvider {
     return raw.isEmpty ? "enhanced" : raw
   }
 
-  static func extractLanguageCode(from locale: String) -> String {
-    let components = locale.split(whereSeparator: { $0 == "_" || $0 == "-" })
-    return components.first.map(String.init)?.lowercased() ?? locale.lowercased()
-  }
-
-  private func debugSnapshot(
-    request: URLRequest,
-    response: HTTPURLResponse? = nil,
-    data: Data? = nil,
-    error: Error? = nil
-  ) -> APIKeyValidationDebugSnapshot {
-    APIKeyValidationDebugSnapshot(
-      url: request.url?.absoluteString ?? "",
-      method: request.httpMethod ?? "GET",
-      requestHeaders: request.allHTTPHeaderFields ?? [:],
-      requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
-      statusCode: response?.statusCode,
-      responseHeaders: response?.allHeaderFields.reduce(into: [String: String]()) { result, pair in
-        if let key = pair.key as? String {
-          result[key] = String(describing: pair.value)
-        }
-      } ?? [:],
-      responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
-      errorDescription: error?.localizedDescription
-    )
-  }
 }
 
 // MARK: - WebSocket response types
@@ -444,7 +396,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
     model: String = "enhanced",
     sampleRate: Int = 16000
   ) throws -> String {
-    let languageCode = language.map(SpeechmaticsTranscriptionProvider.extractLanguageCode(from:)) ?? "en"
+    let languageCode = language.map(\.localeLanguageCode) ?? "en"
     let payload: [String: Any] = [
       "message": "StartRecognition",
       "audio_format": [
@@ -551,7 +503,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
       var returnBuffer = buffer
       self.bufferPool.returnBuffer(&returnBuffer)
       if let error {
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.logger.error("Failed to send audio: \(error.localizedDescription, privacy: .public)")
         self.currentOnError()?(error)
       }
@@ -564,7 +516,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
     else { return }
     enqueueOutbound(.string(json), on: task) { [weak self] error in
       guard let self else { return }
-      if let error, !self.isStoppingState(), !self.shouldIgnoreSocketError(error) {
+      if let error, !self.isStoppingState(), !WebSocketErrorFilter.shouldIgnore(error) {
         self.currentOnError()?(error)
       }
     }
@@ -609,7 +561,7 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
         self.handleMessage(message)
         self.receiveMessages()
       case .failure(let error):
-        if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+        if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
         self.logger.error("Speechmatics receive error: \(error.localizedDescription, privacy: .public)")
         self.currentOnError()?(self.mapConnectionError(error))
       }
@@ -732,15 +684,6 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
       return SpeechmaticsLiveError.invalidAPIKey
     }
     return SpeechmaticsLiveError.serverError(detail)
-  }
-
-  private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-    if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-      return true
-    }
-    return false
   }
 
   private func withStateLock<T>(_ block: () -> T) -> T {

--- a/Sources/SpeakApp/XAITranscriptionProvider.swift
+++ b/Sources/SpeakApp/XAITranscriptionProvider.swift
@@ -80,22 +80,12 @@ struct XAITranscriptionProvider: TranscriptionProvider {
     response: HTTPURLResponse,
     data: Data
   ) -> APIKeyValidationDebugSnapshot {
-    var requestHeaders = request.allHTTPHeaderFields ?? [:]
-    if requestHeaders["Authorization"] != nil {
-      requestHeaders["Authorization"] = "Bearer [REDACTED]"
+    // Blank the key out entirely rather than letting the shared redactor keep a
+    // recognisable prefix/suffix of it.
+    var redacted = request
+    if request.value(forHTTPHeaderField: "Authorization") != nil {
+      redacted.setValue("Bearer [REDACTED]", forHTTPHeaderField: "Authorization")
     }
-    return APIKeyValidationDebugSnapshot(
-      url: request.url?.absoluteString ?? "",
-      method: request.httpMethod ?? "GET",
-      requestHeaders: requestHeaders,
-      requestBody: nil,
-      statusCode: response.statusCode,
-      responseHeaders: response.allHeaderFields.reduce(into: [String: String]()) { result, pair in
-        guard let key = pair.key as? String else { return }
-        result[key] = String(describing: pair.value)
-      },
-      responseBody: String(data: data, encoding: .utf8),
-      errorDescription: nil
-    )
+    return .capture(request: redacted, response: response, data: data)
   }
 }

--- a/Sources/SpeakCore/APIKeyValidationResult.swift
+++ b/Sources/SpeakCore/APIKeyValidationResult.swift
@@ -42,6 +42,36 @@ public struct APIKeyValidationDebugSnapshot: Sendable, Equatable {
     }
 }
 
+extension APIKeyValidationDebugSnapshot {
+    /// Captures the request/response pair of an API-key validation probe.
+    ///
+    /// Every provider used to carry its own verbatim copy of this mapping; they now
+    /// share this one. Sensitive request and response headers are redacted by the
+    /// initialiser this calls.
+    public static func capture(
+        request: URLRequest,
+        response: HTTPURLResponse? = nil,
+        data: Data? = nil,
+        error: Error? = nil
+    ) -> APIKeyValidationDebugSnapshot {
+        APIKeyValidationDebugSnapshot(
+            url: request.url?.absoluteString ?? "",
+            method: request.httpMethod ?? "GET",
+            requestHeaders: request.allHTTPHeaderFields ?? [:],
+            requestBody: request.httpBody.flatMap { String(data: $0, encoding: .utf8) },
+            statusCode: response?.statusCode,
+            responseHeaders: response.map { headers in
+                headers.allHeaderFields.reduce(into: [String: String]()) { partialResult, entry in
+                    guard let key = entry.key as? String else { return }
+                    partialResult[key] = String(describing: entry.value)
+                }
+            } ?? [:],
+            responseBody: data.flatMap { String(data: $0, encoding: .utf8) },
+            errorDescription: error?.localizedDescription
+        )
+    }
+}
+
 public struct APIKeyValidationResult: Sendable, Equatable {
     public enum Outcome: Sendable, Equatable {
         case success(message: String)
@@ -66,5 +96,78 @@ public struct APIKeyValidationResult: Sendable, Equatable {
 
     public func updatingOutcome(_ outcome: Outcome) -> Self {
         APIKeyValidationResult(outcome: outcome, debug: debug)
+    }
+}
+
+/// Validates an API key by issuing an authenticated `GET` probe against a cheap
+/// endpoint: any 2xx response means the key works.
+///
+/// Most providers validate exactly this way and only differ in the probe URL, the
+/// header carrying the credential, and the service name used in the message, so
+/// they share this type instead of each re-implementing
+/// trim → probe → snapshot → classify.
+public struct GETProbeAPIKeyValidator {
+    private let url: URL
+    private let headers: (String) -> [String: String]
+    private let serviceName: String
+    private let session: URLSession
+    private let rejectionStatusCodes: Set<Int>
+
+    /// - Parameters:
+    ///   - url: Probe endpoint, including any query items.
+    ///   - headers: Builds the probe's headers from the trimmed key.
+    ///   - serviceName: Name used in the success and rejection messages.
+    ///   - session: Session used for the probe.
+    ///   - rejectionStatusCodes: Status codes reported as an explicit rejection
+    ///     ("<service> rejected the key (HTTP n)") rather than the generic HTTP failure.
+    public init(
+        url: URL,
+        headers: @escaping (String) -> [String: String],
+        serviceName: String,
+        session: URLSession = .shared,
+        rejectionStatusCodes: Set<Int> = []
+    ) {
+        self.url = url
+        self.headers = headers
+        self.serviceName = serviceName
+        self.session = session
+        self.rejectionStatusCodes = rejectionStatusCodes
+    }
+
+    public func validate(_ key: String) async -> APIKeyValidationResult {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .failure(message: "API key is empty")
+        }
+
+        var request = URLRequest(url: self.url)
+        request.httpMethod = "GET"
+        for (field, value) in self.headers(trimmed) {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+
+        do {
+            let (data, response) = try await self.session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .failure(message: "Received a non-HTTP response", debug: .capture(request: request))
+            }
+
+            let debug = APIKeyValidationDebugSnapshot.capture(request: request, response: http, data: data)
+            if (200..<300).contains(http.statusCode) {
+                return .success(message: "\(self.serviceName) API key validated", debug: debug)
+            }
+            if self.rejectionStatusCodes.contains(http.statusCode) {
+                return .failure(
+                    message: "\(self.serviceName) rejected the key (HTTP \(http.statusCode))",
+                    debug: debug
+                )
+            }
+            return .failure(message: "HTTP \(http.statusCode) while validating key", debug: debug)
+        } catch {
+            return .failure(
+                message: "Validation failed: \(error.localizedDescription)",
+                debug: .capture(request: request, error: error)
+            )
+        }
     }
 }

--- a/Sources/SpeakCore/AssemblyAILiveClient.swift
+++ b/Sources/SpeakCore/AssemblyAILiveClient.swift
@@ -176,7 +176,7 @@ public final class AssemblyAILiveClient: StreamingTranscriptionClient, @unchecke
     private func send(_ audioData: Data, on task: URLSessionWebSocketTask) {
         task.send(.data(audioData)) { [weak self] error in
             guard let self, let error else { return }
-            if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+            if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
             self.currentOnError()?(error)
         }
     }
@@ -202,7 +202,7 @@ public final class AssemblyAILiveClient: StreamingTranscriptionClient, @unchecke
             case .failure(let error):
                 if self.isStoppingState() { return }
                 // Spurious ENOTCONN around the handshake: re-arm instead of failing.
-                if self.shouldIgnoreSocketError(error) {
+                if WebSocketErrorFilter.shouldIgnore(error) {
                     DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.01) { [weak self] in
                         self?.receiveMessages()
                     }
@@ -270,15 +270,6 @@ public final class AssemblyAILiveClient: StreamingTranscriptionClient, @unchecke
         // This client emits a cumulative display string rather than per-turn
         // deltas, so the generic iOS wrapper must replace its text in both cases.
         currentOnTranscript()?(update.displayText, false)
-    }
-
-    private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-        if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-            return true
-        }
-        return false
     }
 
     private func withStateLock<T>(_ block: () -> T) -> T {

--- a/Sources/SpeakCore/CartesiaLiveClient.swift
+++ b/Sources/SpeakCore/CartesiaLiveClient.swift
@@ -128,7 +128,7 @@ public final class CartesiaLiveClient: StreamingTranscriptionClient, @unchecked 
                 self.handleMessage(message)
                 self.receiveMessages()
             case .failure(let error):
-                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
                 self.currentOnError()?(self.mapConnectionError(error))
             }
         }
@@ -182,7 +182,7 @@ public final class CartesiaLiveClient: StreamingTranscriptionClient, @unchecked 
         task.send(.data(audioData)) { [weak self] error in
             defer { sendGroup.leave() }
             guard let self, let error else { return }
-            if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+            if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
             self.currentOnError()?(self.mapConnectionError(error))
         }
     }
@@ -218,15 +218,6 @@ public final class CartesiaLiveClient: StreamingTranscriptionClient, @unchecked 
             return StreamingClientError.invalidAPIKey(provider: "Cartesia")
         }
         return error
-    }
-
-    private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-        if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-            return true
-        }
-        return false
     }
 
     private func withStateLock<T>(_ block: () -> T) -> T {

--- a/Sources/SpeakCore/GladiaLiveClient.swift
+++ b/Sources/SpeakCore/GladiaLiveClient.swift
@@ -152,7 +152,7 @@ public final class GladiaLiveClient: StreamingTranscriptionClient, @unchecked Se
     private func send(_ audioData: Data, on task: URLSessionWebSocketTask) {
         task.send(.data(audioData)) { [weak self] error in
             guard let self, let error else { return }
-            if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+            if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
             self.currentOnError()?(error)
         }
     }
@@ -166,7 +166,7 @@ public final class GladiaLiveClient: StreamingTranscriptionClient, @unchecked Se
                 self.handleMessage(message)
                 self.receiveMessages()
             case .failure(let error):
-                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
                 self.currentOnError()?(error)
             }
         }
@@ -194,15 +194,6 @@ public final class GladiaLiveClient: StreamingTranscriptionClient, @unchecked Se
                 domain: "Gladia", code: -1, userInfo: [NSLocalizedDescriptionKey: message]
             ))
         }
-    }
-
-    private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-        if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-            return true
-        }
-        return false
     }
 
     private func withStateLock<T>(_ block: () -> T) -> T {

--- a/Sources/SpeakCore/ModulateLiveClient.swift
+++ b/Sources/SpeakCore/ModulateLiveClient.swift
@@ -75,7 +75,7 @@ public final class ModulateLiveClient: StreamingTranscriptionClient, @unchecked 
         payload.append(audioData)
         task.send(.data(payload)) { [weak self] error in
             guard let self, let error else { return }
-            if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+            if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
             self.currentOnError()?(error)
         }
     }
@@ -106,7 +106,7 @@ public final class ModulateLiveClient: StreamingTranscriptionClient, @unchecked 
                 self.handleMessage(message)
                 if self.currentWebSocketTask() != nil { self.receiveMessages() }
             case .failure(let error):
-                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
                 self.currentOnError()?(error)
             }
         }
@@ -166,15 +166,6 @@ public final class ModulateLiveClient: StreamingTranscriptionClient, @unchecked 
         append(UInt32(16)); append(UInt16(1)); append(channels); append(UInt32(sampleRate))
         append(byteRate); append(blockAlign); append(bitsPerSample); append("data"); append(UInt32.max)
         return data
-    }
-
-    private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-        if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-            return true
-        }
-        return false
     }
 
     private func withStateLock<T>(_ block: () -> T) -> T {

--- a/Sources/SpeakCore/SonioxLiveClient.swift
+++ b/Sources/SpeakCore/SonioxLiveClient.swift
@@ -59,7 +59,7 @@ public final class SonioxLiveClient: StreamingTranscriptionClient, @unchecked Se
         task.send(.data(audioData)) { [weak self] error in
             defer { sendGroup.leave() }
             guard let self, let error else { return }
-            if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+            if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
             self.currentOnError()?(error)
         }
     }
@@ -143,7 +143,7 @@ public final class SonioxLiveClient: StreamingTranscriptionClient, @unchecked Se
                 self.handleMessage(message)
                 self.receiveMessages()
             case .failure(let error):
-                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
                 self.currentOnError()?(self.mapConnectionError(error))
             }
         }
@@ -223,15 +223,6 @@ public final class SonioxLiveClient: StreamingTranscriptionClient, @unchecked Se
             return StreamingClientError.invalidAPIKey(provider: "Soniox")
         }
         return error
-    }
-
-    private func shouldIgnoreSocketError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-        if nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected") {
-            return true
-        }
-        return false
     }
 
     private func withStateLock<T>(_ block: () -> T) -> T {

--- a/Sources/SpeakCore/TranscriptionProviderHelpers.swift
+++ b/Sources/SpeakCore/TranscriptionProviderHelpers.swift
@@ -1,0 +1,75 @@
+import AVFoundation
+import Foundation
+
+// Small helpers that every transcription provider needs. They live here so the
+// per-provider files stay focused on what is actually provider-specific.
+
+extension String {
+    /// The language portion of a locale identifier, lowercased.
+    ///
+    /// Transcription APIs expect ISO-639-1 (`"en"`), not a full locale, so
+    /// `"en_GB"`, `"en-US"` and `"en"` all map to `"en"`.
+    public var localeLanguageCode: String {
+        let components = self.split(whereSeparator: { $0 == "_" || $0 == "-" })
+        return components.first.map(String.init)?.lowercased() ?? self.lowercased()
+    }
+}
+
+/// Turns the speaker identifiers providers return (`"speaker_0"`, `"Speaker 1"`, `"Alice"`)
+/// into display labels.
+public enum SpeakerLabelNormalizer {
+    /// - Parameters:
+    ///   - value: Raw speaker identifier from the provider; `nil`/blank yields `nil`.
+    ///   - spacedFormIsIndexed: Whether the space-separated form (`"speaker 0"`) is a
+    ///     zero-based index like the underscore form, or is already a display label
+    ///     that only needs capitalising. Providers disagree, so each one says which.
+    public static func displayLabel(for value: String?, spacedFormIsIndexed: Bool) -> String? {
+        guard let raw = value?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return nil
+        }
+        let uppercased = raw.uppercased()
+        if uppercased.hasPrefix("SPEAKER_") || (spacedFormIsIndexed && uppercased.hasPrefix("SPEAKER ")) {
+            let digits = raw.filter(\.isNumber)
+            if let index = Int(digits) {
+                return "Speaker \(index + 1)"
+            }
+            return raw.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+        if uppercased.hasPrefix("SPEAKER ") {
+            return raw.capitalized
+        }
+        return raw
+    }
+}
+
+/// Resolves the duration to report for a transcription, preferring what the provider
+/// said, then the last timestamp it emitted, and finally the audio file itself.
+public func resolvedTranscriptionDuration(
+    reported: TimeInterval?,
+    lastSegmentEnd: TimeInterval?,
+    audioURL: URL
+) async -> TimeInterval {
+    if let reported, reported > 0 {
+        return reported
+    }
+    if let lastSegmentEnd, lastSegmentEnd > 0 {
+        return lastSegmentEnd
+    }
+    let asset = AVURLAsset(url: audioURL)
+    guard let durationTime = try? await asset.load(.duration), durationTime.seconds.isFinite else {
+        return 0
+    }
+    return durationTime.seconds
+}
+
+/// WebSocket teardown races surface as ENOTCONN ("socket is not connected"); every
+/// live transcriber ignores them rather than surfacing a spurious error to the user.
+public enum WebSocketErrorFilter {
+    public static func shouldIgnore(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { // ENOTCONN
+            return true
+        }
+        return nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected")
+    }
+}

--- a/Sources/SpeakCore/XAILiveClient.swift
+++ b/Sources/SpeakCore/XAILiveClient.swift
@@ -141,7 +141,7 @@ private extension XAILiveClient {
                     self.receiveMessages()
                 }
             case .failure(let error):
-                if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+                if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
                 self.currentOnError()?(self.mapConnectionError(error))
                 self.resumeFinishIfNeeded(with: self.currentTranscript())
             }
@@ -216,7 +216,7 @@ private extension XAILiveClient {
         task.send(message) { [weak self] error in
             defer { group.leave() }
             guard let self, let error else { return }
-            if self.isStoppingState() || self.shouldIgnoreSocketError(error) { return }
+            if self.isStoppingState() || WebSocketErrorFilter.shouldIgnore(error) { return }
             self.currentOnError()?(self.mapConnectionError(error))
         }
     }
@@ -322,12 +322,6 @@ private extension XAILiveClient {
             return StreamingClientError.invalidAPIKey(provider: "xAI")
         }
         return error
-    }
-
-    func shouldIgnoreSocketError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == 57 { return true }
-        return nsError.localizedDescription.localizedCaseInsensitiveContains("socket is not connected")
     }
 
     func withStateLock<T>(_ block: () -> T) -> T {


### PR DESCRIPTION
## Summary
Pure de-duplication of transcription-provider boilerplate. **-387 net lines** (682 deleted), zero behaviour change.

Six shared helpers now live in SpeakCore:
| Helper | Replaces |
|---|---|
| `APIKeyValidationDebugSnapshot.capture(...)` | 10 verbatim `debugSnapshot` copies |
| `GETProbeAPIKeyValidator` | 6 identical `validateAPIKey` bodies |
| `String.localeLanguageCode` | 9 `extractLanguageCode` copies |
| `SpeakerLabelNormalizer` | OpenAI + Mistral speaker labelling |
| `resolvedTranscriptionDuration(...)` | OpenAI + Mistral AVAsset fallback |
| `WebSocketErrorFilter.shouldIgnore(_:)` | 15 ENOTCONN filter copies |

## Behaviour preserved
Same URLs, headers, error strings and debug output. Where copies genuinely differed, the difference is now an explicit parameter rather than silently unified:
- OpenAI treats `"speaker 0"` as a zero-based index, Mistral does not → `spacedFormIsIndexed`.
- Speechmatics reports 401/403 as an explicit rejection → `rejectionStatusCodes`.
- Cartesia/xAI fully blank the `Authorization` header before snapshotting (the shared redactor would otherwise keep 7 characters of the key) → kept as a per-provider pre-step.
- Gladia deliberately omits the response body from its success snapshot (the listing echoes previous transcripts) → kept, with a comment explaining why.

Cartesia, Gladia, xAI, Modulate and Soniox keep their own `validateAPIKey` bodies: different messages, POST probes, or richer status mapping. They still share the snapshot helper.

## Follow-ups (blocked on in-flight PRs)
`DeepgramLiveClient` / `ElevenLabsLiveClient` still have their own ENOTCONN filter and language-code helper; `SpeakiOS/Services/iOSBatchTranscriber` duplicates `SpeakCore/DataExtensions`' multipart helpers.

## Test plan
- `swift build` + `swift build --target SpeakiOSLib` clean
- `swift test`: 763 tests, 0 failures
- SwiftLint `--strict` with baseline: 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent API key validation across transcription providers, with clearer diagnostics and secure redaction.
  * Added improved handling for language codes, speaker labels, and transcription duration estimates.
* **Bug Fixes**
  * Improved treatment of expected WebSocket disconnections to reduce unnecessary connection errors and interruptions.
  * Standardized transcription behavior across supported providers for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->