### PR TITLE
feat(watch): keep wrist-down recordings alive and never lose a partial capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,8 @@ jobs:
         # The watch app target only exists when generated with
         # TUIST_WATCH_APP=1 (it needs its own provisioning profile for release
         # signing, so it is excluded from release builds). Build it unsigned
-        # here so the flagged target cannot rot. Cheap: five small source
-        # files plus two shared core files.
+        # here so the flagged target cannot rot. Cheap: six small source files
+        # plus two shared core files.
         run: |
           set -o pipefail
           TUIST_WATCH_APP=1 tuist generate --no-open

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,8 @@ jobs:
         # The watch app target only exists when generated with
         # TUIST_WATCH_APP=1 (it needs its own provisioning profile for release
         # signing, so it is excluded from release builds). Build it unsigned
-        # here so the flagged target cannot rot. Cheap: four small source
-        # files plus one shared protocol file.
+        # here so the flagged target cannot rot. Cheap: five small source
+        # files plus two shared core files.
         run: |
           set -o pipefail
           TUIST_WATCH_APP=1 tuist generate --no-open

--- a/JustSpeakWatch/JustSpeakWatchApp.swift
+++ b/JustSpeakWatch/JustSpeakWatchApp.swift
@@ -15,6 +15,9 @@ struct JustSpeakWatchApp: App {
                 .onAppear {
                     captureStore.activate()
                 }
+                .task {
+                    await recorder.recoverInterruptedCapture()
+                }
         }
     }
 }

--- a/JustSpeakWatch/WatchAudioRecorder.swift
+++ b/JustSpeakWatch/WatchAudioRecorder.swift
@@ -33,17 +33,17 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
     private var didRecoverInterruptedCapture = false
 
     init(
-        store: WatchCaptureStore = WatchCaptureStore.shared,
-        runtime: WatchRecordingRuntime = WatchRecordingRuntime(),
-        activeCaptureRegistry: WatchActiveCaptureRegistry = WatchActiveCaptureRegistry(
-            fileURL: WatchAudioRecorder.activeCaptureMarkerURL
-        )
+        store: WatchCaptureStore? = nil,
+        runtime: WatchRecordingRuntime? = nil,
+        activeCaptureRegistry: WatchActiveCaptureRegistry? = nil
     ) {
-        self.store = store
-        self.runtime = runtime
-        self.activeCaptureRegistry = activeCaptureRegistry
+        self.store = store ?? WatchCaptureStore.shared
+        self.runtime = runtime ?? WatchRecordingRuntime()
+        self.activeCaptureRegistry = activeCaptureRegistry ?? WatchActiveCaptureRegistry(
+            fileURL: Self.activeCaptureMarkerURL
+        )
         super.init()
-        runtime.onRuntimeEnd = { [weak self] reason in
+        self.runtime.onRuntimeEnd = { [weak self] reason in
             Task { @MainActor in
                 await self?.finish(reason: reason)
             }

--- a/JustSpeakWatch/WatchAudioRecorder.swift
+++ b/JustSpeakWatch/WatchAudioRecorder.swift
@@ -158,7 +158,12 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
         // A crash between queue persistence and marker cleanup must not create
         // a duplicate transfer on the next launch.
         if store.containsCapture(id: capture.id) {
-            try? activeCaptureRegistry.clear(matching: capture.id)
+            do {
+                try activeCaptureRegistry.clear(matching: capture.id)
+            } catch {
+                allowRecoveryRetry(for: capture)
+                lastError = "Recording was queued, but recovery cleanup was deferred."
+            }
             return
         }
 
@@ -219,6 +224,7 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
                     lastError = "An interrupted recording could not be recovered."
                 }
             } catch {
+                allowRecoveryRetry(for: finalisation.capture)
                 lastError = "Recording cleanup failed: \(error.localizedDescription)"
             }
         case .enqueue:
@@ -236,15 +242,24 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
                     )
                 }
                 guard enqueued else {
+                    allowRecoveryRetry(for: finalisation.capture)
                     lastError = "Recording was saved but could not be queued. It will be recovered next time."
                     return
                 }
             } catch {
                 // The queue write has succeeded; retaining the marker is safe
                 // because enqueue is idempotent on capture id at relaunch.
+                allowRecoveryRetry(for: finalisation.capture)
                 lastError = "Recording was queued, but recovery cleanup was deferred."
             }
         }
