### PR TITLE
fix(mac): isolate callbacks from superseded live transcription runs

### DIFF
--- a/Sources/SpeakApp/AppleSpeechAnalyzerLiveController.swift
+++ b/Sources/SpeakApp/AppleSpeechAnalyzerLiveController.swift
@@ -13,6 +13,10 @@ final class AppleSpeechAnalyzerLiveController: LiveTranscriptionController {
   private let audioDeviceManager: AudioInputDeviceManager
   private var audioEngine = AVAudioEngine()
   private var analyzerSession: Any?
+  /// Identity of the analyzer run currently allowed to publish transcript text.
+  /// See `LiveTranscriptionRun.Token`: the update handler is an argument to the
+  /// session's initialiser, so it cannot capture the session it belongs to.
+  private var activeRun: LiveTranscriptionRun.Token?
   private var audioConverter: Any?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
   private var currentLanguage: String?
@@ -57,11 +61,22 @@ final class AppleSpeechAnalyzerLiveController: LiveTranscriptionController {
 
   @available(macOS 26.0, *)
   private func startSpeechAnalyzer() async throws {
+    // Published before the session exists so the handler can never observe a
+    // window in which this run is not yet the active one. The handler hops to
+    // the main actor through an unstructured Task, so an update produced by the
+    // previous recording can land after `stop()` has returned — and this
+    // controller instance is reused across recordings, so it would repaint the
+    // next recording's transcript (issue #668).
+    let run = LiveTranscriptionRun.Token()
+    activeRun = run
+
     let session = try await AppleSpeechAnalyzerLiveSession(
       localeIdentifier: currentLanguage ?? appSettings.resolvedPreferredLocaleIdentifier
-    ) { [weak self] update in
-      Task { @MainActor [weak self] in
-        guard let self else { return }
+    ) { [weak self, weak run] update in
+      Task { @MainActor [weak self, weak run] in
+        guard let self,
+          LiveTranscriptionRun.isCurrent(run, activeStream: self.activeRun)
+        else { return }
         self.latestUpdate = LiveTranscriptionUpdate(
           text: update.text,
           isFinal: update.isFinal,
@@ -76,6 +91,7 @@ final class AppleSpeechAnalyzerLiveController: LiveTranscriptionController {
     inputNode.removeTap(onBus: 0)
     let inputFormat = inputNode.outputFormat(forBus: 0)
     guard audioInputFormatIsUsable(inputFormat) else {
+      activeRun = nil
       await session.cancel()
       throw TranscriptionManagerError.noUsableAudioInput
     }
@@ -92,6 +108,7 @@ final class AppleSpeechAnalyzerLiveController: LiveTranscriptionController {
       analyzerSession = session
       audioConverter = converter
     } catch {
+      activeRun = nil
       audioEngine.stop()
       inputNode.removeTap(onBus: 0)
       await session.cancel()
@@ -105,7 +122,10 @@ final class AppleSpeechAnalyzerLiveController: LiveTranscriptionController {
     audioEngine.inputNode.removeTap(onBus: 0)
     isRunning = false
 
+    // Retired after `finish()` so a final flush the analyzer emits through the
+    // update handler still counts towards this recording's result.
     defer {
+      activeRun = nil
       analyzerSession = nil
       audioConverter = nil
     }

--- a/Sources/SpeakApp/AssemblyAILiveController.swift
+++ b/Sources/SpeakApp/AssemblyAILiveController.swift
@@ -35,6 +35,7 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
   private var currentTurnOrder: Int = -1
   private var finalSegmentIndexByTurnOrder: [Int: Int] = [:]
   private var stopContinuation: CheckedContinuation<Void, Never>?
+  private var stopGeneration = LiveTranscriptionStopGeneration()
 
   init(
     appSettings: AppSettings,
@@ -390,11 +391,15 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
       // resume is idempotent.
       let budget = appSettings.liveModelCapabilities.postStopFinalizeBudget
       if budget > 0, serverBegan {
+        let generation = stopGeneration.begin()
         await withCheckedContinuation { continuation in
           stopContinuation = continuation
           Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(budget))
-            guard let self, let cont = self.stopContinuation else { return }
+            guard let self,
+              self.stopGeneration.isCurrent(generation),
+              let cont = self.stopContinuation
+            else { return }
             self.stopContinuation = nil
             cont.resume()
           }

--- a/Sources/SpeakApp/AssemblyAILiveController.swift
+++ b/Sources/SpeakApp/AssemblyAILiveController.swift
@@ -55,7 +55,6 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
   }
 
   // swiftlint:disable:next function_body_length
-  // swiftlint:disable:next function_body_length
   func start() async throws {
     guard await ensurePermissions() else {
       throw TranscriptionManagerError.microphonePermissionMissing
@@ -126,9 +125,10 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
             self.handleTurn(turn)
           }
         },
-        onError: { [weak self] error in
-          Task { @MainActor [weak self] in
+        onError: { [weak self, weak newTranscriber] error in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             if !self.isRunning { return }
             self.delegate?.liveTranscriber(self, didFail: error)
           }

--- a/Sources/SpeakApp/AssemblyAILiveController.swift
+++ b/Sources/SpeakApp/AssemblyAILiveController.swift
@@ -106,18 +106,23 @@ final class AssemblyAILiveController: NSObject, LiveTranscriptionController {
         .filter { !$0.isEmpty }
 
       let provider = AssemblyAITranscriptionProvider()
-      transcriber = provider.createLiveTranscriber(
+      let newTranscriber = provider.createLiveTranscriber(
         apiKey: apiKey,
         sampleRate: 16000,
         model: currentModel ?? appSettings.liveTranscriptionModel,
         keyterms: keyterms,
         language: currentLanguage
       )
+      transcriber = newTranscriber
 
-      transcriber?.start(
-        onTranscript: { [weak self] turn in
-          Task { @MainActor [weak self] in
+      newTranscriber.start(
+        onTranscript: { [weak self, weak newTranscriber] turn in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            // Cached controllers are reused between recordings, so a message
+            // queued by the previous stream can land here after the next
+            // recording started. Only the current stream owns this state.
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             self.handleTurn(turn)
           }
         },

--- a/Sources/SpeakApp/CartesiaLiveController.swift
+++ b/Sources/SpeakApp/CartesiaLiveController.swift
@@ -103,9 +103,10 @@ final class CartesiaLiveController: NSObject, LiveTranscriptionController {
             self.handleTranscript(text: text, isFinal: isFinal)
           }
         },
-        onError: { [weak self] error in
-          Task { @MainActor [weak self] in
+        onError: { [weak self, weak newTranscriber] error in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             self.delegate?.liveTranscriber(self, didFail: error)
           }
         }

--- a/Sources/SpeakApp/CartesiaLiveController.swift
+++ b/Sources/SpeakApp/CartesiaLiveController.swift
@@ -94,9 +94,13 @@ final class CartesiaLiveController: NSObject, LiveTranscriptionController {
       transcriber = newTranscriber
 
       newTranscriber.start(
-        onTranscript: { [weak self] text, isFinal in
-          Task { @MainActor [weak self] in
-            self?.handleTranscript(text: text, isFinal: isFinal)
+        onTranscript: { [weak self, weak newTranscriber] text, isFinal in
+          Task { @MainActor [weak self, weak newTranscriber] in
+            guard let self else { return }
+            // Drop callbacks queued by a previous recording's stream: this
+            // controller instance is reused between recordings (issue #643).
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
+            self.handleTranscript(text: text, isFinal: isFinal)
           }
         },
         onError: { [weak self] error in

--- a/Sources/SpeakApp/DeepgramLiveController.swift
+++ b/Sources/SpeakApp/DeepgramLiveController.swift
@@ -352,9 +352,12 @@ private extension DeepgramLiveController {
       sampleRate: 16000
     )
     transcriber.start(
-      onTranscript: { [weak self] text, isFinal in
-        Task { @MainActor [weak self] in
+      onTranscript: { [weak self, weak transcriber] text, isFinal in
+        Task { @MainActor [weak self, weak transcriber] in
           guard let self else { return }
+          // Drop callbacks queued by a previous recording's stream: this
+          // controller instance is reused between recordings (issue #643).
+          guard LiveTranscriptionRun.isCurrent(transcriber, activeStream: self.transcriber) else { return }
           self.handleTranscript(text: text, isFinal: isFinal)
         }
       },

--- a/Sources/SpeakApp/DeepgramLiveController.swift
+++ b/Sources/SpeakApp/DeepgramLiveController.swift
@@ -351,6 +351,7 @@ private extension DeepgramLiveController {
       language: currentLanguage,
       sampleRate: 16000
     )
+    self.transcriber = transcriber
     transcriber.start(
       onTranscript: { [weak self, weak transcriber] text, isFinal in
         Task { @MainActor [weak self, weak transcriber] in
@@ -361,16 +362,16 @@ private extension DeepgramLiveController {
           self.handleTranscript(text: text, isFinal: isFinal)
         }
       },
-      onError: { [weak self] error in
-        Task { @MainActor [weak self] in
+      onError: { [weak self, weak transcriber] error in
+        Task { @MainActor [weak self, weak transcriber] in
           guard let self else { return }
+          guard LiveTranscriptionRun.isCurrent(transcriber, activeStream: self.transcriber) else { return }
           if !self.isRunning { return }
           print("[DeepgramLiveController] ERROR: \(error.localizedDescription)")
           self.delegate?.liveTranscriber(self, didFail: error)
         }
       }
     )
-    self.transcriber = transcriber
     return transcriber
   }
 

--- a/Sources/SpeakApp/ElevenLabsLiveController.swift
+++ b/Sources/SpeakApp/ElevenLabsLiveController.swift
@@ -91,9 +91,12 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
       transcriber = newTranscriber
 
       newTranscriber.start(
-        onTranscript: { [weak self] text, isFinal in
-          Task { @MainActor [weak self] in
+        onTranscript: { [weak self, weak newTranscriber] text, isFinal in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            // Drop callbacks queued by a previous recording's stream: this
+            // controller instance is reused between recordings (issue #643).
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             self.handleTranscript(text: text, isFinal: isFinal)
           }
         },

--- a/Sources/SpeakApp/ElevenLabsLiveController.swift
+++ b/Sources/SpeakApp/ElevenLabsLiveController.swift
@@ -100,9 +100,10 @@ final class ElevenLabsLiveController: NSObject, LiveTranscriptionController {
             self.handleTranscript(text: text, isFinal: isFinal)
           }
         },
-        onError: { [weak self] error in
-          Task { @MainActor [weak self] in
+        onError: { [weak self, weak newTranscriber] error in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             if !self.isRunning { return }
             self.delegate?.liveTranscriber(self, didFail: error)
           }

--- a/Sources/SpeakApp/GladiaLiveController.swift
+++ b/Sources/SpeakApp/GladiaLiveController.swift
@@ -88,9 +88,13 @@ final class GladiaLiveController: NSObject, LiveTranscriptionController {
       transcriber = newTranscriber
 
       newTranscriber.start(
-        onTranscript: { [weak self] event in
-          Task { @MainActor [weak self] in
+        onTranscript: { [weak self, weak newTranscriber] event in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            // Cached controllers are reused between recordings, so a message
+            // queued by the previous stream can land here after the next
+            // recording started. Only the current stream owns this state.
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             self.handleTranscript(event)
           }
         },

--- a/Sources/SpeakApp/GladiaLiveController.swift
+++ b/Sources/SpeakApp/GladiaLiveController.swift
@@ -98,9 +98,10 @@ final class GladiaLiveController: NSObject, LiveTranscriptionController {
             self.handleTranscript(event)
           }
         },
-        onError: { [weak self] error in
-          Task { @MainActor [weak self] in
+        onError: { [weak self, weak newTranscriber] error in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             if !self.isRunning { return }
             self.delegate?.liveTranscriber(self, didFail: error)
           }

--- a/Sources/SpeakApp/GladiaLiveController.swift
+++ b/Sources/SpeakApp/GladiaLiveController.swift
@@ -23,6 +23,7 @@ final class GladiaLiveController: NSObject, LiveTranscriptionController {
   private let audioProcessor = GladiaAudioProcessor()
   private var hasFinished: Bool = false
   private var stopContinuation: CheckedContinuation<Void, Never>?
+  private var stopGeneration = LiveTranscriptionStopGeneration()
 
   private let targetSampleRate: Double = 16_000
   private var targetFormat: AVAudioFormat?
@@ -149,11 +150,15 @@ final class GladiaLiveController: NSObject, LiveTranscriptionController {
 
       let budget = appSettings.liveModelCapabilities.postStopFinalizeBudget
       if budget > 0 {
+        let generation = stopGeneration.begin()
         await withCheckedContinuation { continuation in
           stopContinuation = continuation
           Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(budget))
-            guard let self, let cont = self.stopContinuation else { return }
+            guard let self,
+              self.stopGeneration.isCurrent(generation),
+              let cont = self.stopContinuation
+            else { return }
             self.stopContinuation = nil
             cont.resume()
           }

--- a/Sources/SpeakApp/LiveTranscriptSession.swift
+++ b/Sources/SpeakApp/LiveTranscriptSession.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Identifies a single live-transcription run for display purposes.
+///
+/// A recording owns exactly one of these; it is minted when the live session
+/// begins and never reused, so any transcript state stamped with a previous
+/// value can be recognised as stale.
+struct LiveTranscriptSessionID: Hashable, Sendable {
+  private let raw: UUID
+
+  init() {
+    self.raw = UUID()
+  }
+}
+
+/// The complete on-screen live-transcript state for one recording.
+///
+/// Text, finality and confidence travel together with the owning session so a
+/// consumer can never observe a mismatched combination, and so run-loop
+/// deferred deliveries belonging to a finished recording can be dropped.
+struct LiveTranscriptSnapshot: Equatable, Sendable {
+  let sessionID: LiveTranscriptSessionID?
+  let text: String
+  let isFinal: Bool
+  let confidence: Double?
+
+  static let empty = LiveTranscriptSnapshot(
+    sessionID: nil,
+    text: "",
+    isFinal: true,
+    confidence: nil
+  )
+}
+
+/// Decides which live-transcription controller currently owns the on-screen
+/// transcript.
+///
+/// Live controllers are cached and reused between recordings, and their
+/// WebSocket/recogniser callbacks can land after `stop()` — sometimes after the
+/// *next* recording has already started. Without an owner check those late
+/// events repaint the previous recording's text over the current live
+/// transcript (issue #643). Display updates are therefore admitted only while a
+/// session is active and only from the controller bound to that session.
+///
+/// This gates display state only: continuation handling, transcription results
+/// and text insertion are deliberately untouched.
+@MainActor
+final class LiveTranscriptDisplayScope {
+  private(set) var activeSessionID: LiveTranscriptSessionID?
+  private var boundSource: ObjectIdentifier?
+
+  var isActive: Bool {
+    self.activeSessionID != nil
+  }
+
+  /// Starts a new display session. The session accepts nothing until a source
+  /// is bound, so a late callback cannot claim ownership of it.
+  @discardableResult
+  func begin() -> LiveTranscriptSessionID {
+    let sessionID = LiveTranscriptSessionID()
+    self.activeSessionID = sessionID
+    self.boundSource = nil
+    return sessionID
+  }
+
+  /// Binds the controller that owns the active session. Ignored when no
+  /// session is active, so a controller torn down out of order cannot revive
+  /// a finished session.
+  func bind(source: AnyObject) {
+    guard self.isActive else { return }
+    self.boundSource = ObjectIdentifier(source)
+  }
+
+  /// Detaches the current source, e.g. once a controller has stopped. The
+  /// session stays open (its final transcript is still on screen) but no
+  /// further updates are accepted until a source is bound again.
+  func unbind() {
+    self.boundSource = nil
+  }
+
+  func end() {
+    self.activeSessionID = nil
+    self.boundSource = nil
+  }
+
+  func accepts(_ source: AnyObject) -> Bool {
+    guard self.isActive, let boundSource = self.boundSource else { return false }
+    return boundSource == ObjectIdentifier(source)
+  }
+}
+
+/// Identity check used by cached live controllers to drop transcript callbacks
+/// emitted by a superseded stream.
+///
+/// Controller instances are reused across recordings, so a socket closed by the
+/// previous recording can still deliver a queued message. The controller's
+/// current stream object is the run identity: anything else is stale and must
+/// not mutate transcript state (issue #643).
+enum LiveTranscriptionRun {
+  static func isCurrent(_ stream: AnyObject?, activeStream: AnyObject?) -> Bool {
+    guard let stream, let activeStream else { return false }
+    return stream === activeStream
+  }
+}

--- a/Sources/SpeakApp/LiveTranscriptSession.swift
+++ b/Sources/SpeakApp/LiveTranscriptSession.swift
@@ -111,3 +111,23 @@ enum LiveTranscriptionRun {
   /// the controller has stored the stream (issue #668).
   final class Token {}
 }
+
+/// Identifies the stop/finalisation wait that currently owns a controller's
+/// continuation.
+///
+/// Provider callbacks can finish a wait before its timeout task wakes. If a
+/// second recording reaches its own stop wait first, the old timeout must not
+/// resume the replacement continuation. Controllers advance this value for
+/// every wait and timeout tasks act only while their captured value is current.
+struct LiveTranscriptionStopGeneration {
+  private var value = 0
+
+  mutating func begin() -> Int {
+    value &+= 1
+    return value
+  }
+
+  func isCurrent(_ generation: Int) -> Bool {
+    generation == value
+  }
+}

--- a/Sources/SpeakApp/LiveTranscriptSession.swift
+++ b/Sources/SpeakApp/LiveTranscriptSession.swift
@@ -101,4 +101,13 @@ enum LiveTranscriptionRun {
     guard let stream, let activeStream else { return false }
     return stream === activeStream
   }
+
+  /// Stand-in run identity for controllers whose stream cannot identify itself.
+  ///
+  /// Some local engines take their transcript callback as an argument to the
+  /// stream's own initialiser, so the callback cannot capture the object it is
+  /// about to create. A token is minted and published *before* the stream
+  /// exists, which also closes the window in which a callback could fire before
+  /// the controller has stored the stream (issue #668).
+  final class Token {}
 }

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -164,24 +164,12 @@ final class MainManager: ObservableObject {
       }
       .store(in: &cancellables)
 
-    transcriptionManager.$livePartialText
+    transcriptionManager.$liveTranscript
       .receive(on: RunLoop.main)
-      .sink { [weak self] text in
-        self?.handleLiveTextUpdate(text)
+      .sink { [weak self] snapshot in
+        self?.handleLiveTranscriptSnapshot(snapshot)
       }
       .store(in: &cancellables)
-
-    // Forward live transcription updates to HUD manager
-    Publishers.CombineLatest3(
-      transcriptionManager.$livePartialText,
-      transcriptionManager.$liveTextIsFinal,
-      transcriptionManager.$liveTextConfidence
-    )
-    .receive(on: RunLoop.main)
-    .sink { [weak self] text, isFinal, confidence in
-      self?.hudManager.updateLiveTranscription(text: text, isFinal: isFinal, confidence: confidence)
-    }
-    .store(in: &cancellables)
 
     // Subscribe to live polish updates
     livePolishManager.$polishedTail
@@ -234,6 +222,22 @@ final class MainManager: ObservableObject {
     ) { [weak self] _ in
       self?.stopAudioLevelMonitoring()
     }
+  }
+
+  /// Applies a live-transcript snapshot to the preview and the HUD.
+  ///
+  /// Delivery is deferred onto the run loop, so a snapshot published by one
+  /// recording can arrive after the next one has already started. Snapshots
+  /// that no longer belong to the current live session are dropped instead of
+  /// repainting the previous recording's text over the live view (issue #643).
+  private func handleLiveTranscriptSnapshot(_ snapshot: LiveTranscriptSnapshot) {
+    guard snapshot.sessionID == transcriptionManager.liveTranscript.sessionID else { return }
+    handleLiveTextUpdate(snapshot.text)
+    hudManager.updateLiveTranscription(
+      text: snapshot.text,
+      isFinal: snapshot.isFinal,
+      confidence: snapshot.confidence
+    )
   }
 
   /// Handle live text updates and trigger live polish if enabled
@@ -481,7 +485,11 @@ final class MainManager: ObservableObject {
       recordingSoundPlayer.play(.start, volume: appSettings.recordingSoundVolume)
     }
     lastErrorMessage = nil
+    livePreview = ""
     polishedLivePreview = ""
+    // Every recording starts from a blank live transcript, including batch
+    // modes that never open a live session (issue #643).
+    transcriptionManager.resetLiveTranscriptDisplay()
     session.events.append(
       HistoryEvent(
         kind: .recordingStarted,

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -468,13 +468,8 @@ final class MainManager: ObservableObject {
     // Failsafe: if live transcription is still running but we have no activeSession,
     // cancel it so the app can always recover without requiring a restart.
     //
-    // Note: `cancelLiveTranscription()` tears the controller down asynchronously,
-    // so its `activeController = nil` can land *after* the recording started
-    // below has bound its own source, unbinding the new session's display scope.
-    // The effect is a blank live transcript for that recording, never text from
-    // the previous one — the per-session/per-stream guards (issue #643) still
-    // hold. Recovering the binding would need a generation token threaded
-    // through SwitchingLiveTranscriber; not worth it for this failsafe path.
+    // The switcher serialises this teardown with a replacement start and guards
+    // ownership by run, including when both runs reuse the same controller.
     if transcriptionManager.isLiveTranscribing {
       logger.warning("Live transcription still running without an active session; cancelling to recover")
       transcriptionManager.cancelLiveTranscription()

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -467,6 +467,14 @@ final class MainManager: ObservableObject {
 
     // Failsafe: if live transcription is still running but we have no activeSession,
     // cancel it so the app can always recover without requiring a restart.
+    //
+    // Note: `cancelLiveTranscription()` tears the controller down asynchronously,
+    // so its `activeController = nil` can land *after* the recording started
+    // below has bound its own source, unbinding the new session's display scope.
+    // The effect is a blank live transcript for that recording, never text from
+    // the previous one — the per-session/per-stream guards (issue #643) still
+    // hold. Recovering the binding would need a generation token threaded
+    // through SwitchingLiveTranscriber; not worth it for this failsafe path.
     if transcriptionManager.isLiveTranscribing {
       logger.warning("Live transcription still running without an active session; cancelling to recover")
       transcriptionManager.cancelLiveTranscription()

--- a/Sources/SpeakApp/ModulateLiveController.swift
+++ b/Sources/SpeakApp/ModulateLiveController.swift
@@ -30,6 +30,7 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
   private var utterances: [ModulateUtterance] = []
   private var streamDurationMs: Int?
   private var stopContinuation: CheckedContinuation<Void, Never>?
+  private var stopGeneration = LiveTranscriptionStopGeneration()
   private var sessionFeatureConfiguration = ModulateFeatureConfiguration(
     speakerDiarization: true,
     emotionSignal: false,
@@ -108,11 +109,15 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
 
       // Wait for the final response (resumed in finished/error callbacks) or a 2s timeout.
       // Both paths nil-out stopContinuation under the MainActor before resuming, so resume is idempotent.
+      let generation = stopGeneration.begin()
       await withCheckedContinuation { continuation in
         stopContinuation = continuation
         Task { @MainActor [weak self] in
           try? await Task.sleep(for: .seconds(2))
-          guard let self, let cont = self.stopContinuation else { return }
+          guard let self,
+            self.stopGeneration.isCurrent(generation),
+            let cont = self.stopContinuation
+          else { return }
           self.stopContinuation = nil
           cont.resume()
         }

--- a/Sources/SpeakApp/ModulateLiveController.swift
+++ b/Sources/SpeakApp/ModulateLiveController.swift
@@ -246,9 +246,11 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
           self.handleDone(durationMs: durationMs)
         }
       },
-      onError: { [weak self] error in
-        Task { @MainActor [weak self] in
-          self?.handleStreamingError(error)
+      onError: { [weak self, weak transcriber] error in
+        Task { @MainActor [weak self, weak transcriber] in
+          guard let self else { return }
+          guard LiveTranscriptionRun.isCurrent(transcriber, activeStream: self.transcriber) else { return }
+          self.handleStreamingError(error)
         }
       }
     )
@@ -276,6 +278,8 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
   }
 
   private func handleStreamingError(_ error: Error) {
+    let failedInputSession = activeInputSession
+    activeInputSession = nil
     hasFinished = true
     audioEngine.stop()
     audioEngine.inputNode.removeTap(onBus: 0)
@@ -290,8 +294,9 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
       continuation.resume()
     }
 
-    Task { @MainActor [weak self] in
-      await self?.endActiveInputSession()
+    Task { @MainActor [audioDeviceManager] in
+      guard let failedInputSession else { return }
+      await audioDeviceManager.endUsingPreferredInput(session: failedInputSession)
     }
 
     delegate?.liveTranscriber(self, didFail: error)

--- a/Sources/SpeakApp/ModulateLiveController.swift
+++ b/Sources/SpeakApp/ModulateLiveController.swift
@@ -226,14 +226,24 @@ final class ModulateLiveController: NSObject, LiveTranscriptionController {
 
     self.transcriber = transcriber
     transcriber.start(
-      onUtterance: { [weak self] utterance in
-        Task { @MainActor [weak self] in
-          self?.handleUtterance(utterance)
+      onUtterance: { [weak self, weak transcriber] utterance in
+        Task { @MainActor [weak self, weak transcriber] in
+          guard let self else { return }
+          // Cached controllers are reused between recordings, so a message
+          // queued by the previous stream can land here after the next
+          // recording started. Only the current stream owns this state.
+          guard LiveTranscriptionRun.isCurrent(transcriber, activeStream: self.transcriber) else { return }
+          self.handleUtterance(utterance)
         }
       },
-      onDone: { [weak self] durationMs in
-        Task { @MainActor [weak self] in
-          self?.handleDone(durationMs: durationMs)
+      onDone: { [weak self, weak transcriber] durationMs in
+        Task { @MainActor [weak self, weak transcriber] in
+          guard let self else { return }
+          // Cached controllers are reused between recordings, so a message
+          // queued by the previous stream can land here after the next
+          // recording started. Only the current stream owns this state.
+          guard LiveTranscriptionRun.isCurrent(transcriber, activeStream: self.transcriber) else { return }
+          self.handleDone(durationMs: durationMs)
         }
       },
       onError: { [weak self] error in

--- a/Sources/SpeakApp/NativeOSXLiveTranscriber.swift
+++ b/Sources/SpeakApp/NativeOSXLiveTranscriber.swift
@@ -4,6 +4,73 @@ import Foundation
 import Speech
 import os.log
 
+protocol NativeSpeechRecognitionTask: AnyObject {
+  func cancel()
+}
+
+extension SFSpeechRecognitionTask: NativeSpeechRecognitionTask {}
+
+struct NativeSpeechRecognitionResult {
+  let text: String
+  let segments: [TranscriptionSegment]
+  let confidence: Double?
+  let isFinal: Bool
+
+  init(text: String, segments: [TranscriptionSegment] = [], confidence: Double? = nil, isFinal: Bool) {
+    self.text = text
+    self.segments = segments
+    self.confidence = confidence
+    self.isFinal = isFinal
+  }
+
+  init(_ result: SFSpeechRecognitionResult) {
+    self.text = result.bestTranscription.formattedString
+    self.segments = result.bestTranscription.segments.map { segment in
+      TranscriptionSegment(
+        startTime: segment.timestamp,
+        endTime: segment.timestamp + segment.duration,
+        text: segment.substring,
+        isFinal: result.isFinal,
+        confidence: Double(segment.confidence)
+      )
+    }
+    self.confidence = result.transcriptionSegmentsConfidence
+    self.isFinal = result.isFinal
+  }
+}
+
+/// Owns the callback identity for one native recognition task at a time.
+/// Tests inject task factories here so delayed callbacks exercise this exact
+/// production guard without microphone or speech-recognition permissions.
+@MainActor
+final class NativeSpeechRecognitionTaskLifecycle {
+  typealias Callback = (NativeSpeechRecognitionResult?, Error?) -> Void
+  typealias Factory = (@escaping Callback) -> any NativeSpeechRecognitionTask
+
+  private var activeRun: LiveTranscriptionRun.Token?
+  private var task: (any NativeSpeechRecognitionTask)?
+
+  func start(factory: Factory, onEvent: @escaping Callback) {
+    retire()
+    let run = LiveTranscriptionRun.Token()
+    activeRun = run
+    task = factory { [weak self, weak run] result, error in
+      Task { @MainActor [weak self, weak run] in
+        guard let self,
+          LiveTranscriptionRun.isCurrent(run, activeStream: self.activeRun)
+        else { return }
+        onEvent(result, error)
+      }
+    }
+  }
+
+  func retire() {
+    activeRun = nil
+    task?.cancel()
+    task = nil
+  }
+}
+
 final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
   weak var delegate: LiveTranscriptionSessionDelegate?
   private(set) var isRunning: Bool = false
@@ -13,18 +80,11 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
   private let audioDeviceManager: AudioInputDeviceManager
   private var speechRecognizer: SFSpeechRecognizer?
   private var audioEngine = AVAudioEngine()
-  private var recognitionTask: SFSpeechRecognitionTask?
-  /// This controller's live run identity, in the sense of `LiveTranscriptionRun`.
-  ///
-  /// A fresh request is minted for every recognition run and retired the moment
-  /// the run ends, so a result handler that captured a different request belongs
-  /// to a superseded run. The request rather than the task is the identity
-  /// because the task only comes into being as `recognitionTask(with:)`
-  /// returns — too late for its own handler to capture it (issue #668).
+  private let recognitionTaskLifecycle = NativeSpeechRecognitionTaskLifecycle()
   private var request: SFSpeechAudioBufferRecognitionRequest?
   private var currentLocaleIdentifier: String?
   private var currentModel: String?
-  private var latestResult: SFSpeechRecognitionResult?
+  private var latestResult: NativeSpeechRecognitionResult?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
   /// Guards against calling finish() more than once per session.
   private var hasFinished: Bool = false
@@ -112,21 +172,16 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
 
   func stop() async {
     guard isRunning else { return }
-    // Retire the run identity before tearing the request/task down so any
-    // callback that fires during teardown is already stale — `cancel()` does
-    // not stop the recogniser delivering queued results. Ordered on the main
-    // actor with the identity reads in the recognition callbacks. `endAudio()`
-    // still needs the object, so it is handed back rather than dropped.
+    // Retire the run before teardown: cancel() can still deliver queued events.
     let finishingRequest = await MainActor.run { () -> SFSpeechAudioBufferRecognitionRequest? in
       let pending = self.request
       self.request = nil
+      self.recognitionTaskLifecycle.retire()
       return pending
     }
     finishingRequest?.endAudio()
     audioEngine.stop()
     audioEngine.inputNode.removeTap(onBus: 0)
-    recognitionTask?.cancel()
-    recognitionTask = nil
     isRunning = false
 
     // Always ensure the delegate is called so the continuation in
@@ -178,34 +233,20 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
     await audioDeviceManager.endUsingPreferredInput(session: session)
   }
 
-  private func finish(with result: SFSpeechRecognitionResult) {
+  private func finish(with result: NativeSpeechRecognitionResult) {
     // Guard against double finish - can happen if recognition callback delivers
     // a final result at the same time stop() is called
     guard !hasFinished else { return }
     hasFinished = true
 
-    Task { await self.endActiveInputSession() }
-
-    let segments = result.bestTranscription.segments.map { segment in
-      TranscriptionSegment(
-        startTime: segment.timestamp,
-        endTime: segment.timestamp + segment.duration,
-        text: segment.substring,
-        isFinal: result.isFinal,
-        confidence: Double(segment.confidence)
-      )
-    }
-
-    let currentText = result.bestTranscription.formattedString
+    let segments = result.segments
+    let currentText = result.text
     let fullText = [committedText, currentText].filter { !$0.isEmpty }.joined(separator: " ")
     let duration = (segments.last?.endTime ?? 0) - (segments.first?.startTime ?? 0)
     let outcome = TranscriptionResult(
       text: fullText,
       segments: segments,
-      confidence: result.bestTranscription.segments.isEmpty
-        ? nil
-        : result
-          .transcriptionSegmentsConfidence,
+      confidence: result.confidence,
       duration: duration,
       modelIdentifier: currentModel ?? AppleLocalModels.legacySpeechModelID,
       cost: nil,
@@ -223,34 +264,27 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
   /// rather than clearing it.
   @MainActor
   private func startRecognitionTask(with recognizer: SFSpeechRecognizer) {
-    // `activeRequest` is this run's identity. `cancel()` is not a hard stop —
-    // the recogniser can still deliver queued results and errors afterwards —
-    // and this controller instance is reused across recordings, so a handler
-    // installed by the previous run would otherwise repaint the next
-    // recording's transcript through a controller the display scope
-    // legitimately accepts (issue #668).
     guard let activeRequest = request else { return }
-    recognitionTask = recognizer.recognitionTask(with: activeRequest) { [weak self, weak activeRequest] result, error in
-      guard let self else { return }
-      if let result {
-        Task { @MainActor [weak self, weak activeRequest] in
-          guard let self,
-            LiveTranscriptionRun.isCurrent(activeRequest, activeStream: self.request)
-          else { return }
+    recognitionTaskLifecycle.start(
+      factory: { callback in
+        recognizer.recognitionTask(with: activeRequest) { result, error in
+          callback(result.map { NativeSpeechRecognitionResult($0) }, error)
+        }
+      },
+      onEvent: { [weak self] result, error in
+        guard let self else { return }
+        if let result {
           self.latestResult = result
-          let currentText = result.bestTranscription.formattedString
+          let currentText = result.text
           self.commitIfImplicitReset(currentText: currentText, isFinal: result.isFinal)
           self.lastFormattedString = currentText
 
           let displayText = [self.committedText, currentText]
             .filter { !$0.isEmpty }.joined(separator: " ")
-          let confidence = result.bestTranscription.segments.isEmpty
-            ? nil
-            : result.transcriptionSegmentsConfidence
           let update = LiveTranscriptionUpdate(
             text: displayText,
             isFinal: false,
-            confidence: confidence
+            confidence: result.confidence
           )
           self.delegate?.liveTranscriber(self, didUpdateWith: update)
           self.delegate?.liveTranscriber(self, didUpdatePartial: displayText)
@@ -262,22 +296,20 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
             self.lastFormattedString = ""
             self.restartRecognitionTask()
           }
-        }
-      } else if let error {
-        Task { @MainActor [weak self, weak activeRequest] in
-          guard let self,
-            LiveTranscriptionRun.isCurrent(activeRequest, activeStream: self.request)
-          else { return }
+        } else if let error {
           self.delegate?.liveTranscriber(self, didFail: error)
-        }
-        Task { [weak self, weak activeRequest] in
-          guard let self else { return }
-          let shouldEnd = await MainActor.run {
-            LiveTranscriptionRun.isCurrent(activeRequest, activeStream: self.request)
-          }
-          if shouldEnd { await self.endActiveInputSession() }
+          self.endInputSessionAfterRecognitionError()
         }
       }
+    )
+  }
+
+  @MainActor
+  private func endInputSessionAfterRecognitionError() {
+    guard let session = activeInputSession else { return }
+    activeInputSession = nil
+    Task { @MainActor [audioDeviceManager] in
+      await audioDeviceManager.endUsingPreferredInput(session: session)
     }
   }
 
@@ -303,8 +335,7 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
   private func restartRecognitionTask() {
     guard isRunning, let recognizer = speechRecognizer else { return }
 
-    recognitionTask?.cancel()
-    recognitionTask = nil
+    recognitionTaskLifecycle.retire()
 
     // Minting the replacement request retires the previous run's identity, so
     // anything the cancelled task still delivers is dropped by the guard in

--- a/Sources/SpeakApp/NativeOSXLiveTranscriber.swift
+++ b/Sources/SpeakApp/NativeOSXLiveTranscriber.swift
@@ -14,6 +14,13 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
   private var speechRecognizer: SFSpeechRecognizer?
   private var audioEngine = AVAudioEngine()
   private var recognitionTask: SFSpeechRecognitionTask?
+  /// This controller's live run identity, in the sense of `LiveTranscriptionRun`.
+  ///
+  /// A fresh request is minted for every recognition run and retired the moment
+  /// the run ends, so a result handler that captured a different request belongs
+  /// to a superseded run. The request rather than the task is the identity
+  /// because the task only comes into being as `recognitionTask(with:)`
+  /// returns — too late for its own handler to capture it (issue #668).
   private var request: SFSpeechAudioBufferRecognitionRequest?
   private var currentLocaleIdentifier: String?
   private var currentModel: String?
@@ -26,11 +33,6 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
   /// Last `formattedString` received from the recognizer, used to detect
   /// implicit text resets where Apple silently clears the transcript.
   private var lastFormattedString: String = ""
-  /// Monotonic counter incremented on each recognition restart so that
-  /// error callbacks from cancelled tasks are ignored. Main-actor isolated:
-  /// every read happens inside a `@MainActor` callback task, so the writes must
-  /// be serialised against them for the stale-callback check to mean anything.
-  @MainActor private var recognitionGeneration: Int = 0
 
   init(
     permissionsManager: PermissionsManager,
@@ -99,34 +101,31 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
       await audioDeviceManager.endUsingPreferredInput(session: sessionContext)
       throw TranscriptionManagerError.recognizerUnavailable
     }
-    // Monotonically increase so late callbacks from a previous session can never
-    // match the generation of this one. Resetting to 0 would let a stale task
-    // whose generation happened to be 0 be treated as current. The bump and the
-    // task creation run on the main actor, where every generation read happens,
-    // so a callback can never observe a half-updated counter.
     await MainActor.run {
       // Publish session state before starting recognition so final/error
       // callbacks (all main-actor ordered) observe a fully started session.
       self.activeInputSession = sessionContext
       self.isRunning = true
-      self.recognitionGeneration += 1
       self.startRecognitionTask(with: recognizer)
     }
   }
 
   func stop() async {
     guard isRunning else { return }
-    // Bump the generation before tearing the request/task down so any callback
-    // that fires during teardown is already stale. Ordered on the main actor
-    // with the generation reads in the recognition callbacks.
-    await MainActor.run {
-      self.recognitionGeneration += 1
+    // Retire the run identity before tearing the request/task down so any
+    // callback that fires during teardown is already stale — `cancel()` does
+    // not stop the recogniser delivering queued results. Ordered on the main
+    // actor with the identity reads in the recognition callbacks. `endAudio()`
+    // still needs the object, so it is handed back rather than dropped.
+    let finishingRequest = await MainActor.run { () -> SFSpeechAudioBufferRecognitionRequest? in
+      let pending = self.request
+      self.request = nil
+      return pending
     }
-    request?.endAudio()
+    finishingRequest?.endAudio()
     audioEngine.stop()
     audioEngine.inputNode.removeTap(onBus: 0)
     recognitionTask?.cancel()
-    request = nil
     recognitionTask = nil
     isRunning = false
 
@@ -224,13 +223,20 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
   /// rather than clearing it.
   @MainActor
   private func startRecognitionTask(with recognizer: SFSpeechRecognizer) {
-    let generation = recognitionGeneration
+    // `activeRequest` is this run's identity. `cancel()` is not a hard stop —
+    // the recogniser can still deliver queued results and errors afterwards —
+    // and this controller instance is reused across recordings, so a handler
+    // installed by the previous run would otherwise repaint the next
+    // recording's transcript through a controller the display scope
+    // legitimately accepts (issue #668).
     guard let activeRequest = request else { return }
-    recognitionTask = recognizer.recognitionTask(with: activeRequest) { [weak self] result, error in
+    recognitionTask = recognizer.recognitionTask(with: activeRequest) { [weak self, weak activeRequest] result, error in
       guard let self else { return }
       if let result {
-        Task { @MainActor [weak self] in
-          guard let self, generation == self.recognitionGeneration else { return }
+        Task { @MainActor [weak self, weak activeRequest] in
+          guard let self,
+            LiveTranscriptionRun.isCurrent(activeRequest, activeStream: self.request)
+          else { return }
           self.latestResult = result
           let currentText = result.bestTranscription.formattedString
           self.commitIfImplicitReset(currentText: currentText, isFinal: result.isFinal)
@@ -258,13 +264,17 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
           }
         }
       } else if let error {
-        Task { @MainActor [weak self] in
-          guard let self, generation == self.recognitionGeneration else { return }
+        Task { @MainActor [weak self, weak activeRequest] in
+          guard let self,
+            LiveTranscriptionRun.isCurrent(activeRequest, activeStream: self.request)
+          else { return }
           self.delegate?.liveTranscriber(self, didFail: error)
         }
-        Task { [weak self] in
+        Task { [weak self, weak activeRequest] in
           guard let self else { return }
-          let shouldEnd = await MainActor.run { generation == self.recognitionGeneration }
+          let shouldEnd = await MainActor.run {
+            LiveTranscriptionRun.isCurrent(activeRequest, activeStream: self.request)
+          }
           if shouldEnd { await self.endActiveInputSession() }
         }
       }
@@ -293,10 +303,12 @@ final class NativeOSXLiveTranscriber: NSObject, LiveTranscriptionController {
   private func restartRecognitionTask() {
     guard isRunning, let recognizer = speechRecognizer else { return }
 
-    recognitionGeneration += 1
     recognitionTask?.cancel()
     recognitionTask = nil
 
+    // Minting the replacement request retires the previous run's identity, so
+    // anything the cancelled task still delivers is dropped by the guard in
+    // `startRecognitionTask(with:)`.
     request = makeRecognitionRequest(for: recognizer)
     latestResult = nil
     lastFormattedString = ""

--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -47,6 +47,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
   /// commit-triggered completion arrives.
   private var preStopCompletedItemIDs: Set<String> = []
   private var stopContinuation: CheckedContinuation<Void, Never>?
+  private var stopGeneration = LiveTranscriptionStopGeneration()
 
   init(
     appSettings: AppSettings,
@@ -213,11 +214,15 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
       //    no audio was ever processed and no `.completed` will arrive.
       let budget = appSettings.liveModelCapabilities.postStopFinalizeBudget
       if budget > 0, sessionReady {
+        let generation = stopGeneration.begin()
         await withCheckedContinuation { continuation in
           stopContinuation = continuation
           Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(budget))
-            guard let self, let cont = self.stopContinuation else { return }
+            guard let self,
+              self.stopGeneration.isCurrent(generation),
+              let cont = self.stopContinuation
+            else { return }
             self.stopContinuation = nil
             cont.resume()
           }

--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -134,9 +134,10 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
             self.handleEvent(event)
           }
         },
-        onError: { [weak self] error in
-          Task { @MainActor [weak self] in
+        onError: { [weak self, weak newTranscriber] error in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             // NOTE: we no longer drop errors that arrive before isRunning
             // flips true. WebSocket failures during the connecting window
             // (invalid API key, 401, DNS, etc.) used to be swallowed,

--- a/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
+++ b/Sources/SpeakApp/OpenAIRealtimeLiveController.swift
@@ -110,7 +110,7 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
       let provider = OpenAIRealtimeTranscriptionProvider()
       let modelID = currentModel ?? appSettings.liveTranscriptionModel
       let realtimeName = OpenAIRealtimeTranscriptionProvider.realtimeModelName(from: modelID)
-      transcriber = provider.createLiveTranscriber(
+      let newTranscriber = provider.createLiveTranscriber(
         apiKey: apiKey,
         model: realtimeName,
         language: currentLanguage.map(\.localeLanguageCode),
@@ -121,11 +121,17 @@ final class OpenAIRealtimeLiveController: NSObject, LiveTranscriptionController 
         prompt: trimmedKeytermsPrompt(),
         sampleRate: 24_000
       )
+      transcriber = newTranscriber
 
-      transcriber?.start(
-        onEvent: { [weak self] event in
-          Task { @MainActor [weak self] in
-            self?.handleEvent(event)
+      newTranscriber.start(
+        onEvent: { [weak self, weak newTranscriber] event in
+          Task { @MainActor [weak self, weak newTranscriber] in
+            guard let self else { return }
+            // Cached controllers are reused between recordings, so a message
+            // queued by the previous stream can land here after the next
+            // recording started. Only the current stream owns this state.
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
+            self.handleEvent(event)
           }
         },
         onError: { [weak self] error in

--- a/Sources/SpeakApp/SharedClientLiveController.swift
+++ b/Sources/SpeakApp/SharedClientLiveController.swift
@@ -79,9 +79,10 @@ final class SharedClientLiveController: NSObject, LiveTranscriptionController {
             self.handleTranscript(text, isFinal: isFinal)
           }
         },
-        onError: { [weak self] error in
-          Task { @MainActor [weak self] in
+        onError: { [weak self, weak client] error in
+          Task { @MainActor [weak self, weak client] in
             guard let self else { return }
+            guard LiveTranscriptionRun.isCurrent(client, activeStream: self.client) else { return }
             self.delegate?.liveTranscriber(self, didFail: error)
           }
         }

--- a/Sources/SpeakApp/SharedClientLiveController.swift
+++ b/Sources/SpeakApp/SharedClientLiveController.swift
@@ -69,9 +69,14 @@ final class SharedClientLiveController: NSObject, LiveTranscriptionController {
 
     do {
       client.start(
-        onTranscript: { [weak self] text, isFinal in
-          Task { @MainActor [weak self] in
-            self?.handleTranscript(text, isFinal: isFinal)
+        onTranscript: { [weak self, weak client] text, isFinal in
+          Task { @MainActor [weak self, weak client] in
+            guard let self else { return }
+            // Cached controllers are reused between recordings, so a message
+            // queued by the previous stream can land here after the next
+            // recording started. Only the current stream owns this state.
+            guard LiveTranscriptionRun.isCurrent(client, activeStream: self.client) else { return }
+            self.handleTranscript(text, isFinal: isFinal)
           }
         },
         onError: { [weak self] error in

--- a/Sources/SpeakApp/SherpaOnnxLiveController.swift
+++ b/Sources/SpeakApp/SherpaOnnxLiveController.swift
@@ -87,11 +87,19 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
     self.stdoutPipe = stdoutPipe
     self.stderrPipe = stderrPipe
 
-    stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+    // `stdoutPipe` is this run's identity. The handler runs on a pipe queue and
+    // hops to the main actor, so a Task it spawned can still land after the
+    // sidecar is torn down — and this controller is reused across recordings,
+    // so that stale output would repaint the next recording's transcript.
+    // `hasFinished` cannot catch it: `start()` resets it to false (issue #668).
+    stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self, weak stdoutPipe] handle in
       let data = handle.availableData
       guard !data.isEmpty else { return }
-      Task { @MainActor [weak self] in
-        self?.handleSidecarOutput(data)
+      Task { @MainActor [weak self, weak stdoutPipe] in
+        guard let self,
+          LiveTranscriptionRun.isCurrent(stdoutPipe, activeStream: self.stdoutPipe)
+        else { return }
+        self.handleSidecarOutput(data)
       }
     }
 

--- a/Sources/SpeakApp/SonioxLiveController.swift
+++ b/Sources/SpeakApp/SonioxLiveController.swift
@@ -99,9 +99,14 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
       newTranscriber.finalizationDelegate = self
 
       newTranscriber.start(
-        onTranscript: { [weak self] text, isFinal in
-          Task { @MainActor [weak self] in
-            self?.handleTranscript(text: text, isFinal: isFinal)
+        onTranscript: { [weak self, weak newTranscriber] text, isFinal in
+          Task { @MainActor [weak self, weak newTranscriber] in
+            guard let self else { return }
+            // Cached controllers are reused between recordings, so a message
+            // queued by the previous stream can land here after the next
+            // recording started. Only the current stream owns this state.
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
+            self.handleTranscript(text: text, isFinal: isFinal)
           }
         },
         onError: { [weak self] error in

--- a/Sources/SpeakApp/SonioxLiveController.swift
+++ b/Sources/SpeakApp/SonioxLiveController.swift
@@ -109,9 +109,10 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
             self.handleTranscript(text: text, isFinal: isFinal)
           }
         },
-        onError: { [weak self] error in
-          Task { @MainActor [weak self] in
+        onError: { [weak self, weak newTranscriber] error in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             // Always release a pending stop() continuation so we don't burn the
             // 2s timeout when an error/close arrives during shutdown.
             if let continuation = self.stopContinuation {
@@ -170,9 +171,10 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
 
   // MARK: - SonioxFinalizationDelegate
 
-  nonisolated func sonioxDidFinishStream() {
-    Task { @MainActor [weak self] in
+  nonisolated func sonioxDidFinishStream(_ transcriber: SonioxLiveTranscriber) {
+    Task { @MainActor [weak self, weak transcriber] in
       guard let self else { return }
+      guard LiveTranscriptionRun.isCurrent(transcriber, activeStream: self.transcriber) else { return }
       if let continuation = self.stopContinuation {
         self.stopContinuation = nil
         continuation.resume()

--- a/Sources/SpeakApp/SonioxLiveController.swift
+++ b/Sources/SpeakApp/SonioxLiveController.swift
@@ -32,6 +32,7 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
   private var currentInterim: String = ""
   private var fullTranscript: String = ""
   private var stopContinuation: CheckedContinuation<Void, Never>?
+  private var stopGeneration = LiveTranscriptionStopGeneration()
 
   init(
     appSettings: AppSettings,
@@ -204,11 +205,15 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
 
       // Wait for `<fin>`/`finished:true` or a 2s timeout. Both paths nil-out
       // stopContinuation idempotently.
+      let generation = stopGeneration.begin()
       await withCheckedContinuation { continuation in
         stopContinuation = continuation
         Task { @MainActor [weak self] in
           try? await Task.sleep(for: .seconds(2))
-          guard let self, let cont = self.stopContinuation else { return }
+          guard let self,
+            self.stopGeneration.isCurrent(generation),
+            let cont = self.stopContinuation
+          else { return }
           self.stopContinuation = nil
           cont.resume()
         }

--- a/Sources/SpeakApp/SonioxLiveController.swift
+++ b/Sources/SpeakApp/SonioxLiveController.swift
@@ -51,7 +51,7 @@ final class SonioxLiveController: NSObject, LiveTranscriptionController, SonioxF
     logger.info("Configured Soniox with model: \(model)")
   }
 
-  // swiftlint:disable:next function_body_length
+  // swiftlint:disable:next cyclomatic_complexity function_body_length
   func start() async throws {
     guard await ensurePermissions() else {
       throw TranscriptionManagerError.microphonePermissionMissing

--- a/Sources/SpeakApp/SonioxTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SonioxTranscriptionProvider.swift
@@ -62,7 +62,7 @@ private struct SonioxStreamResponse: Decodable {
 
 protocol SonioxFinalizationDelegate: AnyObject {
     /// Soniox emitted a `finished: true` signal — caller should release any pending stop().
-    func sonioxDidFinishStream()
+    func sonioxDidFinishStream(_ transcriber: SonioxLiveTranscriber)
 }
 
 // MARK: - Provider
@@ -841,13 +841,13 @@ final class SonioxLiveTranscriber: @unchecked Sendable {
 
                 if sawFinalizationMarker {
                     flushFinal()
-                    finalizationDelegate?.sonioxDidFinishStream()
+                    finalizationDelegate?.sonioxDidFinishStream(self)
                 }
             }
 
             if response.finished == true {
                 flushFinal()
-                finalizationDelegate?.sonioxDidFinishStream()
+                finalizationDelegate?.sonioxDidFinishStream(self)
             }
         } catch {
             logger.debug("Failed to parse Soniox response: \(error.localizedDescription)")

--- a/Sources/SpeakApp/SpeechmaticsLiveController.swift
+++ b/Sources/SpeakApp/SpeechmaticsLiveController.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 @preconcurrency import AVFoundation
 import Foundation
 import os.log
@@ -93,9 +94,10 @@ final class SpeechmaticsLiveController: NSObject, LiveTranscriptionController {
             self.handleTranscript(event)
           }
         },
-        onError: { [weak self] error in
-          Task { @MainActor [weak self] in
+        onError: { [weak self, weak newTranscriber] error in
+          Task { @MainActor [weak self, weak newTranscriber] in
             guard let self else { return }
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
             guard !self.hasFinished else { return }
             self.delegate?.liveTranscriber(self, didFail: error)
           }

--- a/Sources/SpeakApp/SpeechmaticsLiveController.swift
+++ b/Sources/SpeakApp/SpeechmaticsLiveController.swift
@@ -83,9 +83,14 @@ final class SpeechmaticsLiveController: NSObject, LiveTranscriptionController {
       self.transcriber = newTranscriber
 
       newTranscriber.start(
-        onTranscript: { [weak self] event in
-          Task { @MainActor [weak self] in
-            self?.handleTranscript(event)
+        onTranscript: { [weak self, weak newTranscriber] event in
+          Task { @MainActor [weak self, weak newTranscriber] in
+            guard let self else { return }
+            // Cached controllers are reused between recordings, so a message
+            // queued by the previous stream can land here after the next
+            // recording started. Only the current stream owns this state.
+            guard LiveTranscriptionRun.isCurrent(newTranscriber, activeStream: self.transcriber) else { return }
+            self.handleTranscript(event)
           }
         },
         onError: { [weak self] error in

--- a/Sources/SpeakApp/SwitchingLiveTranscriber.swift
+++ b/Sources/SpeakApp/SwitchingLiveTranscriber.swift
@@ -33,12 +33,21 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     activeController?.isRunning ?? false
   }
 
+  /// Notified whenever ownership of the live session moves to another
+  /// controller (or is released on stop), so transcript display state can be
+  /// scoped to the controller that is actually recording (issue #643).
+  var sessionSourceDidChange: (((any LiveTranscriptionController)?) -> Void)?
+
   private let appSettings: AppSettings
   private let permissionsManager: PermissionsManager
   private let audioDeviceManager: AudioInputDeviceManager
   private let secureStorage: SecureAppStorage
   private let nowProvider: () -> Date
-  private var activeController: (any LiveTranscriptionController)?
+  private var activeController: (any LiveTranscriptionController)? {
+    didSet {
+      sessionSourceDidChange?(activeController)
+    }
+  }
   private var controllers: ControllerSet
   private var currentLanguage: String?
   private var currentModel: String?

--- a/Sources/SpeakApp/SwitchingLiveTranscriber.swift
+++ b/Sources/SpeakApp/SwitchingLiveTranscriber.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import SpeakCore
 import AppKit
 @preconcurrency import AVFoundation
@@ -43,11 +44,14 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   private let audioDeviceManager: AudioInputDeviceManager
   private let secureStorage: SecureAppStorage
   private let nowProvider: () -> Date
-  private var activeController: (any LiveTranscriptionController)? {
+  private let controllerOverride: ((String) -> any LiveTranscriptionController)?
+  private var activeRun: ActiveRun? {
     didSet {
       sessionSourceDidChange?(activeController)
     }
   }
+  private var pendingStop: PendingStop?
+  private var activeController: (any LiveTranscriptionController)? { activeRun?.controller }
   private var controllers: ControllerSet
   private var currentLanguage: String?
   private var currentModel: String?
@@ -61,13 +65,15 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     permissionsManager: PermissionsManager,
     audioDeviceManager: AudioInputDeviceManager,
     secureStorage: SecureAppStorage,
-    nowProvider: @escaping () -> Date = Date.init
+    nowProvider: @escaping () -> Date = Date.init,
+    controllerOverride: ((String) -> any LiveTranscriptionController)? = nil
   ) {
     self.appSettings = appSettings
     self.permissionsManager = permissionsManager
     self.audioDeviceManager = audioDeviceManager
     self.secureStorage = secureStorage
     self.nowProvider = nowProvider
+    self.controllerOverride = controllerOverride
     controllers = ControllerSet(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
@@ -96,6 +102,10 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   }
 
   func start() async throws {
+    if let activeRun {
+      await stop(activeRun)
+    }
+
     let model = currentModel ?? appSettings.liveTranscriptionModel
     print("[SwitchingLiveTranscriber] Starting with model: \(model)")
     if shouldResetControllersBeforeStart(at: nowProvider()) {
@@ -104,7 +114,9 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     }
 
     let controller = controller(for: model)
-    activeController = controller
+    controller.delegate = delegate
+    controller.configure(language: currentLanguage, model: model)
+    let run = activate(controller)
     do {
       try await controller.start()
       invalidateBeforeNextStart = false
@@ -118,18 +130,18 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
           language: currentLanguage,
           model: AppleLocalModels.legacySpeechModelID
         )
-        activeController = nativeController
+        let fallbackRun = activate(nativeController)
         do {
           try await nativeController.start()
           invalidateBeforeNextStart = false
           return
         } catch {
-          activeController = nil
+          release(fallbackRun)
           invalidateBeforeNextStart = true
           throw error
         }
       }
-      activeController = nil
+      release(run)
       invalidateBeforeNextStart = true
       throw error
     }
@@ -137,12 +149,21 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
 
   func stop() async {
     print("[SwitchingLiveTranscriber] Stopping...")
-    await activeController?.stop()
-    activeController = nil
-    lastStopDate = nowProvider()
+    guard let activeRun else { return }
+    await stop(activeRun)
+  }
+
+  /// Captures the current run before asynchronous teardown is scheduled. This
+  /// prevents a delayed cancellation task from targeting a replacement run.
+  func scheduleStop() {
+    guard let activeRun else { return }
+    Task { @MainActor [weak self] in
+      await self?.stop(activeRun)
+    }
   }
 
   func controller(for model: String) -> any LiveTranscriptionController {
+    if let controllerOverride { return controllerOverride(model) }
     if model == AppleLocalModels.speechTranscriberModelID {
       return controllers.speechAnalyzer
     }
@@ -195,7 +216,7 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
   }
 
   private func resetControllers() {
-    activeController = nil
+    activeRun = nil
     controllers = ControllerSet(
       appSettings: appSettings,
       permissionsManager: permissionsManager,
@@ -205,6 +226,51 @@ final class SwitchingLiveTranscriber: LiveTranscriptionController {
     invalidateBeforeNextStart = false
     lastStopDate = nil
     applyDelegateAndConfiguration()
+  }
+
+  @discardableResult
+  private func activate(_ controller: any LiveTranscriptionController) -> ActiveRun {
+    let run = ActiveRun(controller: controller)
+    activeRun = run
+    return run
+  }
+
+  private func release(_ run: ActiveRun) {
+    guard activeRun?.id == run.id else { return }
+    activeRun = nil
+  }
+
+  /// Serialises teardown with a replacement start. The run ID matters because
+  /// cached controllers can represent both recordings with the same object.
+  private func stop(_ run: ActiveRun) async {
+    guard activeRun?.id == run.id || pendingStop?.run.id == run.id else { return }
+    let task: Task<Void, Never>
+    if let pendingStop, pendingStop.run.id == run.id {
+      task = pendingStop.task
+    } else {
+      task = Task { @MainActor in
+        await run.controller.stop()
+      }
+      pendingStop = PendingStop(run: run, task: task)
+    }
+
+    await task.value
+    if pendingStop?.run.id == run.id {
+      pendingStop = nil
+    }
+    guard activeRun?.id == run.id else { return }
+    activeRun = nil
+    lastStopDate = nowProvider()
+  }
+
+  private struct ActiveRun {
+    let id = UUID()
+    let controller: any LiveTranscriptionController
+  }
+
+  private struct PendingStop {
+    let run: ActiveRun
+    let task: Task<Void, Never>
   }
 
   private func startObservingLifecycle() {

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -494,8 +494,13 @@ extension TranscriptionManager: LiveTranscriptionSessionDelegate {
     cancelStopTimeout()
     continuation = nil
     isLiveTranscribing = false
-    applyLiveDisplayUpdate(from: session, text: result.text, isFinal: true, confidence: result.confidence)
-    endLiveTranscriptDisplaySession()
+    // Only the controller that owns the on-screen session may publish its
+    // final text or close the session; a late finish from a superseded
+    // recording must leave the current session alone (issue #643).
+    if displayScope.accepts(session) {
+      applyLiveDisplayUpdate(from: session, text: result.text, isFinal: true, confidence: result.confidence)
+      endLiveTranscriptDisplaySession()
+    }
     cont.resume(returning: result)
   }
 
@@ -505,7 +510,9 @@ extension TranscriptionManager: LiveTranscriptionSessionDelegate {
       cancelStopTimeout()
       continuation = nil
       isLiveTranscribing = false
-      endLiveTranscriptDisplaySession()
+      if displayScope.accepts(session) {
+        endLiveTranscriptDisplaySession()
+      }
       cont.resume(throwing: error)
     } else {
       // Error happened mid-session - store it for when stop is called

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -114,10 +114,6 @@ final class TranscriptionManager: ObservableObject {
   @Published private(set) var isLiveTranscribing: Bool = false
   @Published private(set) var utteranceBoundaryText: String?
 
-  var livePartialText: String { liveTranscript.text }
-  var liveTextIsFinal: Bool { liveTranscript.isFinal }
-  var liveTextConfidence: Double? { liveTranscript.confidence }
-
   /// Owns the identity of the recording whose transcript is on screen.
   let displayScope = LiveTranscriptDisplayScope()
 
@@ -166,40 +162,6 @@ final class TranscriptionManager: ObservableObject {
         self.displayScope.unbind()
       }
     }
-  }
-
-  /// Opens a live-transcript display session, clearing the previous
-  /// recording's text before any new partial can arrive.
-  ///
-  /// `source` is the controller that owns the session; production binds it via
-  /// `SwitchingLiveTranscriber.sessionSourceDidChange` as the controller starts.
-  func beginLiveTranscriptDisplaySession(source: AnyObject? = nil) {
-    let sessionID = displayScope.begin()
-    if let source {
-      displayScope.bind(source: source)
-    }
-    liveTranscript = LiveTranscriptSnapshot(
-      sessionID: sessionID,
-      text: "",
-      isFinal: true,
-      confidence: nil
-    )
-    utteranceBoundaryText = nil
-  }
-
-  /// Detaches the live-transcript display session. The final text stays on
-  /// screen; further updates from the finished session are ignored.
-  func endLiveTranscriptDisplaySession() {
-    displayScope.end()
-  }
-
-  /// Clears the live transcript entirely. Called when a recording starts so
-  /// batch modes — which never open a live session — cannot show the previous
-  /// recording's text.
-  func resetLiveTranscriptDisplay() {
-    displayScope.end()
-    liveTranscript = .empty
-    utteranceBoundaryText = nil
   }
 
   func startLiveTranscription() async throws {
@@ -437,6 +399,50 @@ final class TranscriptionManager: ObservableObject {
 
   private func hasAPIKey(for metadata: TranscriptionProviderMetadata) async -> Bool {
     await secureStorage.hasSecret(identifier: metadata.apiKeyIdentifier)
+  }
+}
+
+/// Live-transcript display state, scoped to the recording that owns it.
+///
+/// Kept out of the main class body so the gate and its accessors read as one
+/// unit (issue #643).
+extension TranscriptionManager {
+  var livePartialText: String { liveTranscript.text }
+  var liveTextIsFinal: Bool { liveTranscript.isFinal }
+  var liveTextConfidence: Double? { liveTranscript.confidence }
+
+  /// Opens a live-transcript display session, clearing the previous
+  /// recording's text before any new partial can arrive.
+  ///
+  /// `source` is the controller that owns the session; production binds it via
+  /// `SwitchingLiveTranscriber.sessionSourceDidChange` as the controller starts.
+  func beginLiveTranscriptDisplaySession(source: AnyObject? = nil) {
+    let sessionID = displayScope.begin()
+    if let source {
+      displayScope.bind(source: source)
+    }
+    liveTranscript = LiveTranscriptSnapshot(
+      sessionID: sessionID,
+      text: "",
+      isFinal: true,
+      confidence: nil
+    )
+    utteranceBoundaryText = nil
+  }
+
+  /// Detaches the live-transcript display session. The final text stays on
+  /// screen; further updates from the finished session are ignored.
+  func endLiveTranscriptDisplaySession() {
+    displayScope.end()
+  }
+
+  /// Clears the live transcript entirely. Called when a recording starts so
+  /// batch modes — which never open a live session — cannot show the previous
+  /// recording's text.
+  func resetLiveTranscriptDisplay() {
+    displayScope.end()
+    liveTranscript = .empty
+    utteranceBoundaryText = nil
   }
 }
 

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -107,11 +107,19 @@ func audioInputStartErrorIsBadDevice(_ error: Error) -> Bool {
 
 @MainActor
 final class TranscriptionManager: ObservableObject {
-  @Published private(set) var livePartialText: String = ""
-  @Published private(set) var liveTextIsFinal: Bool = true
-  @Published private(set) var liveTextConfidence: Double?
+  /// Live transcript display state for the current recording. Published as one
+  /// value so text, finality, confidence and the owning session can never be
+  /// observed out of step with each other (issue #643).
+  @Published private(set) var liveTranscript: LiveTranscriptSnapshot = .empty
   @Published private(set) var isLiveTranscribing: Bool = false
   @Published private(set) var utteranceBoundaryText: String?
+
+  var livePartialText: String { liveTranscript.text }
+  var liveTextIsFinal: Bool { liveTranscript.isFinal }
+  var liveTextConfidence: Double? { liveTranscript.confidence }
+
+  /// Owns the identity of the recording whose transcript is on screen.
+  let displayScope = LiveTranscriptDisplayScope()
 
   private let appSettings: AppSettings
   private let liveController: SwitchingLiveTranscriber
@@ -147,6 +155,51 @@ final class TranscriptionManager: ObservableObject {
     self.openRouter = openRouter
     self.secureStorage = secureStorage
     self.liveController.delegate = self
+    // Scope the on-screen transcript to whichever controller owns the current
+    // live session, so a reused controller's late callbacks can be told apart
+    // from the session that is actually recording.
+    self.liveController.sessionSourceDidChange = { [weak self] source in
+      guard let self else { return }
+      if let source {
+        self.displayScope.bind(source: source)
+      } else {
+        self.displayScope.unbind()
+      }
+    }
+  }
+
+  /// Opens a live-transcript display session, clearing the previous
+  /// recording's text before any new partial can arrive.
+  ///
+  /// `source` is the controller that owns the session; production binds it via
+  /// `SwitchingLiveTranscriber.sessionSourceDidChange` as the controller starts.
+  func beginLiveTranscriptDisplaySession(source: AnyObject? = nil) {
+    let sessionID = displayScope.begin()
+    if let source {
+      displayScope.bind(source: source)
+    }
+    liveTranscript = LiveTranscriptSnapshot(
+      sessionID: sessionID,
+      text: "",
+      isFinal: true,
+      confidence: nil
+    )
+    utteranceBoundaryText = nil
+  }
+
+  /// Detaches the live-transcript display session. The final text stays on
+  /// screen; further updates from the finished session are ignored.
+  func endLiveTranscriptDisplaySession() {
+    displayScope.end()
+  }
+
+  /// Clears the live transcript entirely. Called when a recording starts so
+  /// batch modes — which never open a live session — cannot show the previous
+  /// recording's text.
+  func resetLiveTranscriptDisplay() {
+    displayScope.end()
+    liveTranscript = .empty
+    utteranceBoundaryText = nil
   }
 
   func startLiveTranscription() async throws {
@@ -154,12 +207,19 @@ final class TranscriptionManager: ObservableObject {
     let model = try liveTranscriptionModelForCurrentMode()
     let language = appSettings.preferredModelLanguage
     print("[TranscriptionManager] startLiveTranscription - model: \(model), language: \(language ?? "automatic")")
+    // Opened before the controller starts: the first partial can arrive while
+    // `start()` is still awaiting, and it must land in the new session.
+    beginLiveTranscriptDisplaySession()
     liveController.configure(
       language: language,
       model: model
     )
-    try await liveController.start()
-    livePartialText = ""
+    do {
+      try await liveController.start()
+    } catch {
+      endLiveTranscriptDisplaySession()
+      throw error
+    }
     pendingError = nil
     isLiveTranscribing = true
   }
@@ -170,6 +230,7 @@ final class TranscriptionManager: ObservableObject {
     if let error = pendingError {
       pendingError = nil
       isLiveTranscribing = false
+      endLiveTranscriptDisplaySession()
       Task { await liveController.stop() }
       throw error
     }
@@ -195,6 +256,7 @@ final class TranscriptionManager: ObservableObject {
         self.continuation = nil
         self.stopTimeoutTask = nil
         self.isLiveTranscribing = false
+        self.endLiveTranscriptDisplaySession()
         cont.resume(throwing: TranscriptionManagerError.liveSessionNotRunning)
       }
     }
@@ -215,7 +277,7 @@ final class TranscriptionManager: ObservableObject {
       await liveController.stop()
     }
     isLiveTranscribing = false
-    livePartialText = ""
+    resetLiveTranscriptDisplay()
   }
 
   /// Marks the live controller cache as stale so it re-reads credentials on next start.
@@ -379,17 +441,43 @@ final class TranscriptionManager: ObservableObject {
 }
 
 extension TranscriptionManager: LiveTranscriptionSessionDelegate {
+  /// Admits a display update only from the controller that owns the active
+  /// session. Late or out-of-order events from a superseded recording are
+  /// dropped rather than repainting the live view (issue #643).
+  private func applyLiveDisplayUpdate(
+    from session: any LiveTranscriptionController,
+    text: String,
+    isFinal: Bool,
+    confidence: Double?
+  ) {
+    guard displayScope.accepts(session) else { return }
+    liveTranscript = LiveTranscriptSnapshot(
+      sessionID: displayScope.activeSessionID,
+      text: text,
+      isFinal: isFinal,
+      confidence: confidence
+    )
+  }
+
   func liveTranscriber(_ session: any LiveTranscriptionController, didUpdatePartial text: String) {
-    livePartialText = text
+    applyLiveDisplayUpdate(
+      from: session,
+      text: text,
+      isFinal: liveTranscript.isFinal,
+      confidence: liveTranscript.confidence
+    )
   }
 
   func liveTranscriber(
     _ session: any LiveTranscriptionController,
     didUpdateWith update: LiveTranscriptionUpdate
   ) {
-    livePartialText = update.text
-    liveTextIsFinal = update.isFinal
-    liveTextConfidence = update.confidence
+    applyLiveDisplayUpdate(
+      from: session,
+      text: update.text,
+      isFinal: update.isFinal,
+      confidence: update.confidence
+    )
   }
 
   func liveTranscriber(
@@ -406,9 +494,8 @@ extension TranscriptionManager: LiveTranscriptionSessionDelegate {
     cancelStopTimeout()
     continuation = nil
     isLiveTranscribing = false
-    livePartialText = result.text
-    liveTextIsFinal = true
-    liveTextConfidence = result.confidence
+    applyLiveDisplayUpdate(from: session, text: result.text, isFinal: true, confidence: result.confidence)
+    endLiveTranscriptDisplaySession()
     cont.resume(returning: result)
   }
 
@@ -418,6 +505,7 @@ extension TranscriptionManager: LiveTranscriptionSessionDelegate {
       cancelStopTimeout()
       continuation = nil
       isLiveTranscribing = false
+      endLiveTranscriptDisplaySession()
       cont.resume(throwing: error)
     } else {
       // Error happened mid-session - store it for when stop is called
@@ -430,6 +518,7 @@ extension TranscriptionManager: LiveTranscriptionSessionDelegate {
     _ session: any LiveTranscriptionController,
     didDetectUtteranceBoundary utterance: String
   ) {
+    guard displayScope.accepts(session) else { return }
     utteranceBoundaryText = utterance
   }
 }

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -197,7 +197,7 @@ final class TranscriptionManager: ObservableObject {
       pendingError = nil
       isLiveTranscribing = false
       endLiveTranscriptDisplaySession()
-      Task { await liveController.stop() }
+      liveController.scheduleStop()
       throw error
     }
     guard isLiveTranscribing else { throw TranscriptionManagerError.liveSessionNotRunning }
@@ -239,9 +239,7 @@ final class TranscriptionManager: ObservableObject {
     cancelStopTimeout()
     continuation?.resume(throwing: TranscriptionManagerError.liveSessionNotRunning)
     continuation = nil
-    Task {
-      await liveController.stop()
-    }
+    liveController.scheduleStop()
     isLiveTranscribing = false
     resetLiveTranscriptDisplay()
   }

--- a/Sources/SpeakApp/TranscriptionManager.swift
+++ b/Sources/SpeakApp/TranscriptionManager.swift
@@ -117,8 +117,12 @@ final class TranscriptionManager: ObservableObject {
   /// Owns the identity of the recording whose transcript is on screen.
   let displayScope = LiveTranscriptDisplayScope()
 
+  /// Routes to whichever provider controller owns the current recording and
+  /// publishes that ownership through `sessionSourceDidChange`, which is what
+  /// binds `displayScope` to the recording actually on air.
+  let liveController: SwitchingLiveTranscriber
+
   private let appSettings: AppSettings
-  private let liveController: SwitchingLiveTranscriber
   private let batchClient: BatchTranscriptionClient
   private let openRouter: OpenRouterAPIClient
   private let secureStorage: SecureAppStorage
@@ -450,19 +454,25 @@ extension TranscriptionManager: LiveTranscriptionSessionDelegate {
   /// Admits a display update only from the controller that owns the active
   /// session. Late or out-of-order events from a superseded recording are
   /// dropped rather than repainting the live view (issue #643).
+  ///
+  /// Returns `true` when the update was published, so callers that also need to
+  /// act on ownership (e.g. closing the session on finish) can reuse the single
+  /// ownership check rather than repeating it.
+  @discardableResult
   private func applyLiveDisplayUpdate(
     from session: any LiveTranscriptionController,
     text: String,
     isFinal: Bool,
     confidence: Double?
-  ) {
-    guard displayScope.accepts(session) else { return }
+  ) -> Bool {
+    guard displayScope.accepts(session) else { return false }
     liveTranscript = LiveTranscriptSnapshot(
       sessionID: displayScope.activeSessionID,
       text: text,
       isFinal: isFinal,
       confidence: confidence
     )
+    return true
   }
 
   func liveTranscriber(_ session: any LiveTranscriptionController, didUpdatePartial text: String) {
@@ -503,8 +513,13 @@ extension TranscriptionManager: LiveTranscriptionSessionDelegate {
     // Only the controller that owns the on-screen session may publish its
     // final text or close the session; a late finish from a superseded
     // recording must leave the current session alone (issue #643).
-    if displayScope.accepts(session) {
-      applyLiveDisplayUpdate(from: session, text: result.text, isFinal: true, confidence: result.confidence)
+    let published = applyLiveDisplayUpdate(
+      from: session,
+      text: result.text,
+      isFinal: true,
+      confidence: result.confidence
+    )
+    if published {
       endLiveTranscriptDisplaySession()
     }
     cont.resume(returning: result)

--- a/Sources/SpeakApp/WhisperKitLiveController.swift
+++ b/Sources/SpeakApp/WhisperKitLiveController.swift
@@ -11,6 +11,11 @@ final class WhisperKitLiveController: LiveTranscriptionController {
     private let audioDeviceManager: AudioInputDeviceManager
     private let modelManager: LocalModelManager
     private var transcriber: AudioStreamTranscriber?
+    /// Identity of the stream run currently allowed to publish transcript text
+    /// and to resume `startupContinuation`. See `LiveTranscriptionRun.Token`:
+    /// the state-change callback is an argument to the transcriber's
+    /// initialiser, so it cannot capture the transcriber it belongs to.
+    private var activeRun: LiveTranscriptionRun.Token?
     private var streamTask: Task<Void, Never>?
     private var startupTask: Task<Void, Never>?
     private var startupContinuation: CheckedContinuation<Void, Error>?
@@ -69,6 +74,16 @@ final class WhisperKitLiveController: LiveTranscriptionController {
             skipSpecialTokens: true,
             wordTimestamps: true
         )
+        // Published before the transcriber exists so the callback can never
+        // observe a window in which this run is not yet the active one. The
+        // callback hops to the main actor through an unstructured Task, so a
+        // state change from the previous recording can land after `stop()`
+        // returned; this controller instance is reused across recordings, so it
+        // would repaint the next recording's transcript — and worse, resume the
+        // next run's `startupContinuation` early (issue #668).
+        let run = LiveTranscriptionRun.Token()
+        activeRun = run
+
         let transcriber = AudioStreamTranscriber(
             audioEncoder: pipeline.audioEncoder,
             featureExtractor: pipeline.featureExtractor,
@@ -77,9 +92,12 @@ final class WhisperKitLiveController: LiveTranscriptionController {
             tokenizer: tokenizer,
             audioProcessor: pipeline.audioProcessor,
             decodingOptions: options,
-            stateChangeCallback: { [weak self] oldState, newState in
-                Task { @MainActor [weak self] in
-                    self?.handleStateChange(from: oldState, to: newState)
+            stateChangeCallback: { [weak self, weak run] oldState, newState in
+                Task { @MainActor [weak self, weak run] in
+                    guard let self,
+                        LiveTranscriptionRun.isCurrent(run, activeStream: self.activeRun)
+                    else { return }
+                    self.handleStateChange(from: oldState, to: newState)
                 }
             }
         )
@@ -128,6 +146,9 @@ final class WhisperKitLiveController: LiveTranscriptionController {
         }
         await streamTask?.value
         streamTask = nil
+        // Retired only here, after the stream has drained, so the run's final
+        // state changes still count towards this recording's `latestText`.
+        activeRun = nil
         transcriber = nil
         isRunning = false
 
@@ -200,6 +221,7 @@ final class WhisperKitLiveController: LiveTranscriptionController {
         guard !isStopping else { return }
         isRunning = false
         streamTask = nil
+        activeRun = nil
         if let transcriber {
             await transcriber.stopStreamTranscription()
         }
@@ -214,6 +236,7 @@ final class WhisperKitLiveController: LiveTranscriptionController {
 
     private func cleanupAfterFailedStart() async {
         streamTask = nil
+        activeRun = nil
         if let transcriber {
             await transcriber.stopStreamTranscription()
         }

--- a/Tests/SpeakAppTests/LiveTranscriptSessionIsolationTests.swift
+++ b/Tests/SpeakAppTests/LiveTranscriptSessionIsolationTests.swift
@@ -11,6 +11,7 @@ import XCTest
 /// WebSocket/recogniser callbacks arrive late, out of order, or interleaved
 /// with the next recording.
 @MainActor
+// swiftlint:disable:next type_body_length
 final class LiveTranscriptSessionIsolationTests: XCTestCase {
 
   // MARK: - Doubles
@@ -27,6 +28,7 @@ final class LiveTranscriptSessionIsolationTests: XCTestCase {
   /// that mints a fresh stream object per recording and routes stream
   /// callbacks through `LiveTranscriptionRun`.
   private final class StreamingStubController: LiveTranscriptionController {
+    // swiftlint:disable:next nesting
     final class Stream {}
 
     weak var delegate: LiveTranscriptionSessionDelegate?

--- a/Tests/SpeakAppTests/LiveTranscriptSessionIsolationTests.swift
+++ b/Tests/SpeakAppTests/LiveTranscriptSessionIsolationTests.swift
@@ -1,0 +1,220 @@
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// Regression coverage for issue #643 — the live transcript view flickering
+/// with text left over from the previous recording.
+///
+/// These tests drive the real `TranscriptionManager` delegate entry points with
+/// stub controllers, which is the boundary where a superseded recording's
+/// WebSocket/recogniser callbacks arrive late, out of order, or interleaved
+/// with the next recording.
+@MainActor
+final class LiveTranscriptSessionIsolationTests: XCTestCase {
+
+  // MARK: - Doubles
+
+  private final class StubLiveController: LiveTranscriptionController {
+    weak var delegate: LiveTranscriptionSessionDelegate?
+    var isRunning: Bool = false
+    func configure(language: String?, model: String) {}
+    func start() async throws {}
+    func stop() async {}
+  }
+
+  private func makeManager() -> TranscriptionManager {
+    let settings = AppSettings()
+    let permissions = PermissionsManager()
+    let audioDevices = AudioInputDeviceManager(appSettings: settings)
+    let secureStorage = SecureAppStorage(
+      permissionsManager: permissions,
+      appSettings: settings,
+      keychainService: "com.justspeaktoit.tests.live-session.\(UUID().uuidString)"
+    )
+    let openRouter = OpenRouterAPIClient(secureStorage: secureStorage)
+    return TranscriptionManager(
+      appSettings: settings,
+      permissionsManager: permissions,
+      audioDeviceManager: audioDevices,
+      batchClient: RemoteAudioTranscriber(client: openRouter),
+      openRouter: openRouter,
+      secureStorage: secureStorage
+    )
+  }
+
+  private func makeResult(_ text: String) -> TranscriptionResult {
+    TranscriptionResult(
+      text: text,
+      segments: [],
+      confidence: nil,
+      duration: 1,
+      modelIdentifier: "soniox/stt-rt-v5-streaming",
+      cost: nil,
+      rawPayload: nil,
+      debugInfo: nil
+    )
+  }
+
+  // MARK: - Sequential recordings
+
+  func testLatePartialFromPreviousRecording_doesNotReplaceCurrentTranscript() {
+    let manager = self.makeManager()
+    let previous = StubLiveController()
+
+    manager.beginLiveTranscriptDisplaySession(source: previous)
+    manager.liveTranscriber(previous, didUpdatePartial: "previous recording text")
+    XCTAssertEqual(manager.livePartialText, "previous recording text")
+    manager.endLiveTranscriptDisplaySession()
+
+    let current = StubLiveController()
+    manager.beginLiveTranscriptDisplaySession(source: current)
+    XCTAssertEqual(manager.livePartialText, "", "A new recording must start from a blank transcript")
+
+    manager.liveTranscriber(current, didUpdatePartial: "current recording")
+    manager.liveTranscriber(previous, didUpdatePartial: "previous recording text")
+
+    XCTAssertEqual(
+      manager.livePartialText,
+      "current recording",
+      "A late partial from the previous recording must not repaint the live view"
+    )
+  }
+
+  func testRapidSequentialRecordings_reusingOneController_dropSupersededUpdates() {
+    let manager = self.makeManager()
+    // Cached controllers are reused between recordings, so the same instance
+    // reports both sessions.
+    let controller = StubLiveController()
+
+    manager.beginLiveTranscriptDisplaySession(source: controller)
+    manager.liveTranscriber(controller, didUpdatePartial: "first")
+    manager.liveTranscriber(controller, didFinishWith: self.makeResult("first"))
+    manager.endLiveTranscriptDisplaySession()
+
+    manager.beginLiveTranscriptDisplaySession(source: controller)
+    manager.liveTranscriber(controller, didUpdatePartial: "second")
+    let secondSession = manager.liveTranscript.sessionID
+
+    manager.endLiveTranscriptDisplaySession()
+    manager.liveTranscriber(controller, didUpdatePartial: "first")
+
+    XCTAssertEqual(manager.livePartialText, "second")
+    XCTAssertEqual(
+      manager.liveTranscript.sessionID,
+      secondSession,
+      "Updates arriving after a session ends must not be attributed to it"
+    )
+  }
+
+  func testDelayedFinalFromPreviousRecording_doesNotOverwriteCurrentTranscript() {
+    let manager = self.makeManager()
+    let previous = StubLiveController()
+    manager.beginLiveTranscriptDisplaySession(source: previous)
+    manager.liveTranscriber(previous, didUpdatePartial: "previous")
+    manager.endLiveTranscriptDisplaySession()
+
+    let current = StubLiveController()
+    manager.beginLiveTranscriptDisplaySession(source: current)
+    manager.liveTranscriber(
+      current,
+      didUpdateWith: LiveTranscriptionUpdate(text: "current", isFinal: false, confidence: 0.9)
+    )
+
+    manager.liveTranscriber(previous, didFinishWith: self.makeResult("previous"))
+    manager.liveTranscriber(
+      previous,
+      didUpdateWith: LiveTranscriptionUpdate(text: "previous", isFinal: true, confidence: 0.1)
+    )
+
+    XCTAssertEqual(manager.livePartialText, "current")
+    XCTAssertEqual(manager.liveTranscript.confidence, 0.9)
+    XCTAssertFalse(manager.liveTranscript.isFinal)
+  }
+
+  func testOutOfOrderUtteranceBoundary_fromPreviousRecording_isIgnored() {
+    let manager = self.makeManager()
+    let previous = StubLiveController()
+    manager.beginLiveTranscriptDisplaySession(source: previous)
+    manager.endLiveTranscriptDisplaySession()
+
+    let current = StubLiveController()
+    manager.beginLiveTranscriptDisplaySession(source: current)
+    manager.liveTranscriber(previous, didDetectUtteranceBoundary: "previous utterance")
+
+    XCTAssertNil(
+      manager.utteranceBoundaryText,
+      "A boundary from a superseded session must not trigger live polish"
+    )
+
+    manager.liveTranscriber(current, didDetectUtteranceBoundary: "current utterance")
+    XCTAssertEqual(manager.utteranceBoundaryText, "current utterance")
+  }
+
+  // MARK: - Display reset
+
+  func testResetLiveTranscriptDisplay_clearsPreviousRecordingText() {
+    let manager = self.makeManager()
+    let previous = StubLiveController()
+    manager.beginLiveTranscriptDisplaySession(source: previous)
+    manager.liveTranscriber(previous, didUpdatePartial: "previous")
+    manager.endLiveTranscriptDisplaySession()
+
+    manager.resetLiveTranscriptDisplay()
+
+    XCTAssertEqual(manager.liveTranscript, .empty)
+    // A batch-mode recording never opens a live session, so nothing may leak in.
+    manager.liveTranscriber(previous, didUpdatePartial: "previous")
+    XCTAssertEqual(manager.livePartialText, "")
+  }
+
+  func testNewSessionMintsDistinctIdentity() {
+    let manager = self.makeManager()
+    let controller = StubLiveController()
+
+    manager.beginLiveTranscriptDisplaySession(source: controller)
+    let first = manager.liveTranscript.sessionID
+    manager.endLiveTranscriptDisplaySession()
+
+    manager.beginLiveTranscriptDisplaySession(source: controller)
+    let second = manager.liveTranscript.sessionID
+
+    XCTAssertNotNil(first)
+    XCTAssertNotNil(second)
+    XCTAssertNotEqual(first, second)
+  }
+
+  // MARK: - Scope semantics
+
+  func testScopeRejectsUnboundAndSupersededSources() {
+    let scope = LiveTranscriptDisplayScope()
+    let owner = StubLiveController()
+    let other = StubLiveController()
+
+    XCTAssertFalse(scope.accepts(owner), "Nothing is accepted before a session begins")
+
+    scope.begin()
+    XCTAssertFalse(scope.accepts(owner), "An unbound session must not adopt the first caller")
+
+    scope.bind(source: owner)
+    XCTAssertTrue(scope.accepts(owner))
+    XCTAssertFalse(scope.accepts(other))
+
+    scope.unbind()
+    XCTAssertFalse(scope.accepts(owner))
+
+    scope.end()
+    scope.bind(source: owner)
+    XCTAssertFalse(scope.accepts(owner), "Binding must not revive a finished session")
+  }
+
+  func testLiveTranscriptionRun_identifiesSupersededStreams() {
+    let active = StubLiveController()
+    let superseded = StubLiveController()
+
+    XCTAssertTrue(LiveTranscriptionRun.isCurrent(active, activeStream: active))
+    XCTAssertFalse(LiveTranscriptionRun.isCurrent(superseded, activeStream: active))
+    XCTAssertFalse(LiveTranscriptionRun.isCurrent(active, activeStream: nil))
+    XCTAssertFalse(LiveTranscriptionRun.isCurrent(nil, activeStream: active))
+  }
+}

--- a/Tests/SpeakAppTests/LiveTranscriptSessionIsolationTests.swift
+++ b/Tests/SpeakAppTests/LiveTranscriptSessionIsolationTests.swift
@@ -23,6 +23,58 @@ final class LiveTranscriptSessionIsolationTests: XCTestCase {
     func stop() async {}
   }
 
+  /// Mirrors the production controller shape: one cached controller instance
+  /// that mints a fresh stream object per recording and routes stream
+  /// callbacks through `LiveTranscriptionRun`.
+  private final class StreamingStubController: LiveTranscriptionController {
+    final class Stream {}
+
+    weak var delegate: LiveTranscriptionSessionDelegate?
+    var isRunning: Bool = false
+    private(set) var stream: Stream?
+
+    func configure(language: String?, model: String) {}
+
+    @discardableResult
+    func startStream() -> Stream {
+      let stream = Stream()
+      self.stream = stream
+      isRunning = true
+      return stream
+    }
+
+    func start() async throws {
+      startStream()
+    }
+
+    func stop() async {
+      isRunning = false
+    }
+
+    /// Delivers a partial as if it arrived on `stream`'s socket.
+    func deliverPartial(_ text: String, from stream: Stream) {
+      guard LiveTranscriptionRun.isCurrent(stream, activeStream: self.stream) else { return }
+      delegate?.liveTranscriber(self, didUpdatePartial: text)
+    }
+  }
+
+  private func makeSwitchingTranscriber() -> SwitchingLiveTranscriber {
+    let settings = AppSettings()
+    let permissions = PermissionsManager()
+    let audioDevices = AudioInputDeviceManager(appSettings: settings)
+    let secureStorage = SecureAppStorage(
+      permissionsManager: permissions,
+      appSettings: settings,
+      keychainService: "com.justspeaktoit.tests.live-session.\(UUID().uuidString)"
+    )
+    return SwitchingLiveTranscriber(
+      appSettings: settings,
+      permissionsManager: permissions,
+      audioDeviceManager: audioDevices,
+      secureStorage: secureStorage
+    )
+  }
+
   private func makeManager() -> TranscriptionManager {
     let settings = AppSettings()
     let permissions = PermissionsManager()
@@ -206,6 +258,101 @@ final class LiveTranscriptSessionIsolationTests: XCTestCase {
     scope.end()
     scope.bind(source: owner)
     XCTAssertFalse(scope.accepts(owner), "Binding must not revive a finished session")
+  }
+
+  // MARK: - Production wiring
+
+  /// The switcher is what tells its owner which controller is on air. Without
+  /// this notification nothing ever binds the display scope in production.
+  func testSwitchingLiveTranscriber_publishesSessionOwnershipChanges() async {
+    let switcher = self.makeSwitchingTranscriber()
+    // Routes to the "local live streaming unsupported" controller, whose
+    // start() throws before touching the microphone or the network.
+    let model = "local/whisperkit/tiny"
+    let expected = ObjectIdentifier(switcher.controller(for: model))
+
+    var observed: [ObjectIdentifier?] = []
+    switcher.sessionSourceDidChange = { source in
+      observed.append(source.map(ObjectIdentifier.init))
+    }
+
+    switcher.configure(language: nil, model: model)
+    try? await switcher.start()
+    await switcher.stop()
+
+    XCTAssertEqual(
+      observed.first,
+      .some(expected),
+      "Session start must publish the controller that owns the recording"
+    )
+    XCTAssertEqual(observed.last, .some(nil), "Stopping must release session ownership")
+  }
+
+  /// Drives the real closure `TranscriptionManager` installs on
+  /// `sessionSourceDidChange`, rather than the `source:` convenience used by
+  /// the other tests, so the production binding path itself is covered.
+  func testSessionSourceDidChange_bindsAndReleasesTheDisplayScope() {
+    let manager = self.makeManager()
+    let controller = StubLiveController()
+
+    manager.beginLiveTranscriptDisplaySession()
+    XCTAssertFalse(
+      manager.displayScope.accepts(controller),
+      "A session with no bound source must not adopt the first caller"
+    )
+    manager.liveTranscriber(controller, didUpdatePartial: "too early")
+    XCTAssertEqual(manager.livePartialText, "")
+
+    manager.liveController.sessionSourceDidChange?(controller)
+
+    XCTAssertTrue(
+      manager.displayScope.accepts(controller),
+      "The controller published by the switcher must own the display session"
+    )
+    manager.liveTranscriber(controller, didUpdatePartial: "on air")
+    XCTAssertEqual(manager.livePartialText, "on air")
+
+    manager.liveController.sessionSourceDidChange?(nil)
+
+    XCTAssertFalse(manager.displayScope.accepts(controller))
+    manager.liveTranscriber(controller, didUpdatePartial: "after release")
+    XCTAssertEqual(manager.livePartialText, "on air")
+  }
+
+  // MARK: - Per-stream isolation
+
+  /// The display scope keys on the controller instance, and cached controllers
+  /// are reused, so a late callback from the previous recording's socket
+  /// arrives through a controller the scope legitimately accepts. Only the
+  /// per-stream guard can tell the two runs apart.
+  func testStaleStreamOnReusedController_isDroppedDuringTheNextSession() {
+    let manager = self.makeManager()
+    let controller = StreamingStubController()
+    controller.delegate = manager
+
+    let firstStream = controller.startStream()
+    manager.beginLiveTranscriptDisplaySession(source: controller)
+    controller.deliverPartial("first recording", from: firstStream)
+    XCTAssertEqual(manager.livePartialText, "first recording")
+    manager.endLiveTranscriptDisplaySession()
+
+    // Next recording: same cached controller instance, a brand new stream.
+    let secondStream = controller.startStream()
+    manager.beginLiveTranscriptDisplaySession(source: controller)
+    controller.deliverPartial("second recording", from: secondStream)
+    XCTAssertEqual(manager.livePartialText, "second recording")
+
+    XCTAssertTrue(
+      manager.displayScope.accepts(controller),
+      "The session guard cannot catch this — the stale callback shares the controller"
+    )
+    controller.deliverPartial("first recording", from: firstStream)
+
+    XCTAssertEqual(
+      manager.livePartialText,
+      "second recording",
+      "A message queued by the previous stream must not repaint the live view"
+    )
   }
 
   func testLiveTranscriptionRun_identifiesSupersededStreams() {

--- a/Tests/SpeakAppTests/LiveTranscriptSessionIsolationTests.swift
+++ b/Tests/SpeakAppTests/LiveTranscriptSessionIsolationTests.swift
@@ -366,4 +366,19 @@ final class LiveTranscriptSessionIsolationTests: XCTestCase {
     XCTAssertFalse(LiveTranscriptionRun.isCurrent(active, activeStream: nil))
     XCTAssertFalse(LiveTranscriptionRun.isCurrent(nil, activeStream: active))
   }
+
+  func testStopGeneration_rejectsTimeoutFromPreviousStop() {
+    var generation = LiveTranscriptionStopGeneration()
+
+    let previousStop = generation.begin()
+    XCTAssertTrue(generation.isCurrent(previousStop))
+
+    let currentStop = generation.begin()
+
+    XCTAssertFalse(
+      generation.isCurrent(previousStop),
+      "A timeout from the previous recording must not resume the current stop"
+    )
+    XCTAssertTrue(generation.isCurrent(currentStop))
+  }
 }

--- a/Tests/SpeakAppTests/NativeOSXLiveTranscriptIsolationTests.swift
+++ b/Tests/SpeakAppTests/NativeOSXLiveTranscriptIsolationTests.swift
@@ -41,7 +41,10 @@ private enum TestError: Error {
 @MainActor
 final class NativeOSXLiveTranscriptIsolationTests: XCTestCase {
   func testCallbacksAfterStop_areDroppedForResultsAndErrors() async {
-    let (lifecycle, factory, events) = makeLifecycle()
+    let context = makeLifecycle()
+    let lifecycle = context.lifecycle
+    let factory = context.factory
+    let events = context.events
     start(lifecycle, factory: factory, events: events)
     factory.sendResult("current", task: 0)
     factory.sendError(task: 0)
@@ -58,7 +61,10 @@ final class NativeOSXLiveTranscriptIsolationTests: XCTestCase {
   }
 
   func testReusedLifecycle_acceptsCurrentCallbacksAndDropsPreviousRun() async {
-    let (lifecycle, factory, events) = makeLifecycle()
+    let context = makeLifecycle()
+    let lifecycle = context.lifecycle
+    let factory = context.factory
+    let events = context.events
     start(lifecycle, factory: factory, events: events)
     lifecycle.retire()
     start(lifecycle, factory: factory, events: events)
@@ -74,7 +80,10 @@ final class NativeOSXLiveTranscriptIsolationTests: XCTestCase {
   }
 
   func testMidSessionRestart_retiresBothResultAndErrorCallbacksFromCancelledTask() async {
-    let (lifecycle, factory, events) = makeLifecycle()
+    let context = makeLifecycle()
+    let lifecycle = context.lifecycle
+    let factory = context.factory
+    let events = context.events
     start(lifecycle, factory: factory, events: events)
 
     // `NativeOSXLiveTranscriber.restartRecognitionTask()` starts a replacement
@@ -91,12 +100,12 @@ final class NativeOSXLiveTranscriptIsolationTests: XCTestCase {
     XCTAssertEqual(events.errorCount, 1)
   }
 
-  private func makeLifecycle() -> (
-    NativeSpeechRecognitionTaskLifecycle,
-    RecognitionTaskFactoryDouble,
-    RecognitionEvents
-  ) {
-    (NativeSpeechRecognitionTaskLifecycle(), RecognitionTaskFactoryDouble(), RecognitionEvents())
+  private func makeLifecycle() -> RecognitionTestContext {
+    RecognitionTestContext(
+      lifecycle: NativeSpeechRecognitionTaskLifecycle(),
+      factory: RecognitionTaskFactoryDouble(),
+      events: RecognitionEvents()
+    )
   }
 
   private func start(
@@ -116,6 +125,13 @@ final class NativeOSXLiveTranscriptIsolationTests: XCTestCase {
   private func drainCallbacks() async {
     for _ in 0..<3 { await Task.yield() }
   }
+}
+
+@MainActor
+private struct RecognitionTestContext {
+  let lifecycle: NativeSpeechRecognitionTaskLifecycle
+  let factory: RecognitionTaskFactoryDouble
+  let events: RecognitionEvents
 }
 
 @MainActor

--- a/Tests/SpeakAppTests/NativeOSXLiveTranscriptIsolationTests.swift
+++ b/Tests/SpeakAppTests/NativeOSXLiveTranscriptIsolationTests.swift
@@ -1,217 +1,125 @@
-import SpeakCore
 import XCTest
 
 @testable import SpeakApp
 
-/// Regression coverage for issue #668 — `NativeOSXLiveTranscriber` repainting
-/// the live view with text from the previous recording.
-///
-/// `LiveTranscriptSessionIsolationTests` covers the socket-shaped controllers.
-/// The local Apple recogniser differs in two ways that need their own coverage:
-/// it is the default fallback controller, so back-to-back local recordings
-/// really do share one cached instance, and `SFSpeechRecognitionTask.cancel()`
-/// is not a hard stop — the recogniser can still deliver a queued result
-/// afterwards. `LiveTranscriptDisplayScope` keys on the controller, which both
-/// runs share, so only the per-run guard can tell them apart.
+private final class RecognitionTaskDouble: NativeSpeechRecognitionTask {
+  private(set) var isCancelled = false
+
+  func cancel() {
+    isCancelled = true
+  }
+}
+
+@MainActor
+private final class RecognitionTaskFactoryDouble {
+  private(set) var callbacks: [NativeSpeechRecognitionTaskLifecycle.Callback] = []
+  private(set) var tasks: [RecognitionTaskDouble] = []
+
+  func makeTask(callback: @escaping NativeSpeechRecognitionTaskLifecycle.Callback) -> any NativeSpeechRecognitionTask {
+    let task = RecognitionTaskDouble()
+    callbacks.append(callback)
+    tasks.append(task)
+    return task
+  }
+
+  func sendResult(_ text: String, isFinal: Bool = false, task index: Int) {
+    callbacks[index](NativeSpeechRecognitionResult(text: text, isFinal: isFinal), nil)
+  }
+
+  func sendError(task index: Int) {
+    callbacks[index](nil, TestError.recognitionFailed)
+  }
+}
+
+private enum TestError: Error {
+  case recognitionFailed
+}
+
+/// Drives the callback seam used by `NativeOSXLiveTranscriber` in production.
+/// No test-side copy of the identity guard exists here: delayed callbacks are
+/// admitted or rejected only by `NativeSpeechRecognitionTaskLifecycle`.
 @MainActor
 final class NativeOSXLiveTranscriptIsolationTests: XCTestCase {
+  func testCallbacksAfterStop_areDroppedForResultsAndErrors() async {
+    let (lifecycle, factory, events) = makeLifecycle()
+    start(lifecycle, factory: factory, events: events)
+    factory.sendResult("current", task: 0)
+    factory.sendError(task: 0)
+    await drainCallbacks()
 
-  // MARK: - Doubles
+    lifecycle.retire()
+    factory.sendResult("stale after stop", task: 0)
+    factory.sendError(task: 0)
+    await drainCallbacks()
 
-  /// Mirrors `NativeOSXLiveTranscriber`'s run bookkeeping. The run identity is
-  /// the per-run recognition request rather than the task, because
-  /// `SFSpeechRecognizer` only hands the task back once its result handler has
-  /// already been installed — too late for the handler to capture it. And
-  /// `stop()` retires that identity *before* synthesising the result from the
-  /// text the handler accumulated, so the guard must not swallow the final
-  /// result.
-  private final class RecognitionStubController: LiveTranscriptionController {
-    weak var delegate: LiveTranscriptionSessionDelegate?
-    var isRunning: Bool = false
-    private(set) var request: RecognitionRequestStub?
-    private var latestText: String = ""
-
-    func configure(language: String?, model: String) {}
-
-    @discardableResult
-    func startRecognition() -> RecognitionRequestStub {
-      let request = RecognitionRequestStub()
-      self.request = request
-      latestText = ""
-      isRunning = true
-      return request
-    }
-
-    func start() async throws {
-      startRecognition()
-    }
-
-    func stop() async {
-      finishRecognition()
-    }
-
-    /// Delivers a result as if the task installed on `request` produced it.
-    /// A cancelled task can still call this long after its run has ended.
-    func deliverResult(_ text: String, from request: RecognitionRequestStub) {
-      guard LiveTranscriptionRun.isCurrent(request, activeStream: self.request) else { return }
-      latestText = text
-      delegate?.liveTranscriber(self, didUpdatePartial: text)
-    }
-
-    /// Production teardown order: retire the run identity, then finalise from
-    /// the text the handler accumulated.
-    func finishRecognition() {
-      request = nil
-      isRunning = false
-      delegate?.liveTranscriber(
-        self,
-        didFinishWith: TranscriptionResult(
-          text: latestText,
-          segments: [],
-          confidence: nil,
-          duration: 1,
-          modelIdentifier: AppleLocalModels.legacySpeechModelID,
-          cost: nil,
-          rawPayload: nil,
-          debugInfo: nil
-        )
-      )
-    }
+    XCTAssertTrue(factory.tasks[0].isCancelled)
+    XCTAssertEqual(events.results, ["current"])
+    XCTAssertEqual(events.errorCount, 1)
   }
 
-  /// Stands in for `SFSpeechAudioBufferRecognitionRequest`, the object minted
-  /// fresh for every recognition run.
-  private final class RecognitionRequestStub {}
+  func testReusedLifecycle_acceptsCurrentCallbacksAndDropsPreviousRun() async {
+    let (lifecycle, factory, events) = makeLifecycle()
+    start(lifecycle, factory: factory, events: events)
+    lifecycle.retire()
+    start(lifecycle, factory: factory, events: events)
 
-  /// Records what a controller published, for the assertions about the delegate
-  /// contract rather than the on-screen transcript.
-  private final class RecordingDelegate: LiveTranscriptionSessionDelegate {
-    private(set) var partials: [String] = []
-    private(set) var finalText: String?
+    factory.sendResult("stale result", task: 0)
+    factory.sendError(task: 0)
+    factory.sendResult("current result", task: 1)
+    factory.sendError(task: 1)
+    await drainCallbacks()
 
-    func liveTranscriber(_ session: any LiveTranscriptionController, didUpdatePartial text: String) {
-      partials.append(text)
-    }
-
-    func liveTranscriber(
-      _ session: any LiveTranscriptionController,
-      didUpdateWith update: LiveTranscriptionUpdate
-    ) {}
-
-    func liveTranscriber(
-      _ session: any LiveTranscriptionController,
-      didFinishWith result: TranscriptionResult
-    ) {
-      finalText = result.text
-    }
-
-    func liveTranscriber(_ session: any LiveTranscriptionController, didFail error: Error) {}
-
-    func liveTranscriber(
-      _ session: any LiveTranscriptionController,
-      didDetectUtteranceBoundary utterance: String
-    ) {}
+    XCTAssertEqual(events.results, ["current result"])
+    XCTAssertEqual(events.errorCount, 1)
   }
 
-  private func makeManager() -> TranscriptionManager {
-    let settings = AppSettings()
-    let permissions = PermissionsManager()
-    let audioDevices = AudioInputDeviceManager(appSettings: settings)
-    let secureStorage = SecureAppStorage(
-      permissionsManager: permissions,
-      appSettings: settings,
-      keychainService: "com.justspeaktoit.tests.native-osx-run.\(UUID().uuidString)"
-    )
-    let openRouter = OpenRouterAPIClient(secureStorage: secureStorage)
-    return TranscriptionManager(
-      appSettings: settings,
-      permissionsManager: permissions,
-      audioDeviceManager: audioDevices,
-      batchClient: RemoteAudioTranscriber(client: openRouter),
-      openRouter: openRouter,
-      secureStorage: secureStorage
+  func testMidSessionRestart_retiresBothResultAndErrorCallbacksFromCancelledTask() async {
+    let (lifecycle, factory, events) = makeLifecycle()
+    start(lifecycle, factory: factory, events: events)
+
+    // `NativeOSXLiveTranscriber.restartRecognitionTask()` starts a replacement
+    // lifecycle task after Apple's mid-session final result.
+    start(lifecycle, factory: factory, events: events)
+    factory.sendResult("before restart", isFinal: true, task: 0)
+    factory.sendError(task: 0)
+    factory.sendResult("after restart", task: 1)
+    factory.sendError(task: 1)
+    await drainCallbacks()
+
+    XCTAssertTrue(factory.tasks[0].isCancelled)
+    XCTAssertEqual(events.results, ["after restart"])
+    XCTAssertEqual(events.errorCount, 1)
+  }
+
+  private func makeLifecycle() -> (
+    NativeSpeechRecognitionTaskLifecycle,
+    RecognitionTaskFactoryDouble,
+    RecognitionEvents
+  ) {
+    (NativeSpeechRecognitionTaskLifecycle(), RecognitionTaskFactoryDouble(), RecognitionEvents())
+  }
+
+  private func start(
+    _ lifecycle: NativeSpeechRecognitionTaskLifecycle,
+    factory: RecognitionTaskFactoryDouble,
+    events: RecognitionEvents
+  ) {
+    lifecycle.start(
+      factory: { factory.makeTask(callback: $0) },
+      onEvent: { result, error in
+        if let result { events.results.append(result.text) }
+        if error != nil { events.errorCount += 1 }
+      }
     )
   }
 
-  // MARK: - Tests
-
-  func testStaleRecognitionResultOnReusedController_isDroppedDuringTheNextSession() {
-    let manager = self.makeManager()
-    let controller = RecognitionStubController()
-    controller.delegate = manager
-
-    let firstRequest = controller.startRecognition()
-    manager.beginLiveTranscriptDisplaySession(source: controller)
-    controller.deliverResult("first recording", from: firstRequest)
-    XCTAssertEqual(manager.livePartialText, "first recording")
-    controller.finishRecognition()
-    manager.endLiveTranscriptDisplaySession()
-
-    // Next recording: same cached controller, a brand new recognition request.
-    let secondRequest = controller.startRecognition()
-    manager.beginLiveTranscriptDisplaySession(source: controller)
-    controller.deliverResult("second recording", from: secondRequest)
-    XCTAssertEqual(manager.livePartialText, "second recording")
-
-    XCTAssertTrue(
-      manager.displayScope.accepts(controller),
-      "The session guard cannot catch this — the stale result shares the controller"
-    )
-    controller.deliverResult("first recording", from: firstRequest)
-
-    XCTAssertEqual(
-      manager.livePartialText,
-      "second recording",
-      "A result from the previous recognition request must not repaint the live view"
-    )
+  private func drainCallbacks() async {
+    for _ in 0..<3 { await Task.yield() }
   }
+}
 
-  /// The recogniser's own final result is dropped by the guard, because `stop()`
-  /// retires the run identity before tearing the task down. That is only safe
-  /// because the finished result is synthesised from state the handler already
-  /// accumulated — this pins that ordering.
-  func testRetiringTheRecognitionRun_stillPublishesTheAccumulatedFinalResult() {
-    let recorder = RecordingDelegate()
-    let controller = RecognitionStubController()
-    controller.delegate = recorder
-
-    let request = controller.startRecognition()
-    controller.deliverResult("hello world", from: request)
-    controller.finishRecognition()
-
-    XCTAssertEqual(
-      recorder.finalText,
-      "hello world",
-      "Retiring the run identity must not swallow the recording's final text"
-    )
-
-    controller.deliverResult("late result", from: request)
-    XCTAssertEqual(
-      recorder.partials,
-      ["hello world"],
-      "A result delivered after the run is retired must not reach the delegate"
-    )
-  }
-
-  /// A mid-session restart (Apple's recogniser emits `isFinal` on a pause)
-  /// mints a replacement request, which retires the previous one.
-  func testMidSessionRestart_dropsResultsFromTheSupersededRequest() {
-    let manager = self.makeManager()
-    let controller = RecognitionStubController()
-    controller.delegate = manager
-
-    let firstRequest = controller.startRecognition()
-    manager.beginLiveTranscriptDisplaySession(source: controller)
-    controller.deliverResult("before the pause", from: firstRequest)
-
-    let restartedRequest = controller.startRecognition()
-    controller.deliverResult("after the pause", from: restartedRequest)
-    controller.deliverResult("before the pause", from: firstRequest)
-
-    XCTAssertEqual(
-      manager.livePartialText,
-      "after the pause",
-      "The cancelled task's queued results must not survive the restart"
-    )
-  }
+@MainActor
+private final class RecognitionEvents {
+  var results: [String] = []
+  var errorCount = 0
 }

--- a/Tests/SpeakAppTests/NativeOSXLiveTranscriptIsolationTests.swift
+++ b/Tests/SpeakAppTests/NativeOSXLiveTranscriptIsolationTests.swift
@@ -1,0 +1,217 @@
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// Regression coverage for issue #668 — `NativeOSXLiveTranscriber` repainting
+/// the live view with text from the previous recording.
+///
+/// `LiveTranscriptSessionIsolationTests` covers the socket-shaped controllers.
+/// The local Apple recogniser differs in two ways that need their own coverage:
+/// it is the default fallback controller, so back-to-back local recordings
+/// really do share one cached instance, and `SFSpeechRecognitionTask.cancel()`
+/// is not a hard stop — the recogniser can still deliver a queued result
+/// afterwards. `LiveTranscriptDisplayScope` keys on the controller, which both
+/// runs share, so only the per-run guard can tell them apart.
+@MainActor
+final class NativeOSXLiveTranscriptIsolationTests: XCTestCase {
+
+  // MARK: - Doubles
+
+  /// Mirrors `NativeOSXLiveTranscriber`'s run bookkeeping. The run identity is
+  /// the per-run recognition request rather than the task, because
+  /// `SFSpeechRecognizer` only hands the task back once its result handler has
+  /// already been installed — too late for the handler to capture it. And
+  /// `stop()` retires that identity *before* synthesising the result from the
+  /// text the handler accumulated, so the guard must not swallow the final
+  /// result.
+  private final class RecognitionStubController: LiveTranscriptionController {
+    weak var delegate: LiveTranscriptionSessionDelegate?
+    var isRunning: Bool = false
+    private(set) var request: RecognitionRequestStub?
+    private var latestText: String = ""
+
+    func configure(language: String?, model: String) {}
+
+    @discardableResult
+    func startRecognition() -> RecognitionRequestStub {
+      let request = RecognitionRequestStub()
+      self.request = request
+      latestText = ""
+      isRunning = true
+      return request
+    }
+
+    func start() async throws {
+      startRecognition()
+    }
+
+    func stop() async {
+      finishRecognition()
+    }
+
+    /// Delivers a result as if the task installed on `request` produced it.
+    /// A cancelled task can still call this long after its run has ended.
+    func deliverResult(_ text: String, from request: RecognitionRequestStub) {
+      guard LiveTranscriptionRun.isCurrent(request, activeStream: self.request) else { return }
+      latestText = text
+      delegate?.liveTranscriber(self, didUpdatePartial: text)
+    }
+
+    /// Production teardown order: retire the run identity, then finalise from
+    /// the text the handler accumulated.
+    func finishRecognition() {
+      request = nil
+      isRunning = false
+      delegate?.liveTranscriber(
+        self,
+        didFinishWith: TranscriptionResult(
+          text: latestText,
+          segments: [],
+          confidence: nil,
+          duration: 1,
+          modelIdentifier: AppleLocalModels.legacySpeechModelID,
+          cost: nil,
+          rawPayload: nil,
+          debugInfo: nil
+        )
+      )
+    }
+  }
+
+  /// Stands in for `SFSpeechAudioBufferRecognitionRequest`, the object minted
+  /// fresh for every recognition run.
+  private final class RecognitionRequestStub {}
+
+  /// Records what a controller published, for the assertions about the delegate
+  /// contract rather than the on-screen transcript.
+  private final class RecordingDelegate: LiveTranscriptionSessionDelegate {
+    private(set) var partials: [String] = []
+    private(set) var finalText: String?
+
+    func liveTranscriber(_ session: any LiveTranscriptionController, didUpdatePartial text: String) {
+      partials.append(text)
+    }
+
+    func liveTranscriber(
+      _ session: any LiveTranscriptionController,
+      didUpdateWith update: LiveTranscriptionUpdate
+    ) {}
+
+    func liveTranscriber(
+      _ session: any LiveTranscriptionController,
+      didFinishWith result: TranscriptionResult
+    ) {
+      finalText = result.text
+    }
+
+    func liveTranscriber(_ session: any LiveTranscriptionController, didFail error: Error) {}
+
+    func liveTranscriber(
+      _ session: any LiveTranscriptionController,
+      didDetectUtteranceBoundary utterance: String
+    ) {}
+  }
+
+  private func makeManager() -> TranscriptionManager {
+    let settings = AppSettings()
+    let permissions = PermissionsManager()
+    let audioDevices = AudioInputDeviceManager(appSettings: settings)
+    let secureStorage = SecureAppStorage(
+      permissionsManager: permissions,
+      appSettings: settings,
+      keychainService: "com.justspeaktoit.tests.native-osx-run.\(UUID().uuidString)"
+    )
+    let openRouter = OpenRouterAPIClient(secureStorage: secureStorage)
+    return TranscriptionManager(
+      appSettings: settings,
+      permissionsManager: permissions,
+      audioDeviceManager: audioDevices,
+      batchClient: RemoteAudioTranscriber(client: openRouter),
+      openRouter: openRouter,
+      secureStorage: secureStorage
+    )
+  }
+
+  // MARK: - Tests
+
+  func testStaleRecognitionResultOnReusedController_isDroppedDuringTheNextSession() {
+    let manager = self.makeManager()
+    let controller = RecognitionStubController()
+    controller.delegate = manager
+
+    let firstRequest = controller.startRecognition()
+    manager.beginLiveTranscriptDisplaySession(source: controller)
+    controller.deliverResult("first recording", from: firstRequest)
+    XCTAssertEqual(manager.livePartialText, "first recording")
+    controller.finishRecognition()
+    manager.endLiveTranscriptDisplaySession()
+
+    // Next recording: same cached controller, a brand new recognition request.
+    let secondRequest = controller.startRecognition()
+    manager.beginLiveTranscriptDisplaySession(source: controller)
+    controller.deliverResult("second recording", from: secondRequest)
+    XCTAssertEqual(manager.livePartialText, "second recording")
+
+    XCTAssertTrue(
+      manager.displayScope.accepts(controller),
+      "The session guard cannot catch this — the stale result shares the controller"
+    )
+    controller.deliverResult("first recording", from: firstRequest)
+
+    XCTAssertEqual(
+      manager.livePartialText,
+      "second recording",
+      "A result from the previous recognition request must not repaint the live view"
+    )
+  }
+
+  /// The recogniser's own final result is dropped by the guard, because `stop()`
+  /// retires the run identity before tearing the task down. That is only safe
+  /// because the finished result is synthesised from state the handler already
+  /// accumulated — this pins that ordering.
+  func testRetiringTheRecognitionRun_stillPublishesTheAccumulatedFinalResult() {
+    let recorder = RecordingDelegate()
+    let controller = RecognitionStubController()
+    controller.delegate = recorder
+
+    let request = controller.startRecognition()
+    controller.deliverResult("hello world", from: request)
+    controller.finishRecognition()
+
+    XCTAssertEqual(
+      recorder.finalText,
+      "hello world",
+      "Retiring the run identity must not swallow the recording's final text"
+    )
+
+    controller.deliverResult("late result", from: request)
+    XCTAssertEqual(
+      recorder.partials,
+      ["hello world"],
+      "A result delivered after the run is retired must not reach the delegate"
+    )
+  }
+
+  /// A mid-session restart (Apple's recogniser emits `isFinal` on a pause)
+  /// mints a replacement request, which retires the previous one.
+  func testMidSessionRestart_dropsResultsFromTheSupersededRequest() {
+    let manager = self.makeManager()
+    let controller = RecognitionStubController()
+    controller.delegate = manager
+
+    let firstRequest = controller.startRecognition()
+    manager.beginLiveTranscriptDisplaySession(source: controller)
+    controller.deliverResult("before the pause", from: firstRequest)
+
+    let restartedRequest = controller.startRecognition()
+    controller.deliverResult("after the pause", from: restartedRequest)
+    controller.deliverResult("before the pause", from: firstRequest)
+
+    XCTAssertEqual(
+      manager.livePartialText,
+      "after the pause",
+      "The cancelled task's queued results must not survive the restart"
+    )
+  }
+}

--- a/Tests/SpeakAppTests/SwitchingLiveTranscriberLifecycleTests.swift
+++ b/Tests/SpeakAppTests/SwitchingLiveTranscriberLifecycleTests.swift
@@ -1,0 +1,82 @@
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+@MainActor
+final class SwitchingLiveTranscriberLifecycleTests: XCTestCase {
+  private final class SlowStopController: LiveTranscriptionController {
+    weak var delegate: LiveTranscriptionSessionDelegate?
+    private(set) var isRunning = false
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    var stopStarted: (() -> Void)?
+    private var stopContinuation: CheckedContinuation<Void, Never>?
+    private var shouldSuspendStop = true
+
+    func configure(language: String?, model: String) {}
+
+    func start() async throws {
+      startCount += 1
+      isRunning = true
+    }
+
+    func stop() async {
+      stopCount += 1
+      if shouldSuspendStop {
+        shouldSuspendStop = false
+        stopStarted?()
+        await withCheckedContinuation { continuation in
+          stopContinuation = continuation
+        }
+      }
+      isRunning = false
+    }
+
+    func completeStop() {
+      stopContinuation?.resume()
+      stopContinuation = nil
+    }
+  }
+
+  func testOldAsynchronousStop_cannotClearOrOverlapReplacementRun() async throws {
+    let controller = SlowStopController()
+    let switcher = makeSwitcher(controller: controller)
+    let stopStarted = expectation(description: "old controller stop started")
+    controller.stopStarted = { stopStarted.fulfill() }
+
+    try await switcher.start()
+    switcher.scheduleStop()
+    await fulfillment(of: [stopStarted], timeout: 2)
+
+    let replacementStart = Task { try await switcher.start() }
+    await Task.yield()
+    XCTAssertEqual(controller.startCount, 1, "Replacement must wait for the cached controller's old stop")
+
+    controller.completeStop()
+    try await replacementStart.value
+
+    XCTAssertTrue(switcher.isRunning, "The old stop must not clear ownership of the replacement run")
+    XCTAssertEqual(controller.startCount, 2)
+    await switcher.stop()
+    XCTAssertEqual(controller.stopCount, 2, "The replacement controller must remain reachable for teardown")
+  }
+
+  private func makeSwitcher(controller: any LiveTranscriptionController) -> SwitchingLiveTranscriber {
+    let settings = AppSettings()
+    let permissions = PermissionsManager()
+    let audioDevices = AudioInputDeviceManager(appSettings: settings)
+    let secureStorage = SecureAppStorage(
+      permissionsManager: permissions,
+      appSettings: settings,
+      keychainService: "com.justspeaktoit.tests.switcher-lifecycle.\(UUID().uuidString)"
+    )
+    return SwitchingLiveTranscriber(
+      appSettings: settings,
+      permissionsManager: permissions,
+      audioDeviceManager: audioDevices,
+      secureStorage: secureStorage,
+      controllerOverride: { _ in controller }
+    )
+  }
+}


### PR DESCRIPTION
Closes #668

> **Builds on #662 and must merge after it.** Until #662 lands, this PR also contains its live transcript session-isolation commits.

## Summary

- Routes `NativeOSXLiveTranscriber` callbacks through an injectable production task lifecycle. Every stop or restart retires the prior run before cancellation, so queued result and error callbacks cannot mutate a reused controller.
- Captures a unique run in `SwitchingLiveTranscriber` before asynchronous cancellation. Replacement starts wait for the cached controller's pending teardown, and completion only releases the run it stopped.
- Applies the existing stream-identity check to result, final, error and completion callbacks across the reusable remote controllers. Soniox finalisation now identifies its source stream, and Modulate retires the failed input session before asynchronous cleanup.
- Keeps early connection errors visible for the current stream, including OpenAI Realtime and Deepgram.

## Tests

- Production native recognition-task seam covers current and stale result/error callbacks after stop, controller reuse and mid-session restart.
- Switching controller coverage holds a slow stop open while a replacement start is requested, then verifies the replacement remains running and reachable for teardown.
- Existing display-session and per-stream isolation coverage remains in place.

## Verification

No local build or test commands were run, per review direction. CI is the verification gate.
