### PR TITLE
perf(mac): pre-warm audio input and supported provider endpoints

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -312,6 +312,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     case silenceThreshold
     case silenceDuration
     case connectionPreWarmingEnabled
+    case audioPreWarmingEnabled
     case postProcessingStreamingEnabled
     case hudSizePreference
     case showLiveTranscriptInHUD
@@ -722,8 +723,20 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   // Performance Settings
+
+  /// Pre-warms the network path to the post-processing and live-transcription
+  /// providers while idle (DNS + TLS only — no credential is sent and no
+  /// provider session is opened).
   @Published var connectionPreWarmingEnabled: Bool {
     didSet { store(connectionPreWarmingEnabled, key: .connectionPreWarmingEnabled) }
+  }
+
+  /// Creates and prepares the audio recorder while the app is idle so the
+  /// hotkey→capture path only has to start it (issue #663). Pre-warming never
+  /// opens the microphone; capture still begins at session start. Costs one
+  /// prepared encoder and one empty file while idle, so it is on by default.
+  @Published var audioPreWarmingEnabled: Bool {
+    didSet { store(audioPreWarmingEnabled, key: .audioPreWarmingEnabled) }
   }
 
   @Published var postProcessingStreamingEnabled: Bool {
@@ -1057,6 +1070,8 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     }
     connectionPreWarmingEnabled =
       defaults.object(forKey: DefaultsKey.connectionPreWarmingEnabled.rawValue) as? Bool ?? true
+    audioPreWarmingEnabled =
+      defaults.object(forKey: DefaultsKey.audioPreWarmingEnabled.rawValue) as? Bool ?? true
     postProcessingStreamingEnabled =
       defaults.object(forKey: DefaultsKey.postProcessingStreamingEnabled.rawValue) as? Bool ?? true
 

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -724,9 +724,8 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
 
   // Performance Settings
 
-  /// Pre-warms the network path to the post-processing and live-transcription
-  /// providers while idle (DNS + TLS only — no credential is sent and no
-  /// provider session is opened).
+  /// Pre-warms OpenRouter plus supported shared-session transcription endpoints
+  /// while idle. No credential is sent and no provider session is opened.
   @Published var connectionPreWarmingEnabled: Bool {
     didSet { store(connectionPreWarmingEnabled, key: .connectionPreWarmingEnabled) }
   }

--- a/Sources/SpeakApp/AudioFileManager.swift
+++ b/Sources/SpeakApp/AudioFileManager.swift
@@ -13,6 +13,21 @@ struct RecordingSummary: Identifiable, Hashable {
   let fileSize: Int64
 }
 