+    }
+
+    /// A retained marker still owns audio that must be reconciled. Let the next
+    /// start retry recovery rather than blocking recording until app relaunch.
+    private func allowRecoveryRetry(for capture: WatchActiveCapture) {
+        guard activeCaptureRegistry.load()?.id == capture.id else { return }
+        didRecoverInterruptedCapture = false
     }
 
     private func inspectAudio(at url: URL) async -> WatchAudioInspection {
@@ -269,8 +284,10 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
 
 extension WatchAudioRecorder: AVAudioRecorderDelegate {
     nonisolated func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+        let recorderID = ObjectIdentifier(recorder)
         let detail = error?.localizedDescription
         Task { @MainActor in
+            guard self.recorder.map(ObjectIdentifier.init) == recorderID else { return }
             await self.finish(reason: .encodingFailed(reason: detail))
         }
     }
@@ -280,7 +297,9 @@ extension WatchAudioRecorder: AVAudioRecorderDelegate {
         // no-op there. An unsuccessful finish means the system stopped the
         // recorder under us — treat it as lost runtime and keep the partial.
         guard !flag else { return }
+        let recorderID = ObjectIdentifier(recorder)
         Task { @MainActor in
+            guard self.recorder.map(ObjectIdentifier.init) == recorderID else { return }
             await self.finish(reason: .runtimeInvalidated(reason: nil))
         }
     }

--- a/JustSpeakWatch/WatchAudioRecorder.swift
+++ b/JustSpeakWatch/WatchAudioRecorder.swift
@@ -6,6 +6,11 @@ import Foundation
 /// Recording is buffered entirely on-device; hand-off to the iPhone is the
 /// `WatchCaptureStore`'s job, so a capture survives the phone being out of
 /// range (or the transfer failing) without losing audio.
+///
+/// Runtime past the screen turning off comes from `WatchRecordingRuntime`.
+/// Every way a recording can end — a tap, an interruption, watchOS pulling the
+/// runtime — funnels through `finish(reason:)`, so a capture cut short is
+/// queued for the iPhone rather than dropped.
 @MainActor
 final class WatchAudioRecorder: NSObject, ObservableObject {
     struct FinishedRecording {
@@ -19,8 +24,22 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
     @Published private(set) var startedAt: Date?
     @Published private(set) var lastError: String?
 
+    private let store: WatchCaptureStore
+    private let runtime: WatchRecordingRuntime
     private var recorder: AVAudioRecorder?
     private var currentID = UUID()
+
+    init(
+        store: WatchCaptureStore = WatchCaptureStore.shared,
+        runtime: WatchRecordingRuntime = WatchRecordingRuntime()
+    ) {
+        self.store = store
+        self.runtime = runtime
+        super.init()
+        runtime.onRuntimeEnd = { [weak self] reason in
+            self?.finish(reason: reason)
+        }
+    }
 
     /// Directory holding not-yet-transferred capture audio.
     static var capturesDirectory: URL {
@@ -34,9 +53,9 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
             .appendingPathExtension("m4a")
     }
 
-    func toggle(store: WatchCaptureStore) async {
+    func toggle() async {
         if isRecording {
-            stop(store: store)
+            stop()
         } else {
             await start()
         }
@@ -52,9 +71,10 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
         }
 
         do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playAndRecord, mode: .default)
-            try session.setActive(true)
+            // Activating the audio session in the foreground is what buys the
+            // background runtime; watchOS will not let a recording start once
+            // the app is already backgrounded.
+            try runtime.begin()
 
             try FileManager.default.createDirectory(
                 at: Self.capturesDirectory,
@@ -83,68 +103,68 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
             isRecording = true
         } catch {
             lastError = error.localizedDescription
-            deactivateSession()
+            runtime.end()
         }
     }
 
-    func stop(store: WatchCaptureStore) {
+    /// User-initiated stop.
+    func stop() {
+        finish(reason: .userStopped)
+    }
+
+    /// Single exit path for a recording. Stops the recorder, releases the
+    /// runtime, then lets `WatchRecordingEndPolicy` decide whether the audio
+    /// captured so far is worth sending to the iPhone.
+    private func finish(reason: WatchRecordingEndReason) {
         guard isRecording, let recorder else { return }
         let createdAt = startedAt ?? Date()
+        // `currentTime` reads zero once the recorder is stopped.
         let duration = recorder.currentTime
         recorder.stop()
         self.recorder = nil
         isRecording = false
         startedAt = nil
-        deactivateSession()
+        runtime.end()
 
-        let finished = FinishedRecording(
-            id: currentID,
-            url: Self.fileURL(for: currentID),
-            createdAt: createdAt,
-            duration: duration
+        let url = Self.fileURL(for: currentID)
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: reason,
+            duration: duration,
+            hasAudioFile: FileManager.default.fileExists(atPath: url.path)
         )
-        guard duration > 0.2, FileManager.default.fileExists(atPath: finished.url.path) else {
-            // Accidental tap — do not queue an empty capture.
-            try? FileManager.default.removeItem(at: finished.url)
-            return
+        lastError = outcome.message
+
+        switch outcome.disposition {
+        case .discard:
+            try? FileManager.default.removeItem(at: url)
+        case .enqueue:
+            store.enqueue(
+                FinishedRecording(
+                    id: currentID,
+                    url: url,
+                    createdAt: createdAt,
+                    duration: duration
+                )
+            )
         }
-        store.enqueue(finished)
-    }
-
-    /// Terminal failure path for recorder errors the user did not initiate:
-    /// clears the recording state so the UI cannot stay stuck in the
-    /// recording pose, and discards the unusable partial file.
-    private func abortRecording(message: String) {
-        guard isRecording else { return }
-        lastError = message
-        recorder?.stop()
-        recorder = nil
-        isRecording = false
-        startedAt = nil
-        deactivateSession()
-        try? FileManager.default.removeItem(at: Self.fileURL(for: currentID))
-    }
-
-    private func deactivateSession() {
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 }
 
 extension WatchAudioRecorder: AVAudioRecorderDelegate {
     nonisolated func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
-        let message = error?.localizedDescription ?? "Audio encoding failed"
+        let detail = error?.localizedDescription
         Task { @MainActor in
-            self.lastError = message
-            self.abortRecording(message: message)
+            self.finish(reason: .encodingFailed(reason: detail))
         }
     }
 
     nonisolated func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
-        // A user-initiated stop clears the state itself; only unsuccessful
-        // finishes (interruption, encoder failure) need the terminal path.
+        // A user-initiated stop has already cleared the state, so `finish` is a
+        // no-op there. An unsuccessful finish means the system stopped the
+        // recorder under us — treat it as lost runtime and keep the partial.
         guard !flag else { return }
         Task { @MainActor in
-            self.abortRecording(message: "Recording stopped unexpectedly.")
+            self.finish(reason: .runtimeInvalidated(reason: nil))
         }
     }
 }

--- a/JustSpeakWatch/WatchAudioRecorder.swift
+++ b/JustSpeakWatch/WatchAudioRecorder.swift
@@ -26,18 +26,27 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
 
     private let store: WatchCaptureStore
     private let runtime: WatchRecordingRuntime
+    private let activeCaptureRegistry: WatchActiveCaptureRegistry
     private var recorder: AVAudioRecorder?
     private var currentID = UUID()
+    private var isFinalising = false
+    private var didRecoverInterruptedCapture = false
 
     init(
         store: WatchCaptureStore = WatchCaptureStore.shared,
-        runtime: WatchRecordingRuntime = WatchRecordingRuntime()
+        runtime: WatchRecordingRuntime = WatchRecordingRuntime(),
+        activeCaptureRegistry: WatchActiveCaptureRegistry = WatchActiveCaptureRegistry(
+            fileURL: WatchAudioRecorder.activeCaptureMarkerURL
+        )
     ) {
         self.store = store
         self.runtime = runtime
+        self.activeCaptureRegistry = activeCaptureRegistry
         super.init()
         runtime.onRuntimeEnd = { [weak self] reason in
-            self?.finish(reason: reason)
+            Task { @MainActor in
+                await self?.finish(reason: reason)
+            }
         }
     }
 
@@ -53,9 +62,13 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
             .appendingPathExtension("m4a")
     }
 
+    private static var activeCaptureMarkerURL: URL {
+        capturesDirectory.appendingPathComponent("active-capture.json")
+    }
+
     func toggle() async {
         if isRecording {
-            stop()
+            await stop()
         } else {
             await start()
         }
@@ -65,11 +78,18 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
         guard !isRecording else { return }
         lastError = nil
 
+        await recoverInterruptedCapture()
+        guard activeCaptureRegistry.load() == nil else {
+            lastError = "The previous recording is still waiting to be recovered."
+            return
+        }
+
         guard await AVAudioApplication.requestRecordPermission() else {
             lastError = "Microphone access is required. Allow it in the Watch app settings."
             return
         }
 
+        var preparedCapture: WatchActiveCapture?
         do {
             // Activating the audio session in the foreground is what buys the
             // background runtime; watchOS will not let a recording start once
@@ -83,6 +103,8 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
 
             let id = UUID()
             let url = Self.fileURL(for: id)
+            let capture = WatchActiveCapture(id: id, fileURL: url, startedAt: Date())
+            preparedCapture = capture
             // Mono 16 kHz AAC: compact voice-quality audio that keeps
             // WatchConnectivity transfers small (~250 KB per minute).
             let settings: [String: Any] = [
@@ -93,59 +115,154 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
             ]
             let recorder = try AVAudioRecorder(url: url, settings: settings)
             recorder.delegate = self
-            guard recorder.record() else {
-                throw WatchRecorderError.failedToStart
-            }
+
+            // Persist before audio starts flowing. A process kill after this
+            // point leaves enough information for relaunch recovery.
+            try activeCaptureRegistry.persist(capture)
 
             self.recorder = recorder
             currentID = id
-            startedAt = Date()
+            startedAt = capture.startedAt
             isRecording = true
+            guard recorder.record() else {
+                await finish(reason: .encodingFailed(reason: WatchRecorderError.failedToStart.localizedDescription))
+                return
+            }
         } catch {
             lastError = error.localizedDescription
+            if let preparedCapture,
+               activeCaptureRegistry.load()?.id != preparedCapture.id
+            {
+                try? FileManager.default.removeItem(at: preparedCapture.fileURL)
+            }
+            recorder = nil
+            isRecording = false
+            startedAt = nil
             runtime.end()
         }
     }
 
     /// User-initiated stop.
-    func stop() {
-        finish(reason: .userStopped)
+    func stop() async {
+        await finish(reason: .userStopped)
+    }
+
+    /// Reconciles a capture whose marker survived process termination. A
+    /// playable file enters the same persisted transfer queue as a normal
+    /// stop; an unusable file is reported visibly before cleanup.
+    func recoverInterruptedCapture() async {
+        guard !didRecoverInterruptedCapture else { return }
+        didRecoverInterruptedCapture = true
+        guard let capture = activeCaptureRegistry.load() else { return }
+
+        // A crash between queue persistence and marker cleanup must not create
+        // a duplicate transfer on the next launch.
+        if store.containsCapture(id: capture.id) {
+            try? activeCaptureRegistry.clear(matching: capture.id)
+            return
+        }
+
+        let inspection = await inspectAudio(at: capture.fileURL)
+        let finalisation = WatchRecordingFinaliser.finalise(
+            capture: capture,
+            reason: .runtimeInvalidated(reason: "Recording ended while the watch app was unavailable."),
+            recorderDuration: 0,
+            inspection: inspection
+        )
+        complete(finalisation, recovery: true)
     }
 
     /// Single exit path for a recording. Stops the recorder, releases the
     /// runtime, then lets `WatchRecordingEndPolicy` decide whether the audio
     /// captured so far is worth sending to the iPhone.
-    private func finish(reason: WatchRecordingEndReason) {
-        guard isRecording, let recorder else { return }
-        let createdAt = startedAt ?? Date()
-        // `currentTime` reads zero once the recorder is stopped.
-        let duration = recorder.currentTime
+    private func finish(reason: WatchRecordingEndReason) async {
+        guard !isFinalising, isRecording, let recorder else { return }
+        isFinalising = true
+        let capture = activeCaptureRegistry.load()
+            ?? WatchActiveCapture(
+                id: currentID,
+                fileURL: Self.fileURL(for: currentID),
+                startedAt: startedAt ?? Date()
+            )
+        // Preserve the live value for a user stop. System-driven delegate
+        // callbacks may already see zero, so asset inspection below remains
+        // the authoritative fallback.
+        let recorderDuration = recorder.currentTime
         recorder.stop()
         self.recorder = nil
         isRecording = false
         startedAt = nil
         runtime.end()
 
-        let url = Self.fileURL(for: currentID)
-        let outcome = WatchRecordingEndPolicy.outcome(
-            for: reason,
-            duration: duration,
-            hasAudioFile: FileManager.default.fileExists(atPath: url.path)
+        let inspection = await inspectAudio(at: capture.fileURL)
+        let finalisation = WatchRecordingFinaliser.finalise(
+            capture: capture,
+            reason: reason,
+            recorderDuration: recorderDuration,
+            inspection: inspection
         )
-        lastError = outcome.message
+        complete(finalisation, recovery: false)
+        isFinalising = false
+    }
 
-        switch outcome.disposition {
+    private func complete(_ finalisation: WatchRecordingFinalisation, recovery: Bool) {
+        lastError = finalisation.outcome.message
+
+        switch finalisation.outcome.disposition {
         case .discard:
-            try? FileManager.default.removeItem(at: url)
+            do {
+                if FileManager.default.fileExists(atPath: finalisation.capture.fileURL.path) {
+                    try FileManager.default.removeItem(at: finalisation.capture.fileURL)
+                }
+                try activeCaptureRegistry.clear(matching: finalisation.capture.id)
+                if recovery {
+                    lastError = "An interrupted recording could not be recovered."
+                }
+            } catch {
+                lastError = "Recording cleanup failed: \(error.localizedDescription)"
+            }
         case .enqueue:
-            store.enqueue(
-                FinishedRecording(
-                    id: currentID,
-                    url: url,
-                    createdAt: createdAt,
-                    duration: duration
-                )
-            )
+            do {
+                let enqueued = try activeCaptureRegistry.clearAfterSuccessfulEnqueue(
+                    matching: finalisation.capture.id
+                ) {
+                    store.enqueue(
+                        FinishedRecording(
+                            id: finalisation.capture.id,
+                            url: finalisation.capture.fileURL,
+                            createdAt: finalisation.capture.startedAt,
+                            duration: finalisation.duration
+                        )
+                    )
+                }
+                guard enqueued else {
+                    lastError = "Recording was saved but could not be queued. It will be recovered next time."
+                    return
+                }
+            } catch {
+                // The queue write has succeeded; retaining the marker is safe
+                // because enqueue is idempotent on capture id at relaunch.
+                lastError = "Recording was queued, but recovery cleanup was deferred."
+            }
+        }
+    }
+
+    private func inspectAudio(at url: URL) async -> WatchAudioInspection {
+        guard FileManager.default.fileExists(atPath: url.path),
+              let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+              let fileSize = values.fileSize,
+              fileSize > 0
+        else { return .unplayable }
+
+        let asset = AVURLAsset(url: url)
+        do {
+            let isPlayable = try await asset.load(.isPlayable)
+            let assetDuration = try await asset.load(.duration)
+            let duration = assetDuration.seconds
+            guard isPlayable, duration.isFinite, duration > 0 else { return .unplayable }
+            return WatchAudioInspection(isPlayable: true, duration: duration)
+        } catch {
+            return .unplayable
         }
     }
 }
@@ -154,7 +271,7 @@ extension WatchAudioRecorder: AVAudioRecorderDelegate {
     nonisolated func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
         let detail = error?.localizedDescription
         Task { @MainActor in
-            self.finish(reason: .encodingFailed(reason: detail))
+            await self.finish(reason: .encodingFailed(reason: detail))
         }
     }
 
@@ -164,7 +281,7 @@ extension WatchAudioRecorder: AVAudioRecorderDelegate {
         // recorder under us — treat it as lost runtime and keep the partial.
         guard !flag else { return }
         Task { @MainActor in
-            self.finish(reason: .runtimeInvalidated(reason: nil))
+            await self.finish(reason: .runtimeInvalidated(reason: nil))
         }
     }
 }

--- a/JustSpeakWatch/WatchCaptureStore.swift
+++ b/JustSpeakWatch/WatchCaptureStore.swift
@@ -56,7 +56,14 @@ final class WatchCaptureStore: NSObject, ObservableObject {
     // MARK: - Capture queue
 
     /// Registers a finished recording and hands it to WatchConnectivity.
-    func enqueue(_ recording: WatchAudioRecorder.FinishedRecording) {
+    @discardableResult
+    func enqueue(_ recording: WatchAudioRecorder.FinishedRecording) -> Bool {
+        if captures.contains(where: { $0.id == recording.id }) {
+            startTransfer(for: recording.id)
+            return true
+        }
+
+        let previousCaptures = captures
         let capture = WatchCapture(
             id: recording.id,
             createdAt: recording.createdAt,
@@ -65,8 +72,16 @@ final class WatchCaptureStore: NSObject, ObservableObject {
         )
         captures.insert(capture, at: 0)
         prune()
-        save()
+        guard save() else {
+            captures = previousCaptures
+            return false
+        }
         startTransfer(for: capture.id)
+        return true
+    }
+
+    func containsCapture(id: UUID) -> Bool {
+        captures.contains { $0.id == id }
     }
 
     /// Re-queues captures whose transfer never completed (e.g. after the
@@ -116,7 +131,7 @@ final class WatchCaptureStore: NSObject, ObservableObject {
         guard captures[index].status.canTransition(to: status) else { return }
         captures[index].status = status
         captures[index].message = message
-        save()
+        _ = save()
     }
 
     private func handleTransferFinished(id: UUID, error: Error?) {
@@ -180,11 +195,17 @@ final class WatchCaptureStore: NSObject, ObservableObject {
         captures = (try? decoder.decode([WatchCapture].self, from: data)) ?? []
     }
 
-    private func save() {
+    @discardableResult
+    private func save() -> Bool {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        guard let data = try? encoder.encode(captures) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+        guard let data = try? encoder.encode(captures) else { return false }
+        do {
+            try data.write(to: fileURL, options: .atomic)
+            return true
+        } catch {
+            return false
+        }
     }
 
     private func prune() {

--- a/JustSpeakWatch/WatchContentView.swift
+++ b/JustSpeakWatch/WatchContentView.swift
@@ -27,7 +27,7 @@ struct WatchContentView: View {
     private var recordButton: some View {
         Button {
             Task {
-                await recorder.toggle(store: captureStore)
+                await recorder.toggle()
             }
         } label: {
             VStack(spacing: 6) {

--- a/JustSpeakWatch/WatchRecordingRuntime.swift
+++ b/JustSpeakWatch/WatchRecordingRuntime.swift
@@ -52,7 +52,9 @@ final class WatchRecordingRuntime {
     /// background.
     func begin() throws {
         let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playAndRecord, mode: .default)
+        // This app only records on watch; `.record` truthfully describes the
+        // active hardware behaviour and still participates in background audio.
+        try session.setCategory(.record, mode: .default)
         try session.setActive(true)
         observeRuntimeLoss()
     }

--- a/JustSpeakWatch/WatchRecordingRuntime.swift
+++ b/JustSpeakWatch/WatchRecordingRuntime.swift
@@ -45,6 +45,7 @@ final class WatchRecordingRuntime {
     var onRuntimeEnd: ((WatchRecordingEndReason) -> Void)?
 
     private var observers: [NSObjectProtocol] = []
+    private var activeRunID: UUID?
 
     /// Activates the audio session that grants the background runtime. Must be
     /// called while the app is frontmost — watchOS only allows a recording to
@@ -56,11 +57,14 @@ final class WatchRecordingRuntime {
         // active hardware behaviour and still participates in background audio.
         try session.setCategory(.record, mode: .default)
         try session.setActive(true)
-        observeRuntimeLoss()
+        let runID = UUID()
+        activeRunID = runID
+        observeRuntimeLoss(runID: runID)
     }
 
     /// Releases the audio session and stops watching for runtime loss.
     func end() {
+        activeRunID = nil
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -68,7 +72,7 @@ final class WatchRecordingRuntime {
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
-    private func observeRuntimeLoss() {
+    private func observeRuntimeLoss(runID: UUID) {
         guard observers.isEmpty else { return }
         let center = NotificationCenter.default
 
@@ -81,6 +85,7 @@ final class WatchRecordingRuntime {
                 let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
                 guard let raw, AVAudioSession.InterruptionType(rawValue: raw) == .began else { return }
                 Task { @MainActor in
+                    guard self?.activeRunID == runID else { return }
                     self?.onRuntimeEnd?(.interrupted)
                 }
             }
@@ -93,6 +98,7 @@ final class WatchRecordingRuntime {
                 queue: nil
             ) { [weak self] _ in
                 Task { @MainActor in
+                    guard self?.activeRunID == runID else { return }
                     self?.onRuntimeEnd?(.runtimeInvalidated(reason: nil))
                 }
             }

--- a/JustSpeakWatch/WatchRecordingRuntime.swift
+++ b/JustSpeakWatch/WatchRecordingRuntime.swift
@@ -1,0 +1,99 @@
+import AVFoundation
+import Foundation
+
+/// Keeps a watch recording running once the wrist drops and the screen goes
+/// off, and reports when watchOS is about to take that runtime away.
+///
+/// ## Why the audio background mode, and not `WKExtendedRuntimeSession`
+///
+/// watchOS offers two ways to keep running past the screen turning off, and
+/// only one of them is legitimate for a dictation app:
+///
+/// 1. **The `audio` background mode** (`UIBackgroundModes` in the watch app's
+///    Info.plist — see `Project.swift`). An `AVAudioSession` activated while
+///    the app is in the foreground keeps the app alive for as long as audio is
+///    actually flowing, including with the wrist down, the screen off, and the
+///    user back on the watch face. This is the mechanism this app uses.
+/// 2. **`WKExtendedRuntimeSession`**, which has no "recording" session type.
+///    The only types are self care, mindfulness, physical therapy, smart alarm
+///    and underwater depth, and Apple's guidance is explicit: *"Select a
+///    session type based on the app's intended use — not based on the features
+///    that the session provides."* Claiming `.mindfulness` or `.selfCare` to
+///    buy runtime for dictation is exactly the misuse that guidance targets.
+///    It would also buy nothing here: both are frontmost-only sessions that
+///    invalidate with `.resignedFrontmost` the moment the user presses the
+///    Digital Crown, whereas the audio background mode survives that. Apple's
+///    own documentation closes the question — *"if your app plays audio during
+///    the entire [...] session, there's no reason to use a
+///    `WKExtendedRuntimeSession`. The background audio mode provides
+///    additional runtime as long as the audio plays."*
+///
+/// The trade-off the audio background mode brings is that an interruption
+/// (call, Siri, another audio app) cannot be recovered from while the app is
+/// backgrounded — the audio session simply cannot be reactivated. That is why
+/// this type reports interruptions as an end of runtime rather than trying to
+/// resume: the recorder stops cleanly and the partial capture is queued for
+/// the iPhone instead of being lost.
+///
+/// See: developer.apple.com/documentation/watchkit/using-extended-runtime-sessions
+/// and developer.apple.com/documentation/watchkit/playing-background-audio
+@MainActor
+final class WatchRecordingRuntime {
+    /// Called when watchOS ends the runtime under an active recording. The
+    /// recorder is expected to stop and hand whatever it captured to the
+    /// capture queue.
+    var onRuntimeEnd: ((WatchRecordingEndReason) -> Void)?
+
+    private var observers: [NSObjectProtocol] = []
+
+    /// Activates the audio session that grants the background runtime. Must be
+    /// called while the app is frontmost — watchOS only allows a recording to
+    /// *start* in the foreground, after which it may continue in the
+    /// background.
+    func begin() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, mode: .default)
+        try session.setActive(true)
+        observeRuntimeLoss()
+    }
+
+    /// Releases the audio session and stops watching for runtime loss.
+    func end() {
+        for observer in observers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        observers.removeAll()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func observeRuntimeLoss() {
+        guard observers.isEmpty else { return }
+        let center = NotificationCenter.default
+
+        observers.append(
+            center.addObserver(
+                forName: AVAudioSession.interruptionNotification,
+                object: nil,
+                queue: nil
+            ) { [weak self] notification in
+                let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
+                guard let raw, AVAudioSession.InterruptionType(rawValue: raw) == .began else { return }
+                Task { @MainActor in
+                    self?.onRuntimeEnd?(.interrupted)
+                }
+            }
+        )
+
+        observers.append(
+            center.addObserver(
+                forName: AVAudioSession.mediaServicesWereResetNotification,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.onRuntimeEnd?(.runtimeInvalidated(reason: nil))
+                }
+            }
+        )
+    }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -270,15 +270,24 @@ let watchAppTarget: Target = .target(
         "CFBundleShortVersionString": "$(MARKETING_VERSION)",
         "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
         "NSMicrophoneUsageDescription":
-            "Just Speak to It records audio on your watch and transcribes it on your iPhone."
+            "Just Speak to It records audio on your watch and transcribes it on your iPhone.",
+        // The audio background mode is what keeps a capture running once the
+        // wrist drops and the screen turns off: an AVAudioSession activated
+        // while the app is frontmost stays alive for as long as audio flows.
+        // Deliberately *not* one of the `WKBackgroundModes` extended-runtime
+        // types (self-care/mindfulness/physical-therapy/alarm) — none of them
+        // describes dictation, and all are frontmost-only. See the rationale
+        // in JustSpeakWatch/WatchRecordingRuntime.swift.
+        "UIBackgroundModes": ["audio"]
     ]),
     // The watch target cannot depend on the SpeakCore package product
     // (several transitive package manifests do not declare watchOS support),
-    // so it compiles the shared watch protocol file directly. Pure
-    // Foundation; unit-tested via SpeakCoreTests.
+    // so it compiles the shared watch files directly. Pure Foundation;
+    // unit-tested via SpeakCoreTests.
     sources: [
         "JustSpeakWatch/**",
-        "Sources/SpeakCore/WatchCaptureProtocol.swift"
+        "Sources/SpeakCore/WatchCaptureProtocol.swift",
+        "Sources/SpeakCore/WatchRecordingLifecycle.swift"
     ],
     settings: .settings(base: watchAppSettings)
 )

--- a/Sources/SpeakCore/WatchRecordingLifecycle.swift
+++ b/Sources/SpeakCore/WatchRecordingLifecycle.swift
@@ -2,9 +2,8 @@ import Foundation
 
 // MARK: - Watch Recording Lifecycle
 //
-// Decides what happens to the audio captured so far when a watch recording
-// ends — whether the user tapped stop, or watchOS took the app's extra
-// runtime away mid-capture.
+// Persists enough state to recover a recording after process termination and
+// decides what happens to the audio captured so far when recording ends.
 //
 // Pure Foundation, no AVFoundation: the watch app target compiles this file by
 // direct source reference (like `WatchCaptureProtocol.swift`) and the rules are
@@ -14,6 +13,64 @@ import Foundation
 // thrown away. Anything long enough to be worth transcribing goes into the
 // same `recorded → transferring → delivered` queue as a normal capture, so a
 // wrist-down recording cut short still reaches iPhone history.
+
+/// Durable identity for a recording that has started but has not yet reached
+/// the transfer queue.
+public struct WatchActiveCapture: Codable, Equatable, Sendable {
+    public let id: UUID
+    public let fileURL: URL
+    public let startedAt: Date
+
+    public init(id: UUID, fileURL: URL, startedAt: Date) {
+        self.id = id
+        self.fileURL = fileURL
+        self.startedAt = startedAt
+    }
+}
+
+/// File-backed active-capture marker. A new instance reading the same URL
+/// models app relaunch, so recovery behaviour can be tested without watchOS.
+public struct WatchActiveCaptureRegistry: Sendable {
+    private let fileURL: URL
+
+    public init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    public func persist(_ capture: WatchActiveCapture) throws {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(capture).write(to: fileURL, options: .atomic)
+    }
+
+    public func load() -> WatchActiveCapture? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(WatchActiveCapture.self, from: data)
+    }
+
+    public func clear(matching id: UUID) throws {
+        guard let capture = load(), capture.id == id else { return }
+        try FileManager.default.removeItem(at: fileURL)
+    }
+
+    /// Runs the durable queue write first and consumes the marker only when it
+    /// succeeds. A failed write deliberately leaves recovery state intact.
+    @discardableResult
+    public func clearAfterSuccessfulEnqueue(
+        matching id: UUID,
+        enqueue: () -> Bool
+    ) throws -> Bool {
+        guard enqueue() else { return false }
+        try clear(matching: id)
+        return true
+    }
+}
 
 /// Why an in-progress watch recording stopped.
 public enum WatchRecordingEndReason: Equatable, Sendable {
@@ -26,8 +83,22 @@ public enum WatchRecordingEndReason: Equatable, Sendable {
     /// On watchOS a background audio session cannot be reactivated after an
     /// interruption, so this always ends the capture.
     case interrupted
-    /// The encoder failed, so the bytes already on disk cannot be trusted.
+    /// The encoder reported a failure. The prefix already written may still be
+    /// playable, so finalisation validates the asset before discarding it.
     case encodingFailed(reason: String?)
+}
+
+/// Result of inspecting the audio asset after the recorder has stopped.
+public struct WatchAudioInspection: Equatable, Sendable {
+    public let isPlayable: Bool
+    public let duration: TimeInterval
+
+    public init(isPlayable: Bool, duration: TimeInterval) {
+        self.isPlayable = isPlayable
+        self.duration = duration
+    }
+
+    public static let unplayable = WatchAudioInspection(isPlayable: false, duration: 0)
 }
 
 /// What to do with the audio captured up to the stop.
@@ -51,6 +122,43 @@ public struct WatchRecordingOutcome: Equatable, Sendable {
     }
 }
 
+/// One stopped capture after combining the recorder's live duration with the
+/// duration recovered from the finished asset.
+public struct WatchRecordingFinalisation: Equatable, Sendable {
+    public let capture: WatchActiveCapture
+    public let duration: TimeInterval
+    public let outcome: WatchRecordingOutcome
+
+    public init(capture: WatchActiveCapture, duration: TimeInterval, outcome: WatchRecordingOutcome) {
+        self.capture = capture
+        self.duration = duration
+        self.outcome = outcome
+    }
+}
+
+/// Production finalisation boundary shared by normal stops, runtime loss,
+/// interruptions, encoder errors and relaunch recovery.
+public enum WatchRecordingFinaliser {
+    public static func finalise(
+        capture: WatchActiveCapture,
+        reason: WatchRecordingEndReason,
+        recorderDuration: TimeInterval,
+        inspection: WatchAudioInspection
+    ) -> WatchRecordingFinalisation {
+        // `AVAudioRecorder.currentTime` becomes zero after a system-driven
+        // stop. Prefer the finished asset's duration whenever it is valid.
+        let inspectedDuration = inspection.duration.isFinite ? max(0, inspection.duration) : 0
+        let liveDuration = recorderDuration.isFinite ? max(0, recorderDuration) : 0
+        let duration = max(inspectedDuration, liveDuration)
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: reason,
+            duration: duration,
+            hasPlayableAudio: inspection.isPlayable
+        )
+        return WatchRecordingFinalisation(capture: capture, duration: duration, outcome: outcome)
+    }
+}
+
 /// Maps "the recording ended, for this reason, with this much audio" onto a
 /// keep-or-drop decision.
 public enum WatchRecordingEndPolicy {
@@ -61,18 +169,9 @@ public enum WatchRecordingEndPolicy {
     public static func outcome(
         for reason: WatchRecordingEndReason,
         duration: TimeInterval,
-        hasAudioFile: Bool
+        hasPlayableAudio: Bool
     ) -> WatchRecordingOutcome {
-        // A failed encoder can leave a file behind, but its contents are
-        // unusable however long the recording ran.
-        if case let .encodingFailed(detail) = reason {
-            return WatchRecordingOutcome(
-                disposition: .discard,
-                message: detail ?? "Recording failed while saving audio."
-            )
-        }
-
-        let captured = hasAudioFile && duration >= minimumUsableDuration
+        let captured = hasPlayableAudio && duration >= minimumUsableDuration
         return WatchRecordingOutcome(
             disposition: captured ? .enqueue : .discard,
             message: message(for: reason, captured: captured)
@@ -94,8 +193,12 @@ public enum WatchRecordingEndPolicy {
             return captured
                 ? "Recording was interrupted. Sending what was captured."
                 : "Recording was interrupted before any audio was captured."
-        case .encodingFailed:
-            return nil // Handled above.
+        case .encodingFailed(let detail):
+            if captured {
+                return detail.map { "\($0) Sending what was captured." }
+                    ?? "Recording ended while saving. Sending what was captured."
+            }
+            return detail ?? "Recording failed while saving audio."
         }
     }
 }

--- a/Sources/SpeakCore/WatchRecordingLifecycle.swift
+++ b/Sources/SpeakCore/WatchRecordingLifecycle.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// MARK: - Watch Recording Lifecycle
+//
+// Decides what happens to the audio captured so far when a watch recording
+// ends — whether the user tapped stop, or watchOS took the app's extra
+// runtime away mid-capture.
+//
+// Pure Foundation, no AVFoundation: the watch app target compiles this file by
+// direct source reference (like `WatchCaptureProtocol.swift`) and the rules are
+// unit-tested in `SpeakCoreTests` without watch hardware.
+//
+// The rule that matters: an interrupted or OS-terminated recording is *not*
+// thrown away. Anything long enough to be worth transcribing goes into the
+// same `recorded → transferring → delivered` queue as a normal capture, so a
+// wrist-down recording cut short still reaches iPhone history.
+
+/// Why an in-progress watch recording stopped.
+public enum WatchRecordingEndReason: Equatable, Sendable {
+    /// The user tapped stop.
+    case userStopped
+    /// watchOS revoked the runtime keeping the recording alive — the app was
+    /// suspended, or the recorder was stopped by the system rather than by us.
+    case runtimeInvalidated(reason: String?)
+    /// The audio session was interrupted (phone call, Siri, another audio app).
+    /// On watchOS a background audio session cannot be reactivated after an
+    /// interruption, so this always ends the capture.
+    case interrupted
+    /// The encoder failed, so the bytes already on disk cannot be trusted.
+    case encodingFailed(reason: String?)
+}
+
+/// What to do with the audio captured up to the stop.
+public enum WatchRecordingDisposition: String, Equatable, Sendable {
+    /// Hand the file to the capture queue for transfer to the iPhone.
+    case enqueue
+    /// Delete the file; it holds nothing worth transcribing.
+    case discard
+}
+
+/// The decision for one ended recording, plus the message (if any) the watch
+/// UI should show to explain it.
+public struct WatchRecordingOutcome: Equatable, Sendable {
+    public let disposition: WatchRecordingDisposition
+    /// User-facing explanation, or `nil` when nothing needs saying.
+    public let message: String?
+
+    public init(disposition: WatchRecordingDisposition, message: String?) {
+        self.disposition = disposition
+        self.message = message
+    }
+}
+
+/// Maps "the recording ended, for this reason, with this much audio" onto a
+/// keep-or-drop decision.
+public enum WatchRecordingEndPolicy {
+    /// Below this, a capture is an accidental tap (or an OS stop that landed
+    /// before any audio was written) rather than speech worth sending.
+    public static let minimumUsableDuration: TimeInterval = 0.2
+
+    public static func outcome(
+        for reason: WatchRecordingEndReason,
+        duration: TimeInterval,
+        hasAudioFile: Bool
+    ) -> WatchRecordingOutcome {
+        // A failed encoder can leave a file behind, but its contents are
+        // unusable however long the recording ran.
+        if case let .encodingFailed(detail) = reason {
+            return WatchRecordingOutcome(
+                disposition: .discard,
+                message: detail ?? "Recording failed while saving audio."
+            )
+        }
+
+        let captured = hasAudioFile && duration >= minimumUsableDuration
+        return WatchRecordingOutcome(
+            disposition: captured ? .enqueue : .discard,
+            message: message(for: reason, captured: captured)
+        )
+    }
+
+    private static func message(for reason: WatchRecordingEndReason, captured: Bool) -> String? {
+        switch reason {
+        case .userStopped:
+            // Both outcomes are exactly what the user asked for: a stop, or an
+            // accidental tap that is silently dropped.
+            return nil
+        case .runtimeInvalidated(let detail):
+            if let detail { return detail }
+            return captured
+                ? "Recording ended on the watch. Sending what was captured."
+                : "Recording ended on the watch before any audio was captured."
+        case .interrupted:
+            return captured
+                ? "Recording was interrupted. Sending what was captured."
+                : "Recording was interrupted before any audio was captured."
+        case .encodingFailed:
+            return nil // Handled above.
+        }
+    }
+}

--- a/Tests/SpeakCoreTests/WatchRecordingLifecycleTests.swift
+++ b/Tests/SpeakCoreTests/WatchRecordingLifecycleTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import SpeakCore
+
+final class WatchRecordingLifecycleTests: XCTestCase {
+    private let usableDuration: TimeInterval = 42
+
+    // MARK: - Runtime loss keeps the partial capture
+
+    func testRuntimeInvalidated_enqueuesThePartialCapture() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .runtimeInvalidated(reason: nil),
+            duration: usableDuration,
+            hasAudioFile: true
+        )
+
+        // The whole point of the extended-runtime work: a wrist-down recording
+        // the OS cuts short still reaches iPhone history.
+        XCTAssertEqual(outcome.disposition, .enqueue)
+        XCTAssertNotNil(outcome.message, "The user should be told the capture was cut short")
+    }
+
+    func testInterruption_enqueuesThePartialCapture() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .interrupted,
+            duration: usableDuration,
+            hasAudioFile: true
+        )
+
+        XCTAssertEqual(outcome.disposition, .enqueue)
+        XCTAssertNotNil(outcome.message)
+    }
+
+    func testRuntimeInvalidated_surfacesTheSystemReasonWhenGiven() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .runtimeInvalidated(reason: "Session expired"),
+            duration: usableDuration,
+            hasAudioFile: true
+        )
+
+        XCTAssertEqual(outcome.message, "Session expired")
+    }
+
+    // MARK: - Nothing worth sending
+
+    func testRuntimeInvalidated_discardsWhenNoAudioWasWritten() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .runtimeInvalidated(reason: nil),
+            duration: usableDuration,
+            hasAudioFile: false
+        )
+
+        XCTAssertEqual(outcome.disposition, .discard)
+        XCTAssertNotNil(outcome.message)
+    }
+
+    func testInterruption_discardsWhenItLandsBeforeAnyAudio() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .interrupted,
+            duration: 0.05,
+            hasAudioFile: true
+        )
+
+        XCTAssertEqual(outcome.disposition, .discard)
+    }
+
+    // MARK: - User-initiated stops
+
+    func testUserStop_enqueuesSilently() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .userStopped,
+            duration: usableDuration,
+            hasAudioFile: true
+        )
+
+        XCTAssertEqual(outcome.disposition, .enqueue)
+        XCTAssertNil(outcome.message, "A normal stop needs no explanation")
+    }
+
+    func testUserStop_discardsAnAccidentalTapSilently() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .userStopped,
+            duration: 0.1,
+            hasAudioFile: true
+        )
+
+        XCTAssertEqual(outcome.disposition, .discard)
+        XCTAssertNil(outcome.message)
+    }
+
+    // MARK: - Duration threshold
+
+    func testMinimumUsableDuration_isInclusive() {
+        let atThreshold = WatchRecordingEndPolicy.outcome(
+            for: .userStopped,
+            duration: WatchRecordingEndPolicy.minimumUsableDuration,
+            hasAudioFile: true
+        )
+        let belowThreshold = WatchRecordingEndPolicy.outcome(
+            for: .userStopped,
+            duration: WatchRecordingEndPolicy.minimumUsableDuration - 0.01,
+            hasAudioFile: true
+        )
+
+        XCTAssertEqual(atThreshold.disposition, .enqueue)
+        XCTAssertEqual(belowThreshold.disposition, .discard)
+    }
+
+    // MARK: - Encoder failure
+
+    func testEncodingFailure_discardsEvenALongRecording() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .encodingFailed(reason: nil),
+            duration: usableDuration,
+            hasAudioFile: true
+        )
+
+        // The bytes on disk cannot be trusted, however long the capture ran.
+        XCTAssertEqual(outcome.disposition, .discard)
+        XCTAssertNotNil(outcome.message)
+    }
+
+    func testEncodingFailure_surfacesTheUnderlyingError() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .encodingFailed(reason: "Encoder ran out of space"),
+            duration: usableDuration,
+            hasAudioFile: true
+        )
+
+        XCTAssertEqual(outcome.message, "Encoder ran out of space")
+    }
+
+    // MARK: - Queue hand-off
+
+    func testEnqueuedPartialCapture_startsInTheRecordedState() {
+        let outcome = WatchRecordingEndPolicy.outcome(
+            for: .runtimeInvalidated(reason: nil),
+            duration: usableDuration,
+            hasAudioFile: true
+        )
+
+        XCTAssertEqual(outcome.disposition, .enqueue)
+        // An enqueued capture enters the queue as `.recorded` and must be able
+        // to walk the normal path to the iPhone from there.
+        XCTAssertTrue(WatchCaptureStatus.recorded.canTransition(to: .transferring))
+        XCTAssertTrue(WatchCaptureStatus.transferring.canTransition(to: .delivered))
+    }
+}

