### PR TITLE
feat(profiles): per-app dictation profiles (Power Mode) on macOS

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -811,6 +811,11 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   private let defaults: UserDefaults
   private let log = Logger(subsystem: "com.github.speakapp", category: "AppSettings")
 
+  /// When true, `store` skips writing to `UserDefaults` while the published
+  /// in-memory values still update. Used by `SessionProfileApplier` so
+  /// session-scoped dictation-profile overrides never touch persisted defaults.
+  var suppressesPersistence = false
+
   init(defaults: UserDefaults = .standard) { // swiftlint:disable:this function_body_length
     self.defaults = defaults
 
@@ -1088,6 +1093,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   private func store<T>(_ value: T, key: DefaultsKey) {
+    guard !suppressesPersistence else { return }
     switch value {
     case let boolValue as Bool:
       defaults.set(boolValue, forKey: key.rawValue)

--- a/Sources/SpeakApp/DictationProfileStore.swift
+++ b/Sources/SpeakApp/DictationProfileStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SpeakCore
+import os.log
+
+/// Persists the user's per-app dictation profiles as Codable JSON in
+/// `UserDefaults`, following the AppSettings storage convention.
+@MainActor
+final class DictationProfileStore: ObservableObject {
+  static let defaultsKey = "dictationProfiles"
+
+  @Published var profiles: [DictationProfile] {
+    didSet { persist() }
+  }
+
+  private let defaults: UserDefaults
+  private let log = Logger(subsystem: "com.github.speakapp", category: "DictationProfileStore")
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+    if let data = defaults.data(forKey: Self.defaultsKey),
+      let decoded = try? DictationProfile.decodeList(data) {
+      profiles = decoded
+    } else {
+      profiles = []
+    }
+  }
+
+  func upsert(_ profile: DictationProfile) {
+    if let index = profiles.firstIndex(where: { $0.id == profile.id }) {
+      profiles[index] = profile
+    } else {
+      profiles.append(profile)
+    }
+  }
+
+  func remove(id: UUID) {
+    profiles.removeAll { $0.id == id }
+  }
+
+  private func persist() {
+    if profiles.isEmpty {
+      defaults.removeObject(forKey: Self.defaultsKey)
+      return
+    }
+    do {
+      defaults.set(try DictationProfile.encodeList(profiles), forKey: Self.defaultsKey)
+    } catch {
+      log.error("Failed to persist dictation profiles: \(error.localizedDescription)")
+    }
+  }
+}

--- a/Sources/SpeakApp/HUDManager.swift
+++ b/Sources/SpeakApp/HUDManager.swift
@@ -98,7 +98,9 @@ final class HUDManager: ObservableObject {
     }
   }
 
-  func beginRecording() {
+  /// Begins the recording phase. When a dictation profile is active for the
+  /// session, its name is surfaced in the HUD subheadline.
+  func beginRecording(profileName: String? = nil) {
     // Set initial expansion state based on user preference
     switch appSettings.hudSizePreference {
     case .compact:
@@ -108,7 +110,8 @@ final class HUDManager: ObservableObject {
     case .autoExpand:
       isExpanded = false  // Will auto-expand when transcript exceeds threshold
     }
-    transition(.recording, headline: "Recording", subheadline: "Capturing audio")
+    let subheadline = profileName.map { "Profile: \($0)" } ?? "Capturing audio"
+    transition(.recording, headline: "Recording", subheadline: subheadline)
   }
 
   /// Update the current audio level during recording (0.0 to 1.0)

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -58,10 +58,21 @@ final class MainManager: ObservableObject {
   let liveTextInserter: LiveTextInserter
   let textProcessor: TranscriptionTextProcessor
   let autoCorrectionTracker: AutoCorrectionTracker
+  let profileStore: DictationProfileStore
   let logger = Logger(subsystem: "com.github.speakapp", category: "MainManager")
   private let recordingSoundPlayer = RecordingSoundPlayer()
+  /// Applies/reverts per-app dictation profile overrides for a session.
+  private let profileApplier = SessionProfileApplier()
 
-  var activeSession: ActiveSession?
+  var activeSession: ActiveSession? {
+    didSet {
+      // Every session-teardown path clears `activeSession`, so this is the one
+      // place profile overrides are reverted back to the user's own settings.
+      if activeSession == nil {
+        profileApplier.end(settings: appSettings, postProcessing: postProcessingManager)
+      }
+    }
+  }
   /// Guards against re-entrant calls to endSession (e.g. silence detection + user hotkey racing).
   var isEndingSession = false
   let recordingStopTimeout: TimeInterval = 8
@@ -116,7 +127,8 @@ final class MainManager: ObservableObject {
     livePolishManager: LivePolishManager,
     liveTextInserter: LiveTextInserter,
     textProcessor: TranscriptionTextProcessor,
-    autoCorrectionTracker: AutoCorrectionTracker
+    autoCorrectionTracker: AutoCorrectionTracker,
+    profileStore: DictationProfileStore
   ) {
     self.appSettings = appSettings
     self.permissionsManager = permissionsManager
@@ -133,6 +145,7 @@ final class MainManager: ObservableObject {
     self.liveTextInserter = liveTextInserter
     self.textProcessor = textProcessor
     self.autoCorrectionTracker = autoCorrectionTracker
+    self.profileStore = profileStore
 
     recordingSoundPlayer.profile = appSettings.recordingSoundProfile
     appSettings.$recordingSoundProfile
@@ -397,9 +410,26 @@ final class MainManager: ObservableObject {
   // swiftlint:disable:next function_body_length
   private func startSession(trigger: SessionTriggerSource) async {
     guard activeSession == nil else { return }
-    if await presentMissingLiveAPIKeyAlertIfNeeded() { return }
+
+    // Per-app dictation profile: resolve the frontmost app and apply its
+    // overrides for this session only. Applied before the API-key check so the
+    // check sees the profile's provider. Reverted whenever `activeSession`
+    // returns to nil; the early-exit paths below revert explicitly because no
+    // session was created yet.
+    profileApplier.begin(
+      settings: appSettings,
+      postProcessing: postProcessingManager,
+      profiles: profileStore.profiles,
+      frontmostBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    )
+
+    if await presentMissingLiveAPIKeyAlertIfNeeded() {
+      profileApplier.end(settings: appSettings, postProcessing: postProcessingManager)
+      return
+    }
 
     if audioInputDeviceManager.devices.isEmpty {
+      profileApplier.end(settings: appSettings, postProcessing: postProcessingManager)
       let message = "No microphone connected. Plug in a USB or Bluetooth microphone and try again."
       state = .failed(message)
       lastErrorMessage = message
@@ -452,7 +482,7 @@ final class MainManager: ObservableObject {
     if appSettings.showHUDDuringSessions {
       permissionsManager.refresh(.microphone)
       hudManager.updateCaptureHealth(buildCaptureHealthSnapshot())
-      hudManager.beginRecording()
+      hudManager.beginRecording(profileName: profileApplier.activeProfileName)
     }
 
     do {

--- a/Sources/SpeakApp/PostProcessingManager.swift
+++ b/Sources/SpeakApp/PostProcessingManager.swift
@@ -20,6 +20,10 @@ final class PostProcessingManager: ObservableObject {
 
   static let defaultPrompt = TranscriptCleanupPolicy.baseSystemPrompt
 
+  /// Session-scoped custom polish prompt from the active dictation profile.
+  /// Set by `SessionProfileApplier` for the duration of a session; never persisted.
+  var sessionPromptOverride: String?
+
   init(client: ChatLLMClient, settings: AppSettings, personalLexicon: PersonalLexiconService) {
     self.client = client
     self.settings = settings
@@ -338,6 +342,7 @@ final class PostProcessingManager: ObservableObject {
 
   private func basePrompt() -> String {
     TranscriptCleanupPolicy.systemPrompt(
+      customBasePrompt: sessionPromptOverride,
       outputLanguage: normalizedOutputLanguage()
     )
   }
@@ -348,6 +353,7 @@ final class PostProcessingManager: ObservableObject {
   ) -> String {
     let directives = lexiconDirectives(for: context, corrections: corrections)
     return TranscriptCleanupPolicy.systemPrompt(
+      customBasePrompt: sessionPromptOverride,
       outputLanguage: normalizedOutputLanguage(),
       lexiconDirectives: settings.postProcessingIncludeLexiconDirectives ? directives : [],
       lexiconContextTags: settings.postProcessingIncludeContextTags ? Array(context.tags) : []

--- a/Sources/SpeakApp/Services/ShortcutManager.swift
+++ b/Sources/SpeakApp/Services/ShortcutManager.swift
@@ -19,6 +19,7 @@ enum ShortcutAction: String, CaseIterable, Identifiable, Codable {
     case openTroubleshooting
     case openTranscriptionSettings
     case openPostProcessingSettings
+    case openProfilesSettings
     case openVoiceOutputSettings
     case openPronunciationSettings
     case openAPIKeysSettings
@@ -47,6 +48,7 @@ enum ShortcutAction: String, CaseIterable, Identifiable, Codable {
         case .openTroubleshooting: return "Open Troubleshooting"
         case .openTranscriptionSettings: return "Open Transcription Settings"
         case .openPostProcessingSettings: return "Open Post-processing Settings"
+        case .openProfilesSettings: return "Open Profiles Settings"
         case .openVoiceOutputSettings: return "Open Voice Output Settings"
         case .openPronunciationSettings: return "Open Pronunciation Settings"
         case .openAPIKeysSettings: return "Open API Keys Settings"
@@ -88,6 +90,8 @@ enum ShortcutAction: String, CaseIterable, Identifiable, Codable {
             return KeyBinding(keyCode: 19, modifiers: [.command], isGlobal: false)  // ⌘2
         case .openPostProcessingSettings:
             return KeyBinding(keyCode: 20, modifiers: [.command], isGlobal: false)  // ⌘3
+        case .openProfilesSettings:
+            return KeyBinding(keyCode: 29, modifiers: [.command], isGlobal: false)  // ⌘0
         case .openVoiceOutputSettings:
             return KeyBinding(keyCode: 21, modifiers: [.command], isGlobal: false)  // ⌘4
         case .openPronunciationSettings:

--- a/Sources/SpeakApp/SessionProfileApplier.swift
+++ b/Sources/SpeakApp/SessionProfileApplier.swift
@@ -1,0 +1,150 @@
+import Foundation
+import SpeakCore
+import os.log
+
+/// Applies a dictation profile's overrides to `AppSettings` for the duration of
+/// a single session and restores the user's own values afterwards.
+///
+/// All profile-override resolution lives here: `MainManager` calls `begin` at
+/// the session-start choke point and `end` whenever the session finishes (any
+/// path). Overrides are applied with persistence suppressed, so a session-only
+/// profile never touches the stored defaults.
+@MainActor
+final class SessionProfileApplier {
+  private struct Snapshot {
+    let transcriptionMode: AppSettings.TranscriptionMode
+    let liveTranscriptionModel: String
+    let batchTranscriptionModel: String
+    let localTranscriptionModel: String
+    let localTranscriptionMode: AppSettings.LocalTranscriptionMode
+    let speedMode: AppSettings.SpeedMode
+    let postProcessingEnabled: Bool
+    let postProcessingModel: String
+    let postProcessingOutputLanguage: String
+    let postProcessingIncludeLexiconDirectives: Bool
+    let postProcessingIncludeContextTags: Bool
+    let preferredLocaleIdentifier: String
+  }
+
+  /// Name of the profile applied to the current session, for HUD display.
+  private(set) var activeProfileName: String?
+  private var snapshot: Snapshot?
+  private let log = Logger(subsystem: "com.github.speakapp", category: "SessionProfileApplier")
+
+  /// Resolves the profile for the frontmost app and applies its overrides.
+  /// A `nil` resolution leaves every setting untouched (the default profile).
+  func begin(
+    settings: AppSettings,
+    postProcessing: PostProcessingManager,
+    profiles: [DictationProfile],
+    frontmostBundleID: String?
+  ) {
+    // Never stack overrides: restore any leftover snapshot first.
+    end(settings: settings, postProcessing: postProcessing)
+    let resolver = ProfileResolver(profiles: profiles)
+    guard let profile = resolver.profile(forBundleID: frontmostBundleID) else { return }
+
+    snapshot = Snapshot(
+      transcriptionMode: settings.transcriptionMode,
+      liveTranscriptionModel: settings.liveTranscriptionModel,
+      batchTranscriptionModel: settings.batchTranscriptionModel,
+      localTranscriptionModel: settings.localTranscriptionModel,
+      localTranscriptionMode: settings.localTranscriptionMode,
+      speedMode: settings.speedMode,
+      postProcessingEnabled: settings.postProcessingEnabled,
+      postProcessingModel: settings.postProcessingModel,
+      postProcessingOutputLanguage: settings.postProcessingOutputLanguage,
+      postProcessingIncludeLexiconDirectives: settings.postProcessingIncludeLexiconDirectives,
+      postProcessingIncludeContextTags: settings.postProcessingIncludeContextTags,
+      preferredLocaleIdentifier: settings.preferredLocaleIdentifier
+    )
+    activeProfileName = profile.name
+    apply(profile, to: settings, postProcessing: postProcessing)
+    let bundleID = frontmostBundleID ?? "unknown"
+    log.info("Applied dictation profile \"\(profile.name, privacy: .public)\" for \(bundleID, privacy: .public)")
+  }
+
+  /// Restores the user's own settings. Safe to call repeatedly; a call without
+  /// an active override is a no-op.
+  func end(settings: AppSettings, postProcessing: PostProcessingManager) {
+    postProcessing.sessionPromptOverride = nil
+    activeProfileName = nil
+    guard let snapshot else { return }
+    self.snapshot = nil
+
+    settings.suppressesPersistence = true
+    defer { settings.suppressesPersistence = false }
+    settings.transcriptionMode = snapshot.transcriptionMode
+    settings.liveTranscriptionModel = snapshot.liveTranscriptionModel
+    settings.batchTranscriptionModel = snapshot.batchTranscriptionModel
+    settings.localTranscriptionModel = snapshot.localTranscriptionModel
+    settings.localTranscriptionMode = snapshot.localTranscriptionMode
+    settings.preferredLocaleIdentifier = snapshot.preferredLocaleIdentifier
+    settings.speedMode = snapshot.speedMode
+    settings.postProcessingModel = snapshot.postProcessingModel
+    settings.postProcessingOutputLanguage = snapshot.postProcessingOutputLanguage
+    settings.postProcessingIncludeLexiconDirectives = snapshot.postProcessingIncludeLexiconDirectives
+    settings.postProcessingIncludeContextTags = snapshot.postProcessingIncludeContextTags
+    // Last: the didSet invariant can reject `true` while a speed mode is
+    // active, so restore it after the speed mode is back.
+    settings.postProcessingEnabled = snapshot.postProcessingEnabled
+  }
+
+  private func apply(
+    _ profile: DictationProfile,
+    to settings: AppSettings,
+    postProcessing: PostProcessingManager
+  ) {
+    settings.suppressesPersistence = true
+    defer { settings.suppressesPersistence = false }
+
+    if let modelID = normalized(profile.transcriptionModelID) {
+      applyTranscriptionModel(modelID, to: settings)
+    }
+    if let language = normalized(profile.languageIdentifier) {
+      settings.preferredLocaleIdentifier = language
+    }
+    if let polishEnabled = profile.polishEnabled {
+      settings.postProcessingEnabled = polishEnabled
+    }
+    if let model = normalized(profile.polishModelID) {
+      settings.postProcessingModel = model
+    }
+    if let outputLanguage = normalized(profile.polishOutputLanguage) {
+      settings.postProcessingOutputLanguage = outputLanguage
+    }
+    if let includeDirectives = profile.polishIncludeLexiconDirectives {
+      settings.postProcessingIncludeLexiconDirectives = includeDirectives
+    }
+    if let includeTags = profile.polishIncludeContextTags {
+      settings.postProcessingIncludeContextTags = includeTags
+    }
+    postProcessing.sessionPromptOverride = normalized(profile.polishPrompt)
+  }
+
+  /// Derives the transcription mode from the catalog identifier and applies it
+  /// to the matching model slot.
+  private func applyTranscriptionModel(_ modelID: String, to settings: AppSettings) {
+    let isLiveModel = ModelCatalog.liveTranscription.contains {
+      $0.id.caseInsensitiveCompare(modelID) == .orderedSame
+    }
+    if isLiveModel {
+      settings.transcriptionMode = .liveNative
+      settings.liveTranscriptionModel = modelID
+    } else if modelID.lowercased().hasPrefix("local/") {
+      settings.transcriptionMode = .localModel
+      settings.localTranscriptionMode = .batch
+      settings.localTranscriptionModel = modelID
+    } else {
+      settings.transcriptionMode = .batchRemote
+      settings.batchTranscriptionModel = modelID
+    }
+  }
+
+  private func normalized(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+      return nil
+    }
+    return trimmed
+  }
+}

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -465,6 +465,8 @@ struct SettingsView: View {
       transcriptionSettings
     case .postProcessing:
       postProcessingSettings
+    case .profiles:
+      profilesSettings
     case .voiceOutput:
       voiceOutputSettings
     case .pronunciation:

--- a/Sources/SpeakApp/SideBarView.swift
+++ b/Sources/SpeakApp/SideBarView.swift
@@ -276,6 +276,8 @@ private extension SettingsTab {
       return .openTranscriptionSettings
     case .postProcessing:
       return .openPostProcessingSettings
+    case .profiles:
+      return .openProfilesSettings
     case .voiceOutput:
       return .openVoiceOutputSettings
     case .pronunciation:

--- a/Sources/SpeakApp/Views/Settings/ProfileEditorView.swift
+++ b/Sources/SpeakApp/Views/Settings/ProfileEditorView.swift
@@ -1,0 +1,295 @@
+import SpeakCore
+import AppKit
+import SwiftUI
+
+private enum ProfileTranscriptionChoice: String, CaseIterable, Identifiable {
+  case useDefault
+  case streaming
+  case batch
+
+  var id: String { rawValue }
+
+  var displayName: String {
+    switch self {
+    case .useDefault: return "Use Default"
+    case .streaming: return "Remote Streaming"
+    case .batch: return "Remote Batch"
+    }
+  }
+}
+
+private enum ProfilePolishChoice: String, CaseIterable, Identifiable {
+  case useDefault
+  case enabled
+  case disabled
+
+  var id: String { rawValue }
+
+  var displayName: String {
+    switch self {
+    case .useDefault: return "Use Default"
+    case .enabled: return "Enabled"
+    case .disabled: return "Disabled"
+    }
+  }
+}
+
+/// Sheet for creating or editing a single dictation profile.
+struct ProfileEditorView: View {
+  @Environment(\.dismiss) private var dismiss
+  @ObservedObject var settings: AppSettings
+  private let originalID: UUID?
+  private let onSave: (DictationProfile) -> Void
+
+  @State private var name: String
+  @State private var bundleIDs: [String]
+  @State fileprivate var transcriptionChoice: ProfileTranscriptionChoice
+  @State private var streamingModel: String
+  @State private var batchModel: String
+  @State fileprivate var polishChoice: ProfilePolishChoice
+  @State private var polishModel: String
+  @State private var useCustomPrompt: Bool
+  @State private var customPrompt: String
+  @State private var outputLanguage: String
+  @State private var includeLexiconDirectives: Bool
+  @State private var includeContextTags: Bool
+  @State private var languageIdentifier: String
+
+  init(profile: DictationProfile?, settings: AppSettings, onSave: @escaping (DictationProfile) -> Void) {
+    self.settings = settings
+    self.originalID = profile?.id
+    self.onSave = onSave
+
+    _name = State(initialValue: profile?.name ?? "")
+    _bundleIDs = State(initialValue: profile?.matchers.filter { $0.kind == .bundleID }.map(\.value) ?? [])
+
+    let transcriptionModelID = profile?.transcriptionModelID?
+      .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let isLiveModel = ModelCatalog.liveTranscription.contains {
+      $0.id.caseInsensitiveCompare(transcriptionModelID) == .orderedSame
+    }
+    if transcriptionModelID.isEmpty {
+      _transcriptionChoice = State(initialValue: .useDefault)
+      _streamingModel = State(initialValue: settings.liveTranscriptionModel)
+      _batchModel = State(initialValue: settings.batchTranscriptionModel)
+    } else if isLiveModel {
+      _transcriptionChoice = State(initialValue: .streaming)
+      _streamingModel = State(initialValue: transcriptionModelID)
+      _batchModel = State(initialValue: settings.batchTranscriptionModel)
+    } else {
+      _transcriptionChoice = State(initialValue: .batch)
+      _streamingModel = State(initialValue: settings.liveTranscriptionModel)
+      _batchModel = State(initialValue: transcriptionModelID)
+    }
+
+    switch profile?.polishEnabled {
+    case .some(true):
+      _polishChoice = State(initialValue: .enabled)
+    case .some(false):
+      _polishChoice = State(initialValue: .disabled)
+    case .none:
+      _polishChoice = State(initialValue: .useDefault)
+    }
+    _polishModel = State(initialValue: profile?.polishModelID ?? settings.postProcessingModel)
+    let prompt = profile?.polishPrompt ?? ""
+    _useCustomPrompt = State(initialValue: !prompt.isEmpty)
+    _customPrompt = State(initialValue: prompt)
+    _outputLanguage = State(initialValue: profile?.polishOutputLanguage ?? "")
+    _includeLexiconDirectives = State(
+      initialValue: profile?.polishIncludeLexiconDirectives ?? settings.postProcessingIncludeLexiconDirectives
+    )
+    _includeContextTags = State(
+      initialValue: profile?.polishIncludeContextTags ?? settings.postProcessingIncludeContextTags
+    )
+    _languageIdentifier = State(initialValue: profile?.languageIdentifier ?? "")
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        Text(originalID == nil ? "New Profile" : "Edit Profile")
+          .font(.headline)
+        Spacer()
+        Button("Cancel") { dismiss() }
+        Button("Save") {
+          onSave(builtProfile)
+          dismiss()
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      }
+      .padding(16)
+
+      Divider()
+
+      ScrollView {
+        VStack(alignment: .leading, spacing: 20) {
+          VStack(alignment: .leading, spacing: 6) {
+            Text("Name")
+              .font(.subheadline.weight(.semibold))
+            TextField("e.g. Slack, Email, Code", text: $name)
+              .textFieldStyle(.roundedBorder)
+          }
+
+          ProfileAppsSection(bundleIDs: $bundleIDs)
+
+          transcriptionSection
+          polishSection
+          languageSection
+        }
+        .padding(16)
+      }
+    }
+    .frame(minWidth: 560, minHeight: 620)
+  }
+
+  fileprivate var builtProfile: DictationProfile {
+    let polishEnabled: Bool?
+    switch polishChoice {
+    case .useDefault: polishEnabled = nil
+    case .enabled: polishEnabled = true
+    case .disabled: polishEnabled = false
+    }
+
+    let transcriptionModelID: String?
+    switch transcriptionChoice {
+    case .useDefault:
+      transcriptionModelID = nil
+    case .streaming:
+      transcriptionModelID = normalized(streamingModel)
+    case .batch:
+      transcriptionModelID = normalized(batchModel)
+    }
+
+    let isPolishOverridden = polishChoice == .enabled
+    return DictationProfile(
+      id: originalID ?? UUID(),
+      name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+      matchers: bundleIDs.map(DictationProfileMatcher.bundleID),
+      transcriptionModelID: transcriptionModelID,
+      polishEnabled: polishEnabled,
+      polishModelID: isPolishOverridden ? normalized(polishModel) : nil,
+      polishPrompt: isPolishOverridden && useCustomPrompt ? normalized(customPrompt) : nil,
+      polishOutputLanguage: isPolishOverridden ? normalized(outputLanguage) : nil,
+      polishIncludeLexiconDirectives: isPolishOverridden ? includeLexiconDirectives : nil,
+      polishIncludeContextTags: isPolishOverridden ? includeContextTags : nil,
+      languageIdentifier: normalized(languageIdentifier)
+    )
+  }
+
+  private func normalized(_ value: String) -> String? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}
+
+// MARK: - Editor sections
+
+extension ProfileEditorView {
+  fileprivate var transcriptionSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Transcription")
+        .font(.subheadline.weight(.semibold))
+      Picker("Transcription", selection: $transcriptionChoice) {
+        ForEach(ProfileTranscriptionChoice.allCases) { choice in
+          Text(choice.displayName).tag(choice)
+        }
+      }
+      .pickerStyle(.segmented)
+      .labelsHidden()
+
+      if transcriptionChoice == .streaming {
+        ModelPicker(
+          title: "Streaming Model",
+          help: "Model used while recording when this profile is active.",
+          options: ModelCatalog.liveTranscription,
+          value: $streamingModel,
+          credentialPurpose: .liveTranscription,
+          storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers)
+        )
+      } else if transcriptionChoice == .batch {
+        ModelPicker(
+          title: "Batch Model",
+          help: "Model the finished recording is sent to when this profile is active.",
+          options: ModelCatalog.batchTranscription,
+          value: $batchModel,
+          credentialPurpose: .batchTranscription,
+          storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers)
+        )
+      }
+    }
+  }
+
+  fileprivate var polishSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Polish (Post-processing)")
+        .font(.subheadline.weight(.semibold))
+      Picker("Polish", selection: $polishChoice) {
+        ForEach(ProfilePolishChoice.allCases) { choice in
+          Text(choice.displayName).tag(choice)
+        }
+      }
+      .pickerStyle(.segmented)
+      .labelsHidden()
+
+      if polishChoice == .enabled {
+        ModelPicker(
+          title: "Polish Model",
+          help: "LLM used to clean up the transcript for this profile.",
+          options: ModelCatalog.postProcessing,
+          value: $polishModel,
+          credentialPurpose: .postProcessing,
+          storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
+          usesDetailedChooser: true
+        )
+
+        Toggle("Custom polish prompt", isOn: $useCustomPrompt)
+        if useCustomPrompt {
+          TextEditor(text: $customPrompt)
+            .font(.body.monospaced())
+            .frame(minHeight: 120)
+            .overlay(
+              RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(Color.secondary.opacity(0.3))
+            )
+          Text("Replaces the built-in cleanup instructions for this profile.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
+        Picker("Output Language", selection: $outputLanguage) {
+          Text("Use Default").tag("")
+          ForEach(Self.outputLanguages, id: \.self) { language in
+            Text(language).tag(language)
+          }
+        }
+        .pickerStyle(.menu)
+
+        Toggle("Include personal lexicon directives", isOn: $includeLexiconDirectives)
+        Toggle("Include context tags", isOn: $includeContextTags)
+      }
+    }
+  }
+
+  fileprivate var languageSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Spoken Language")
+        .font(.subheadline.weight(.semibold))
+      Picker("Spoken Language", selection: $languageIdentifier) {
+        Text("Use Default").tag("")
+        ForEach(TranscriptionLanguageCatalog.options) { option in
+          Text(option.displayName).tag(option.id)
+        }
+      }
+      .pickerStyle(.menu)
+      .labelsHidden()
+    }
+  }
+
+  fileprivate static var outputLanguages: [String] {
+    [
+      "English", "British English", "Spanish", "French", "German", "Italian",
+      "Portuguese", "Chinese", "Japanese", "Korean", "Russian", "Arabic", "Hindi"
+    ]
+  }
+}

--- a/Sources/SpeakApp/Views/Settings/SettingsTab.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsTab.swift
@@ -4,6 +4,7 @@ enum SettingsTab: String, CaseIterable, Identifiable, Hashable {
   case general
   case transcription
   case postProcessing
+  case profiles
   case voiceOutput
   case pronunciation
   case apiKeys
@@ -22,6 +23,7 @@ enum SettingsTab: String, CaseIterable, Identifiable, Hashable {
     case .general: return "General"
     case .transcription: return "Transcription"
     case .postProcessing: return isAssemblyAI ? "Pre-processing" : "Post-processing"
+    case .profiles: return "Profiles"
     case .voiceOutput: return "Voice Output"
     case .pronunciation: return "Pronunciation"
     case .apiKeys: return "API Keys"
@@ -36,6 +38,7 @@ enum SettingsTab: String, CaseIterable, Identifiable, Hashable {
     case .general: return "gearshape"
     case .transcription: return "waveform"
     case .postProcessing: return "wand.and.stars"
+    case .profiles: return "person.crop.rectangle.stack"
     case .voiceOutput: return "speaker.wave.3"
     case .pronunciation: return "character.book.closed"
     case .apiKeys: return "key.fill"

--- a/Sources/SpeakApp/Views/Settings/SettingsView+Profiles.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+Profiles.swift
@@ -1,0 +1,201 @@
+import SpeakCore
+import AppKit
+import SwiftUI
+
+extension SettingsView {
+  var profilesSettings: some View {
+    ProfilesSettingsContent(store: environment.profiles, settings: settings)
+  }
+}
+
+// MARK: - Profiles list
+
+struct ProfilesSettingsContent: View {
+  @ObservedObject var store: DictationProfileStore
+  @ObservedObject var settings: AppSettings
+  @State private var editingProfile: DictationProfile?
+  @State private var isCreatingProfile = false
+
+  var body: some View {
+    SpeakDensitySettingsSection(density: settings.visualDensity) {
+      SettingsCard(
+        title: "Per-App Profiles",
+        systemImage: "person.crop.rectangle.stack",
+        tint: Color.brandAccent
+      ) {
+        VStack(alignment: .leading, spacing: 12) {
+          Text(
+            """
+            Bind transcription, polish and language settings to specific apps. When you start \
+            dictating, Speak matches the frontmost app and applies that profile for the session. \
+            Apps without a profile keep your default settings.
+            """
+          )
+          .font(.callout)
+          .foregroundStyle(.secondary)
+
+          if store.profiles.isEmpty {
+            Text("No profiles yet. Dictation always uses your default settings.")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+              .padding(.vertical, 8)
+          } else {
+            VStack(spacing: 8) {
+              ForEach(store.profiles) { profile in
+                profileRow(profile)
+              }
+            }
+          }
+
+          Button {
+            isCreatingProfile = true
+          } label: {
+            Label("Add Profile", systemImage: "plus")
+          }
+          .buttonStyle(.bordered)
+          .speakTooltip("Create a profile that activates automatically for chosen apps.")
+        }
+      }
+      .speakTooltip("Configure per-app dictation profiles (Power Mode).")
+    }
+    .sheet(item: $editingProfile) { profile in
+      ProfileEditorView(profile: profile, settings: settings) { updated in
+        store.upsert(updated)
+      }
+    }
+    .sheet(isPresented: $isCreatingProfile) {
+      ProfileEditorView(profile: nil, settings: settings) { created in
+        store.upsert(created)
+      }
+    }
+  }
+
+  private func profileRow(_ profile: DictationProfile) -> some View {
+    HStack(alignment: .center, spacing: 12) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(profile.name)
+          .font(.body.weight(.semibold))
+        Text(matcherSummary(for: profile))
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+      Spacer()
+      Button("Edit") {
+        editingProfile = profile
+      }
+      .buttonStyle(.bordered)
+      Button {
+        store.remove(id: profile.id)
+      } label: {
+        Image(systemName: "trash")
+      }
+      .buttonStyle(.bordered)
+      .accessibilityLabel("Delete profile \(profile.name)")
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+    .background(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .fill(Color(nsColor: .controlBackgroundColor))
+    )
+  }
+
+  private func matcherSummary(for profile: DictationProfile) -> String {
+    let bundleIDs = profile.matchers
+      .filter { $0.kind == .bundleID }
+      .map(\.value)
+    guard !bundleIDs.isEmpty else { return "No apps assigned — never auto-activates" }
+    return bundleIDs.joined(separator: ", ")
+  }
+}
+
+// MARK: - App matcher section (shared with the profile editor)
+
+struct ProfileAppsSection: View {
+  @Binding var bundleIDs: [String]
+  @State private var manualBundleID = ""
+
+  private struct RunningApp: Identifiable {
+    let name: String
+    let bundleID: String
+    var id: String { bundleID }
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Apps")
+        .font(.subheadline.weight(.semibold))
+      Text("The profile activates when dictation starts while one of these apps is frontmost.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      if bundleIDs.isEmpty {
+        Text("No apps assigned yet.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      } else {
+        ForEach(bundleIDs, id: \.self) { bundleID in
+          HStack {
+            Text(bundleID)
+              .font(.callout.monospaced())
+            Spacer()
+            Button {
+              bundleIDs.removeAll { $0 == bundleID }
+            } label: {
+              Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove \(bundleID)")
+          }
+          .padding(.horizontal, 10)
+          .padding(.vertical, 4)
+          .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+              .fill(Color(nsColor: .controlBackgroundColor))
+          )
+        }
+      }
+
+      HStack(spacing: 8) {
+        Menu("Add Running App") {
+          ForEach(runningApps) { app in
+            Button("\(app.name) — \(app.bundleID)") {
+              append(app.bundleID)
+            }
+          }
+        }
+        .frame(maxWidth: 220)
+
+        TextField("Bundle ID (e.g. com.apple.mail)", text: $manualBundleID)
+          .textFieldStyle(.roundedBorder)
+          .autocorrectionDisabled()
+          .onSubmit(addManualBundleID)
+        Button("Add", action: addManualBundleID)
+          .disabled(manualBundleID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      }
+    }
+  }
+
+  private var runningApps: [RunningApp] {
+    NSWorkspace.shared.runningApplications
+      .filter { $0.activationPolicy == .regular }
+      .compactMap { app -> RunningApp? in
+        guard let bundleID = app.bundleIdentifier else { return nil }
+        return RunningApp(name: app.localizedName ?? bundleID, bundleID: bundleID)
+      }
+      .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+  }
+
+  private func addManualBundleID() {
+    append(manualBundleID)
+    manualBundleID = ""
+  }
+
+  private func append(_ bundleID: String) {
+    let trimmed = bundleID.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    guard !bundleIDs.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) else { return }
+    bundleIDs.append(trimmed)
+  }
+}

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -7,7 +7,7 @@ import SpeakSync
 // swiftlint:disable file_length
 
 @MainActor
-final class AppEnvironment: ObservableObject {
+final class AppEnvironment: ObservableObject { // swiftlint:disable:this type_body_length
   let settings: AppSettings
   let permissions: PermissionsManager
   let history: HistoryManager
@@ -26,6 +26,7 @@ final class AppEnvironment: ObservableObject {
   let livePolish: LivePolishManager
   let liveTextInserter: LiveTextInserter
   let autoCorrectionTracker: AutoCorrectionTracker
+  let profiles: DictationProfileStore
   let main: MainManager
   let transportServer: TransportServer
   private let hudPresenter: HUDWindowPresenter
@@ -68,6 +69,7 @@ final class AppEnvironment: ObservableObject {
     livePolish: LivePolishManager,
     liveTextInserter: LiveTextInserter,
     autoCorrectionTracker: AutoCorrectionTracker,
+    profiles: DictationProfileStore,
     main: MainManager,
     transportServer: TransportServer,
     hudPresenter: HUDWindowPresenter
@@ -90,6 +92,7 @@ final class AppEnvironment: ObservableObject {
     self.livePolish = livePolish
     self.liveTextInserter = liveTextInserter
     self.autoCorrectionTracker = autoCorrectionTracker
+    self.profiles = profiles
     self.main = main
     self.transportServer = transportServer
     self.hudPresenter = hudPresenter
@@ -231,6 +234,7 @@ final class AppEnvironment: ObservableObject {
       .openSettings: .settings(.general),
       .openTranscriptionSettings: .settings(.transcription),
       .openPostProcessingSettings: .settings(.postProcessing),
+      .openProfilesSettings: .settings(.profiles),
       .openVoiceOutputSettings: .settings(.voiceOutput),
       .openPronunciationSettings: .settings(.pronunciation),
       .openAPIKeysSettings: .settings(.apiKeys),
@@ -396,6 +400,7 @@ enum WireUp {
       lexiconService: personalLexicon,
       appSettings: settings
     )
+    let profiles = DictationProfileStore()
     let main = MainManager(
       appSettings: settings,
       permissionsManager: permissions,
@@ -411,7 +416,8 @@ enum WireUp {
       livePolishManager: livePolish,
       liveTextInserter: liveTextInserter,
       textProcessor: textProcessor,
-      autoCorrectionTracker: autoCorrectionTracker
+      autoCorrectionTracker: autoCorrectionTracker,
+      profileStore: profiles
     )
     let hudPresenter = HUDWindowPresenter(manager: hud, settings: settings)
     let shortcuts = ShortcutManager(permissionsManager: permissions)
@@ -438,6 +444,7 @@ enum WireUp {
       livePolish: livePolish,
       liveTextInserter: liveTextInserter,
       autoCorrectionTracker: autoCorrectionTracker,
+      profiles: profiles,
       main: main,
       transportServer: transportServer,
       hudPresenter: hudPresenter

--- a/Sources/SpeakCore/DictationProfile.swift
+++ b/Sources/SpeakCore/DictationProfile.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+// MARK: - Matchers
+
+/// A rule binding a dictation profile to a target context.
+///
+/// Today only `bundleID` matchers are evaluated (macOS frontmost-app matching).
+/// `urlPattern` is reserved so browser URL matching (Safari/Chrome via AX) can be
+/// added later without a storage or sync format change; unknown kinds written by
+/// newer clients are dropped on decode instead of failing the whole profile list.
+public struct DictationProfileMatcher: Codable, Equatable, Hashable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        /// Matches the frontmost application's bundle identifier (case-insensitive).
+        case bundleID
+        /// Reserved: matches the frontmost browser tab's URL. Not evaluated yet.
+        case urlPattern
+    }
+
+    public var kind: Kind
+    public var value: String
+
+    public init(kind: Kind = .bundleID, value: String) {
+        self.kind = kind
+        self.value = value
+    }
+
+    public static func bundleID(_ identifier: String) -> DictationProfileMatcher {
+        DictationProfileMatcher(kind: .bundleID, value: identifier)
+    }
+}
+
+// MARK: - Profile
+
+/// A per-app dictation configuration ("Power Mode" profile).
+///
+/// Every override is optional; `nil` means "keep the user's normal setting".
+/// A resolved profile is applied for the duration of a single dictation session
+/// and never mutates the persisted defaults.
+public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
+    public var id: UUID
+    public var name: String
+    public var matchers: [DictationProfileMatcher]
+
+    /// Transcription model override (catalog identifier, e.g. `deepgram/nova-3-streaming`
+    /// or `openai/whisper-1`). The transcription mode is derived from the identifier.
+    public var transcriptionModelID: String?
+
+    /// Whether LLM polish (post-processing) runs for this profile.
+    public var polishEnabled: Bool?
+    /// Polish model override (catalog identifier).
+    public var polishModelID: String?
+    /// Custom polish system prompt replacing the built-in cleanup prompt.
+    public var polishPrompt: String?
+    /// Output language for the polished transcript (e.g. `British English`).
+    public var polishOutputLanguage: String?
+    /// Formatting: include personal-lexicon normalisation directives in the prompt.
+    public var polishIncludeLexiconDirectives: Bool?
+    /// Formatting: include detected context tags in the prompt.
+    public var polishIncludeContextTags: Bool?
+
+    /// Spoken-language override (`TranscriptionLanguageCatalog` identifier, e.g. `en_GB`).
+    public var languageIdentifier: String?
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        matchers: [DictationProfileMatcher] = [],
+        transcriptionModelID: String? = nil,
+        polishEnabled: Bool? = nil,
+        polishModelID: String? = nil,
+        polishPrompt: String? = nil,
+        polishOutputLanguage: String? = nil,
+        polishIncludeLexiconDirectives: Bool? = nil,
+        polishIncludeContextTags: Bool? = nil,
+        languageIdentifier: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.matchers = matchers
+        self.transcriptionModelID = transcriptionModelID
+        self.polishEnabled = polishEnabled
+        self.polishModelID = polishModelID
+        self.polishPrompt = polishPrompt
+        self.polishOutputLanguage = polishOutputLanguage
+        self.polishIncludeLexiconDirectives = polishIncludeLexiconDirectives
+        self.polishIncludeContextTags = polishIncludeContextTags
+        self.languageIdentifier = languageIdentifier
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case matchers
+        case transcriptionModelID
+        case polishEnabled
+        case polishModelID
+        case polishPrompt
+        case polishOutputLanguage
+        case polishIncludeLexiconDirectives
+        case polishIncludeContextTags
+        case languageIdentifier
+    }
+
+    /// Wrapper making individual matcher decode failures (e.g. a kind added by a
+    /// newer client) non-fatal for the containing profile.
+    private struct LossyMatcher: Decodable {
+        let matcher: DictationProfileMatcher?
+
+        init(from decoder: Decoder) throws {
+            matcher = try? DictationProfileMatcher(from: decoder)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        let lossyMatchers = try container.decodeIfPresent([LossyMatcher].self, forKey: .matchers) ?? []
+        matchers = lossyMatchers.compactMap(\.matcher)
+        transcriptionModelID = try container.decodeIfPresent(String.self, forKey: .transcriptionModelID)
+        polishEnabled = try container.decodeIfPresent(Bool.self, forKey: .polishEnabled)
+        polishModelID = try container.decodeIfPresent(String.self, forKey: .polishModelID)
+        polishPrompt = try container.decodeIfPresent(String.self, forKey: .polishPrompt)
+        polishOutputLanguage = try container.decodeIfPresent(String.self, forKey: .polishOutputLanguage)
+        polishIncludeLexiconDirectives = try container.decodeIfPresent(
+            Bool.self, forKey: .polishIncludeLexiconDirectives
+        )
+        polishIncludeContextTags = try container.decodeIfPresent(Bool.self, forKey: .polishIncludeContextTags)
+        languageIdentifier = try container.decodeIfPresent(String.self, forKey: .languageIdentifier)
+    }
+}
+
+// MARK: - List serialisation
+
+public extension DictationProfile {
+    /// Canonical JSON encoding used by the local store and cross-device transfer.
+    static func encodeList(_ profiles: [DictationProfile]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(profiles)
+    }
+
+    static func decodeList(_ data: Data) throws -> [DictationProfile] {
+        try JSONDecoder().decode([DictationProfile].self, from: data)
+    }
+}
+
+// MARK: - Resolver
+
+/// Resolves which profile applies to a dictation session.
+///
+/// Precedence: the first profile in user order with an explicit bundle-ID match
+/// wins. When nothing matches (or no bundle ID is known) the resolver returns
+/// `nil`, which means "use the app's normal settings" — the implicit default
+/// profile that preserves today's behaviour.
+public struct ProfileResolver: Sendable {
+    public var profiles: [DictationProfile]
+
+    public init(profiles: [DictationProfile]) {
+        self.profiles = profiles
+    }
+
+    public func profile(forBundleID bundleID: String?) -> DictationProfile? {
+        guard let target = Self.normalized(bundleID) else { return nil }
+        return profiles.first { profile in
+            profile.matchers.contains { matcher in
+                matcher.kind == .bundleID && Self.normalized(matcher.value) == target
+            }
+        }
+    }
+
+    private static func normalized(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Sources/SpeakCore/TranscriptCleanupPolicy.swift
+++ b/Sources/SpeakCore/TranscriptCleanupPolicy.swift
@@ -29,12 +29,18 @@ public enum TranscriptCleanupPolicy {
     """
 
     /// Builds the shared policy while safely layering optional user and platform context.
+    ///
+    /// `customBasePrompt` (e.g. from a dictation profile) replaces the built-in
+    /// cleanup instructions while keeping the language/lexicon layering and the
+    /// output contract intact.
     public static func systemPrompt(
+        customBasePrompt: String? = nil,
         outputLanguage: String? = nil,
         lexiconDirectives: [String] = [],
         lexiconContextTags: [String] = []
     ) -> String {
-        var sections = [baseSystemPrompt]
+        let customPrompt = normalized(customBasePrompt)
+        var sections = [customPrompt ?? baseSystemPrompt]
 
         if let language = normalized(outputLanguage) {
             sections.append(
@@ -68,7 +74,9 @@ public enum TranscriptCleanupPolicy {
         }
 
         sections.append(
-            "The hard constraints are always authoritative. Return only the cleaned transcript text."
+            customPrompt == nil
+                ? "The hard constraints are always authoritative. Return only the cleaned transcript text."
+                : "Return only the cleaned transcript text."
         )
         return sections.joined(separator: "\n\n")
     }

--- a/Tests/SpeakAppTests/ShortcutNavigationTests.swift
+++ b/Tests/SpeakAppTests/ShortcutNavigationTests.swift
@@ -23,6 +23,7 @@ final class ShortcutNavigationTests: XCTestCase {
             .openSettings,
             .openTranscriptionSettings,
             .openPostProcessingSettings,
+            .openProfilesSettings,
             .openVoiceOutputSettings,
             .openPronunciationSettings,
             .openAPIKeysSettings,
@@ -54,6 +55,7 @@ final class ShortcutNavigationTests: XCTestCase {
         XCTAssertEqual(ShortcutAction.openKeyboardSettings.defaultKeyBinding.displayString, "⌘7")
         XCTAssertEqual(ShortcutAction.openPermissionsSettings.defaultKeyBinding.displayString, "⌘8")
         XCTAssertEqual(ShortcutAction.openAboutSettings.defaultKeyBinding.displayString, "⌘9")
+        XCTAssertEqual(ShortcutAction.openProfilesSettings.defaultKeyBinding.displayString, "⌘0")
 
         XCTAssertEqual(ShortcutAction.quickVoice1.defaultKeyBinding.displayString, "⌥⌘1")
         XCTAssertEqual(ShortcutAction.quickVoice2.defaultKeyBinding.displayString, "⌥⌘2")

--- a/Tests/SpeakCoreTests/DictationProfileTests.swift
+++ b/Tests/SpeakCoreTests/DictationProfileTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import XCTest
+@testable import SpeakCore
+
+final class DictationProfileResolverTests: XCTestCase {
+    private let slackProfile = DictationProfile(
+        name: "Slack",
+        matchers: [.bundleID("com.tinyspeck.slackmacgap")],
+        polishEnabled: false
+    )
+    private let mailProfile = DictationProfile(
+        name: "Email",
+        matchers: [.bundleID("com.apple.mail"), .bundleID("com.microsoft.Outlook")],
+        polishEnabled: true,
+        polishOutputLanguage: "British English"
+    )
+
+    func testExplicitBundleIDMatchWins() {
+        let resolver = ProfileResolver(profiles: [slackProfile, mailProfile])
+
+        XCTAssertEqual(resolver.profile(forBundleID: "com.apple.mail")?.name, "Email")
+        XCTAssertEqual(resolver.profile(forBundleID: "com.microsoft.Outlook")?.name, "Email")
+        XCTAssertEqual(resolver.profile(forBundleID: "com.tinyspeck.slackmacgap")?.name, "Slack")
+    }
+
+    func testMatchingIsCaseInsensitiveAndTrimsWhitespace() {
+        let resolver = ProfileResolver(profiles: [mailProfile])
+
+        XCTAssertEqual(resolver.profile(forBundleID: "COM.APPLE.MAIL")?.name, "Email")
+        XCTAssertEqual(resolver.profile(forBundleID: "  com.apple.mail  ")?.name, "Email")
+    }
+
+    func testUnmatchedBundleIDFallsBackToDefault() {
+        let resolver = ProfileResolver(profiles: [slackProfile, mailProfile])
+
+        XCTAssertNil(resolver.profile(forBundleID: "com.apple.Safari"))
+    }
+
+    func testNilAndEmptyBundleIDsFallBackToDefault() {
+        let resolver = ProfileResolver(profiles: [slackProfile])
+
+        XCTAssertNil(resolver.profile(forBundleID: nil))
+        XCTAssertNil(resolver.profile(forBundleID: ""))
+        XCTAssertNil(resolver.profile(forBundleID: "   "))
+    }
+
+    func testFirstProfileInUserOrderWinsWhenSeveralMatch() {
+        let duplicate = DictationProfile(
+            name: "Slack Override",
+            matchers: [.bundleID("com.tinyspeck.slackmacgap")]
+        )
+        let resolver = ProfileResolver(profiles: [slackProfile, duplicate])
+
+        XCTAssertEqual(resolver.profile(forBundleID: "com.tinyspeck.slackmacgap")?.name, "Slack")
+    }
+
+    func testEmptyMatcherValuesNeverMatch() {
+        let blank = DictationProfile(name: "Blank", matchers: [.bundleID("   ")])
+        let resolver = ProfileResolver(profiles: [blank])
+
+        XCTAssertNil(resolver.profile(forBundleID: ""))
+        XCTAssertNil(resolver.profile(forBundleID: "com.apple.mail"))
+    }
+
+    func testURLPatternMatchersAreIgnoredForBundleResolution() {
+        let urlProfile = DictationProfile(
+            name: "GitHub",
+            matchers: [DictationProfileMatcher(kind: .urlPattern, value: "github.com")]
+        )
+        let resolver = ProfileResolver(profiles: [urlProfile])
+
+        XCTAssertNil(resolver.profile(forBundleID: "github.com"))
+    }
+}
+
+final class DictationProfileCodableTests: XCTestCase {
+    func testProfileListRoundTripsThroughCanonicalEncoding() throws {
+        let profiles = [
+            DictationProfile(
+                name: "Code",
+                matchers: [.bundleID("com.microsoft.VSCode")],
+                transcriptionModelID: "deepgram/nova-3-streaming",
+                polishEnabled: true,
+                polishModelID: "inception/mercury",
+                polishPrompt: "Format as code comments.",
+                polishOutputLanguage: "English",
+                polishIncludeLexiconDirectives: false,
+                polishIncludeContextTags: true,
+                languageIdentifier: "en_GB"
+            ),
+            DictationProfile(name: "Defaults Only", matchers: [.bundleID("com.apple.Notes")])
+        ]
+
+        let data = try DictationProfile.encodeList(profiles)
+        let decoded = try DictationProfile.decodeList(data)
+
+        XCTAssertEqual(decoded, profiles)
+    }
+
+    func testUnknownMatcherKindsAreDroppedInsteadOfFailingDecode() throws {
+        let json = """
+        [
+          {
+            "id": "6F1E32F9-31A5-4C1E-9E32-9E4CB25B7A4C",
+            "name": "Browser",
+            "matchers": [
+              {"kind": "bundleID", "value": "com.apple.Safari"},
+              {"kind": "windowTitle", "value": "Inbox"}
+            ]
+          }
+        ]
+        """
+        let decoded = try DictationProfile.decodeList(Data(json.utf8))
+
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded[0].matchers, [.bundleID("com.apple.Safari")])
+        XCTAssertNil(decoded[0].transcriptionModelID)
+        XCTAssertNil(decoded[0].polishEnabled)
+    }
+}
+
+final class TranscriptCleanupPolicyCustomPromptTests: XCTestCase {
+    func testCustomBasePromptReplacesBuiltInInstructionsButKeepsLayering() {
+        let prompt = TranscriptCleanupPolicy.systemPrompt(
+            customBasePrompt: "Rewrite as terse engineering notes.",
+            outputLanguage: "British English",
+            lexiconDirectives: ["Normalize JSTI to \"Just Speak to It\"."]
+        )
+
+        XCTAssertTrue(prompt.hasPrefix("Rewrite as terse engineering notes."))
+        XCTAssertFalse(prompt.contains("You are a transcription formatter."))
+        XCTAssertTrue(prompt.contains("British English"))
+        XCTAssertTrue(prompt.contains("Just Speak to It"))
+        XCTAssertTrue(prompt.hasSuffix("Return only the cleaned transcript text."))
+    }
+
+    func testBlankCustomBasePromptFallsBackToBuiltInPolicy() {
+        let prompt = TranscriptCleanupPolicy.systemPrompt(customBasePrompt: "   ")
+
+        XCTAssertTrue(prompt.hasPrefix(TranscriptCleanupPolicy.baseSystemPrompt))
+    }
+}


### PR DESCRIPTION
## Summary

Implements per-app auto profiles (#606): transcription model, LLM polish (on/off, model, custom prompt, output language, lexicon formatting flags) and spoken language bound to the frontmost app, applied automatically when dictation starts and reverted when the session ends.

## Design

**Model (SpeakCore)** — `Sources/SpeakCore/DictationProfile.swift`
- `DictationProfile`: Codable/Sendable value type; every override is optional (`nil` = keep the user's normal setting).
- `DictationProfileMatcher {kind, value}`: `bundleID` is evaluated today; `urlPattern` is reserved for browser matching so no storage/sync format change is needed later. Unknown matcher kinds written by newer clients are dropped lossily on decode instead of failing the profile list.
- `ProfileResolver`: first profile in user order with a case-insensitive, trimmed bundle-ID match wins; no match returns `nil`, the implicit default profile that preserves today's behaviour.
- `TranscriptCleanupPolicy.systemPrompt(customBasePrompt:)`: a profile's polish prompt replaces the built-in cleanup instructions while keeping the output-language/lexicon layering and the "return only the transcript" contract.

**Persistence** — `DictationProfileStore`: Codable JSON array under the `dictationProfiles` UserDefaults key, following the AppSettings storage convention.

**Session wiring (mac)** — all override resolution lives in `Sources/SpeakApp/SessionProfileApplier.swift`:
- `MainManager.startSession` resolves `NSWorkspace.shared.frontmostApplication?.bundleIdentifier` and applies the profile *before* the missing-API-key check, so the check validates the profile's provider.
- Overrides are applied with a new `AppSettings.suppressesPersistence` gate: published in-memory values update (so TranscriptionManager/PostProcessingManager read them as usual) but nothing is written to disk — a crash mid-session leaves stored defaults untouched.
- Restore happens in exactly one place: the `MainManager.activeSession` didSet (nil ⇒ restore), which every teardown path (success, failure, cancel, cleanupAfterFailure) already goes through; the two pre-session early exits restore explicitly.
- Transcription override is a single model ID; the mode is derived (live-catalog match → streaming, `local/` prefix → local batch, otherwise remote batch).

**Settings UI (mac)** — new Settings › Profiles tab (`SettingsView+Profiles.swift`, `ProfileEditorView.swift`): profile list with add/edit/delete; editor sheet with name, app picker (running apps + manual bundle ID), streaming/batch model pickers (reusing `ModelPicker`), polish Default/Enabled/Disabled with model, custom prompt editor, output language and lexicon formatting toggles, and a spoken-language override. Navigable via a new ⌘0 shortcut. With no profiles, behaviour is unchanged.

**HUD** — the recording subheadline shows `Profile: <name>` when a profile is active (one optional parameter on `HUDManager.beginRecording`).

## Tests

`Tests/SpeakCoreTests/DictationProfileTests.swift`: resolver precedence (explicit match > default, first-in-user-order tie-break), case-insensitivity/trimming, nil/empty/unmatched fallback, urlPattern ignored for bundle resolution, codable round-trip, lossy unknown-matcher decode, custom-prompt layering. `ShortcutNavigationTests` extended for the new shortcut. Full SwiftLint strict pass against the baseline: 0 violations.

## Deferred (follow-ups)

- **iOS UI**: profiles selectable from the HUD/keyboard — iOS cannot observe the frontmost app; the model lives in SpeakCore ready for reuse.
- **URL-pattern matchers** (Safari/Chrome via AX): matcher kind reserved.
- **Settings-sync / QR transfer**: not included in this PR. The QR payload is size-constrained and profiles with custom prompts can be multi-KB, which would push the encrypted QR beyond reliable scan density. Profiles serialise canonically via `DictationProfile.encodeList`, so adding a CloudKit/KV-store sync key is a clean follow-up.

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)