+enum AudioRecordingOwner: Sendable {
+  case dictation
+  case auxiliary
+}
+
+enum AudioRecordingLifecycleEvent: Sendable {
+  case auxiliaryStarted
+  case auxiliaryEnded
+}
+
+struct RecordingStart: Sendable {
+  let url: URL
+  let usedWarmRecorder: Bool
+}
+
 enum AudioFileManagerError: LocalizedError {
   case alreadyRecording
   case noActiveRecording
@@ -68,8 +83,11 @@ actor AudioFileManager {
   nonisolated(unsafe) private var recorder: AVAudioRecorder?
   private var currentRecordingID: UUID?
   private var currentRecordingStart: Date?
+  private var currentRecordingOwner: AudioRecordingOwner?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
   private var staged: StagedRecorder?
+  private var warmMachine = CaptureWarmStateMachine()
+  private var lifecycleHandler: (@Sendable (AudioRecordingLifecycleEvent) -> Void)?
   private let logger = Logger(subsystem: "com.github.speakapp", category: "AudioFileManager")
 
   /// Identifier for the encoder settings every recording uses.
@@ -108,6 +126,41 @@ actor AudioFileManager {
 
   // MARK: - Pre-warming (issue #663)
 
+  func setRecordingLifecycleHandler(
+    _ handler: (@Sendable (AudioRecordingLifecycleEvent) -> Void)?
+  ) {
+    self.lifecycleHandler = handler
+  }
+
+  /// Reconciles the staged recorder and its state as one actor-owned operation.
+  /// Keeping both together prevents auxiliary recording flows from invalidating
+  /// the recorder while a separate coordinator still believes it is ready.
+  func reconcileWarmRecorder(for context: CaptureWarmContext, enabled: Bool) {
+    guard self.recorder == nil else {
+      self.applyWarmAction(self.warmMachine.recordingBeganWithoutClaim())
+      return
+    }
+    self.applyWarmAction(self.warmMachine.reconcile(with: context, enabled: enabled))
+  }
+
+  func invalidateWarmRecorder() {
+    self.applyWarmAction(self.warmMachine.reset())
+  }
+
+  private func applyWarmAction(_ action: CaptureWarmAction) {
+    switch action {
+    case .none:
+      return
+    case .discard:
+      self.discardWarmRecorder()
+    case .prepare(let context):
+      self.prepareWarmRecorder(for: context)
+    case .discardThenPrepare(let context):
+      self.discardWarmRecorder()
+      self.prepareWarmRecorder(for: context)
+    }
+  }
+
   /// Creates and prepares a recorder ahead of the hotkey so session start only
   /// has to call `record()`.
   ///
@@ -120,11 +173,16 @@ actor AudioFileManager {
   /// already been granted (see ``CaptureWarmContext/isWarmable``), so warm-up
   /// can never be the thing that provokes a permission prompt.
   ///
-  /// - Returns: `true` when a recorder was staged for `context`.
-  func prepareWarmRecorder(for context: CaptureWarmContext) -> Bool {
-    guard self.recorder == nil, context.isWarmable else { return false }
+  private func prepareWarmRecorder(for context: CaptureWarmContext) {
+    guard self.recorder == nil, context.isWarmable else {
+      self.warmMachine.markFailed(context)
+      return
+    }
     if let staged = self.staged {
-      guard staged.context != context else { return true }
+      guard staged.context != context else {
+        _ = self.warmMachine.markReady(context)
+        return
+      }
       self.discardWarmRecorder()
     }
 
@@ -137,22 +195,35 @@ actor AudioFileManager {
       let warmRecorder = try AVAudioRecorder(url: fileURL, settings: EncoderProfile.settings)
       warmRecorder.isMeteringEnabled = true
       // Creates the file and readies the encoder. Does NOT open the microphone.
-      warmRecorder.prepareToRecord()
+      guard warmRecorder.prepareToRecord() else {
+        _ = warmRecorder.deleteRecording()
+        try? FileManager.default.removeItem(at: fileURL)
+        self.warmMachine.markFailed(context)
+        return
+      }
       self.staged = StagedRecorder(context: context, recorder: warmRecorder, id: id, url: fileURL)
-      return true
+      if !self.warmMachine.markReady(context) {
+        self.discardWarmRecorder()
+      }
     } catch {
       self.logger.debug("Capture pre-warm failed; falling back to cold start")
       try? FileManager.default.removeItem(at: fileURL)
-      return false
+      self.warmMachine.markFailed(context)
     }
   }
 
   /// Tears the staged recorder down and removes the empty file it created.
-  func discardWarmRecorder() {
+  private func discardWarmRecorder() {
     guard let staged = self.staged else { return }
     self.staged = nil
     _ = staged.recorder.deleteRecording()
-    try? FileManager.default.removeItem(at: staged.url)
+    do {
+      try FileManager.default.removeItem(at: staged.url)
+    } catch where (error as NSError).code == NSFileNoSuchFileError {
+      return
+    } catch {
+      self.logger.error("Failed to remove staged recording: \(error.localizedDescription, privacy: .public)")
+    }
   }
 
   // MARK: - Recording
@@ -160,7 +231,10 @@ actor AudioFileManager {
   /// Starts capture, claiming the staged recorder when `warmContext` matches
   /// the one it was prepared for. On the warm path the only work left on the
   /// hotkey→capture path is the input-device session and `record()` itself.
-  func startRecording(warmContext: CaptureWarmContext? = nil) async throws -> URL {
+  func startRecording(
+    warmContext: CaptureWarmContext? = nil,
+    owner: AudioRecordingOwner = .auxiliary
+  ) async throws -> RecordingStart {
     guard recorder == nil else { throw AudioFileManagerError.alreadyRecording }
 
     let permissionStatus = await MainActor.run {
@@ -168,7 +242,7 @@ actor AudioFileManager {
       return permissionsManager.status(for: .microphone)
     }
     if !permissionStatus.isGranted {
-      self.discardWarmRecorder()
+      self.invalidateWarmRecorder()
       let requested = await permissionsManager.request(.microphone)
       guard requested.isGranted else {
         throw AudioFileManagerError.microphonePermissionMissing
@@ -178,7 +252,9 @@ actor AudioFileManager {
     let claimed = self.claimWarmRecorder(matching: warmContext)
     // A staged recorder the starting session cannot use is stale by definition:
     // discard it rather than leave an orphaned file behind.
-    if claimed == nil { self.discardWarmRecorder() }
+    if claimed == nil {
+      self.applyWarmAction(self.warmMachine.recordingBeganWithoutClaim())
+    }
 
     let sessionContext = await audioDeviceManager.beginUsingPreferredInput()
 
@@ -196,22 +272,29 @@ actor AudioFileManager {
         fileURL = directory.appendingPathComponent("Recording-\(id.uuidString).m4a")
         newRecorder = try AVAudioRecorder(url: fileURL, settings: EncoderProfile.settings)
         newRecorder.isMeteringEnabled = true
-        newRecorder.prepareToRecord()
+        guard newRecorder.prepareToRecord() else {
+          throw AudioFileManagerError.failedToCreateRecorder
+        }
       }
-      newRecorder.record()
+      guard newRecorder.record() else {
+        _ = newRecorder.deleteRecording()
+        throw AudioFileManagerError.failedToCreateRecorder
+      }
       let startDate = Date()
       recorder = newRecorder
       currentRecordingID = id
       currentRecordingStart = startDate
+      currentRecordingOwner = owner
       activeInputSession = sessionContext
       if claimed != nil {
         // The staged file was created while the app was idle, so its creation
         // date would otherwise misdate the recording in listings.
-        try? FileManager.default.setAttributes(
-          [.creationDate: startDate], ofItemAtPath: fileURL.path
-        )
+        try? FileManager.default.setAttributes([.creationDate: startDate], ofItemAtPath: fileURL.path)
       }
-      return fileURL
+      if owner == .auxiliary {
+        self.lifecycleHandler?(.auxiliaryStarted)
+      }
+      return RecordingStart(url: fileURL, usedWarmRecorder: claimed != nil)
     } catch {
       await audioDeviceManager.endUsingPreferredInput(session: sessionContext)
       throw AudioFileManagerError.failedToCreateRecorder
@@ -219,7 +302,8 @@ actor AudioFileManager {
   }
 
   private func claimWarmRecorder(matching context: CaptureWarmContext?) -> StagedRecorder? {
-    guard let context, let staged = self.staged, staged.context == context else { return nil }
+    guard let context, self.warmMachine.claim(for: context) else { return nil }
+    guard let staged = self.staged, staged.context == context else { return nil }
     self.staged = nil
     return staged
   }
@@ -229,12 +313,15 @@ actor AudioFileManager {
       throw AudioFileManagerError.noActiveRecording
     }
 
+    let owner = self.currentRecordingOwner
     recorder.stop()
     self.recorder = nil
     currentRecordingStart = nil
+    currentRecordingID = nil
+    currentRecordingOwner = nil
 
     let url = recorder.url
-    let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+    let attributes = (try? FileManager.default.attributesOfItem(atPath: url.path)) ?? [:]
     let fileSize = (attributes[.size] as? NSNumber)?.int64Value ?? 0
     let measuredDuration = recorder.currentTime
     let preciseDuration = (try? AVAudioPlayer(contentsOf: url).duration) ?? measuredDuration
@@ -254,11 +341,16 @@ actor AudioFileManager {
       activeInputSession = nil
     }
 
+    if owner == .auxiliary {
+      self.lifecycleHandler?(.auxiliaryEnded)
+    }
+
     return summary
   }
 
   func cancelRecording(deleteFile: Bool = true) async {
     let session = activeInputSession
+    let owner = currentRecordingOwner
 
     if let recorder {
       recorder.stop()
@@ -266,6 +358,7 @@ actor AudioFileManager {
       self.recorder = nil
       currentRecordingStart = nil
       currentRecordingID = nil
+      currentRecordingOwner = nil
       if deleteFile {
         try? FileManager.default.removeItem(at: url)
       }
@@ -274,6 +367,10 @@ actor AudioFileManager {
     if let session {
       await audioDeviceManager.endUsingPreferredInput(session: session)
       activeInputSession = nil
+    }
+
+    if owner == .auxiliary {
+      self.lifecycleHandler?(.auxiliaryEnded)
     }
   }
 

--- a/Sources/SpeakApp/AudioFileManager.swift
+++ b/Sources/SpeakApp/AudioFileManager.swift
@@ -51,7 +51,7 @@ enum AudioFileManagerError: LocalizedError {
   }
 }
 
-actor AudioFileManager {
+actor AudioFileManager { // swiftlint:disable:this type_body_length
   /// AAC encoder settings for every recording. Kept as one value so the warm-up
   /// fingerprint can name the exact profile a staged recorder was built for.
   private enum EncoderProfile {
@@ -231,6 +231,7 @@ actor AudioFileManager {
   /// Starts capture, claiming the staged recorder when `warmContext` matches
   /// the one it was prepared for. On the warm path the only work left on the
   /// hotkey→capture path is the input-device session and `record()` itself.
+  // swiftlint:disable:next function_body_length
   func startRecording(
     warmContext: CaptureWarmContext? = nil,
     owner: AudioRecordingOwner = .auxiliary
@@ -426,4 +427,4 @@ actor AudioFileManager {
     try FileManager.default.copyItem(at: url, to: destination)
     return destination
   }
-}
+} // swiftlint:disable:this file_length

--- a/Sources/SpeakApp/AudioFileManager.swift
+++ b/Sources/SpeakApp/AudioFileManager.swift
@@ -281,6 +281,8 @@ actor AudioFileManager { // swiftlint:disable:this type_body_length
         newRecorder = try AVAudioRecorder(url: fileURL, settings: EncoderProfile.settings)
         newRecorder.isMeteringEnabled = true
         guard newRecorder.prepareToRecord() else {
+          _ = newRecorder.deleteRecording()
+          try? FileManager.default.removeItem(at: fileURL)
           throw AudioFileManagerError.failedToCreateRecorder
         }
       }

--- a/Sources/SpeakApp/AudioFileManager.swift
+++ b/Sources/SpeakApp/AudioFileManager.swift
@@ -235,8 +235,7 @@ actor AudioFileManager { // swiftlint:disable:this type_body_length
   /// Starts capture, claiming the staged recorder when `warmContext` matches
   /// the one it was prepared for. On the warm path the only work left on the
   /// hotkey→capture path is the input-device session and `record()` itself.
-  // swiftlint:disable:next function_body_length
-  func startRecording(
+  func startRecording( // swiftlint:disable:this function_body_length
     warmContext: CaptureWarmContext? = nil,
     owner: AudioRecordingOwner = .auxiliary
   ) async throws -> RecordingStart {

--- a/Sources/SpeakApp/AudioFileManager.swift
+++ b/Sources/SpeakApp/AudioFileManager.swift
@@ -309,16 +309,16 @@ actor AudioFileManager {
   }
 
   func stopRecording() async throws -> RecordingSummary {
-    guard let recorder, let currentRecordingID, let start = currentRecordingStart else {
+    guard let recorder, let recordingID = currentRecordingID, let start = currentRecordingStart else {
       throw AudioFileManagerError.noActiveRecording
     }
 
     let owner = self.currentRecordingOwner
     recorder.stop()
     self.recorder = nil
-    currentRecordingStart = nil
-    currentRecordingID = nil
-    currentRecordingOwner = nil
+    self.currentRecordingStart = nil
+    self.currentRecordingID = nil
+    self.currentRecordingOwner = nil
 
     let url = recorder.url
     let attributes = (try? FileManager.default.attributesOfItem(atPath: url.path)) ?? [:]
@@ -329,7 +329,7 @@ actor AudioFileManager {
       preciseDuration.isFinite && preciseDuration > 0 ? preciseDuration : measuredDuration
 
     let summary = RecordingSummary(
-      id: currentRecordingID,
+      id: recordingID,
       url: url,
       startedAt: start,
       duration: duration,

--- a/Sources/SpeakApp/AudioFileManager.swift
+++ b/Sources/SpeakApp/AudioFileManager.swift
@@ -84,6 +84,10 @@ actor AudioFileManager { // swiftlint:disable:this type_body_length
   private var currentRecordingID: UUID?
   private var currentRecordingStart: Date?
   private var currentRecordingOwner: AudioRecordingOwner?
+  /// Reserves the recorder across permission and input-device awaits. Without
+  /// this, actor reentrancy can admit a second start or stage a new warm
+  /// recorder while the first start is still configuring its input session.
+  private var isStartingRecording = false
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
   private var staged: StagedRecorder?
   private var warmMachine = CaptureWarmStateMachine()
@@ -136,7 +140,7 @@ actor AudioFileManager { // swiftlint:disable:this type_body_length
   /// Keeping both together prevents auxiliary recording flows from invalidating
   /// the recorder while a separate coordinator still believes it is ready.
   func reconcileWarmRecorder(for context: CaptureWarmContext, enabled: Bool) {
-    guard self.recorder == nil else {
+    guard self.recorder == nil, !self.isStartingRecording else {
       self.applyWarmAction(self.warmMachine.recordingBeganWithoutClaim())
       return
     }
@@ -236,7 +240,11 @@ actor AudioFileManager { // swiftlint:disable:this type_body_length
     warmContext: CaptureWarmContext? = nil,
     owner: AudioRecordingOwner = .auxiliary
   ) async throws -> RecordingStart {
-    guard recorder == nil else { throw AudioFileManagerError.alreadyRecording }
+    guard self.recorder == nil, !self.isStartingRecording else {
+      throw AudioFileManagerError.alreadyRecording
+    }
+    self.isStartingRecording = true
+    defer { self.isStartingRecording = false }
 
     let permissionStatus = await MainActor.run {
       permissionsManager.refresh(.microphone)

--- a/Sources/SpeakApp/AudioFileManager.swift
+++ b/Sources/SpeakApp/AudioFileManager.swift
@@ -1,5 +1,7 @@
 import AVFoundation
 import Foundation
+import SpeakCore
+import os.log
 
 // @Implement: This file manages the audio recording bit rate and other audio settings. It also depends on app settings to know where to write the audio files to. It never loses any data during recording. It also has the ability to manager audio files e.g. listing, deleting, accessing etc.
 
@@ -35,6 +37,29 @@ enum AudioFileManagerError: LocalizedError {
 }
 
 actor AudioFileManager {
+  /// AAC encoder settings for every recording. Kept as one value so the warm-up
+  /// fingerprint can name the exact profile a staged recorder was built for.
+  private enum EncoderProfile {
+    static let id = "aac-44100-mono-128k"
+    static var settings: [String: Any] {
+      [
+        AVFormatIDKey: kAudioFormatMPEG4AAC,
+        AVSampleRateKey: 44_100,
+        AVNumberOfChannelsKey: 1,
+        AVEncoderBitRateKey: 128_000,
+        AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+      ]
+    }
+  }
+
+  /// A recorder created and prepared ahead of the hotkey, waiting to be claimed.
+  private struct StagedRecorder {
+    let context: CaptureWarmContext
+    let recorder: AVAudioRecorder
+    let id: UUID
+    let url: URL
+  }
+
   private let appSettings: AppSettings
   private let permissionsManager: PermissionsManager
   private let audioDeviceManager: AudioInputDeviceManager
@@ -44,6 +69,11 @@ actor AudioFileManager {
   private var currentRecordingID: UUID?
   private var currentRecordingStart: Date?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
+  private var staged: StagedRecorder?
+  private let logger = Logger(subsystem: "com.github.speakapp", category: "AudioFileManager")
+
+  /// Identifier for the encoder settings every recording uses.
+  static let encoderProfileID = EncoderProfile.id
 
   init(
     appSettings: AppSettings,
@@ -76,7 +106,61 @@ actor AudioFileManager {
     return max(0, min(1, (combinedPower - minDb) / (-minDb)))
   }
 
-  func startRecording() async throws -> URL {
+  // MARK: - Pre-warming (issue #663)
+
+  /// Creates and prepares a recorder ahead of the hotkey so session start only
+  /// has to call `record()`.
+  ///
+  /// **Privacy boundary.** `AVAudioRecorder.prepareToRecord()` creates the
+  /// output file and readies the encoder; it is `record()` that starts pulling
+  /// samples from the microphone and lights the macOS recording indicator.
+  /// Nothing in this method starts capture, and nothing here may ever call
+  /// `record()` — the staged recorder stays silent until a real session claims
+  /// it. Staging is also skipped entirely unless microphone permission has
+  /// already been granted (see ``CaptureWarmContext/isWarmable``), so warm-up
+  /// can never be the thing that provokes a permission prompt.
+  ///
+  /// - Returns: `true` when a recorder was staged for `context`.
+  func prepareWarmRecorder(for context: CaptureWarmContext) -> Bool {
+    guard self.recorder == nil, context.isWarmable else { return false }
+    if let staged = self.staged {
+      guard staged.context != context else { return true }
+      self.discardWarmRecorder()
+    }
+
+    let id = UUID()
+    let directory = URL(fileURLWithPath: context.recordingsDirectoryPath, isDirectory: true)
+    let fileURL = directory.appendingPathComponent("Recording-\(id.uuidString).m4a")
+
+    do {
+      try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      let warmRecorder = try AVAudioRecorder(url: fileURL, settings: EncoderProfile.settings)
+      warmRecorder.isMeteringEnabled = true
+      // Creates the file and readies the encoder. Does NOT open the microphone.
+      warmRecorder.prepareToRecord()
+      self.staged = StagedRecorder(context: context, recorder: warmRecorder, id: id, url: fileURL)
+      return true
+    } catch {
+      self.logger.debug("Capture pre-warm failed; falling back to cold start")
+      try? FileManager.default.removeItem(at: fileURL)
+      return false
+    }
+  }
+
+  /// Tears the staged recorder down and removes the empty file it created.
+  func discardWarmRecorder() {
+    guard let staged = self.staged else { return }
+    self.staged = nil
+    _ = staged.recorder.deleteRecording()
+    try? FileManager.default.removeItem(at: staged.url)
+  }
+
+  // MARK: - Recording
+
+  /// Starts capture, claiming the staged recorder when `warmContext` matches
+  /// the one it was prepared for. On the warm path the only work left on the
+  /// hotkey→capture path is the input-device session and `record()` itself.
+  func startRecording(warmContext: CaptureWarmContext? = nil) async throws -> URL {
     guard recorder == nil else { throw AudioFileManagerError.alreadyRecording }
 
     let permissionStatus = await MainActor.run {
@@ -84,41 +168,60 @@ actor AudioFileManager {
       return permissionsManager.status(for: .microphone)
     }
     if !permissionStatus.isGranted {
+      self.discardWarmRecorder()
       let requested = await permissionsManager.request(.microphone)
       guard requested.isGranted else {
         throw AudioFileManagerError.microphonePermissionMissing
       }
     }
 
+    let claimed = self.claimWarmRecorder(matching: warmContext)
+    // A staged recorder the starting session cannot use is stale by definition:
+    // discard it rather than leave an orphaned file behind.
+    if claimed == nil { self.discardWarmRecorder() }
+
     let sessionContext = await audioDeviceManager.beginUsingPreferredInput()
 
-    let id = UUID()
-    let startDate = Date()
-    let directory = await MainActor.run { appSettings.recordingsDirectory }
-    let fileURL = directory.appendingPathComponent("Recording-\(id.uuidString).m4a")
-
-    let settings: [String: Any] = [
-      AVFormatIDKey: kAudioFormatMPEG4AAC,
-      AVSampleRateKey: 44_100,
-      AVNumberOfChannelsKey: 1,
-      AVEncoderBitRateKey: 128_000,
-      AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
-    ]
-
     do {
-      let newRecorder = try AVAudioRecorder(url: fileURL, settings: settings)
-      newRecorder.isMeteringEnabled = true
-      newRecorder.prepareToRecord()
+      let id: UUID
+      let fileURL: URL
+      let newRecorder: AVAudioRecorder
+      if let claimed {
+        id = claimed.id
+        fileURL = claimed.url
+        newRecorder = claimed.recorder
+      } else {
+        id = UUID()
+        let directory = await MainActor.run { appSettings.recordingsDirectory }
+        fileURL = directory.appendingPathComponent("Recording-\(id.uuidString).m4a")
+        newRecorder = try AVAudioRecorder(url: fileURL, settings: EncoderProfile.settings)
+        newRecorder.isMeteringEnabled = true
+        newRecorder.prepareToRecord()
+      }
       newRecorder.record()
+      let startDate = Date()
       recorder = newRecorder
       currentRecordingID = id
       currentRecordingStart = startDate
       activeInputSession = sessionContext
+      if claimed != nil {
+        // The staged file was created while the app was idle, so its creation
+        // date would otherwise misdate the recording in listings.
+        try? FileManager.default.setAttributes(
+          [.creationDate: startDate], ofItemAtPath: fileURL.path
+        )
+      }
       return fileURL
     } catch {
       await audioDeviceManager.endUsingPreferredInput(session: sessionContext)
       throw AudioFileManagerError.failedToCreateRecorder
     }
+  }
+
+  private func claimWarmRecorder(matching context: CaptureWarmContext?) -> StagedRecorder? {
+    guard let context, let staged = self.staged, staged.context == context else { return nil }
+    self.staged = nil
+    return staged
   }
 
   func stopRecording() async throws -> RecordingSummary {

--- a/Sources/SpeakApp/CaptureWarmCoordinator.swift
+++ b/Sources/SpeakApp/CaptureWarmCoordinator.swift
@@ -1,11 +1,67 @@
+import AppKit
 import Combine
 import Foundation
+import Network
 import SpeakCore
-import os.log
+
+@MainActor
+protocol CaptureWarmScheduling: AnyObject {
+  func schedule(after delay: TimeInterval, operation: @escaping @MainActor @Sendable () -> Void)
+  func cancel()
+}
+
+@MainActor
+private final class SystemCaptureWarmScheduler: CaptureWarmScheduling {
+  private var task: Task<Void, Never>?
+
+  func schedule(after delay: TimeInterval, operation: @escaping @MainActor @Sendable () -> Void) {
+    self.cancel()
+    self.task = Task { @MainActor in
+      let nanoseconds = UInt64(max(0, delay) * 1_000_000_000)
+      try? await Task.sleep(nanoseconds: nanoseconds)
+      guard !Task.isCancelled else { return }
+      operation()
+    }
+  }
+
+  func cancel() {
+    self.task?.cancel()
+    self.task = nil
+  }
+}
+
+@MainActor
+protocol CaptureWarmNetworkMonitoring: AnyObject {
+  var statusDidChange: ((NWPath.Status) -> Void)? { get set }
+  func start()
+  func cancel()
+}
+
+@MainActor
+private final class SystemCaptureWarmNetworkMonitor: CaptureWarmNetworkMonitoring {
+  var statusDidChange: ((NWPath.Status) -> Void)?
+
+  private let monitor = NWPathMonitor()
+  private let queue = DispatchQueue(label: "com.github.speakapp.capture-warm-network")
+
+  func start() {
+    self.monitor.pathUpdateHandler = { [weak self] path in
+      Task { @MainActor [weak self] in
+        self?.statusDidChange?(path.status)
+      }
+    }
+    self.monitor.start(queue: self.queue)
+  }
+
+  func cancel() {
+    self.monitor.cancel()
+    self.statusDidChange = nil
+  }
+}
 
 /// Keeps the capture start path warm while the app is idle (issue #663).
 ///
-/// Two independent warm-ups, both driven from the same triggers:
+/// Two independent warm-ups, both driven from the same lifecycle:
 ///
 /// 1. **Audio input.** A recorder is created and prepared while idle so the
 ///    hotkey path only has to call `record()`. The microphone is never opened
@@ -13,11 +69,9 @@ import os.log
 ///    privacy boundary — and the staged recorder is discarded and rebuilt
 ///    whenever the audio route, device selection, recordings directory or
 ///    microphone permission changes.
-/// 2. **Streaming provider endpoint.** A DNS + TLS handshake against the
-///    selected provider's host, so the `wss://` upgrade at session start skips
-///    resolution and can resume the TLS session. No credential is sent and no
-///    provider-side session is created; see ``LiveStreamWarmUp`` for why no
-///    provider gets a fully pre-connected socket.
+/// 2. **Streaming provider endpoint.** A credential-free HTTPS probe for live
+///    clients that use `URLSession.shared`. This warms resolver state and may
+///    seed TLS resumption, but does not claim to pre-connect the WebSocket.
 ///
 /// Warm-up is suspended for the duration of a session and resumed when the app
 /// returns to idle, so it never competes with a live capture.
@@ -28,26 +82,79 @@ final class CaptureWarmCoordinator {
   private let audioInputDeviceManager: AudioInputDeviceManager
   private let audioFileManager: AudioFileManager
   private let endpointWarmer: StreamingEndpointWarming
-  private let logger = Logger(subsystem: "com.github.speakapp", category: "CaptureWarmUp")
+  private let networkMonitor: CaptureWarmNetworkMonitoring
+  private let scheduler: CaptureWarmScheduling
+  private let workspaceNotificationCenter: NotificationCenter
+  private let notificationCenter: NotificationCenter
+  private let now: @MainActor () -> Date
+  private let warmAudio: @MainActor (CaptureWarmContext, Bool) async -> Void
+  private let invalidateAudio: @MainActor () async -> Void
 
-  private var machine = CaptureWarmStateMachine()
   private var streamTracker = LiveStreamWarmTracker()
   private var isSessionActive = false
+  private var isStarted = false
+  private var isInvalidated = false
+  private var lastNetworkStatus: NWPath.Status?
   private var cancellables: Set<AnyCancellable> = []
+  private var workspaceObservers: [NSObjectProtocol] = []
+  private var observers: [NSObjectProtocol] = []
+  private var audioWarmTask: Task<Void, Never>?
+  private var endpointProbeTask: Task<Void, Never>?
 
   init(
     appSettings: AppSettings,
     permissionsManager: PermissionsManager,
     audioInputDeviceManager: AudioInputDeviceManager,
     audioFileManager: AudioFileManager,
-    endpointWarmer: StreamingEndpointWarming = StreamingEndpointWarmer()
+    endpointWarmer: StreamingEndpointWarming? = nil,
+    networkMonitor: CaptureWarmNetworkMonitoring? = nil,
+    scheduler: CaptureWarmScheduling? = nil,
+    workspaceNotificationCenter: NotificationCenter? = nil,
+    notificationCenter: NotificationCenter? = nil,
+    now: (@MainActor () -> Date)? = nil,
+    warmAudio: (@MainActor (CaptureWarmContext, Bool) async -> Void)? = nil,
+    invalidateAudio: (@MainActor () async -> Void)? = nil
   ) {
     self.appSettings = appSettings
     self.permissionsManager = permissionsManager
     self.audioInputDeviceManager = audioInputDeviceManager
     self.audioFileManager = audioFileManager
-    self.endpointWarmer = endpointWarmer
+    self.endpointWarmer = endpointWarmer ?? StreamingEndpointWarmer()
+    self.networkMonitor = networkMonitor ?? SystemCaptureWarmNetworkMonitor()
+    self.scheduler = scheduler ?? SystemCaptureWarmScheduler()
+    self.workspaceNotificationCenter = workspaceNotificationCenter ?? NSWorkspace.shared.notificationCenter
+    self.notificationCenter = notificationCenter ?? .default
+    self.now = now ?? Date.init
+    if let warmAudio {
+      self.warmAudio = warmAudio
+    } else {
+      self.warmAudio = { context, enabled in
+        await audioFileManager.reconcileWarmRecorder(for: context, enabled: enabled)
+      }
+    }
+    self.invalidateAudio = invalidateAudio ?? {
+      await audioFileManager.invalidateWarmRecorder()
+    }
+  }
+
+  func start() {
+    guard !self.isStarted else { return }
+    self.isStarted = true
     self.observeEnvironmentChanges()
+    self.observeSleepAndWake()
+    self.observeCredentialChanges()
+    self.observeNetworkChanges()
+
+    let eventSink = CaptureWarmLifecycleSink(coordinator: self)
+    let manager = self.audioFileManager
+    Task { [weak self, eventSink] in
+      await manager.setRecordingLifecycleHandler { event in
+        eventSink.handle(event)
+      }
+      await MainActor.run {
+        self?.warmUp()
+      }
+    }
   }
 
   // MARK: - Triggers
@@ -55,84 +162,74 @@ final class CaptureWarmCoordinator {
   /// Brings both warm-ups in line with the current environment. Safe to call
   /// from any trigger; it no-ops when nothing has changed.
   func warmUp() {
-    guard !self.isSessionActive else { return }
+    guard self.isStarted, !self.isInvalidated, !self.isSessionActive else { return }
+    self.permissionsManager.refresh(.microphone)
+    guard self.permissionsManager.status(for: .microphone).isGranted else {
+      self.reconcileAudioWarmUp()
+      self.invalidateEndpointWarmUp()
+      return
+    }
     self.reconcileAudioWarmUp()
     self.reconcileEndpointWarmUp()
   }
 
   /// Called when a session starts. Returns the context to hand to
-  /// `AudioFileManager.startRecording(warmContext:)` when a staged recorder is
-  /// ready for exactly this environment, otherwise `nil` (cold path).
+  /// `AudioFileManager.startRecording(warmContext:)`. The recorder actor owns
+  /// the authoritative warm state and reports whether it actually claimed it.
   func claimWarmContext() -> CaptureWarmContext? {
-    self.isSessionActive = true
+    self.sessionWillBegin()
     let context = self.currentContext()
-    guard self.machine.claim(for: context) else {
-      // Anything staged is for a different environment; drop it rather than
-      // leave the file behind.
-      self.apply(self.machine.reset())
-      return nil
-    }
-    return context
+    return self.appSettings.audioPreWarmingEnabled && context.isWarmable ? context : nil
+  }
+
+  func sessionWillBegin() {
+    self.isSessionActive = true
+    self.scheduler.cancel()
+    self.endpointProbeTask?.cancel()
+    self.endpointProbeTask = nil
+    self.streamTracker.invalidate()
   }
 
   /// Called when the app returns to idle after a session.
   func sessionDidEnd() {
+    guard !self.isInvalidated else { return }
     self.isSessionActive = false
     self.warmUp()
   }
 
-  /// Drops all warm state, e.g. at app termination.
-  func invalidate() {
-    let action = self.machine.reset()
+  /// Drops all warm state and waits for the staged file to be removed.
+  func invalidate() async {
+    guard !self.isInvalidated else { return }
+    self.isInvalidated = true
+    self.scheduler.cancel()
+    self.endpointProbeTask?.cancel()
+    self.audioWarmTask?.cancel()
+    self.networkMonitor.cancel()
+    for observer in self.workspaceObservers {
+      self.workspaceNotificationCenter.removeObserver(observer)
+    }
+    self.workspaceObservers.removeAll()
+    for observer in self.observers {
+      self.notificationCenter.removeObserver(observer)
+    }
+    self.observers.removeAll()
+    self.cancellables.removeAll()
     self.streamTracker.invalidate()
-    self.apply(action)
+    await self.audioWarmTask?.value
+    await self.endpointProbeTask?.value
+    await self.audioFileManager.setRecordingLifecycleHandler(nil)
+    await self.invalidateAudio()
   }
 
   // MARK: - Audio input
 
   private func reconcileAudioWarmUp() {
-    // Off the hot path, so this is the right place to pay for a permission
-    // refresh: `currentContext()` is also called at session start and must stay
-    // cheap there.
-    self.permissionsManager.refresh(.microphone)
     let context = self.currentContext()
-    let action = self.machine.reconcile(
-      with: context,
-      enabled: self.appSettings.audioPreWarmingEnabled
-    )
-    self.apply(action)
-  }
-
-  private func apply(_ action: CaptureWarmAction) {
-    switch action {
-    case .none:
-      return
-    case .discard:
-      let manager = self.audioFileManager
-      Task { await manager.discardWarmRecorder() }
-    case .prepare(let context):
-      self.stage(context, discardFirst: false)
-    case .discardThenPrepare(let context):
-      self.stage(context, discardFirst: true)
-    }
-  }
-
-  private func stage(_ context: CaptureWarmContext, discardFirst: Bool) {
-    let manager = self.audioFileManager
-    Task { [weak self] in
-      if discardFirst { await manager.discardWarmRecorder() }
-      let prepared = await manager.prepareWarmRecorder(for: context)
-      guard let self else { return }
-      guard prepared else {
-        self.logger.debug("Capture pre-warm did not stage a recorder; next session starts cold")
-        self.machine.markFailed(context)
-        return
-      }
-      // The environment may have moved on while we were staging; if so the
-      // machine rejects the result and the recorder must not be kept.
-      if !self.machine.markReady(context) {
-        await manager.discardWarmRecorder()
-      }
+    let enabled = self.appSettings.audioPreWarmingEnabled
+    self.audioWarmTask?.cancel()
+    self.audioWarmTask = Task { [weak self] in
+      guard !Task.isCancelled, let self else { return }
+      await self.warmAudio(context, enabled)
     }
   }
 
@@ -159,32 +256,76 @@ final class CaptureWarmCoordinator {
 
   private func reconcileEndpointWarmUp() {
     let provider = self.currentStreamingProvider()
+    let now = self.now()
     guard
       let host = self.streamTracker.hostNeedingWarmUp(
         for: provider,
-        now: Date(),
+        now: now,
         enabled: self.appSettings.connectionPreWarmingEnabled
       )
     else {
+      self.scheduleEndpointRefresh(for: provider, now: now)
       return
     }
 
     let warmer = self.endpointWarmer
-    Task { [weak self] in
+    self.endpointProbeTask?.cancel()
+    self.endpointProbeTask = Task { [weak self] in
       let succeeded = await warmer.warmUp(host: host)
-      guard let self else { return }
+      guard let self, !Task.isCancelled else { return }
       if succeeded {
-        self.streamTracker.markWarmed(host: host, at: Date())
+        let completedAt = self.now()
+        if self.streamTracker.markWarmed(host: host, at: completedAt) {
+          self.scheduleEndpointRefresh(for: self.currentStreamingProvider(), now: completedAt)
+        }
       } else {
         self.streamTracker.markFailed(host: host)
+        self.scheduleEndpointRetry()
       }
     }
+  }
+
+  private func scheduleEndpointRefresh(
+    for provider: LiveTranscriptionProviderID?,
+    now: Date
+  ) {
+    guard let deadline = self.streamTracker.refreshDeadline(
+      for: provider,
+      enabled: self.appSettings.connectionPreWarmingEnabled
+    ) else {
+      self.scheduler.cancel()
+      return
+    }
+    self.scheduleEndpointWake(after: max(0, deadline.timeIntervalSince(now)))
+  }
+
+  private func scheduleEndpointRetry() {
+    self.scheduleEndpointWake(after: 15)
+  }
+
+  private func scheduleEndpointWake(after delay: TimeInterval) {
+    self.scheduler.schedule(after: delay) { [weak self] in
+      self?.warmUp()
+    }
+  }
+
+  private func invalidateEndpointWarmUp() {
+    self.scheduler.cancel()
+    self.endpointProbeTask?.cancel()
+    self.endpointProbeTask = nil
+    self.streamTracker.invalidate()
   }
 
   /// The streaming provider a session would use right now, or `nil` when the
   /// current mode does not stream to a cloud provider.
   private func currentStreamingProvider() -> LiveTranscriptionProviderID? {
     guard self.appSettings.transcriptionMode == .liveNative else { return nil }
+    let availability = ModelCredentialResolver.availability(
+      for: self.appSettings.liveTranscriptionModel,
+      purpose: .liveTranscription,
+      storedAPIKeyIdentifiers: self.appSettings.trackedAPIKeyIdentifiers
+    )
+    if case .missing = availability { return nil }
     return LiveTranscriptionRouting.route(for: self.appSettings.liveTranscriptionModel)?.provider
   }
 
@@ -200,17 +341,13 @@ final class CaptureWarmCoordinator {
     self.rewarm(on: self.appSettings.$recordingsDirectory)
     self.rewarm(on: self.appSettings.$audioPreWarmingEnabled)
     self.rewarm(on: self.appSettings.$connectionPreWarmingEnabled)
+    self.rewarm(on: self.permissionsManager.$statuses)
 
-    // A provider change makes the warm host wrong, not merely stale.
-    self.appSettings.$liveTranscriptionModel
-      .removeDuplicates()
-      .dropFirst()
-      .receive(on: RunLoop.main)
-      .sink { [weak self] _ in
-        self?.streamTracker.invalidate()
-        self?.warmUp()
-      }
-      .store(in: &self.cancellables)
+    self.invalidateEndpoint(on: self.appSettings.$transcriptionMode)
+    self.invalidateEndpoint(on: self.appSettings.$liveTranscriptionModel)
+    self.invalidateEndpoint(on: self.appSettings.$preferredLocaleIdentifier)
+    self.invalidateEndpoint(on: self.appSettings.$assemblyAIKeyterms)
+    self.invalidateEndpoint(on: self.appSettings.$trackedAPIKeyIdentifiers)
   }
 
   private func rewarm<P: Publisher>(on publisher: P) where P.Output: Equatable, P.Failure == Never {
@@ -220,5 +357,92 @@ final class CaptureWarmCoordinator {
       .receive(on: RunLoop.main)
       .sink { [weak self] _ in self?.warmUp() }
       .store(in: &self.cancellables)
+  }
+
+  private func invalidateEndpoint<P: Publisher>(on publisher: P)
+    where P.Output: Equatable, P.Failure == Never {
+    publisher
+      .removeDuplicates()
+      .dropFirst()
+      .receive(on: RunLoop.main)
+      .sink { [weak self] _ in
+        self?.invalidateEndpointWarmUp()
+        self?.warmUp()
+      }
+      .store(in: &self.cancellables)
+  }
+
+  private func observeSleepAndWake() {
+    let willSleep = self.workspaceNotificationCenter.addObserver(
+      forName: NSWorkspace.willSleepNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor [weak self] in
+        self?.invalidateEndpointWarmUp()
+      }
+    }
+    let didWake = self.workspaceNotificationCenter.addObserver(
+      forName: NSWorkspace.didWakeNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor [weak self] in
+        self?.invalidateEndpointWarmUp()
+        self?.warmUp()
+      }
+    }
+    self.workspaceObservers = [willSleep, didWake]
+  }
+
+  private func observeNetworkChanges() {
+    self.networkMonitor.statusDidChange = { [weak self] status in
+      guard let self else { return }
+      guard self.lastNetworkStatus != status else { return }
+      self.lastNetworkStatus = status
+      self.invalidateEndpointWarmUp()
+      if status == .satisfied {
+        self.warmUp()
+      }
+    }
+    self.networkMonitor.start()
+  }
+
+  private func observeCredentialChanges() {
+    let observer = self.notificationCenter.addObserver(
+      forName: .secureAppStorageDidChange,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor [weak self] in
+        self?.invalidateEndpointWarmUp()
+        self?.warmUp()
+      }
+    }
+    self.observers.append(observer)
+  }
+
+  fileprivate func handleRecordingLifecycle(_ event: AudioRecordingLifecycleEvent) {
+    switch event {
+    case .auxiliaryStarted:
+      self.isSessionActive = true
+      self.scheduler.cancel()
+    case .auxiliaryEnded:
+      self.sessionDidEnd()
+    }
+  }
+}
+
+private final class CaptureWarmLifecycleSink: @unchecked Sendable {
+  private weak var coordinator: CaptureWarmCoordinator?
+
+  init(coordinator: CaptureWarmCoordinator) {
+    self.coordinator = coordinator
+  }
+
+  func handle(_ event: AudioRecordingLifecycleEvent) {
+    Task { @MainActor [weak self] in
+      self?.coordinator?.handleRecordingLifecycle(event)
+    }
   }
 }

--- a/Sources/SpeakApp/CaptureWarmCoordinator.swift
+++ b/Sources/SpeakApp/CaptureWarmCoordinator.swift
@@ -76,7 +76,7 @@ private final class SystemCaptureWarmNetworkMonitor: CaptureWarmNetworkMonitorin
 /// Warm-up is suspended for the duration of a session and resumed when the app
 /// returns to idle, so it never competes with a live capture.
 @MainActor
-final class CaptureWarmCoordinator {
+final class CaptureWarmCoordinator { // swiftlint:disable:this type_body_length
   private let appSettings: AppSettings
   private let permissionsManager: PermissionsManager
   private let audioInputDeviceManager: AudioInputDeviceManager
@@ -445,4 +445,4 @@ private final class CaptureWarmLifecycleSink: @unchecked Sendable {
       self?.coordinator?.handleRecordingLifecycle(event)
     }
   }
-}
+} // swiftlint:disable:this file_length

--- a/Sources/SpeakApp/CaptureWarmCoordinator.swift
+++ b/Sources/SpeakApp/CaptureWarmCoordinator.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Combine
 import Foundation
 import SpeakCore
@@ -125,6 +124,7 @@ final class CaptureWarmCoordinator {
       let prepared = await manager.prepareWarmRecorder(for: context)
       guard let self else { return }
       guard prepared else {
+        self.logger.debug("Capture pre-warm did not stage a recorder; next session starts cold")
         self.machine.markFailed(context)
         return
       }

--- a/Sources/SpeakApp/CaptureWarmCoordinator.swift
+++ b/Sources/SpeakApp/CaptureWarmCoordinator.swift
@@ -185,6 +185,8 @@ final class CaptureWarmCoordinator { // swiftlint:disable:this type_body_length
   func sessionWillBegin() {
     self.isSessionActive = true
     self.scheduler.cancel()
+    self.audioWarmTask?.cancel()
+    self.audioWarmTask = nil
     self.endpointProbeTask?.cancel()
     self.endpointProbeTask = nil
     self.streamTracker.invalidate()

--- a/Sources/SpeakApp/CaptureWarmCoordinator.swift
+++ b/Sources/SpeakApp/CaptureWarmCoordinator.swift
@@ -1,0 +1,224 @@
+import AppKit
+import Combine
+import Foundation
+import SpeakCore
+import os.log
+
+/// Keeps the capture start path warm while the app is idle (issue #663).
+///
+/// Two independent warm-ups, both driven from the same triggers:
+///
+/// 1. **Audio input.** A recorder is created and prepared while idle so the
+///    hotkey path only has to call `record()`. The microphone is never opened
+///    by pre-warming — see `AudioFileManager.prepareWarmRecorder(for:)` for the
+///    privacy boundary — and the staged recorder is discarded and rebuilt
+///    whenever the audio route, device selection, recordings directory or
+///    microphone permission changes.
+/// 2. **Streaming provider endpoint.** A DNS + TLS handshake against the
+///    selected provider's host, so the `wss://` upgrade at session start skips
+///    resolution and can resume the TLS session. No credential is sent and no
+///    provider-side session is created; see ``LiveStreamWarmUp`` for why no
+///    provider gets a fully pre-connected socket.
+///
+/// Warm-up is suspended for the duration of a session and resumed when the app
+/// returns to idle, so it never competes with a live capture.
+@MainActor
+final class CaptureWarmCoordinator {
+  private let appSettings: AppSettings
+  private let permissionsManager: PermissionsManager
+  private let audioInputDeviceManager: AudioInputDeviceManager
+  private let audioFileManager: AudioFileManager
+  private let endpointWarmer: StreamingEndpointWarming
+  private let logger = Logger(subsystem: "com.github.speakapp", category: "CaptureWarmUp")
+
+  private var machine = CaptureWarmStateMachine()
+  private var streamTracker = LiveStreamWarmTracker()
+  private var isSessionActive = false
+  private var cancellables: Set<AnyCancellable> = []
+
+  init(
+    appSettings: AppSettings,
+    permissionsManager: PermissionsManager,
+    audioInputDeviceManager: AudioInputDeviceManager,
+    audioFileManager: AudioFileManager,
+    endpointWarmer: StreamingEndpointWarming = StreamingEndpointWarmer()
+  ) {
+    self.appSettings = appSettings
+    self.permissionsManager = permissionsManager
+    self.audioInputDeviceManager = audioInputDeviceManager
+    self.audioFileManager = audioFileManager
+    self.endpointWarmer = endpointWarmer
+    self.observeEnvironmentChanges()
+  }
+
+  // MARK: - Triggers
+
+  /// Brings both warm-ups in line with the current environment. Safe to call
+  /// from any trigger; it no-ops when nothing has changed.
+  func warmUp() {
+    guard !self.isSessionActive else { return }
+    self.reconcileAudioWarmUp()
+    self.reconcileEndpointWarmUp()
+  }
+
+  /// Called when a session starts. Returns the context to hand to
+  /// `AudioFileManager.startRecording(warmContext:)` when a staged recorder is
+  /// ready for exactly this environment, otherwise `nil` (cold path).
+  func claimWarmContext() -> CaptureWarmContext? {
+    self.isSessionActive = true
+    let context = self.currentContext()
+    guard self.machine.claim(for: context) else {
+      // Anything staged is for a different environment; drop it rather than
+      // leave the file behind.
+      self.apply(self.machine.reset())
+      return nil
+    }
+    return context
+  }
+
+  /// Called when the app returns to idle after a session.
+  func sessionDidEnd() {
+    self.isSessionActive = false
+    self.warmUp()
+  }
+
+  /// Drops all warm state, e.g. at app termination.
+  func invalidate() {
+    let action = self.machine.reset()
+    self.streamTracker.invalidate()
+    self.apply(action)
+  }
+
+  // MARK: - Audio input
+
+  private func reconcileAudioWarmUp() {
+    // Off the hot path, so this is the right place to pay for a permission
+    // refresh: `currentContext()` is also called at session start and must stay
+    // cheap there.
+    self.permissionsManager.refresh(.microphone)
+    let context = self.currentContext()
+    let action = self.machine.reconcile(
+      with: context,
+      enabled: self.appSettings.audioPreWarmingEnabled
+    )
+    self.apply(action)
+  }
+
+  private func apply(_ action: CaptureWarmAction) {
+    switch action {
+    case .none:
+      return
+    case .discard:
+      let manager = self.audioFileManager
+      Task { await manager.discardWarmRecorder() }
+    case .prepare(let context):
+      self.stage(context, discardFirst: false)
+    case .discardThenPrepare(let context):
+      self.stage(context, discardFirst: true)
+    }
+  }
+
+  private func stage(_ context: CaptureWarmContext, discardFirst: Bool) {
+    let manager = self.audioFileManager
+    Task { [weak self] in
+      if discardFirst { await manager.discardWarmRecorder() }
+      let prepared = await manager.prepareWarmRecorder(for: context)
+      guard let self else { return }
+      guard prepared else {
+        self.machine.markFailed(context)
+        return
+      }
+      // The environment may have moved on while we were staging; if so the
+      // machine rejects the result and the recorder must not be kept.
+      if !self.machine.markReady(context) {
+        await manager.discardWarmRecorder()
+      }
+    }
+  }
+
+  /// The environment the next session would start in.
+  ///
+  /// `requiresDefaultDeviceSwitch` mirrors `AudioInputDeviceManager`: a
+  /// preferred device that is not already the system default is only activated
+  /// at session start, so a recorder staged beforehand could capture from the
+  /// wrong microphone. Those sessions deliberately take the cold path.
+  private func currentContext() -> CaptureWarmContext {
+    let preferredUID = self.audioInputDeviceManager.selectedDeviceUID
+    let activeUID = self.audioInputDeviceManager.activeDeviceUID
+    let requiresSwitch = preferredUID != nil && preferredUID != activeUID
+    return CaptureWarmContext(
+      inputDeviceUID: activeUID,
+      recordingsDirectoryPath: self.appSettings.recordingsDirectory.path,
+      encoderProfileID: AudioFileManager.encoderProfileID,
+      requiresDefaultDeviceSwitch: requiresSwitch,
+      microphonePermissionGranted: self.permissionsManager.status(for: .microphone).isGranted
+    )
+  }
+
+  // MARK: - Streaming endpoint
+
+  private func reconcileEndpointWarmUp() {
+    let provider = self.currentStreamingProvider()
+    guard
+      let host = self.streamTracker.hostNeedingWarmUp(
+        for: provider,
+        now: Date(),
+        enabled: self.appSettings.connectionPreWarmingEnabled
+      )
+    else {
+      return
+    }
+
+    let warmer = self.endpointWarmer
+    Task { [weak self] in
+      let succeeded = await warmer.warmUp(host: host)
+      guard let self else { return }
+      if succeeded {
+        self.streamTracker.markWarmed(host: host, at: Date())
+      } else {
+        self.streamTracker.markFailed(host: host)
+      }
+    }
+  }
+
+  /// The streaming provider a session would use right now, or `nil` when the
+  /// current mode does not stream to a cloud provider.
+  private func currentStreamingProvider() -> LiveTranscriptionProviderID? {
+    guard self.appSettings.transcriptionMode == .liveNative else { return nil }
+    return LiveTranscriptionRouting.route(for: self.appSettings.liveTranscriptionModel)?.provider
+  }
+
+  // MARK: - Observation
+
+  /// Re-warms on everything that can invalidate a staged recorder or a warm
+  /// endpoint. The audio device publishers are fed by the CoreAudio hardware
+  /// listeners `AudioInputDeviceManager` already installs, so route changes
+  /// (device added/removed, default input changed) land here for free.
+  private func observeEnvironmentChanges() {
+    self.rewarm(on: self.audioInputDeviceManager.$activeDeviceUID)
+    self.rewarm(on: self.audioInputDeviceManager.$selectedDeviceUID)
+    self.rewarm(on: self.appSettings.$recordingsDirectory)
+    self.rewarm(on: self.appSettings.$audioPreWarmingEnabled)
+    self.rewarm(on: self.appSettings.$connectionPreWarmingEnabled)
+
+    // A provider change makes the warm host wrong, not merely stale.
+    self.appSettings.$liveTranscriptionModel
+      .removeDuplicates()
+      .dropFirst()
+      .receive(on: RunLoop.main)
+      .sink { [weak self] _ in
+        self?.streamTracker.invalidate()
+        self?.warmUp()
+      }
+      .store(in: &self.cancellables)
+  }
+
+  private func rewarm<P: Publisher>(on publisher: P) where P.Output: Equatable, P.Failure == Never {
+    publisher
+      .removeDuplicates()
+      .dropFirst()
+      .receive(on: RunLoop.main)
+      .sink { [weak self] _ in self?.warmUp() }
+      .store(in: &self.cancellables)
+  }
+}

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -76,9 +76,11 @@ final class MainManager: ObservableObject {
   var activeSession: ActiveSession? {
     didSet {
       // Every session-teardown path clears `activeSession`, so this is the one
-      // place profile overrides are reverted back to the user's own settings.
+      // place profile overrides are reverted back to the user's own settings —
+      // and the one place capture pre-warming can safely resume.
       if activeSession == nil {
         profileApplier.end(settings: appSettings, postProcessing: postProcessingManager)
+        captureWarmer?.sessionDidEnd()
       }
     }
   }
@@ -86,6 +88,10 @@ final class MainManager: ObservableObject {
   /// Hands-free ("armed") dictation. Created eagerly but inert until the user
   /// arms it, which only the hands-free setting allows.
   private(set) lazy var handsFreeCoordinator = makeHandsFreeCoordinator()
+
+  /// Keeps the audio recorder and the streaming provider's network path warm
+  /// while idle so hotkey→capture does not pay setup cost (issue #663).
+  private var captureWarmer: CaptureWarmCoordinator?
   /// Guards against re-entrant calls to endSession (e.g. silence detection + user hotkey racing).
   var isEndingSession = false
   let recordingStopTimeout: TimeInterval = 8
@@ -238,7 +244,17 @@ final class MainManager: ObservableObject {
       queue: .main
     ) { [weak self] _ in
       self?.stopAudioLevelMonitoring()
+      self?.captureWarmer?.invalidate()
     }
+
+    let warmer = CaptureWarmCoordinator(
+      appSettings: appSettings,
+      permissionsManager: permissionsManager,
+      audioInputDeviceManager: audioInputDeviceManager,
+      audioFileManager: audioFileManager
+    )
+    captureWarmer = warmer
+    warmer.warmUp()
   }
 
   /// Applies a live-transcript snapshot to the preview and the HUD.
@@ -300,7 +316,8 @@ final class MainManager: ObservableObject {
   func toggleRecordingFromUI() {
     guard !isEndingSession else { return }
     if activeSession == nil {
-      Task { await startSession(trigger: .uiButton) }
+      let triggeredAt = Date()
+      Task { await startSession(trigger: .uiButton, triggeredAt: triggeredAt) }
     } else {
       Task { await endSession(trigger: .uiButton) }
     }
@@ -335,10 +352,10 @@ final class MainManager: ObservableObject {
   }
 
   /// Hands-free replaces press-to-talk with press-to-arm.
-  private func handleHoldStartGesture() async {
+  private func handleHoldStartGesture(triggeredAt: Date) async {
     guard appSettings.hotKeyActivationStyle.allowsHold else { return }
     if await handleHandsFreeHotKey() { return }
-    await startSession(trigger: .hold)
+    await startSession(trigger: .hold, triggeredAt: triggeredAt)
   }
 
   /// The arming press already consumed the gesture, so releasing the key must
@@ -358,7 +375,7 @@ final class MainManager: ObservableObject {
 
   /// Double-tap toggles: it arms hands-free dictation when that mode is on,
   /// otherwise it starts a session or ends the one it started.
-  private func handleDoubleTapGesture() async {
+  private func handleDoubleTapGesture(triggeredAt: Date) async {
     guard appSettings.hotKeyActivationStyle.allowsDoubleTap else { return }
     let now = ProcessInfo.processInfo.systemUptime
     guard now - lastDoubleTapEventUptime >= 0.25 else { return }
@@ -370,15 +387,19 @@ final class MainManager: ObservableObject {
       guard session.gesture == .doubleTap else { return }
       await endSession(trigger: .doubleTap)
     } else {
-      await startSession(trigger: .doubleTap)
+      await startSession(trigger: .doubleTap, triggeredAt: triggeredAt)
     }
   }
 
+  // swiftlint:disable:next function_body_length
   private func configureHotKeys() {
     hotKeyTokens.append(
       hotKeyManager.register(gesture: .holdStart) { [weak self] in
+        // Stamped here, before the actor hop, so the latency dashboard measures
+        // from the key press rather than from where `startSession` gets to run.
+        let triggeredAt = Date()
         Task { @MainActor in
-          await self?.handleHoldStartGesture()
+          await self?.handleHoldStartGesture(triggeredAt: triggeredAt)
         }
       }
     )
@@ -393,8 +414,9 @@ final class MainManager: ObservableObject {
 
     hotKeyTokens.append(
       hotKeyManager.register(gesture: .doubleTap) { [weak self] in
+        let triggeredAt = Date()
         Task { @MainActor in
-          await self?.handleDoubleTapGesture()
+          await self?.handleDoubleTapGesture(triggeredAt: triggeredAt)
         }
       }
     )
@@ -474,7 +496,8 @@ final class MainManager: ObservableObject {
   // swiftlint:disable:next cyclomatic_complexity function_body_length
   func startSession(
     trigger: SessionTriggerSource,
-    preRollBuffers: [AVAudioPCMBuffer] = []
+    preRollBuffers: [AVAudioPCMBuffer] = [],
+    triggeredAt: Date = Date()
   ) async -> HandsFreeCaptureStartOutcome {
     guard activeSession == nil else { return .rejected(.captureFailed) }
 
@@ -531,7 +554,11 @@ final class MainManager: ObservableObject {
     clearRetryData()
 
     let gesture = trigger.historyGesture
-    let session = ActiveSession(gesture: gesture, hotKeyDescription: appSettings.selectedHotKey.displayString)
+    let session = ActiveSession(
+      gesture: gesture,
+      hotKeyDescription: appSettings.selectedHotKey.displayString,
+      triggeredAt: triggeredAt
+    )
     session.outputTarget = TextOutputTarget.capture()
     session.diagnosticContext = makeHistoryDiagnosticContext()
     activeSession = session
@@ -577,9 +604,13 @@ final class MainManager: ObservableObject {
       hudManager.beginRecording(profileName: profileApplier.activeProfileName)
     }
 
+    // Claim the recorder staged while idle. Returns nil — and the cold path
+    // runs — whenever the environment moved since it was staged.
+    let warmContext = captureWarmer?.claimWarmContext()
+
     do {
-      _ = try await audioFileManager.startRecording()
-      recordCaptureStart(for: session)
+      _ = try await audioFileManager.startRecording(warmContext: warmContext)
+      recordCaptureStart(for: session, wasWarm: warmContext != nil)
       startAudioLevelMonitoring()
       if isStreamingTranscriptionMode {
         try await transcriptionManager.startLiveTranscription(
@@ -602,13 +633,16 @@ final class MainManager: ObservableObject {
   }
 
   /// Latency checkpoint: the recorder is live. hotkey → capture-start is the
-  /// cold-start figure competitors market, so log it explicitly every session.
-  private func recordCaptureStart(for session: ActiveSession) {
+  /// cold-start figure competitors market, so log it explicitly every session,
+  /// tagged with whether the pre-warmed recorder was used (issue #663) so the
+  /// dashboard percentiles can be read against the warm/cold split.
+  private func recordCaptureStart(for session: ActiveSession, wasWarm: Bool) {
     session.captureStarted = Date()
     if let coldStartMs = SessionLatencyMetrics.milliseconds(
       from: session.recordingStarted, to: session.captureStarted
     ) {
-      self.logger.info("Latency: capture started \(coldStartMs)ms after trigger (cold start)")
+      let path = wasWarm ? "pre-warmed" : "cold"
+      self.logger.info("Latency: capture started \(coldStartMs)ms after trigger (\(path, privacy: .public))")
     }
   }
 

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -400,7 +400,6 @@ final class MainManager: ObservableObject {
     }
   }
 
-  // swiftlint:disable:next function_body_length
   private func configureHotKeys() {
     hotKeyTokens.append(
       hotKeyManager.register(gesture: .holdStart) { [weak self] in

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -108,7 +108,6 @@ final class MainManager: ObservableObject {
   /// Tracks whether the HUD window is visible to skip unnecessary UI updates
   var isHUDOccluded: Bool = false
   var occlusionObserver: NSObjectProtocol?
-  private var willTerminateObserver: NSObjectProtocol?
 
   struct RetryData {
     let transcriptionResult: TranscriptionResult
@@ -237,15 +236,18 @@ final class MainManager: ObservableObject {
     configureHotKeys()
     setupCaptureHealthBindings()
 
-    // Observe app termination to clean up timer
-    willTerminateObserver = NotificationCenter.default.addObserver(
-      forName: NSApplication.willTerminateNotification,
-      object: nil,
-      queue: .main
-    ) { [weak self] _ in
-      self?.stopAudioLevelMonitoring()
-      self?.captureWarmer?.invalidate()
+    Publishers.CombineLatest(
+      appSettings.$connectionPreWarmingEnabled,
+      permissionsManager.$statuses.map { $0[.microphone]?.isGranted == true }
+    )
+    .removeDuplicates { lhs, rhs in lhs.0 == rhs.0 && lhs.1 == rhs.1 }
+    .dropFirst()
+    .receive(on: RunLoop.main)
+    .sink { [weak self] enabled, permissionGranted in
+      guard enabled, permissionGranted else { return }
+      self?.warmUpConnectionIfEnabled()
     }
+    .store(in: &cancellables)
 
     let warmer = CaptureWarmCoordinator(
       appSettings: appSettings,
@@ -254,7 +256,14 @@ final class MainManager: ObservableObject {
       audioFileManager: audioFileManager
     )
     captureWarmer = warmer
-    warmer.warmUp()
+    warmer.start()
+  }
+
+  /// Completes asynchronous warm-resource teardown before AppKit permits the
+  /// process to exit, so the prepared recorder cannot leave an empty file.
+  func prepareForTermination() async {
+    self.stopAudioLevelMonitoring()
+    await self.captureWarmer?.invalidate()
   }
 
   /// Applies a live-transcript snapshot to the preview and the HUD.
@@ -316,8 +325,8 @@ final class MainManager: ObservableObject {
   func toggleRecordingFromUI() {
     guard !isEndingSession else { return }
     if activeSession == nil {
-      let triggeredAt = Date()
-      Task { await startSession(trigger: .uiButton, triggeredAt: triggeredAt) }
+      let triggerTiming = SessionTriggerTiming.nonHotKey()
+      Task { await startSession(trigger: .uiButton, triggerTiming: triggerTiming) }
     } else {
       Task { await endSession(trigger: .uiButton) }
     }
@@ -352,10 +361,10 @@ final class MainManager: ObservableObject {
   }
 
   /// Hands-free replaces press-to-talk with press-to-arm.
-  private func handleHoldStartGesture(triggeredAt: Date) async {
+  private func handleHoldStartGesture(triggerTiming: SessionTriggerTiming) async {
     guard appSettings.hotKeyActivationStyle.allowsHold else { return }
     if await handleHandsFreeHotKey() { return }
-    await startSession(trigger: .hold, triggeredAt: triggeredAt)
+    await startSession(trigger: .hold, triggerTiming: triggerTiming)
   }
 
   /// The arming press already consumed the gesture, so releasing the key must
@@ -375,7 +384,7 @@ final class MainManager: ObservableObject {
 
   /// Double-tap toggles: it arms hands-free dictation when that mode is on,
   /// otherwise it starts a session or ends the one it started.
-  private func handleDoubleTapGesture(triggeredAt: Date) async {
+  private func handleDoubleTapGesture(triggerTiming: SessionTriggerTiming) async {
     guard appSettings.hotKeyActivationStyle.allowsDoubleTap else { return }
     let now = ProcessInfo.processInfo.systemUptime
     guard now - lastDoubleTapEventUptime >= 0.25 else { return }
@@ -387,7 +396,7 @@ final class MainManager: ObservableObject {
       guard session.gesture == .doubleTap else { return }
       await endSession(trigger: .doubleTap)
     } else {
-      await startSession(trigger: .doubleTap, triggeredAt: triggeredAt)
+      await startSession(trigger: .doubleTap, triggerTiming: triggerTiming)
     }
   }
 
@@ -397,9 +406,9 @@ final class MainManager: ObservableObject {
       hotKeyManager.register(gesture: .holdStart) { [weak self] in
         // Stamped here, before the actor hop, so the latency dashboard measures
         // from the key press rather than from where `startSession` gets to run.
-        let triggeredAt = Date()
+        let triggerTiming = SessionTriggerTiming.recognisedHotKey()
         Task { @MainActor in
-          await self?.handleHoldStartGesture(triggeredAt: triggeredAt)
+          await self?.handleHoldStartGesture(triggerTiming: triggerTiming)
         }
       }
     )
@@ -414,9 +423,9 @@ final class MainManager: ObservableObject {
 
     hotKeyTokens.append(
       hotKeyManager.register(gesture: .doubleTap) { [weak self] in
-        let triggeredAt = Date()
+        let triggerTiming = SessionTriggerTiming.recognisedHotKey()
         Task { @MainActor in
-          await self?.handleDoubleTapGesture(triggeredAt: triggeredAt)
+          await self?.handleDoubleTapGesture(triggerTiming: triggerTiming)
         }
       }
     )
@@ -457,6 +466,7 @@ final class MainManager: ObservableObject {
   /// This is called at app launch and when recording starts.
   private func warmUpConnectionIfEnabled() {
     guard appSettings.connectionPreWarmingEnabled else { return }
+    guard permissionsManager.status(for: .microphone).isGranted else { return }
     let client = openRouterClient
     Task.detached {
       await client.warmUp()
@@ -497,9 +507,10 @@ final class MainManager: ObservableObject {
   func startSession(
     trigger: SessionTriggerSource,
     preRollBuffers: [AVAudioPCMBuffer] = [],
-    triggeredAt: Date = Date()
+    triggerTiming: SessionTriggerTiming = .nonHotKey()
   ) async -> HandsFreeCaptureStartOutcome {
     guard activeSession == nil else { return .rejected(.captureFailed) }
+    captureWarmer?.sessionWillBegin()
 
     // Per-app dictation profile: resolve the frontmost app and apply its
     // overrides for this session only. Applied before the API-key check so the
@@ -520,17 +531,20 @@ final class MainManager: ObservableObject {
       )
       else {
         profileApplier.end(settings: appSettings, postProcessing: postProcessingManager)
+        captureWarmer?.sessionDidEnd()
         return .rejected(.unsupportedConfiguration)
       }
     }
 
     if await presentMissingLiveAPIKeyAlertIfNeeded() {
       profileApplier.end(settings: appSettings, postProcessing: postProcessingManager)
+      captureWarmer?.sessionDidEnd()
       return .rejected(.captureFailed)
     }
 
     if audioInputDeviceManager.devices.isEmpty {
       profileApplier.end(settings: appSettings, postProcessing: postProcessingManager)
+      captureWarmer?.sessionDidEnd()
       let message = "No microphone connected. Plug in a USB or Bluetooth microphone and try again."
       state = .failed(message)
       lastErrorMessage = message
@@ -557,28 +571,17 @@ final class MainManager: ObservableObject {
     let session = ActiveSession(
       gesture: gesture,
       hotKeyDescription: appSettings.selectedHotKey.displayString,
-      triggeredAt: triggeredAt
+      triggerTiming: triggerTiming
     )
     session.outputTarget = TextOutputTarget.capture()
     session.diagnosticContext = makeHistoryDiagnosticContext()
     activeSession = session
-    state = .recording
-
-    if appSettings.recordingSoundsEnabled {
-      recordingSoundPlayer.play(.start, volume: appSettings.recordingSoundVolume)
-    }
     lastErrorMessage = nil
     livePreview = ""
     polishedLivePreview = ""
     // Every recording starts from a blank live transcript, including batch
     // modes that never open a live session (issue #643).
     transcriptionManager.resetLiveTranscriptDisplay()
-    session.events.append(
-      HistoryEvent(
-        kind: .recordingStarted,
-        description: "Recording started via \(gesture.rawValue)"
-      )
-    )
 
     // Reset live polish for new session
     livePolishManager.reset()
@@ -598,19 +601,31 @@ final class MainManager: ObservableObject {
       }
     }
 
-    if appSettings.showHUDDuringSessions {
-      permissionsManager.refresh(.microphone)
-      hudManager.updateCaptureHealth(buildCaptureHealthSnapshot())
-      hudManager.beginRecording(profileName: profileApplier.activeProfileName)
-    }
-
     // Claim the recorder staged while idle. Returns nil — and the cold path
     // runs — whenever the environment moved since it was staged.
     let warmContext = captureWarmer?.claimWarmContext()
 
     do {
-      _ = try await audioFileManager.startRecording(warmContext: warmContext)
-      recordCaptureStart(for: session, wasWarm: warmContext != nil)
+      let recording = try await audioFileManager.startRecording(
+        warmContext: warmContext,
+        owner: .dictation
+      )
+      recordCaptureStart(for: session, wasWarm: recording.usedWarmRecorder)
+      state = .recording
+      session.events.append(
+        HistoryEvent(
+          kind: .recordingStarted,
+          description: "Recording started via \(gesture.rawValue)"
+        )
+      )
+      if appSettings.recordingSoundsEnabled {
+        recordingSoundPlayer.play(.start, volume: appSettings.recordingSoundVolume)
+      }
+      if appSettings.showHUDDuringSessions {
+        permissionsManager.refresh(.microphone)
+        hudManager.updateCaptureHealth(buildCaptureHealthSnapshot())
+        hudManager.beginRecording(profileName: profileApplier.activeProfileName)
+      }
       startAudioLevelMonitoring()
       if isStreamingTranscriptionMode {
         try await transcriptionManager.startLiveTranscription(
@@ -638,9 +653,8 @@ final class MainManager: ObservableObject {
   /// dashboard percentiles can be read against the warm/cold split.
   private func recordCaptureStart(for session: ActiveSession, wasWarm: Bool) {
     session.captureStarted = Date()
-    if let coldStartMs = SessionLatencyMetrics.milliseconds(
-      from: session.recordingStarted, to: session.captureStarted
-    ) {
+    session.captureStartedUptime = ProcessInfo.processInfo.systemUptime
+    if let coldStartMs = session.captureStartMilliseconds {
       let path = wasWarm ? "pre-warmed" : "cold"
       self.logger.info("Latency: capture started \(coldStartMs)ms after trigger (\(path, privacy: .public))")
     }

--- a/Sources/SpeakApp/MainManagerSession.swift
+++ b/Sources/SpeakApp/MainManagerSession.swift
@@ -26,6 +26,32 @@ enum SessionTriggerSource: Equatable {
   }
 }
 
+/// Wall-clock identity plus an optional monotonic hotkey checkpoint. UI and
+/// programmatic starts deliberately omit the monotonic value so they never
+/// enter the hotkey-to-capture percentile cohort.
+struct SessionTriggerTiming: Equatable {
+  let occurredAt: Date
+  let hotKeyUptime: TimeInterval?
+
+  static func recognisedHotKey(
+    occurredAt: Date = Date(),
+    uptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+  ) -> SessionTriggerTiming {
+    SessionTriggerTiming(occurredAt: occurredAt, hotKeyUptime: uptime)
+  }
+
+  static func nonHotKey(occurredAt: Date = Date()) -> SessionTriggerTiming {
+    SessionTriggerTiming(occurredAt: occurredAt, hotKeyUptime: nil)
+  }
+
+  func milliseconds(to uptime: TimeInterval?) -> Int? {
+    guard let start = self.hotKeyUptime, let uptime else { return nil }
+    let interval = uptime - start
+    guard interval >= 0 else { return nil }
+    return Int((interval * 1000).rounded())
+  }
+}
+
 final class ActiveSession {
   let id = UUID()
   let gesture: HistoryTrigger.HotKeyGesture
@@ -46,6 +72,7 @@ final class ActiveSession {
   /// capturing, when the first live partial arrived, when the first character
   /// reached the target app, and when the user requested stop.
   var captureStarted: Date?
+  var captureStartedUptime: TimeInterval?
   var firstPartialReceived: Date?
   var firstInsertion: Date?
   var stopRequested: Date?
@@ -61,18 +88,23 @@ final class ActiveSession {
   var diagnosticContext: HistoryDiagnosticContext?
   var outputTarget: TextOutputTarget?
 
-  /// - Parameter triggeredAt: when the user actually asked to record. Taken in
-  ///   the hotkey callback rather than here, so `captureStartMs` covers the
-  ///   whole hotkey→capture path — including the pre-session credential and
-  ///   profile checks — instead of starting the clock after them (issue #663).
+  private let triggerTiming: SessionTriggerTiming
+
+  var captureStartMilliseconds: Int? {
+    self.triggerTiming.milliseconds(to: self.captureStartedUptime)
+  }
+
+  /// - Parameter triggerTiming: wall time for history plus a monotonic uptime
+  ///   only when a recognised hotkey initiated this session.
   init(
     gesture: HistoryTrigger.HotKeyGesture,
     hotKeyDescription: String,
-    triggeredAt: Date = Date()
+    triggerTiming: SessionTriggerTiming = .nonHotKey()
   ) {
     self.gesture = gesture
     self.hotKeyDescription = hotKeyDescription
-    self.recordingStarted = triggeredAt
+    self.triggerTiming = triggerTiming
+    self.recordingStarted = triggerTiming.occurredAt
   }
 
   func recordCostFragment(_ fragment: ChatCostBreakdown) {
@@ -88,12 +120,16 @@ final class ActiveSession {
   /// Latency intervals derived from this session's checkpoints (issue #611).
   private var latencyMetrics: SessionLatencyMetrics {
     SessionLatencyMetrics(
-      hotKeyPressedAt: self.recordingStarted,
-      captureStartedAt: self.captureStarted,
-      firstPartialAt: self.firstPartialReceived,
-      firstInsertAt: self.firstInsertion ?? self.outputDelivered,
-      stopPressedAt: self.stopRequested,
-      finalInsertAt: self.outputDelivered
+      captureStartMs: self.captureStartMilliseconds,
+      firstPartialMs: SessionLatencyMetrics.milliseconds(
+        from: self.captureStarted, to: self.firstPartialReceived
+      ),
+      firstInsertMs: SessionLatencyMetrics.milliseconds(
+        from: self.captureStarted, to: self.firstInsertion ?? self.outputDelivered
+      ),
+      stopToFinalMs: SessionLatencyMetrics.milliseconds(
+        from: self.stopRequested, to: self.outputDelivered
+      )
     )
   }
 

--- a/Sources/SpeakApp/MainManagerSession.swift
+++ b/Sources/SpeakApp/MainManagerSession.swift
@@ -61,10 +61,18 @@ final class ActiveSession {
   var diagnosticContext: HistoryDiagnosticContext?
   var outputTarget: TextOutputTarget?
 
-  init(gesture: HistoryTrigger.HotKeyGesture, hotKeyDescription: String) {
+  /// - Parameter triggeredAt: when the user actually asked to record. Taken in
+  ///   the hotkey callback rather than here, so `captureStartMs` covers the
+  ///   whole hotkey→capture path — including the pre-session credential and
+  ///   profile checks — instead of starting the clock after them (issue #663).
+  init(
+    gesture: HistoryTrigger.HotKeyGesture,
+    hotKeyDescription: String,
+    triggeredAt: Date = Date()
+  ) {
     self.gesture = gesture
     self.hotKeyDescription = hotKeyDescription
-    self.recordingStarted = Date()
+    self.recordingStarted = triggeredAt
   }
 
   func recordCostFragment(_ fragment: ChatCostBreakdown) {

--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -1099,8 +1099,8 @@ struct TestRecordingStepView: View {
         state.testRecordingText = nil
         state.isTestRecording = true
         do {
-            let url = try await state.audioFileManager.startRecording()
-            recordingURL = url
+            let recording = try await state.audioFileManager.startRecording()
+            recordingURL = recording.url
         } catch {
             state.isTestRecording = false
             state.testRecordingError = "Failed to start recording: \(error.localizedDescription)"

--- a/Sources/SpeakApp/SecureAppStorage.swift
+++ b/Sources/SpeakApp/SecureAppStorage.swift
@@ -3,6 +3,10 @@ import os.log
 import Security
 import SpeakCore
 
+extension Notification.Name {
+    static let secureAppStorageDidChange = Notification.Name("SecureAppStorageDidChange")
+}
+
 // MARK: - Legacy Error Type (kept for compatibility)
 
 enum SecureAppStorageError: LocalizedError {
@@ -121,6 +125,7 @@ actor SecureAppStorage {
     func storeSecret(_ value: String, identifier: String, label _: String? = nil) async throws {
         do {
             try await storage.storeSecret(value, identifier: identifier)
+            NotificationCenter.default.post(name: .secureAppStorageDidChange, object: nil)
         } catch let error as SecureStorageError {
             throw SecureAppStorageError(from: error)
         }
@@ -137,6 +142,7 @@ actor SecureAppStorage {
     func removeSecret(identifier: String) async throws {
         do {
             try await storage.removeSecret(identifier: identifier)
+            NotificationCenter.default.post(name: .secureAppStorageDidChange, object: nil)
         } catch let error as SecureStorageError {
             throw SecureAppStorageError(from: error)
         }

--- a/Sources/SpeakApp/SpeakApp.swift
+++ b/Sources/SpeakApp/SpeakApp.swift
@@ -187,6 +187,7 @@ struct CheckForUpdatesView: View {
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     var environment: AppEnvironment?
+    private var terminationTask: Task<Void, Never>?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
@@ -197,6 +198,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         DispatchQueue.global(qos: .utility).async { _ = AVAudioEngine() } // Sentry JUSTSPEAKTOIT-A
         checkAndOfferDMGCleanup()
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard let mainManager = environment?.main else { return .terminateNow }
+        guard terminationTask == nil else { return .terminateLater }
+
+        terminationTask = Task { @MainActor in
+            await mainManager.prepareForTermination()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
     }
     
     private func checkAndOfferDMGCleanup() {

--- a/Sources/SpeakApp/StreamingEndpointWarmer.swift
+++ b/Sources/SpeakApp/StreamingEndpointWarmer.swift
@@ -1,0 +1,57 @@
+import Foundation
+import os.log
+
+/// Warms the network path to a streaming transcription host.
+protocol StreamingEndpointWarming: Sendable {
+  /// Performs the handshake. Returns `true` when the host answered.
+  func warmUp(host: String) async -> Bool
+}
+
+/// Completes DNS resolution, TCP connect and the TLS handshake against a
+/// streaming provider's host so the `wss://` upgrade at session start does not
+/// pay for them (issue #663).
+///
+/// Deliberately a bare `HEAD /` with no credential and no API path: the point is
+/// to populate the resolver cache, the URLSession connection pool and the
+/// process TLS session cache, not to talk to the provider. No API key leaves the
+/// machine, and no provider-side transcription session is created — see
+/// ``LiveStreamWarmUp`` for why a fully pre-connected WebSocket is not safe for
+/// any of the supported providers. Any HTTP status (including 401/404) counts as
+/// success; the bytes we wanted were the handshake.
+///
+/// Mirrors the existing `OpenRouterAPIClient.warmUp()` approach used for the
+/// post-processing connection.
+struct StreamingEndpointWarmer: StreamingEndpointWarming {
+  private let session: URLSession
+  private let timeout: TimeInterval
+  private let logger = Logger(subsystem: "com.github.speakapp", category: "StreamWarmUp")
+
+  /// Uses `URLSession.shared` on purpose: that is the session the streaming
+  /// clients connect through, so the warmed resolver entry, connection pool and
+  /// TLS session ticket are the ones session start will actually reach for.
+  init(session: URLSession = .shared, timeout: TimeInterval = 5) {
+    self.session = session
+    self.timeout = timeout
+  }
+
+  func warmUp(host: String) async -> Bool {
+    guard var components = URLComponents(string: "https://\(host)") else { return false }
+    components.path = "/"
+    guard let url = components.url else { return false }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "HEAD"
+    request.timeoutInterval = self.timeout
+
+    let startedAt = CFAbsoluteTimeGetCurrent()
+    do {
+      _ = try await self.session.data(for: request)
+      let elapsed = String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+      self.logger.debug("Warmed \(host, privacy: .public) in \(elapsed, privacy: .public)ms")
+      return true
+    } catch {
+      self.logger.debug("Warm-up for \(host, privacy: .public) failed; session start will connect cold")
+      return false
+    }
+  }
+}

--- a/Sources/SpeakApp/StreamingEndpointWarmer.swift
+++ b/Sources/SpeakApp/StreamingEndpointWarmer.swift
@@ -1,23 +1,21 @@
 import Foundation
 import os.log
 
-/// Warms the network path to a streaming transcription host.
+/// Performs a credential-free endpoint probe for a streaming host.
 protocol StreamingEndpointWarming: Sendable {
   /// Performs the handshake. Returns `true` when the host answered.
   func warmUp(host: String) async -> Bool
 }
 
-/// Completes DNS resolution, TCP connect and the TLS handshake against a
-/// streaming provider's host so the `wss://` upgrade at session start does not
-/// pay for them (issue #663).
+/// Completes DNS resolution and an HTTPS exchange against a streaming
+/// provider's host (issue #663).
 ///
 /// Deliberately a bare `HEAD /` with no credential and no API path: the point is
-/// to populate the resolver cache, the URLSession connection pool and the
-/// process TLS session cache, not to talk to the provider. No API key leaves the
-/// machine, and no provider-side transcription session is created — see
-/// ``LiveStreamWarmUp`` for why a fully pre-connected WebSocket is not safe for
-/// any of the supported providers. Any HTTP status (including 401/404) counts as
-/// success; the bytes we wanted were the handshake.
+/// to populate resolver state and potentially seed TLS resumption, not to talk
+/// to the provider. It does not pre-connect the WebSocket or claim that an HTTP
+/// connection pool is reusable by a dedicated live-client `URLSession`. No API
+/// key leaves the machine and no provider-side transcription session is created.
+/// Any HTTP status (including 401/404) counts as success.
 ///
 /// Mirrors the existing `OpenRouterAPIClient.warmUp()` approach used for the
 /// post-processing connection.
@@ -26,9 +24,8 @@ struct StreamingEndpointWarmer: StreamingEndpointWarming {
   private let timeout: TimeInterval
   private let logger = Logger(subsystem: "com.github.speakapp", category: "StreamWarmUp")
 
-  /// Uses `URLSession.shared` on purpose: that is the session the streaming
-  /// clients connect through, so the warmed resolver entry, connection pool and
-  /// TLS session ticket are the ones session start will actually reach for.
+  /// Only providers whose live client also uses `URLSession.shared` opt into
+  /// this probe. Dedicated-session clients are excluded by `LiveStreamWarmUp`.
   init(session: URLSession = .shared, timeout: TimeInterval = 5) {
     self.session = session
     self.timeout = timeout

--- a/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
@@ -279,6 +279,35 @@ extension SettingsView {
       }
       .speakTooltip("Pick the microphone Speak should use. We fall back to the system default if a device disconnects.")
 
+      SettingsCard(title: "Fast Start", systemImage: "bolt.circle", tint: Color.brandAccentWarm) {
+        VStack(alignment: .leading, spacing: 12) {
+          Text("Prepare recording ahead of time so dictation begins the moment you press your shortcut.")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+
+          settingsToggle(
+            "Prepare the microphone while idle",
+            isOn: settingsBinding(\AppSettings.audioPreWarmingEnabled),
+            tint: .brandAccentWarm
+          )
+          .speakTooltip(
+            "Sets up the recorder in advance so your shortcut starts capture immediately. "
+              + "The microphone is never opened until you actually start dictating."
+          )
+
+          settingsToggle(
+            "Keep the connection warm",
+            isOn: settingsBinding(\AppSettings.connectionPreWarmingEnabled),
+            tint: .brandAccentWarm
+          )
+          .speakTooltip(
+            "Opens the network path to your transcription provider ahead of time. "
+              + "No audio, API key, or transcription request is sent while idle."
+          )
+        }
+      }
+      .speakTooltip("Trade a little idle work for a faster start when you press your dictation shortcut.")
+
       SettingsCard(title: "Recording Sounds", systemImage: "speaker.wave.2", tint: Color.brandLagoon) {
         VStack(alignment: .leading, spacing: 12) {
           settingsToggle(

--- a/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
@@ -296,12 +296,12 @@ extension SettingsView {
           )
 
           settingsToggle(
-            "Keep the connection warm",
+            "Warm supported connections",
             isOn: settingsBinding(\AppSettings.connectionPreWarmingEnabled),
             tint: .brandAccentWarm
           )
           .speakTooltip(
-            "Opens the network path to your transcription provider ahead of time. "
+            "Probes supported provider endpoints ahead of time without opening a live session. "
               + "No audio, API key, or transcription request is sent while idle."
           )
         }

--- a/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
@@ -286,7 +286,7 @@ extension SettingsView {
             .foregroundStyle(.secondary)
 
           settingsToggle(
-            "Prepare the microphone while idle",
+            "Prepare recording while idle",
             isOn: settingsBinding(\AppSettings.audioPreWarmingEnabled),
             tint: .brandAccentWarm
           )

--- a/Sources/SpeakCore/CaptureWarmUp.swift
+++ b/Sources/SpeakCore/CaptureWarmUp.swift
@@ -157,6 +157,14 @@ public struct CaptureWarmStateMachine: Equatable, Sendable {
         return true
     }
 
+    /// Invalidates warm state when any recording owner starts without claiming
+    /// the staged recorder. The recorder owner calls this for auxiliary flows
+    /// such as onboarding and Voice Edit so coordinator state cannot remain
+    /// `ready` after the backing recorder has been discarded.
+    public mutating func recordingBeganWithoutClaim() -> CaptureWarmAction {
+        self.reset()
+    }
+
     /// Drops any staged state. Returns the teardown the owner owes.
     public mutating func reset() -> CaptureWarmAction {
         switch self.phase {

--- a/Sources/SpeakCore/CaptureWarmUp.swift
+++ b/Sources/SpeakCore/CaptureWarmUp.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+// MARK: - Capture warm-up (issue #663)
+
+/// Identity of the capture environment a staged (pre-warmed) recorder was built
+/// for.
+///
+/// Pre-warming trades a small amount of idle work for a faster
+/// hotkey→capture path, but a staged recorder is only reusable while the
+/// environment it was built for still holds. Everything that can invalidate a
+/// staged recorder lives in this value, so "is the staged recorder still good?"
+/// is a single equality check.
+///
+/// `requiresDefaultDeviceSwitch` deserves a note: on macOS the app honours a
+/// preferred input device by temporarily changing the *system* default input at
+/// session start. A recorder staged before that switch would capture from the
+/// wrong device, and switching the system default while the user is idle would
+/// be user-hostile. So a session that needs the switch is simply not eligible
+/// for warm-up and pays the cold path.
+public struct CaptureWarmContext: Equatable, Sendable {
+    /// UID of the device the next session will capture from, when known.
+    public let inputDeviceUID: String?
+    /// Directory the staged audio file is created in.
+    public let recordingsDirectoryPath: String
+    /// Stable identifier for the encoder settings (format, rate, channels, bitrate).
+    public let encoderProfileID: String
+    /// Whether session start will have to change the system default input device.
+    public let requiresDefaultDeviceSwitch: Bool
+    /// Whether microphone permission is already granted. Staging a recorder
+    /// must never be the thing that triggers a permission prompt, so warm-up
+    /// waits until the user has granted access through a real session.
+    public let microphonePermissionGranted: Bool
+
+    public init(
+        inputDeviceUID: String?,
+        recordingsDirectoryPath: String,
+        encoderProfileID: String,
+        requiresDefaultDeviceSwitch: Bool,
+        microphonePermissionGranted: Bool
+    ) {
+        self.inputDeviceUID = inputDeviceUID
+        self.recordingsDirectoryPath = recordingsDirectoryPath
+        self.encoderProfileID = encoderProfileID
+        self.requiresDefaultDeviceSwitch = requiresDefaultDeviceSwitch
+        self.microphonePermissionGranted = microphonePermissionGranted
+    }
+
+    /// Whether a recorder may be staged for this environment at all.
+    public var isWarmable: Bool {
+        guard self.microphonePermissionGranted else { return false }
+        guard !self.requiresDefaultDeviceSwitch else { return false }
+        guard self.inputDeviceUID != nil else { return false }
+        return !self.recordingsDirectoryPath.isEmpty
+    }
+}
+
+/// Where the staged recorder currently stands.
+public enum CaptureWarmPhase: Equatable, Sendable {
+    /// Nothing staged.
+    case cold
+    /// A recorder is being staged for this context.
+    case warming(CaptureWarmContext)
+    /// A recorder is staged and ready to be claimed by the next session.
+    case ready(CaptureWarmContext)
+}
+
+/// What the owner should do to the staged recorder after a state transition.
+public enum CaptureWarmAction: Equatable, Sendable {
+    case none
+    /// Stage a recorder for this context (create + prepare, never record).
+    case prepare(CaptureWarmContext)
+    /// Tear the staged recorder down and delete the file it created.
+    case discard
+    /// Tear the stale staged recorder down, then stage one for this context.
+    case discardThenPrepare(CaptureWarmContext)
+}
+
+/// Warm-state machine for the capture start path.
+///
+/// Pure logic: it decides *when* a recorder should be staged, discarded, or
+/// re-staged, and never touches AVFoundation. Every trigger — idle after a
+/// session, audio route change, device selection change, permission change,
+/// preference toggle — funnels through ``reconcile(with:enabled:)``, so there
+/// is exactly one place where the rules live.
+public struct CaptureWarmStateMachine: Equatable, Sendable {
+    public private(set) var phase: CaptureWarmPhase
+
+    public init() {
+        self.phase = .cold
+    }
+
+    /// The context a staged recorder is ready for, if any.
+    public var readyContext: CaptureWarmContext? {
+        switch self.phase {
+        case .ready(let context):
+            return context
+        case .cold, .warming:
+            return nil
+        }
+    }
+
+    /// Brings the machine in line with the current environment.
+    ///
+    /// - Parameters:
+    ///   - context: the environment the *next* session would start in.
+    ///   - enabled: the user's pre-warm preference.
+    /// - Returns: the work the owner must perform to match the new state.
+    public mutating func reconcile(
+        with context: CaptureWarmContext,
+        enabled: Bool
+    ) -> CaptureWarmAction {
+        guard enabled, context.isWarmable else {
+            return self.reset()
+        }
+
+        switch self.phase {
+        case .cold:
+            self.phase = .warming(context)
+            return .prepare(context)
+        case .warming(let staged):
+            guard staged != context else { return .none }
+            self.phase = .warming(context)
+            return .discardThenPrepare(context)
+        case .ready(let staged):
+            guard staged != context else { return .none }
+            self.phase = .warming(context)
+            return .discardThenPrepare(context)
+        }
+    }
+
+    /// Records that staging finished. Returns `false` when the result is stale
+    /// (the environment moved on while the recorder was being staged), in which
+    /// case the caller must throw the freshly staged recorder away.
+    @discardableResult
+    public mutating func markReady(_ context: CaptureWarmContext) -> Bool {
+        guard case .warming(let pending) = self.phase, pending == context else {
+            return false
+        }
+        self.phase = .ready(context)
+        return true
+    }
+
+    /// Records that staging failed. Only clears state when the failure belongs
+    /// to the context currently being staged.
+    public mutating func markFailed(_ context: CaptureWarmContext) {
+        guard case .warming(let pending) = self.phase, pending == context else { return }
+        self.phase = .cold
+    }
+
+    /// Hands the staged recorder to a starting session. Returns `false` when
+    /// nothing usable is staged, and the session must take the cold path.
+    public mutating func claim(for context: CaptureWarmContext) -> Bool {
+        guard case .ready(let staged) = self.phase, staged == context else {
+            return false
+        }
+        self.phase = .cold
+        return true
+    }
+
+    /// Drops any staged state. Returns the teardown the owner owes.
+    public mutating func reset() -> CaptureWarmAction {
+        switch self.phase {
+        case .cold:
+            return .none
+        case .warming, .ready:
+            self.phase = .cold
+            return .discard
+        }
+    }
+}

--- a/Sources/SpeakCore/LiveStreamWarmUp.swift
+++ b/Sources/SpeakCore/LiveStreamWarmUp.swift
@@ -7,15 +7,17 @@ import Foundation
 ///
 /// Two levels are possible in principle:
 ///
-/// * **Endpoint handshake** — resolve DNS and complete a TLS handshake against
-///   the provider's host so the `wss://` upgrade that follows session start
-///   skips resolution and can resume the TLS session. No credential is sent,
-///   no provider-side session exists, nothing is billed.
+/// * **Endpoint probe** — resolve DNS and complete a credential-free HTTPS
+///   request against the provider's host. This warms resolver state and may
+///   make a TLS session ticket available, but it does not claim to pre-connect
+///   the WebSocket or populate a different `URLSession`'s connection pool.
 /// * **Pre-connect** — open the WebSocket and send the provider's config frame
 ///   before the hotkey, holding the session open until it is needed.
 ///
-/// Every cloud provider the app supports is ``endpointHandshake`` today, and
-/// the reason is the same in each case: the first frame on the socket *is* the
+/// A probe is only enabled when the live client uses `URLSession.shared`.
+/// AssemblyAI and OpenAI construct dedicated sessions, so probing through the
+/// shared session would not prove transport reuse and is deliberately disabled.
+/// No provider is fully pre-connected: the first frame on the socket *is* the
 /// session. Soniox, Speechmatics, ElevenLabs, Cartesia, Gladia, Modulate,
 /// OpenAI Realtime and xAI all require an authenticated config/`StartRecognition`
 /// frame immediately after the upgrade, which creates a server-side session;
@@ -34,15 +36,15 @@ import Foundation
 public enum LiveStreamWarmUp: Equatable, Sendable {
     /// Nothing to warm: the provider runs on-device.
     case unsupported
-    /// Warm DNS + TLS against this host. No credential, no provider session.
-    case endpointHandshake(host: String)
+    /// Probe this host without credentials or a provider session.
+    case endpointProbe(host: String)
 
     /// The host to warm, when there is one.
     public var host: String? {
         switch self {
         case .unsupported:
             return nil
-        case .endpointHandshake(let host):
+        case .endpointProbe(let host):
             return host
         }
     }
@@ -83,21 +85,27 @@ extension LiveTranscriptionProviderID {
 
     /// How far this provider's connection may be warmed ahead of a session.
     public var streamWarmUp: LiveStreamWarmUp {
-        guard let host = self.streamingHost else { return .unsupported }
-        return .endpointHandshake(host: host)
+        switch self {
+        case .apple, .assemblyai, .openai:
+            return .unsupported
+        case .deepgram, .cartesia, .gladia, .modulate, .soniox, .elevenlabs,
+             .speechmatics, .xai:
+            guard let host = self.streamingHost else { return .unsupported }
+            return .endpointProbe(host: host)
+        }
     }
 }
 
 // MARK: - Warm tracker
 
-/// Tracks which streaming host has a warm connection and when it goes stale.
+/// Tracks which streaming host has a recent endpoint probe and when it expires.
 ///
 /// Pure logic so the freshness and re-warm rules are testable without touching
 /// the network. The owner asks ``hostNeedingWarmUp(for:now:)`` on every trigger
-/// (app launch, session end, provider change) and only performs a handshake
+/// (app launch, session end, provider change) and only performs a probe
 /// when a host comes back.
 public struct LiveStreamWarmTracker: Equatable, Sendable {
-    /// How long a completed handshake is considered fresh. Chosen to sit above
+    /// How long a completed probe is considered fresh. Chosen to sit above
     /// typical provider DNS TTLs while staying well inside TLS session-ticket
     /// lifetimes, so a user dictating repeatedly re-warms at most once a minute.
     public static let defaultFreshness: TimeInterval = 90
@@ -129,23 +137,27 @@ public struct LiveStreamWarmTracker: Equatable, Sendable {
         return host
     }
 
-    /// Records a completed handshake.
-    public mutating func markWarmed(host: String, at date: Date) {
-        if self.inFlightHost == host { self.inFlightHost = nil }
+    /// Records a completed probe.
+    @discardableResult
+    public mutating func markWarmed(host: String, at date: Date) -> Bool {
+        guard self.inFlightHost == host else { return false }
+        self.inFlightHost = nil
         self.warmedHost = host
         self.warmedAt = date
+        return true
     }
 
-    /// Records a failed handshake so the next trigger retries it.
+    /// Records a failed probe so the next trigger retries it.
     public mutating func markFailed(host: String) {
-        if self.inFlightHost == host { self.inFlightHost = nil }
+        guard self.inFlightHost == host else { return }
+        self.inFlightHost = nil
         if self.warmedHost == host {
             self.warmedHost = nil
             self.warmedAt = nil
         }
     }
 
-    /// Forgets the warm connection (provider changed, network changed, disabled).
+    /// Forgets the probe (provider changed, network changed, disabled).
     public mutating func invalidate() {
         self.warmedHost = nil
         self.warmedAt = nil
@@ -156,5 +168,16 @@ public struct LiveStreamWarmTracker: Equatable, Sendable {
     public func isWarm(host: String, now: Date) -> Bool {
         guard self.warmedHost == host, let warmedAt = self.warmedAt else { return false }
         return now.timeIntervalSince(warmedAt) < self.freshness
+    }
+
+    /// When the current provider should next be probed. Owners schedule this
+    /// deadline so freshness expires while the app remains otherwise idle.
+    public func refreshDeadline(
+        for provider: LiveTranscriptionProviderID?,
+        enabled: Bool = true
+    ) -> Date? {
+        guard enabled, let host = provider?.streamWarmUp.host else { return nil }
+        guard self.warmedHost == host, let warmedAt = self.warmedAt else { return nil }
+        return warmedAt.addingTimeInterval(self.freshness)
     }
 }

--- a/Sources/SpeakCore/LiveStreamWarmUp.swift
+++ b/Sources/SpeakCore/LiveStreamWarmUp.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+// MARK: - Streaming provider warm-up policy (issue #663)
+
+/// How far a live-transcription provider's connection may be warmed before the
+/// user presses the hotkey.
+///
+/// Two levels are possible in principle:
+///
+/// * **Endpoint handshake** — resolve DNS and complete a TLS handshake against
+///   the provider's host so the `wss://` upgrade that follows session start
+///   skips resolution and can resume the TLS session. No credential is sent,
+///   no provider-side session exists, nothing is billed.
+/// * **Pre-connect** — open the WebSocket and send the provider's config frame
+///   before the hotkey, holding the session open until it is needed.
+///
+/// Every cloud provider the app supports is ``endpointHandshake`` today, and
+/// the reason is the same in each case: the first frame on the socket *is* the
+/// session. Soniox, Speechmatics, ElevenLabs, Cartesia, Gladia, Modulate,
+/// OpenAI Realtime and xAI all require an authenticated config/`StartRecognition`
+/// frame immediately after the upgrade, which creates a server-side session;
+/// AssemblyAI's Universal-Streaming meters *session duration* rather than audio
+/// duration, so an idle warm socket bills the user for silence; and Deepgram
+/// closes a connection that receives no audio within roughly ten seconds
+/// (`NET-0001`), which would turn a warm socket into a reconnect storm. Holding
+/// a configured socket open on the chance the user might dictate is therefore
+/// either billable, rate-limited, or unstable depending on the provider — so
+/// the app does not do it for any of them.
+///
+/// ``preconnect`` is deliberately absent from this enum rather than present and
+/// unused: adding it is the right change on the day a provider documents a free
+/// idle handshake, and until then a case no provider returns would be untested
+/// machinery.
+public enum LiveStreamWarmUp: Equatable, Sendable {
+    /// Nothing to warm: the provider runs on-device.
+    case unsupported
+    /// Warm DNS + TLS against this host. No credential, no provider session.
+    case endpointHandshake(host: String)
+
+    /// The host to warm, when there is one.
+    public var host: String? {
+        switch self {
+        case .unsupported:
+            return nil
+        case .endpointHandshake(let host):
+            return host
+        }
+    }
+}
+
+extension LiveTranscriptionProviderID {
+    /// The host the provider's streaming socket connects to, or `nil` for
+    /// on-device providers. Kept beside the clients that own these URLs; a test
+    /// asserts every cloud provider declares one.
+    public var streamingHost: String? {
+        switch self {
+        case .apple:
+            return nil
+        case .deepgram:
+            return "api.deepgram.com"
+        case .cartesia:
+            return "api.cartesia.ai"
+        case .gladia:
+            return "api.gladia.io"
+        case .modulate:
+            return "modulate-developer-apis.com"
+        case .assemblyai:
+            // The app prefers the EU endpoint and falls back to global; warming
+            // the preferred one is what matters for the common path.
+            return "streaming.eu.assemblyai.com"
+        case .soniox:
+            return "stt-rt.soniox.com"
+        case .elevenlabs:
+            return "api.elevenlabs.io"
+        case .openai:
+            return "api.openai.com"
+        case .speechmatics:
+            return "eu.rt.speechmatics.com"
+        case .xai:
+            return "api.x.ai"
+        }
+    }
+
+    /// How far this provider's connection may be warmed ahead of a session.
+    public var streamWarmUp: LiveStreamWarmUp {
+        guard let host = self.streamingHost else { return .unsupported }
+        return .endpointHandshake(host: host)
+    }
+}
+
+// MARK: - Warm tracker
+
+/// Tracks which streaming host has a warm connection and when it goes stale.
+///
+/// Pure logic so the freshness and re-warm rules are testable without touching
+/// the network. The owner asks ``hostNeedingWarmUp(for:now:)`` on every trigger
+/// (app launch, session end, provider change) and only performs a handshake
+/// when a host comes back.
+public struct LiveStreamWarmTracker: Equatable, Sendable {
+    /// How long a completed handshake is considered fresh. Chosen to sit above
+    /// typical provider DNS TTLs while staying well inside TLS session-ticket
+    /// lifetimes, so a user dictating repeatedly re-warms at most once a minute.
+    public static let defaultFreshness: TimeInterval = 90
+
+    private let freshness: TimeInterval
+    private var warmedHost: String?
+    private var warmedAt: Date?
+    private var inFlightHost: String?
+
+    public init(freshness: TimeInterval = LiveStreamWarmTracker.defaultFreshness) {
+        self.freshness = freshness
+    }
+
+    /// The host that should be warmed now, or `nil` when there is nothing to do.
+    public mutating func hostNeedingWarmUp(
+        for provider: LiveTranscriptionProviderID?,
+        now: Date,
+        enabled: Bool = true
+    ) -> String? {
+        guard enabled, let provider, let host = provider.streamWarmUp.host else {
+            self.invalidate()
+            return nil
+        }
+        if self.inFlightHost == host { return nil }
+        if self.warmedHost == host, let warmedAt, now.timeIntervalSince(warmedAt) < self.freshness {
+            return nil
+        }
+        self.inFlightHost = host
+        return host
+    }
+
+    /// Records a completed handshake.
+    public mutating func markWarmed(host: String, at date: Date) {
+        if self.inFlightHost == host { self.inFlightHost = nil }
+        self.warmedHost = host
+        self.warmedAt = date
+    }
+
+    /// Records a failed handshake so the next trigger retries it.
+    public mutating func markFailed(host: String) {
+        if self.inFlightHost == host { self.inFlightHost = nil }
+        if self.warmedHost == host {
+            self.warmedHost = nil
+            self.warmedAt = nil
+        }
+    }
+
+    /// Forgets the warm connection (provider changed, network changed, disabled).
+    public mutating func invalidate() {
+        self.warmedHost = nil
+        self.warmedAt = nil
+        self.inFlightHost = nil
+    }
+
+    /// Whether `host` is currently considered warm at `now`.
+    public func isWarm(host: String, now: Date) -> Bool {
+        guard self.warmedHost == host, let warmedAt = self.warmedAt else { return false }
+        return now.timeIntervalSince(warmedAt) < self.freshness
+    }
+}

--- a/Tests/SpeakAppTests/CaptureWarmCoordinatorTests.swift
+++ b/Tests/SpeakAppTests/CaptureWarmCoordinatorTests.swift
@@ -1,0 +1,250 @@
+import Foundation
+import Network
+import XCTest
+
+@testable import SpeakApp
+
+@MainActor
+final class CaptureWarmCoordinatorTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        self.suiteName = "com.speakapp.capture-warm-tests.\(UUID().uuidString)"
+        self.defaults = UserDefaults(suiteName: self.suiteName)!
+        self.defaults.set(AppSettings.TranscriptionMode.liveNative.rawValue, forKey: "transcriptionMode")
+        self.defaults.set("deepgram/nova-3-streaming", forKey: "liveTranscriptionModel")
+        self.defaults.set(true, forKey: "connectionPreWarmingEnabled")
+        self.defaults.set(false, forKey: "audioPreWarmingEnabled")
+        self.defaults.set(["deepgram.apiKey"], forKey: "trackedKeyIdentifiers")
+    }
+
+    override func tearDown() {
+        self.defaults.removePersistentDomain(forName: self.suiteName)
+        self.defaults = nil
+        self.suiteName = nil
+        super.tearDown()
+    }
+
+    func testFreshnessDeadline_ActivelySchedulesAndRunsAReplacementProbe() async {
+        var now = Date(timeIntervalSince1970: 1_700_000_000)
+        let harness = self.makeHarness(now: { now })
+        harness.coordinator.start()
+        await self.drainTasks()
+
+        let firstProbeHosts = await harness.warmer.hosts()
+        XCTAssertEqual(firstProbeHosts, ["api.deepgram.com"])
+        XCTAssertEqual(harness.scheduler.delay, 90)
+
+        now = now.addingTimeInterval(90)
+        harness.scheduler.fire()
+        await self.drainTasks()
+
+        let refreshedProbeHosts = await harness.warmer.hosts()
+        XCTAssertEqual(refreshedProbeHosts, ["api.deepgram.com", "api.deepgram.com"])
+        await harness.coordinator.invalidate()
+    }
+
+    func testSleepAndWake_CancelThenReprobeTheEndpoint() async {
+        let harness = self.makeHarness()
+        harness.coordinator.start()
+        await self.drainTasks()
+
+        harness.workspaceCenter.post(name: NSWorkspace.willSleepNotification, object: nil)
+        await self.drainTasks()
+        XCTAssertNil(harness.scheduler.delay)
+
+        harness.workspaceCenter.post(name: NSWorkspace.didWakeNotification, object: nil)
+        await self.drainTasks()
+        let probeHosts = await harness.warmer.hosts()
+        XCTAssertEqual(probeHosts.count, 2)
+        await harness.coordinator.invalidate()
+    }
+
+    func testNetworkRecovery_InvalidatesAndReprobesTheEndpoint() async {
+        let harness = self.makeHarness()
+        harness.coordinator.start()
+        await self.drainTasks()
+
+        harness.network.send(.unsatisfied)
+        await self.drainTasks()
+        XCTAssertNil(harness.scheduler.delay)
+
+        harness.network.send(.satisfied)
+        await self.drainTasks()
+        let probeHosts = await harness.warmer.hosts()
+        XCTAssertEqual(probeHosts.count, 2)
+        await harness.coordinator.invalidate()
+    }
+
+    func testTranscriptionModeChange_InvalidatesTheScheduledProbe() async {
+        let harness = self.makeHarness()
+        harness.coordinator.start()
+        await self.drainTasks()
+
+        harness.settings.transcriptionMode = .batchRemote
+        await self.drainTasks()
+
+        XCTAssertNil(harness.scheduler.delay)
+        let probeHosts = await harness.warmer.hosts()
+        XCTAssertEqual(probeHosts.count, 1)
+        await harness.coordinator.invalidate()
+    }
+
+    func testMicrophoneDenied_DoesNotProbeTheNetwork() async {
+        let harness = self.makeHarness(microphoneStatus: .denied)
+        harness.coordinator.start()
+        await self.drainTasks()
+
+        let probeHosts = await harness.warmer.hosts()
+        XCTAssertTrue(probeHosts.isEmpty)
+        XCTAssertNil(harness.scheduler.delay)
+        await harness.coordinator.invalidate()
+    }
+
+    func testShutdown_AwaitsAudioInvalidationAndCancelsOwnedResources() async {
+        let harness = self.makeHarness()
+        harness.coordinator.start()
+        await self.drainTasks()
+
+        await harness.coordinator.invalidate()
+
+        XCTAssertEqual(harness.audioInvalidation.count, 1)
+        XCTAssertTrue(harness.network.wasCancelled)
+        XCTAssertNil(harness.scheduler.delay)
+    }
+
+    private func makeHarness(
+        microphoneStatus: PermissionStatus = .granted,
+        now: @escaping @MainActor () -> Date = Date.init
+    ) -> Harness {
+        let settings = AppSettings(defaults: self.defaults)
+        let permissions = PermissionsManager(
+            statusProvider: { type in type == .microphone ? microphoneStatus : .denied },
+            notificationCenter: NotificationCenter()
+        )
+        let audioDevices = AudioInputDeviceManager(appSettings: settings)
+        let audioFiles = AudioFileManager(
+            appSettings: settings,
+            permissionsManager: permissions,
+            audioDeviceManager: audioDevices
+        )
+        let warmer = EndpointWarmerSpy()
+        let scheduler = CaptureWarmSchedulerSpy()
+        let network = CaptureWarmNetworkMonitorSpy()
+        let audioInvalidation = AudioInvalidationSpy()
+        let workspaceCenter = NotificationCenter()
+        let coordinator = CaptureWarmCoordinator(
+            appSettings: settings,
+            permissionsManager: permissions,
+            audioInputDeviceManager: audioDevices,
+            audioFileManager: audioFiles,
+            endpointWarmer: warmer,
+            networkMonitor: network,
+            scheduler: scheduler,
+            workspaceNotificationCenter: workspaceCenter,
+            notificationCenter: NotificationCenter(),
+            now: now,
+            warmAudio: { _, _ in },
+            invalidateAudio: { audioInvalidation.record() }
+        )
+        return Harness(
+            coordinator: coordinator,
+            settings: settings,
+            warmer: warmer,
+            scheduler: scheduler,
+            network: network,
+            audioInvalidation: audioInvalidation,
+            workspaceCenter: workspaceCenter
+        )
+    }
+
+    private func drainTasks() async {
+        for _ in 0..<5 { await Task.yield() }
+    }
+}
+
+@MainActor
+private struct Harness {
+    let coordinator: CaptureWarmCoordinator
+    let settings: AppSettings
+    let warmer: EndpointWarmerSpy
+    let scheduler: CaptureWarmSchedulerSpy
+    let network: CaptureWarmNetworkMonitorSpy
+    let audioInvalidation: AudioInvalidationSpy
+    let workspaceCenter: NotificationCenter
+}
+
+private actor EndpointWarmCalls {
+    private var storedHosts: [String] = []
+
+    func append(_ host: String) {
+        self.storedHosts.append(host)
+    }
+
+    func hosts() -> [String] {
+        self.storedHosts
+    }
+}
+
+private final class EndpointWarmerSpy: StreamingEndpointWarming, @unchecked Sendable {
+    private let calls = EndpointWarmCalls()
+
+    func hosts() async -> [String] {
+        await self.calls.hosts()
+    }
+
+    func warmUp(host: String) async -> Bool {
+        await self.calls.append(host)
+        return true
+    }
+}
+
+@MainActor
+private final class CaptureWarmSchedulerSpy: CaptureWarmScheduling {
+    private(set) var delay: TimeInterval?
+    private var operation: (@MainActor @Sendable () -> Void)?
+
+    func schedule(after delay: TimeInterval, operation: @escaping @MainActor @Sendable () -> Void) {
+        self.delay = delay
+        self.operation = operation
+    }
+
+    func cancel() {
+        self.delay = nil
+        self.operation = nil
+    }
+
+    func fire() {
+        let operation = self.operation
+        self.cancel()
+        operation?()
+    }
+}
+
+@MainActor
+private final class CaptureWarmNetworkMonitorSpy: CaptureWarmNetworkMonitoring {
+    var statusDidChange: ((NWPath.Status) -> Void)?
+    private(set) var wasCancelled = false
+
+    func start() {}
+
+    func cancel() {
+        self.wasCancelled = true
+        self.statusDidChange = nil
+    }
+
+    func send(_ status: NWPath.Status) {
+        self.statusDidChange?(status)
+    }
+}
+
+@MainActor
+private final class AudioInvalidationSpy {
+    private(set) var count = 0
+
+    func record() {
+        self.count += 1
+    }
+}

--- a/Tests/SpeakAppTests/SessionTriggerTimingTests.swift
+++ b/Tests/SpeakAppTests/SessionTriggerTimingTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+
+final class SessionTriggerTimingTests: XCTestCase {
+    private let wallClock = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func testRecognisedHotKey_UsesMonotonicCaptureInterval() {
+        let session = ActiveSession(
+            gesture: .hold,
+            hotKeyDescription: "Fn",
+            triggerTiming: .recognisedHotKey(occurredAt: self.wallClock, uptime: 100)
+        )
+        session.captureStarted = self.wallClock.addingTimeInterval(-10)
+        session.captureStartedUptime = 100.075
+
+        XCTAssertEqual(session.captureStartMilliseconds, 75)
+        XCTAssertEqual(session.buildHistoryItem(finalText: nil).latency?.captureStartMs, 75)
+    }
+
+    func testUIButtonStart_DoesNotEnterHotKeyLatencyCohort() {
+        let session = ActiveSession(
+            gesture: .uiButton,
+            hotKeyDescription: "Fn",
+            triggerTiming: .nonHotKey(occurredAt: self.wallClock)
+        )
+        session.captureStarted = self.wallClock.addingTimeInterval(0.1)
+        session.captureStartedUptime = 100.1
+        session.firstPartialReceived = self.wallClock.addingTimeInterval(0.4)
+
+        let latency = session.buildHistoryItem(finalText: nil).latency
+        XCTAssertNil(latency?.captureStartMs)
+        XCTAssertEqual(latency?.firstPartialMs, 300)
+    }
+
+    func testLatencyOverview_ExcludesUIButtonSessions() {
+        let hotKeySession = ActiveSession(
+            gesture: .hold,
+            hotKeyDescription: "Fn",
+            triggerTiming: .recognisedHotKey(occurredAt: self.wallClock, uptime: 10)
+        )
+        hotKeySession.captureStarted = self.wallClock.addingTimeInterval(0.08)
+        hotKeySession.captureStartedUptime = 10.08
+
+        let uiSession = ActiveSession(
+            gesture: .uiButton,
+            hotKeyDescription: "Fn",
+            triggerTiming: .nonHotKey(occurredAt: self.wallClock)
+        )
+        uiSession.captureStarted = self.wallClock.addingTimeInterval(4)
+        uiSession.captureStartedUptime = 14
+
+        let overview = [
+            hotKeySession.buildHistoryItem(finalText: nil),
+            uiSession.buildHistoryItem(finalText: nil)
+        ].latencyOverview()
+
+        XCTAssertEqual(overview.sessionCount, 1)
+        XCTAssertEqual(overview.captureStartP50, 80)
+        XCTAssertEqual(overview.captureStartP95, 80)
+    }
+
+    func testMonotonicClockRegression_DropsInvalidSample() {
+        let timing = SessionTriggerTiming.recognisedHotKey(
+            occurredAt: self.wallClock,
+            uptime: 100
+        )
+
+        XCTAssertNil(timing.milliseconds(to: 99))
+    }
+
+}

--- a/Tests/SpeakCoreTests/CaptureWarmUpTests.swift
+++ b/Tests/SpeakCoreTests/CaptureWarmUpTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import XCTest
+@testable import SpeakCore
+
+final class CaptureWarmStateMachineTests: XCTestCase {
+    private func context(
+        device: String? = "built-in-mic",
+        directory: String = "/Users/test/Recordings",
+        encoder: String = "aac-44100-mono-128k",
+        requiresSwitch: Bool = false,
+        permissionGranted: Bool = true
+    ) -> CaptureWarmContext {
+        CaptureWarmContext(
+            inputDeviceUID: device,
+            recordingsDirectoryPath: directory,
+            encoderProfileID: encoder,
+            requiresDefaultDeviceSwitch: requiresSwitch,
+            microphonePermissionGranted: permissionGranted
+        )
+    }
+
+    // MARK: - Eligibility
+
+    func testWarmable_RequiresPermissionDeviceAndNoDefaultSwitch() {
+        XCTAssertTrue(self.context().isWarmable)
+        XCTAssertFalse(self.context(permissionGranted: false).isWarmable)
+        XCTAssertFalse(self.context(requiresSwitch: true).isWarmable)
+        XCTAssertFalse(self.context(device: nil).isWarmable)
+        XCTAssertFalse(self.context(directory: "").isWarmable)
+    }
+
+    // MARK: - Happy path
+
+    func testReconcile_StagesThenClaims() {
+        var machine = CaptureWarmStateMachine()
+        let context = self.context()
+
+        XCTAssertEqual(machine.reconcile(with: context, enabled: true), .prepare(context))
+        XCTAssertNil(machine.readyContext)
+
+        XCTAssertTrue(machine.markReady(context))
+        XCTAssertEqual(machine.readyContext, context)
+
+        XCTAssertTrue(machine.claim(for: context))
+        XCTAssertEqual(machine.phase, .cold)
+        XCTAssertNil(machine.readyContext)
+    }
+
+    func testReconcile_IsIdempotentWhileStagedForSameEnvironment() {
+        var machine = CaptureWarmStateMachine()
+        let context = self.context()
+
+        _ = machine.reconcile(with: context, enabled: true)
+        XCTAssertEqual(machine.reconcile(with: context, enabled: true), .none)
+
+        machine.markReady(context)
+        XCTAssertEqual(machine.reconcile(with: context, enabled: true), .none)
+    }
+
+    // MARK: - Rewarm triggers
+
+    func testRouteChange_RestagesForTheNewDevice() {
+        var machine = CaptureWarmStateMachine()
+        let original = self.context(device: "built-in-mic")
+        _ = machine.reconcile(with: original, enabled: true)
+        machine.markReady(original)
+
+        let rerouted = self.context(device: "usb-mic")
+        XCTAssertEqual(
+            machine.reconcile(with: rerouted, enabled: true),
+            .discardThenPrepare(rerouted)
+        )
+        XCTAssertNil(machine.readyContext)
+        machine.markReady(rerouted)
+        XCTAssertEqual(machine.readyContext, rerouted)
+    }
+
+    func testRecordingsDirectoryChange_Restages() {
+        var machine = CaptureWarmStateMachine()
+        let original = self.context()
+        _ = machine.reconcile(with: original, enabled: true)
+        machine.markReady(original)
+
+        let moved = self.context(directory: "/Users/test/Elsewhere")
+        XCTAssertEqual(machine.reconcile(with: moved, enabled: true), .discardThenPrepare(moved))
+    }
+
+    func testEncoderProfileChange_Restages() {
+        var machine = CaptureWarmStateMachine()
+        let original = self.context()
+        _ = machine.reconcile(with: original, enabled: true)
+        machine.markReady(original)
+
+        let reencoded = self.context(encoder: "aac-16000-mono-64k")
+        XCTAssertEqual(machine.reconcile(with: reencoded, enabled: true), .discardThenPrepare(reencoded))
+    }
+
+    func testRouteChangeWhileStaging_RestagesWithoutAcceptingTheStaleResult() {
+        var machine = CaptureWarmStateMachine()
+        let original = self.context(device: "built-in-mic")
+        _ = machine.reconcile(with: original, enabled: true)
+
+        let rerouted = self.context(device: "usb-mic")
+        XCTAssertEqual(
+            machine.reconcile(with: rerouted, enabled: true),
+            .discardThenPrepare(rerouted)
+        )
+
+        // The in-flight staging for the old device finishes late and is rejected.
+        XCTAssertFalse(machine.markReady(original))
+        XCTAssertNil(machine.readyContext)
+
+        XCTAssertTrue(machine.markReady(rerouted))
+        XCTAssertEqual(machine.readyContext, rerouted)
+    }
+
+    // MARK: - Ineligible environments
+
+    func testDisabledPreference_DiscardsAndStaysCold() {
+        var machine = CaptureWarmStateMachine()
+        let context = self.context()
+        _ = machine.reconcile(with: context, enabled: true)
+        machine.markReady(context)
+
+        XCTAssertEqual(machine.reconcile(with: context, enabled: false), .discard)
+        XCTAssertEqual(machine.phase, .cold)
+        XCTAssertEqual(machine.reconcile(with: context, enabled: false), .none)
+    }
+
+    func testMissingMicrophonePermission_NeverStages() {
+        var machine = CaptureWarmStateMachine()
+        let denied = self.context(permissionGranted: false)
+        XCTAssertEqual(machine.reconcile(with: denied, enabled: true), .none)
+        XCTAssertEqual(machine.phase, .cold)
+    }
+
+    func testPreferredDeviceNeedingDefaultSwitch_NeverStages() {
+        var machine = CaptureWarmStateMachine()
+        let needsSwitch = self.context(requiresSwitch: true)
+        XCTAssertEqual(machine.reconcile(with: needsSwitch, enabled: true), .none)
+        XCTAssertEqual(machine.phase, .cold)
+    }
+
+    func testPermissionRevoked_DiscardsStagedRecorder() {
+        var machine = CaptureWarmStateMachine()
+        let granted = self.context()
+        _ = machine.reconcile(with: granted, enabled: true)
+        machine.markReady(granted)
+
+        let revoked = self.context(permissionGranted: false)
+        XCTAssertEqual(machine.reconcile(with: revoked, enabled: true), .discard)
+        XCTAssertEqual(machine.phase, .cold)
+    }
+
+    // MARK: - Claiming
+
+    func testClaim_FailsWhenEnvironmentDiffersFromStagedOne() {
+        var machine = CaptureWarmStateMachine()
+        let staged = self.context(device: "built-in-mic")
+        _ = machine.reconcile(with: staged, enabled: true)
+        machine.markReady(staged)
+
+        XCTAssertFalse(machine.claim(for: self.context(device: "usb-mic")))
+        XCTAssertEqual(machine.readyContext, staged)
+    }
+
+    func testClaim_FailsWhileStillStaging() {
+        var machine = CaptureWarmStateMachine()
+        let context = self.context()
+        _ = machine.reconcile(with: context, enabled: true)
+
+        XCTAssertFalse(machine.claim(for: context))
+    }
+
+    func testMarkFailed_ReturnsToColdSoTheNextTriggerRetries() {
+        var machine = CaptureWarmStateMachine()
+        let context = self.context()
+        _ = machine.reconcile(with: context, enabled: true)
+
+        machine.markFailed(context)
+        XCTAssertEqual(machine.phase, .cold)
+        XCTAssertEqual(machine.reconcile(with: context, enabled: true), .prepare(context))
+    }
+
+    func testMarkFailed_IgnoresStaleFailures() {
+        var machine = CaptureWarmStateMachine()
+        let staged = self.context(device: "usb-mic")
+        _ = machine.reconcile(with: staged, enabled: true)
+
+        machine.markFailed(self.context(device: "built-in-mic"))
+        XCTAssertEqual(machine.phase, .warming(staged))
+    }
+
+    func testReset_DiscardsOnlyWhenSomethingIsStaged() {
+        var machine = CaptureWarmStateMachine()
+        XCTAssertEqual(machine.reset(), .none)
+
+        let context = self.context()
+        _ = machine.reconcile(with: context, enabled: true)
+        XCTAssertEqual(machine.reset(), .discard)
+        XCTAssertEqual(machine.phase, .cold)
+    }
+}

--- a/Tests/SpeakCoreTests/CaptureWarmUpTests.swift
+++ b/Tests/SpeakCoreTests/CaptureWarmUpTests.swift
@@ -200,4 +200,15 @@ final class CaptureWarmStateMachineTests: XCTestCase {
         XCTAssertEqual(machine.reset(), .discard)
         XCTAssertEqual(machine.phase, .cold)
     }
+
+    func testAuxiliaryRecordingStart_DiscardsReadyWarmState() {
+        var machine = CaptureWarmStateMachine()
+        let context = self.context()
+        _ = machine.reconcile(with: context, enabled: true)
+        machine.markReady(context)
+
+        XCTAssertEqual(machine.recordingBeganWithoutClaim(), .discard)
+        XCTAssertEqual(machine.phase, .cold)
+        XCTAssertFalse(machine.claim(for: context))
+    }
 }

--- a/Tests/SpeakCoreTests/LiveStreamWarmUpTests.swift
+++ b/Tests/SpeakCoreTests/LiveStreamWarmUpTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import XCTest
+@testable import SpeakCore
+
+final class LiveStreamWarmUpPolicyTests: XCTestCase {
+    func testOnDeviceProvider_HasNothingToWarm() {
+        XCTAssertNil(LiveTranscriptionProviderID.apple.streamingHost)
+        XCTAssertEqual(LiveTranscriptionProviderID.apple.streamWarmUp, .unsupported)
+    }
+
+    func testEveryCloudProvider_DeclaresAHostToWarm() {
+        for provider in LiveTranscriptionProviderID.allCases where provider != .apple {
+            guard let host = provider.streamingHost else {
+                XCTFail("\(provider.rawValue) has no streaming host declared")
+                continue
+            }
+            XCTAssertFalse(host.isEmpty, "\(provider.rawValue) declares an empty host")
+            XCTAssertEqual(
+                provider.streamWarmUp,
+                .endpointHandshake(host: host),
+                "\(provider.rawValue) should warm its endpoint only"
+            )
+        }
+    }
+
+    func testBillingSensitiveProviders_AreNotPreConnected() {
+        // AssemblyAI meters session duration and Deepgram drops a socket that
+        // receives no audio, so neither may be held open before the hotkey.
+        // Both must resolve to the credential-free endpoint handshake.
+        for provider in [LiveTranscriptionProviderID.assemblyai, .deepgram, .soniox] {
+            guard let host = provider.streamingHost else {
+                XCTFail("\(provider.rawValue) has no streaming host declared")
+                continue
+            }
+            XCTAssertEqual(provider.streamWarmUp, .endpointHandshake(host: host))
+        }
+    }
+}
+
+final class LiveStreamWarmTrackerTests: XCTestCase {
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func testFirstRequest_ReturnsTheProviderHost() {
+        var tracker = LiveStreamWarmTracker()
+        XCTAssertEqual(
+            tracker.hostNeedingWarmUp(for: .soniox, now: self.base),
+            LiveTranscriptionProviderID.soniox.streamingHost
+        )
+    }
+
+    func testRequestWhileInFlight_DoesNotWarmTwice() {
+        var tracker = LiveStreamWarmTracker()
+        XCTAssertNotNil(tracker.hostNeedingWarmUp(for: .soniox, now: self.base))
+        XCTAssertNil(tracker.hostNeedingWarmUp(for: .soniox, now: self.base))
+    }
+
+    func testWarmHost_StaysFreshUntilTheIdleTimeoutExpires() {
+        var tracker = LiveStreamWarmTracker(freshness: 90)
+        guard let host = tracker.hostNeedingWarmUp(for: .deepgram, now: self.base) else {
+            return XCTFail("expected a host to warm")
+        }
+        tracker.markWarmed(host: host, at: self.base)
+
+        XCTAssertTrue(tracker.isWarm(host: host, now: self.base.addingTimeInterval(89)))
+        XCTAssertNil(tracker.hostNeedingWarmUp(for: .deepgram, now: self.base.addingTimeInterval(89)))
+
+        XCTAssertFalse(tracker.isWarm(host: host, now: self.base.addingTimeInterval(91)))
+        XCTAssertEqual(
+            tracker.hostNeedingWarmUp(for: .deepgram, now: self.base.addingTimeInterval(91)),
+            host
+        )
+    }
+
+    func testProviderChange_WarmsTheNewHostImmediately() {
+        var tracker = LiveStreamWarmTracker()
+        guard let sonioxHost = tracker.hostNeedingWarmUp(for: .soniox, now: self.base) else {
+            return XCTFail("expected a host to warm")
+        }
+        tracker.markWarmed(host: sonioxHost, at: self.base)
+
+        XCTAssertEqual(
+            tracker.hostNeedingWarmUp(for: .deepgram, now: self.base.addingTimeInterval(1)),
+            LiveTranscriptionProviderID.deepgram.streamingHost
+        )
+    }
+
+    func testFailedHandshake_IsRetriedOnTheNextTrigger() {
+        var tracker = LiveStreamWarmTracker()
+        guard let host = tracker.hostNeedingWarmUp(for: .cartesia, now: self.base) else {
+            return XCTFail("expected a host to warm")
+        }
+        tracker.markFailed(host: host)
+
+        XCTAssertFalse(tracker.isWarm(host: host, now: self.base))
+        XCTAssertEqual(tracker.hostNeedingWarmUp(for: .cartesia, now: self.base), host)
+    }
+
+    func testDisabledOrOnDeviceProvider_ClearsWarmState() {
+        var tracker = LiveStreamWarmTracker()
+        guard let host = tracker.hostNeedingWarmUp(for: .gladia, now: self.base) else {
+            return XCTFail("expected a host to warm")
+        }
+        tracker.markWarmed(host: host, at: self.base)
+
+        XCTAssertNil(tracker.hostNeedingWarmUp(for: .gladia, now: self.base, enabled: false))
+        XCTAssertFalse(tracker.isWarm(host: host, now: self.base))
+
+        tracker.markWarmed(host: host, at: self.base)
+        XCTAssertNil(tracker.hostNeedingWarmUp(for: .apple, now: self.base))
+        XCTAssertFalse(tracker.isWarm(host: host, now: self.base))
+
+        tracker.markWarmed(host: host, at: self.base)
+        XCTAssertNil(tracker.hostNeedingWarmUp(for: nil, now: self.base))
+        XCTAssertFalse(tracker.isWarm(host: host, now: self.base))
+    }
+
+    func testInvalidate_ForgetsTheWarmHost() {
+        var tracker = LiveStreamWarmTracker()
+        guard let host = tracker.hostNeedingWarmUp(for: .xai, now: self.base) else {
+            return XCTFail("expected a host to warm")
+        }
+        tracker.markWarmed(host: host, at: self.base)
+        tracker.invalidate()
+
+        XCTAssertFalse(tracker.isWarm(host: host, now: self.base))
+        XCTAssertEqual(tracker.hostNeedingWarmUp(for: .xai, now: self.base), host)
+    }
+}

--- a/Tests/SpeakCoreTests/LiveStreamWarmUpTests.swift
+++ b/Tests/SpeakCoreTests/LiveStreamWarmUpTests.swift
@@ -8,32 +8,33 @@ final class LiveStreamWarmUpPolicyTests: XCTestCase {
         XCTAssertEqual(LiveTranscriptionProviderID.apple.streamWarmUp, .unsupported)
     }
 
-    func testEveryCloudProvider_DeclaresAHostToWarm() {
+    func testEveryCloudProvider_DeclaresAStreamingHost() {
         for provider in LiveTranscriptionProviderID.allCases where provider != .apple {
             guard let host = provider.streamingHost else {
                 XCTFail("\(provider.rawValue) has no streaming host declared")
                 continue
             }
             XCTAssertFalse(host.isEmpty, "\(provider.rawValue) declares an empty host")
-            XCTAssertEqual(
-                provider.streamWarmUp,
-                .endpointHandshake(host: host),
-                "\(provider.rawValue) should warm its endpoint only"
-            )
         }
     }
 
-    func testBillingSensitiveProviders_AreNotPreConnected() {
-        // AssemblyAI meters session duration and Deepgram drops a socket that
-        // receives no audio, so neither may be held open before the hotkey.
-        // Both must resolve to the credential-free endpoint handshake.
-        for provider in [LiveTranscriptionProviderID.assemblyai, .deepgram, .soniox] {
+    func testSharedSessionProviders_UseCredentialFreeEndpointProbe() {
+        let providers: [LiveTranscriptionProviderID] = [
+            .deepgram, .cartesia, .gladia, .modulate, .soniox, .elevenlabs,
+            .speechmatics, .xai
+        ]
+        for provider in providers {
             guard let host = provider.streamingHost else {
                 XCTFail("\(provider.rawValue) has no streaming host declared")
                 continue
             }
-            XCTAssertEqual(provider.streamWarmUp, .endpointHandshake(host: host))
+            XCTAssertEqual(provider.streamWarmUp, .endpointProbe(host: host))
         }
+    }
+
+    func testDedicatedSessionProviders_AreNotClaimedAsTransportWarm() {
+        XCTAssertEqual(LiveTranscriptionProviderID.assemblyai.streamWarmUp, .unsupported)
+        XCTAssertEqual(LiveTranscriptionProviderID.openai.streamWarmUp, .unsupported)
     }
 }
 
@@ -71,6 +72,34 @@ final class LiveStreamWarmTrackerTests: XCTestCase {
         )
     }
 
+    func testCompletedProbe_ExposesRefreshDeadlineForIdleScheduling() {
+        var tracker = LiveStreamWarmTracker(freshness: 90)
+        guard let host = tracker.hostNeedingWarmUp(for: .deepgram, now: self.base) else {
+            return XCTFail("expected a host to warm")
+        }
+        XCTAssertTrue(tracker.markWarmed(host: host, at: self.base))
+
+        XCTAssertEqual(
+            tracker.refreshDeadline(for: .deepgram),
+            self.base.addingTimeInterval(90)
+        )
+        XCTAssertNil(tracker.refreshDeadline(for: .deepgram, enabled: false))
+    }
+
+    func testStaleProbeCompletion_DoesNotOverwriteCurrentProviderState() {
+        var tracker = LiveStreamWarmTracker()
+        guard let oldHost = tracker.hostNeedingWarmUp(for: .soniox, now: self.base) else {
+            return XCTFail("expected the original host")
+        }
+        guard let currentHost = tracker.hostNeedingWarmUp(for: .deepgram, now: self.base) else {
+            return XCTFail("expected the replacement host")
+        }
+
+        XCTAssertFalse(tracker.markWarmed(host: oldHost, at: self.base))
+        XCTAssertTrue(tracker.markWarmed(host: currentHost, at: self.base))
+        XCTAssertTrue(tracker.isWarm(host: currentHost, now: self.base))
+    }
+
     func testProviderChange_WarmsTheNewHostImmediately() {
         var tracker = LiveStreamWarmTracker()
         guard let sonioxHost = tracker.hostNeedingWarmUp(for: .soniox, now: self.base) else {
@@ -84,7 +113,7 @@ final class LiveStreamWarmTrackerTests: XCTestCase {
         )
     }
 
-    func testFailedHandshake_IsRetriedOnTheNextTrigger() {
+    func testFailedProbe_IsRetriedOnTheNextTrigger() {
         var tracker = LiveStreamWarmTracker()
         guard let host = tracker.hostNeedingWarmUp(for: .cartesia, now: self.base) else {
             return XCTFail("expected a host to warm")

--- a/Tests/SpeakCoreTests/LiveStreamWarmUpTests.swift
+++ b/Tests/SpeakCoreTests/LiveStreamWarmUpTests.swift
@@ -134,11 +134,13 @@ final class LiveStreamWarmTrackerTests: XCTestCase {
         XCTAssertNil(tracker.hostNeedingWarmUp(for: .gladia, now: self.base, enabled: false))
         XCTAssertFalse(tracker.isWarm(host: host, now: self.base))
 
-        tracker.markWarmed(host: host, at: self.base)
+        XCTAssertEqual(tracker.hostNeedingWarmUp(for: .gladia, now: self.base), host)
+        XCTAssertTrue(tracker.markWarmed(host: host, at: self.base))
         XCTAssertNil(tracker.hostNeedingWarmUp(for: .apple, now: self.base))
         XCTAssertFalse(tracker.isWarm(host: host, now: self.base))
 
-        tracker.markWarmed(host: host, at: self.base)
+        XCTAssertEqual(tracker.hostNeedingWarmUp(for: .gladia, now: self.base), host)
+        XCTAssertTrue(tracker.markWarmed(host: host, at: self.base))
         XCTAssertNil(tracker.hostNeedingWarmUp(for: nil, now: self.base))
         XCTAssertFalse(tracker.isWarm(host: host, now: self.base))
     }


### PR DESCRIPTION
## Summary

- stages the macOS audio recorder while idle and keeps warm state inside the recorder owner so dictation, Voice Edit, and onboarding cannot drift
- probes supported shared-session streaming endpoints without credentials, with explicit freshness, retry, mode, key, sleep, wake, and network invalidation
- excludes AssemblyAI and OpenAI dedicated WebSocket sessions from transport warming claims
- records hotkey-to-capture latency with a monotonic clock and excludes UI/programmatic starts from the hotkey percentile cohort
- awaits staged-recorder cleanup during normal app termination and only presents recording UI after capture starts

## Coverage

- recorder state-machine transitions across auxiliary owners
- active endpoint refresh scheduling plus mode, network, sleep/wake, permission, and shutdown behaviour
- stale endpoint-probe completion and provider transport policy
- hotkey-only monotonic capture metrics and percentile aggregation

## Verification

Local builds and tests were intentionally not run, as requested. GitHub CI is the verification gate for this update.

Hardware acceptance still requires at least 50 hold and 50 double-tap starts on a named Mac/macOS build, with warm/cold p50/p95 capture, first-partial, and stop-to-final measurements. The target remains capture-start p95 below 100 ms, plus an idle microphone indicator and normal-quit empty-file check.

Closes #663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Fast Start** settings card with controls for audio recording and supported connection pre-warming.
  - Audio recording can be prepared while idle, helping sessions begin faster without starting microphone capture prematurely.
  - Supported live transcription connections can be checked in advance to reduce startup delays.
  - Pre-warming automatically adapts to permissions, network changes, sleep/wake, provider changes, and recording activity.

- **Bug Fixes**
  - Improved cleanup and reliability when closing the application or ending recording sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->