### PR TITLE
feat(ios): refresh launch screen with adaptive brand mark

### DIFF
--- a/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/Contents.json
+++ b/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "filename" : "LaunchMark.svg",
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "filename" : "LaunchMark-dark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/LaunchMark-dark.svg
+++ b/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/LaunchMark-dark.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="112" height="112" viewBox="0 0 112 112" fill="none">
+  <circle cx="56" cy="56" r="52" fill="#2B211C"/>
+  <circle cx="56" cy="56" r="51.5" stroke="#523728"/>
+  <g fill="#FF9C73">
+    <rect x="25" y="46" width="6" height="20" rx="3"/>
+    <rect x="35" y="38" width="6" height="36" rx="3"/>
+    <rect x="45" y="30" width="6" height="52" rx="3"/>
+    <rect x="55" y="22" width="6" height="68" rx="3"/>
+    <rect x="65" y="30" width="6" height="52" rx="3"/>
+    <rect x="75" y="38" width="6" height="36" rx="3"/>
+    <rect x="85" y="46" width="6" height="20" rx="3"/>
+  </g>
+</svg>

--- a/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/LaunchMark.svg
+++ b/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/LaunchMark.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="112" height="112" viewBox="0 0 112 112" fill="none">
+  <circle cx="56" cy="56" r="52" fill="#FFF3E9"/>
+  <circle cx="56" cy="56" r="51.5" stroke="#F4D7C1"/>
+  <g fill="#925B3A">
+    <rect x="25" y="46" width="6" height="20" rx="3"/>
+    <rect x="35" y="38" width="6" height="36" rx="3"/>
+    <rect x="45" y="30" width="6" height="52" rx="3"/>
+    <rect x="55" y="22" width="6" height="68" rx="3"/>
+    <rect x="65" y="30" width="6" height="52" rx="3"/>
+    <rect x="75" y="38" width="6" height="36" rx="3"/>
+    <rect x="85" y="46" width="6" height="20" rx="3"/>
+  </g>
+</svg>

--- a/SpeakiOSApp/Resources/LaunchScreen.storyboard
+++ b/SpeakiOSApp/Resources/LaunchScreen.storyboard
@@ -15,12 +15,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Just Speak to It" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
-                                <rect key="frame" x="86.666666666666671" y="411" width="219.66666666666666" height="30"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <imageView opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LaunchMark" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="140.66666666666666" y="370" width="112" height="112"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="112" id="8LR-M4-kF7"/>
+                                    <constraint firstAttribute="height" constant="112" id="eC2-xi-j71"/>
+                                </constraints>
+                            </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -36,6 +37,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="LaunchMark" width="112" height="112"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Tests/SpeakAppTests/IOSLaunchScreenTests.swift
+++ b/Tests/SpeakAppTests/IOSLaunchScreenTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import XCTest
+
+final class IOSLaunchScreenTests: XCTestCase {
+    private var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    func testLaunchScreen_usesAnAdaptiveImageWithoutText() throws {
+        let storyboard = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("SpeakiOSApp/Resources/LaunchScreen.storyboard"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(storyboard.contains("image=\"LaunchMark\""))
+        XCTAssertTrue(storyboard.contains("systemColor=\"systemBackgroundColor\""))
+        XCTAssertFalse(storyboard.contains("<label"))
+    }
+
+    func testLaunchMark_hasLightAndDarkVectorVariants() throws {
+        let imageSet = repositoryRoot.appendingPathComponent("SpeakiOSApp/Assets.xcassets/LaunchMark.imageset")
+        let contents = try String(
+            contentsOf: imageSet.appendingPathComponent("Contents.json"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(contents.contains("LaunchMark.svg"))
+        XCTAssertTrue(contents.contains("LaunchMark-dark.svg"))
+        XCTAssertTrue(contents.contains("preserves-vector-representation"))
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: imageSet.appendingPathComponent("LaunchMark.svg").path)
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: imageSet.appendingPathComponent("LaunchMark-dark.svg").path)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- replace the text-only iOS launch screen with a centred waveform brand mark
- keep the native system background for a smooth transition into the app
- provide light and dark vector variants with no loading UI or stale launch text
- add regression coverage for the storyboard and adaptive asset variants

## Validation
- xcrun actool asset compilation
- xcrun ibtool storyboard compilation
- swift test --filter IOSLaunchScreenTests
- strict SwiftLint: 0 violations