--- a/Tests/SpeakCoreTests/WatchRecordingLifecycleTests.swift
+++ b/Tests/SpeakCoreTests/WatchRecordingLifecycleTests.swift
@@ -4,13 +4,21 @@ import XCTest
 final class WatchRecordingLifecycleTests: XCTestCase {
     private let usableDuration: TimeInterval = 42
 
+    private var capture: WatchActiveCapture {
+        WatchActiveCapture(
+            id: UUID(),
+            fileURL: URL(fileURLWithPath: "/tmp/watch-capture.m4a"),
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
     // MARK: - Runtime loss keeps the partial capture
 
     func testRuntimeInvalidated_enqueuesThePartialCapture() {
         let outcome = WatchRecordingEndPolicy.outcome(
             for: .runtimeInvalidated(reason: nil),
             duration: usableDuration,
-            hasAudioFile: true
+            hasPlayableAudio: true
         )
 
         // The whole point of the extended-runtime work: a wrist-down recording
@@ -23,7 +31,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let outcome = WatchRecordingEndPolicy.outcome(
             for: .interrupted,
             duration: usableDuration,
-            hasAudioFile: true
+            hasPlayableAudio: true
         )
 
         XCTAssertEqual(outcome.disposition, .enqueue)
@@ -34,7 +42,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let outcome = WatchRecordingEndPolicy.outcome(
             for: .runtimeInvalidated(reason: "Session expired"),
             duration: usableDuration,
-            hasAudioFile: true
+            hasPlayableAudio: true
         )
 
         XCTAssertEqual(outcome.message, "Session expired")
@@ -46,7 +54,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let outcome = WatchRecordingEndPolicy.outcome(
             for: .runtimeInvalidated(reason: nil),
             duration: usableDuration,
-            hasAudioFile: false
+            hasPlayableAudio: false
         )
 
         XCTAssertEqual(outcome.disposition, .discard)
@@ -57,7 +65,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let outcome = WatchRecordingEndPolicy.outcome(
             for: .interrupted,
             duration: 0.05,
-            hasAudioFile: true
+            hasPlayableAudio: true
         )
 
         XCTAssertEqual(outcome.disposition, .discard)
@@ -69,7 +77,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let outcome = WatchRecordingEndPolicy.outcome(
             for: .userStopped,
             duration: usableDuration,
-            hasAudioFile: true
+            hasPlayableAudio: true
         )
 
         XCTAssertEqual(outcome.disposition, .enqueue)
@@ -80,7 +88,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let outcome = WatchRecordingEndPolicy.outcome(
             for: .userStopped,
             duration: 0.1,
-            hasAudioFile: true
+            hasPlayableAudio: true
         )
 
         XCTAssertEqual(outcome.disposition, .discard)
@@ -93,12 +101,12 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let atThreshold = WatchRecordingEndPolicy.outcome(
             for: .userStopped,
             duration: WatchRecordingEndPolicy.minimumUsableDuration,
-            hasAudioFile: true
+            hasPlayableAudio: true
         )
         let belowThreshold = WatchRecordingEndPolicy.outcome(
             for: .userStopped,
             duration: WatchRecordingEndPolicy.minimumUsableDuration - 0.01,
-            hasAudioFile: true
+            hasPlayableAudio: true
         )
 
         XCTAssertEqual(atThreshold.disposition, .enqueue)
@@ -107,26 +115,125 @@ final class WatchRecordingLifecycleTests: XCTestCase {
 
     // MARK: - Encoder failure
 
-    func testEncodingFailure_discardsEvenALongRecording() {
-        let outcome = WatchRecordingEndPolicy.outcome(
-            for: .encodingFailed(reason: nil),
-            duration: usableDuration,
-            hasAudioFile: true
+    func testSystemEndedRecording_usesPlayableAssetDurationWhenRecorderHasResetToZero() {
+        let finalisation = WatchRecordingFinaliser.finalise(
+            capture: capture,
+            reason: .runtimeInvalidated(reason: nil),
+            recorderDuration: 0,
+            inspection: WatchAudioInspection(isPlayable: true, duration: usableDuration)
         )
 
-        // The bytes on disk cannot be trusted, however long the capture ran.
-        XCTAssertEqual(outcome.disposition, .discard)
-        XCTAssertNotNil(outcome.message)
+        XCTAssertEqual(finalisation.duration, usableDuration)
+        XCTAssertEqual(finalisation.outcome.disposition, .enqueue)
+    }
+
+    func testEncodingFailure_enqueuesAPlayablePrefix() {
+        let finalisation = WatchRecordingFinaliser.finalise(
+            capture: capture,
+            reason: .encodingFailed(reason: "Encoder stopped."),
+            recorderDuration: 0,
+            inspection: WatchAudioInspection(isPlayable: true, duration: usableDuration)
+        )
+
+        XCTAssertEqual(finalisation.outcome.disposition, .enqueue)
+        XCTAssertEqual(finalisation.duration, usableDuration)
+        XCTAssertEqual(finalisation.outcome.message, "Encoder stopped. Sending what was captured.")
+    }
+
+    func testEncodingFailure_discardsAnUnplayableAsset() {
+        let finalisation = WatchRecordingFinaliser.finalise(
+            capture: capture,
+            reason: .encodingFailed(reason: nil),
+            recorderDuration: usableDuration,
+            inspection: .unplayable
+        )
+
+        XCTAssertEqual(finalisation.outcome.disposition, .discard)
+        XCTAssertNotNil(finalisation.outcome.message)
     }
 
     func testEncodingFailure_surfacesTheUnderlyingError() {
         let outcome = WatchRecordingEndPolicy.outcome(
             for: .encodingFailed(reason: "Encoder ran out of space"),
             duration: usableDuration,
-            hasAudioFile: true
+            hasPlayableAudio: false
         )
 
         XCTAssertEqual(outcome.message, "Encoder ran out of space")
+    }
+
+    // MARK: - Relaunch recovery
+
+    func testPersistedActiveCapture_isRecoveredAfterRelaunchAndFinalisedFromTheAsset() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let markerURL = directory.appendingPathComponent("active-capture.json")
+        let originalRegistry = WatchActiveCaptureRegistry(fileURL: markerURL)
+        let activeCapture = WatchActiveCapture(
+            id: UUID(),
+            fileURL: directory.appendingPathComponent("capture.m4a"),
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try originalRegistry.persist(activeCapture)
+
+        let relaunchedRegistry = WatchActiveCaptureRegistry(fileURL: markerURL)
+        let recovered = try XCTUnwrap(relaunchedRegistry.load())
+        let finalisation = WatchRecordingFinaliser.finalise(
+            capture: recovered,
+            reason: .runtimeInvalidated(reason: nil),
+            recorderDuration: 0,
+            inspection: WatchAudioInspection(isPlayable: true, duration: usableDuration)
+        )
+
+        XCTAssertEqual(recovered, activeCapture)
+        XCTAssertEqual(finalisation.outcome.disposition, .enqueue)
+        XCTAssertEqual(finalisation.duration, usableDuration)
+        try relaunchedRegistry.clear(matching: activeCapture.id)
+        XCTAssertNil(relaunchedRegistry.load())
+        try FileManager.default.removeItem(at: directory)
+    }
+
+    func testFailedQueuePersistence_leavesActiveCaptureMarkerForNextLaunch() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let markerURL = directory.appendingPathComponent("active-capture.json")
+        let registry = WatchActiveCaptureRegistry(fileURL: markerURL)
+        let activeCapture = WatchActiveCapture(
+            id: UUID(),
+            fileURL: directory.appendingPathComponent("capture.m4a"),
+            startedAt: Date()
+        )
+        try registry.persist(activeCapture)
+
+        var enqueueAttempts = 0
+        let enqueued = try registry.clearAfterSuccessfulEnqueue(matching: activeCapture.id) {
+            enqueueAttempts += 1
+            return false
+        }
+
+        XCTAssertFalse(enqueued)
+        XCTAssertEqual(enqueueAttempts, 1)
+        XCTAssertEqual(registry.load(), activeCapture)
+        try FileManager.default.removeItem(at: directory)
+    }
+
+    func testSuccessfulQueuePersistence_clearsActiveCaptureMarker() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let markerURL = directory.appendingPathComponent("active-capture.json")
+        let registry = WatchActiveCaptureRegistry(fileURL: markerURL)
+        let activeCapture = WatchActiveCapture(
+            id: UUID(),
+            fileURL: directory.appendingPathComponent("capture.m4a"),
+            startedAt: Date()
+        )
+        try registry.persist(activeCapture)
+
+        let enqueued = try registry.clearAfterSuccessfulEnqueue(matching: activeCapture.id) { true }
+
+        XCTAssertTrue(enqueued)
+        XCTAssertNil(registry.load())
+        try FileManager.default.removeItem(at: directory)
     }
 
     // MARK: - Queue hand-off
@@ -135,7 +242,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let outcome = WatchRecordingEndPolicy.outcome(
             for: .runtimeInvalidated(reason: nil),
             duration: usableDuration,
-            hasAudioFile: true
+            hasPlayableAudio: true
         )
 
         XCTAssertEqual(outcome.disposition, .enqueue)

--- a/Tests/SpeakCoreTests/WatchRecordingLifecycleTests.swift
+++ b/Tests/SpeakCoreTests/WatchRecordingLifecycleTests.swift
@@ -201,7 +201,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let activeCapture = WatchActiveCapture(
             id: UUID(),
             fileURL: directory.appendingPathComponent("capture.m4a"),
-            startedAt: Date()
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )
         try registry.persist(activeCapture)
 


### PR DESCRIPTION
Refs #659

## Why

Watch capture previously had no declared audio background mode, and system-ended or encoder-failed recordings could be deleted even when a playable partial existed. Process termination could also leave an untracked m4a because capture metadata was only persisted after a clean stop.

## Runtime mechanism

This uses the ordinary watchOS audio background mode, not `WKExtendedRuntimeSession`:

- The watch target declares `UIBackgroundModes: ["audio"]`.
- `WatchRecordingRuntime` activates an `AVAudioSession` with the truthful record-only category while the app is foreground.
- Dictation does not truthfully fit an extended-runtime self-care, mindfulness, physical-therapy, alarm or underwater-depth category. There is therefore no extended-session `willExpire` callback in this implementation; user stop, audio interruption, media-services reset and recorder invalidation all enter the same idempotent finalisation path.

## What changed

- Persist the active capture ID, file URL and start date atomically before recording begins.
- Recover that marker on relaunch: playable non-empty audio is finalised and queued as a partial; unusable audio surfaces a visible failure and is cleaned up.
- Inspect the finished `AVURLAsset` and use its real duration when a system callback has reset `AVAudioRecorder.currentTime` to zero.
- Recover a playable prefix after encoder failure instead of deleting it unconditionally.
- Make queue insertion durable and idempotent by capture ID, retaining the active marker when persistence fails and clearing it only after enqueue succeeds.
- Keep all normal stop, runtime loss, interruption, recorder invalidation and encoder-failure exits behind one guarded `finish(reason:)` operation.

## Verification

Local builds and tests were deliberately not run; GitHub CI is the build/test gate. The added behavioural tests cover real marker persistence across a simulated relaunch, marker retention on queue-write failure, marker clearing after successful enqueue, system-ended duration recovery from inspected audio, and playable/unplayable encoder-failure outcomes. CI also builds the flagged watch target unsigned.

## Hardware acceptance still required

- [ ] Record for at least 60 seconds with spoken markers near 0, 30 and 60 seconds while lowering the wrist and turning off the screen.
- [ ] Return to the watch face mid-capture and confirm the recording continues.
- [ ] Trigger a real interruption and confirm exactly one partial reaches iPhone History, including after the phone is initially unreachable.
- [ ] Record Watch model, watchOS version, Low Power Mode, battery health, duration and charge change for at least three runs.

## Integration note

PR #683 also changes watch recording orchestration. This PR targets current `main` and should land first; #683 must then rebase and preserve this finalisation/recovery behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved watch recording reliability during interruptions, background runtime changes, and app relaunches.
  - Automatically recovers interrupted recordings when the app becomes active.
  - Preserves valid recordings for delivery and discards unusable or very short captures.
  - Added clear status messages for interrupted, failed, or invalid recordings.
  - Enabled background audio recording support on watchOS.

- **Bug Fixes**
  - Prevented duplicate recordings from being queued.
  - Improved cleanup and recovery when recording startup or saving fails.

- **Tests**
  - Added comprehensive coverage for recording interruptions, recovery, persistence, and completion outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->