### PR TITLE
fix(ios): harden keyboard dictation rollout

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -143,7 +143,10 @@ jobs:
         run: |
           NEW_VERSION="${{ steps.version.outputs.new_version }}"
           echo "🚀 Triggering iOS TestFlight build for v$NEW_VERSION"
-          if gh workflow run "Release iOS (TestFlight)" --ref main -f version="$NEW_VERSION"; then
+          if gh workflow run "Release iOS (TestFlight)" --ref main \
+            -f version="$NEW_VERSION" \
+            -f include_keyboard=true \
+            -f enable_direct_capture=false; then
             echo "✅ Triggered iOS TestFlight release for v$NEW_VERSION"
           else
             echo "⚠️ Could not trigger iOS TestFlight release; continuing without failing macOS auto-release"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,8 @@ jobs:
           echo "SIMULATOR_ID=$SIMULATOR_ID" >> "$GITHUB_ENV"
 
       - name: Generate iOS App Project
-        # Internal CI builds include the flagged-off keyboard extension so it
-        # keeps compiling and its flag-gated tests run. Release and TestFlight
-        # builds stay gated behind the manual `include_keyboard` input.
+        # CI includes the keyboard in its shipping handoff-only shape so the
+        # extension and its flow tests compile without enabling direct capture.
         env:
           TUIST_IOS_KEYBOARD: "1"
         run: tuist generate --no-open

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -292,6 +292,17 @@ jobs:
             KEYBOARD_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$KEYBOARD_PATH/Info.plist")
             [ "$KEYBOARD_VERSION" = "$VERSION" ] || { echo "Keyboard version mismatch: expected '$VERSION', got '$KEYBOARD_VERSION'"; exit 1; }
             [ "$KEYBOARD_BUILD" = "$BUILD_NUMBER" ] || { echo "Keyboard build mismatch: expected '$BUILD_NUMBER', got '$KEYBOARD_BUILD'"; exit 1; }
+            for usage_key in NSMicrophoneUsageDescription NSSpeechRecognitionUsageDescription; do
+              if [ "$TUIST_IOS_KEYBOARD_DIRECT_CAPTURE" = "1" ]; then
+                /usr/libexec/PlistBuddy -c "Print :$usage_key" "$KEYBOARD_PATH/Info.plist" >/dev/null 2>&1 || {
+                  echo "::error::Direct-capture keyboard is missing $usage_key."
+                  exit 1
+                }
+              elif /usr/libexec/PlistBuddy -c "Print :$usage_key" "$KEYBOARD_PATH/Info.plist" >/dev/null 2>&1; then
+                echo "::error::Handoff-only keyboard unexpectedly declares $usage_key."
+                exit 1
+              fi
+            done
           else
             [ ! -e "$KEYBOARD_PATH" ] || {
               echo "::error::Keyboard feature is off, but JustSpeakKeyboard.appex was embedded in the archive."

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -11,16 +11,23 @@ on:
         description: 'Build number (auto-increments if empty)'
         required: false
       include_keyboard:
-        description: 'Internal only: include the experimental custom keyboard extension'
+        description: 'Include the custom keyboard extension (persistent release default; disable only for build rollback)'
+        required: false
+        default: true
+        type: boolean
+      enable_direct_capture:
+        description: 'Device-matrix only: let the keyboard request microphone/Speech permission and capture directly'
         required: false
         default: false
         type: boolean
 
 env:
   APP_STORE_CONNECT_KEY_ID: S747NJ9DZY
-  # Off by default. Auto Release dispatches only `version`, so production
-  # TestFlight archives omit the experimental keyboard unless explicitly opted in.
+  # The extension now ships by default, while direct capture remains an
+  # independent, default-off rollout. Handoff-only builds never attempt the
+  # keyboard-process microphone or Speech permission path.
   TUIST_IOS_KEYBOARD: ${{ inputs.include_keyboard && '1' || '0' }}
+  TUIST_IOS_KEYBOARD_DIRECT_CAPTURE: ${{ inputs.include_keyboard && inputs.enable_direct_capture && '1' || '0' }}
 
 jobs:
   build-and-upload:
@@ -116,7 +123,14 @@ jobs:
           fi
 
       - name: Generate Xcode Project
-        run: tuist generate --no-open
+        run: |
+          tuist generate --no-open
+          {
+            echo "### Keyboard rollout policy"
+            echo "- Extension included: $TUIST_IOS_KEYBOARD"
+            echo "- Direct capture enabled: $TUIST_IOS_KEYBOARD_DIRECT_CAPTURE"
+            echo "- Commit: $GITHUB_SHA"
+          } >> "$GITHUB_STEP_SUMMARY"
       
       - name: Patch iOS Signing Settings
         env:

--- a/Docs/ios-keyboard-instant-dictation.md
+++ b/Docs/ios-keyboard-instant-dictation.md
@@ -1,14 +1,11 @@
 # iOS Keyboard Instant Dictation
 
-> **Shipping status:** disabled, and since keyboard v2 this is the **fallback**
-> capture path. The primary path records inside the keyboard extension itself —
-> see [iOS Keyboard v2 design](ios-keyboard-v2-design.md). Instant Dictation is
-> used when the extension cannot run the microphone or Apple Speech (permission
-> denied, recognizer unavailable, or in-extension capture failed). Default
-> local, archive, and TestFlight builds do not include the extension; internal
-> development requires `TUIST_IOS_KEYBOARD=1 tuist generate`, and a manual
-> TestFlight run additionally requires the off-by-default `include_keyboard`
-> input. Do not ship until the physical-device release matrix passes.
+> **Shipping status:** the keyboard is included in TestFlight and Instant
+> Dictation is its default capture path. Direct extension capture remains an
+> independent, default-off candidate — see
+> [iOS Keyboard v2 design](ios-keyboard-v2-design.md). Normal automated builds
+> use `include_keyboard=true` and `enable_direct_capture=false`, so the
+> extension does not read or request microphone/Speech permissions.
 
 ## Product decision
 
@@ -23,9 +20,9 @@ the user turns it off, the app is force-quit, the phone restarts, or iOS
 interrupts the audio session. After one of those events, opening Just Speak once
 reconnects the persisted Instant Dictation preference.
 
-In this fallback path the keyboard extension never opens the microphone: the
+In this handoff path the keyboard extension never opens the microphone: the
 containing app owns the foreground-consented audio session and stays alive with
-the `audio` background mode. (The v2 primary path *attempts* to record inside
+the `audio` background mode. (The v2 candidate path *attempts* to record inside
 the extension with Full Access plus user-granted microphone and speech
 permissions; that capability is an unverified platform assumption, and this
 handoff exists precisely for devices and users where it is refused or

--- a/Docs/ios-keyboard-instant-dictation.md
+++ b/Docs/ios-keyboard-instant-dictation.md
@@ -5,7 +5,9 @@
 > independent, default-off candidate — see
 > [iOS Keyboard v2 design](ios-keyboard-v2-design.md). Normal automated builds
 > use `include_keyboard=true` and `enable_direct_capture=false`, so the
-> extension does not read or request microphone/Speech permissions.
+> extension does not read or request microphone/Speech permissions. It reads
+> bounded context immediately before and after the cursor locally to prove its
+> replacement anchor, but never persists or transmits that host context.
 
 ## Product decision
 

--- a/Docs/ios-keyboard-mvp-verification.md
+++ b/Docs/ios-keyboard-mvp-verification.md
@@ -264,7 +264,9 @@ dictation), and touch targets of at least 44 points.
   permissions" above; the handoff path covers devices that refuse.
 - When direct capture is enabled, the extension records only while the mic key
   is active and prefers on-device recognition.
-- `Local` sends no transcript to an app or network post-processor. `App`
+- `Local` never routes a transcript to a network post-processor. With direct
+  capture enabled it runs in the extension; while direct capture is off or
+  unavailable, the app executes the same Apple Speech snapshot. `App`
   explicitly routes the selected model through the containing app; credentials
   stay in Keychain and never enter the App Group.
 - The keyboard reads bounded context immediately before and after the cursor

--- a/Docs/ios-keyboard-mvp-verification.md
+++ b/Docs/ios-keyboard-mvp-verification.md
@@ -1,10 +1,12 @@
 # iOS Custom Keyboard v2 Verification
 
-The keyboard is an internal, off-by-default feature. Generate with
-`TUIST_IOS_KEYBOARD=1 tuist generate` before running this matrix. A normal
-project generation or TestFlight release must omit `JustSpeakKeyboard.appex`
-(CI generates with the flag so the extension keeps compiling, but release
-workflows stay gated behind the manual `include_keyboard` input).
+TestFlight includes `JustSpeakKeyboard.appex` by default so automated releases
+cannot silently drop an enabled keyboard. Direct capture is an independent,
+default-off build policy: normal releases set
+`TUIST_IOS_KEYBOARD_DIRECT_CAPTURE=0` and use the proven Instant Dictation
+handoff without requesting microphone or Speech permission in the extension.
+Generate with `TUIST_IOS_KEYBOARD=1 tuist generate` for that shipping shape;
+add `TUIST_IOS_KEYBOARD_DIRECT_CAPTURE=1` only for the direct-capture matrix.
 
 Architecture, path selection, and open risks are documented in
 [iOS Keyboard v2 design](ios-keyboard-v2-design.md). The fallback path's
@@ -21,7 +23,7 @@ one line at the same ~170 pt height. There is deliberately no QWERTY layer; the
 globe key returns to a system keyboard for typing. Two capture paths exist
 behind `KeyboardCapturePlanner`:
 
-- **Direct** (primary): the extension records via `AVAudioEngine` and
+- **Direct** (candidate, policy-gated): the extension records via `AVAudioEngine` and
   transcribes with Apple Speech (on-device preferred), streaming text into the
   host field through stable-prefix commit + tail replacement.
 - **Handoff** (fallback): the v1 Instant Dictation flow, used when the
@@ -47,11 +49,11 @@ xcodebuild test \
   -only-testing:SpeakiOSUITests
 ```
 
-`SpeakiOSTests` and `SpeakiOSUITests` are the only generated Tuist test targets
-(sourced from `Tests/SpeakiOSTests/**` and `Tests/SpeakiOSUITests/**`), so they
-do not contain the new keyboard suites. State-machine, streaming-edit, planner,
-and language-preference logic are pure SpeakCore types, and the keyboard
-distribution guards live in `Tests/SpeakAppTests`; run both through SwiftPM:
+`SpeakiOSTests` contains the injectable keyboard view-model/document-proxy flow
+tests, including stale callback, same-field caret, empty capture, policy, and
+composed-character scenarios. State-machine, streaming-edit, planner, and
+language-preference logic are pure SpeakCore types, while keyboard distribution
+guards live in `Tests/SpeakAppTests`; run both through SwiftPM:
 
 ```bash
 swift test --filter Keyboard
@@ -68,13 +70,38 @@ Expected entries are `JustSpeakKeyboard.appex` and
 `JustSpeakToItWidgetExtension.appex`. The nonce, transcript, API keys, and
 surrounding text must not appear in logs.
 
-## Physical-device matrix (release gate)
+## Physical-device matrix (direct-capture release gate)
 
 Use a development or TestFlight build signed with App Group
 `group.com.justspeaktoit.ios` for the app and keyboard extension. The
 TestFlight workflow needs a provisioning profile for bundle ID
-`com.justspeaktoit.ios.keyboard`, stored as GitHub secret
-`IOS_KEYBOARD_APPSTORE_PROFILE`.
+`com.justspeaktoit.ios.keyboard`. It uses the
+`IOS_KEYBOARD_APPSTORE_PROFILE` secret when present, otherwise it reuses or
+creates the validated portal profile described in the TestFlight runbook.
+
+Record one row per device/host scenario in issue #661 with the tester's name,
+device model, exact iOS version, host app/version, workflow URL, commit SHA,
+marketing version/build, pass/fail result, screenshots or screen recording,
+and any console/memory evidence. Minimum coverage is:
+
+- one physical iPhone on iOS 17 and one physical iPhone on the current iOS;
+- Notes and WhatsApp on both iPhones, plus Safari on the current-iOS iPhone;
+- one current-iPadOS iPad for full-width/split layout and VoiceOver checks.
+
+Do not infer a pass from simulator or CI results. A missing row is a failed
+release gate, not an implicit pass.
+
+### Handoff-only shipping build
+
+1. Run **Release iOS (TestFlight)** with `include_keyboard=true` and
+   `enable_direct_capture=false`.
+2. Confirm `JustSpeakKeyboard.appex` is present and carries the App Group
+   entitlement, then install the processed build on a physical iPhone.
+3. With permissions undecided, tap the keyboard mic. No extension microphone
+   or Speech prompt may appear; the first action must select handoff.
+4. With Instant Dictation ready, complete dictation through handoff. With it
+   not ready, show the actionable reconnect state and leave the host field
+   unchanged.
 
 ### Enablement and Full Access
 
@@ -90,17 +117,23 @@ TestFlight workflow needs a provisioning profile for bundle ID
 
 ### Direct path: permissions (open risk — verify first)
 
+Run this section only in an explicitly identified build made with
+`enable_direct_capture=true`.
+
 1. Fresh install, Full Access on, no permissions granted. In Notes, open the
    Just Speak keyboard and tap the mic.
 2. **Record whether iOS presents the microphone and speech-recognition
    prompts inside the keyboard.** This is the load-bearing platform
    assumption; note OS version and device.
-3. Grant both → recording must start with a visible red stop state.
+3. Grant both → recording must start with a visible red stop state. Complete
+   dictation in Notes and WhatsApp without leaving either host app.
 4. With Instant Dictation enabled in the app (Settings › Set Up Keyboard),
-   repeat on a second install and **deny** the microphone → the keyboard must
-   surface the failure and degrade to the Instant Dictation fallback without
-   hanging.
-5. Revoke permissions in Settings afterwards and confirm the keyboard plans
+   repeat fresh installs denying microphone and Speech separately. Each denial
+   must degrade to handoff without hanging and must leave no separator or other
+   failed-attempt mutation in the host field.
+5. Repeat each denial with Instant Dictation not ready. The keyboard must show
+   an actionable reconnect state and leave the host field unchanged.
+6. Revoke permissions in Settings afterwards and confirm the keyboard plans
    the fallback path on next appearance.
 
 ### Direct path: happy flow
@@ -130,7 +163,8 @@ TestFlight workflow needs a provisioning profile for bundle ID
 2. Tap the chip → it cycles to the next quick language in one tap (≤2 taps
    from anywhere in the keyboard). Chip is disabled while recording.
 3. Dictate in the switched language and verify recognition uses it.
-4. Switch the app language, reopen the keyboard → chip follows the app.
+4. Switch the app language and immediately switch to another app's keyboard
+   without reopening Just Speak → the chip and recogniser use the new selection.
 
 ### Profile/mode quick-switch
 
@@ -171,20 +205,21 @@ app Keychain, and the menu remains available without Apple Intelligence.
 2. Switch to a different text field or app mid-dictation → capture cancels,
    already-streamed text stays in the original field, nothing streams into
    the new target.
-3. Stop or cancel dictation **before** moving the cursor elsewhere in the same
-   field: the streamer's tail bound only holds while the selection stays where
-   it left it. Then assert that unrelated text in the field is unchanged.
-   Moving the cursor mid-dictation is a known risk — if you do it, record the
-   observed behaviour; edits must at worst touch text within the streamed tail
-   length of the new cursor, never beyond it.
-4. Dismiss the keyboard mid-dictation → audio session releases (no stuck
+3. Move the cursor/selection earlier and later in the same field before a
+   revising partial. The run must pause or terminate truthfully before another
+   replacement, and unrelated host text must remain byte-for-byte unchanged.
+4. Edit text before and after the cursor in the host app during capture. Any
+   unprovable replacement anchor must pause the run; no best-effort deletion is
+   permitted.
+5. Dismiss the keyboard mid-dictation → audio session releases (no stuck
    orange indicator).
 
 ### Direct path: memory
 
 With the Xcode memory gauge attached to the extension, dictate continuously
-for 2+ minutes with on-device speech. The extension must stay comfortably
-under the keyboard budget (~60–80 MB) and must not be jetsammed.
+for at least two minutes with on-device speech. Record resident and peak memory
+at 30-second intervals. The gate is a peak below 60 MB with no sustained rise
+over the final minute and no jetsam. A peak of 60 MB or more fails the gate.
 
 ### Fallback path (Instant Dictation handoff)
 
@@ -227,12 +262,14 @@ dictation), and touch targets of at least 44 points.
   Whether iOS presents those prompts to a keyboard extension — and honours the
   grants — is the unverified platform assumption tracked in "Direct path:
   permissions" above; the handoff path covers devices that refuse.
-- The extension records only while the mic key is active and prefers on-device
-  recognition.
+- When direct capture is enabled, the extension records only while the mic key
+  is active and prefers on-device recognition.
 - `Local` sends no transcript to an app or network post-processor. `App`
   explicitly routes the selected model through the containing app; credentials
   stay in Keychain and never enter the App Group.
-- The keyboard does not read, persist, or transmit surrounding host text.
+- The keyboard reads bounded context immediately before and after the cursor
+  locally to prove replacement anchors. It never persists or transmits that
+  context.
 - The App Group contains: versioned handoff records (schema version, request
   UUID, document identifier, timestamps, phase, safe failure enum, throttled
   interim text, short-lived final transcript), the language selection, and a
@@ -244,3 +281,19 @@ dictation), and touch targets of at least 44 points.
 - App Review notes should describe both capture paths, the permission grants,
   and the secure-field, phone-pad, and host-app restrictions exactly as users
   see them.
+
+## Rollout and rollback
+
+1. Keep automated releases at `include_keyboard=true` and
+   `enable_direct_capture=false` until every row above is attached to #661.
+2. Use one manual TestFlight build with `enable_direct_capture=true` for the
+   direct matrix, recording the workflow URL, commit, version/build, archive
+   presence, entitlement, processing/group assignment, installation, and
+   extension presence.
+3. After the matrix passes, change the repository's automated-release dispatch
+   and workflow default to `enable_direct_capture=true` in a reviewed PR. A
+   one-off manual input is not rollout completion.
+4. Direct-path rollback is a new build with `include_keyboard=true` and
+   `enable_direct_capture=false`. Extension rollback is a new build with
+   `include_keyboard=false`. Already installed builds cannot be changed
+   remotely, so record the replacement build and tester assignment in #661.

--- a/Docs/ios-keyboard-mvp-verification.md
+++ b/Docs/ios-keyboard-mvp-verification.md
@@ -257,8 +257,9 @@ dictation), and touch targets of at least 44 points.
   the network (Apple's server dictation for locales without on-device support,
   and the fallback path's user-selected cloud transcription).
 - Microphone capture and Apple Speech inside the extension are *not* granted by
-  Full Access. The extension declares `NSMicrophoneUsageDescription` and
-  `NSSpeechRecognitionUsageDescription`, and the user must authorise both.
+  Full Access. Direct-capture builds declare `NSMicrophoneUsageDescription` and
+  `NSSpeechRecognitionUsageDescription`; handoff-only builds omit both. The user
+  must authorise both permissions when testing direct capture.
   Whether iOS presents those prompts to a keyboard extension — and honours the
   grants — is the unverified platform assumption tracked in "Direct path:
   permissions" above; the handoff path covers devices that refuse.

--- a/Docs/ios-keyboard-v2-design.md
+++ b/Docs/ios-keyboard-v2-design.md
@@ -36,7 +36,7 @@ extension with `RequestsOpenAccess` and user-granted Full Access **can** in
 practice activate an audio session and use the Speech framework. Apple
 documents Full Access as gating shared containers and network access, not
 microphone capture, and does not state that extensions may record; the
-extension must separately declare `NSMicrophoneUsageDescription`/
+direct-capture build must separately declare `NSMicrophoneUsageDescription`/
 `NSSpeechRecognitionUsageDescription` and the user must grant both. **Treat
 in-extension capture as an unverified platform assumption** until the
 physical-device matrix signs it off: first-run permission behaviour on real
@@ -159,8 +159,9 @@ One compact layout (~170 pt portrait iPhone; v1 was 300 pt):
   host context.
 - The App Group carries handoff records, language selection, and a non-secret
   profile projection. Never audio, credentials, custom prompts, or surrounding text.
-- Extension Info.plist declares microphone and speech-recognition usage
-  strings; both permissions are user-granted and revocable in Settings.
+- Direct-capture builds add microphone and speech-recognition usage strings to
+  the extension Info.plist; handoff-only builds omit them. Both permissions are
+  user-granted and revocable in Settings when direct capture is enabled.
 
 ## Open risks (device-matrix items)
 

--- a/Docs/ios-keyboard-v2-design.md
+++ b/Docs/ios-keyboard-v2-design.md
@@ -1,11 +1,11 @@
 # iOS Keyboard v2: In-Keyboard Dictation Design
 
-> **Shipping status:** disabled. Default local, archive, and TestFlight builds
-> omit the extension. Internal CI generates with `TUIST_IOS_KEYBOARD=1` so the
-> extension keeps compiling; a manual TestFlight run additionally requires the
-> off-by-default `include_keyboard` input. The physical-device matrix in
-> [iOS keyboard verification](ios-keyboard-mvp-verification.md) is the release
-> gate.
+> **Shipping status:** the keyboard extension is included in TestFlight by
+> default, using the existing Instant Dictation handoff. Direct capture is an
+> independent build policy and remains default-off until the physical-device
+> matrix in [iOS keyboard verification](ios-keyboard-mvp-verification.md)
+> passes. This lets the handoff-only keyboard ship without attempting
+> microphone or Speech permissions inside the extension.
 
 ## Audit: why v1 bounced to the main app
 
@@ -45,12 +45,14 @@ fallback for devices that refuse.
 
 ## Decision
 
-Two capture paths behind one planner (`KeyboardCapturePlanner` in SpeakCore):
+Two capture paths behind one planner (`KeyboardCapturePlanner` in SpeakCore)
+and an independent direct-capture policy:
 
 | Condition | Path |
 | --- | --- |
 | No Full Access (no audio session, no App Group) | **Blocked** — setup guidance in the strip |
-| Full Access, mic + speech permission not denied | **Direct**: record + transcribe inside the extension |
+| Full Access, direct capture disabled by policy | **Handoff** without reading/requesting extension permissions |
+| Full Access, direct capture enabled, mic + speech permission not denied | **Direct**: record + transcribe inside the extension |
 | Full Access, mic or speech denied / recognizer missing / capture fails | **Handoff**: v1 Instant Dictation flow |
 
 Note: issue #610 sketched "handoff when Full Access is off", but Full Access
@@ -64,7 +66,7 @@ Speech support is unverified on device (see above), so any denied prompt,
 missing recogniser, or capture failure degrades to **Handoff** at runtime
 (`fallBackToHandoffIfDirectCaptureIsImpossible`).
 
-### Direct path (primary)
+### Direct path (candidate)
 
 - `KeyboardDictationEngine` (extension-only): `AVAudioEngine` input tap →
   `SFSpeechAudioBufferRecognitionRequest` with partial results.
@@ -85,11 +87,13 @@ missing recogniser, or capture failure degrades to **Handoff** at runtime
   (`deleteCount` + `insertion`) against the document proxy. Words that survive
   one revision are committed at word boundaries and never rewritten; the final
   two words stay volatile (engines revise those most). Structural invariant:
-  deletes never exceed the volatile tail, so **while the selection stays where
-  the streamer left it** host-app text is never eaten. If the user moves the
-  cursor mid-dictation the tail no longer maps to the streamed text, so the
-  verification matrix requires stopping dictation before editing elsewhere in
-  the same field and records observed behaviour when it is not.
+  deletes never exceed the volatile tail. `KeyboardDocumentSession` also owns
+  the leading separator and snapshots bounded context on both sides of the
+  cursor after every extension-authored edit. A caret move or host edit that
+  makes the replacement anchor unprovable pauses the run before another tail
+  deletion. Composed clusters are deleted only while the complete context
+  proves scalar-wise progress; ambiguous outcomes are never followed by an
+  insert.
   Text therefore **streams into the field as the user speaks**, with the same
   live text mirrored in the keyboard strip.
 - Language quick-switch chip: `KeyboardDictationPreferencesStore` (App Group)
@@ -102,7 +106,10 @@ missing recogniser, or capture failure degrades to **Handoff** at runtime
   are defined by `KeyboardDictationProfileCatalog` in SpeakCore, remain
   reachable in two taps, and stay available without Apple Foundation Models.
   The projection contains no credentials or custom prompt text.
-- Guardrails: a `documentIdentifier` change mid-session cancels capture and
+- Guardrails: every engine callback carries a per-run UUID, so a delayed result,
+  final, error, timeout, or interruption from a cancelled recogniser cannot
+  mutate or tear down a newer run. A document/selection mutation mid-session
+  cancels capture and
   commits what was already streamed (never streams into the wrong field);
   audio interruptions finish gracefully, keeping inserted words.
 
@@ -146,8 +153,9 @@ One compact layout (~170 pt portrait iPhone; v1 was 300 pt):
 - Recording happens only while the mic key is active; there is no idle
   listening in the direct path. The permanent orange indicator now exists only
   when the user explicitly enables the fallback.
-- The keyboard still never reads or transmits surrounding host text; edits go
-  one way through `textDocumentProxy`.
+- The keyboard reads bounded context immediately before and after the cursor
+  locally to prove its replacement anchor. It never persists or transmits that
+  host context.
 - The App Group carries handoff records, language selection, and a non-secret
   profile projection. Never audio, credentials, custom prompts, or surrounding text.
 - Extension Info.plist declares microphone and speech-recognition usage
@@ -160,9 +168,8 @@ One compact layout (~170 pt portrait iPhone; v1 was 300 pt):
    If a device declines, the engine reports failure and the keyboard degrades
    to handoff — but the prompt flow must be confirmed on hardware.
 2. **Memory ceiling** under long dictation with on-device speech.
-3. **Cursor moves mid-dictation**: `selectionDidChange` is unreliable in
-   keyboard extensions; a user tapping elsewhere in the same field during
-   dictation can misplace tail replacements. Document-change cancellation
-   covers the cross-field case; same-field cursor taps need device testing.
+3. **Cursor/host mutations mid-dictation**: code now pauses when the bounded
+   before/after context no longer matches the session anchor. Device testing
+   must confirm callback ordering across Notes, WhatsApp, and Safari.
 4. **`SFSpeechRecognizer` availability inside extensions** per locale asset
    state (undownloaded on-device models fall back to server dictation).

--- a/Docs/ios-keyboard-v2-design.md
+++ b/Docs/ios-keyboard-v2-design.md
@@ -122,7 +122,8 @@ transcript mirroring, single insert on completion. Each request snapshots its
 selected profile, and the app executes that exact model/language/polish
 configuration or returns `profileUnavailable`; it never silently downgrades.
 The keyboard also automatically degrades to this path when direct capture fails with a permission-style error.
-Setup copy now frames Instant Dictation as the fallback, not the primary flow.
+Setup copy distinguishes the App profile from Local mode's default-off and
+permission-failure handoff without implying that the rollout flag is enabled.
 
 ### Surface
 

--- a/Docs/ios-testflight-release.md
+++ b/Docs/ios-testflight-release.md
@@ -2,6 +2,12 @@
 
 Use this runbook for normal TestFlight releases and for failures involving the iOS app, widget, or transcription keyboard provisioning profiles.
 
+Normal automated and manual releases include the keyboard extension. Direct
+capture inside the extension is independently disabled until the physical
+matrix in [iOS keyboard verification](ios-keyboard-mvp-verification.md) passes;
+the shipping keyboard uses Instant Dictation handoff and makes no extension
+microphone or Speech permission attempt.
+
 ## Release identifiers
 
 | Component | Bundle identifier | Required shared capability |
@@ -18,7 +24,7 @@ Do not commit certificates, private keys, decoded profiles, or their base64 cont
 
 1. Confirm the intended commit is on `main` and its required checks passed.
 2. Open App Store Connect and check the latest iOS TestFlight marketing version and build number.
-3. Run the GitHub Actions workflow **Release iOS (TestFlight)**. Enter the intended semantic version explicitly, without a leading `v`. The repository `VERSION` file is not authoritative for iOS.
+3. Run the GitHub Actions workflow **Release iOS (TestFlight)**. Enter the intended semantic version explicitly, without a leading `v`. Keep `include_keyboard=true`. Keep `enable_direct_capture=false` unless this exact build is the recorded direct-capture matrix build. The repository `VERSION` file is not authoritative for iOS.
 4. Monitor all distribution gates in the workflow:
    - signing certificate and three profiles install successfully;
    - the keyboard profile authorizes `group.com.justspeaktoit.ios`;
@@ -60,11 +66,25 @@ The command must exit successfully. The release workflow performs the same exact
 
 1. Install or update the processed build from TestFlight and confirm its version/build in the app.
 2. In iOS Settings, enable **Just Speak to It** under **General** → **Keyboard** → **Keyboards**. Enable Full Access only when the app's current onboarding requires it.
-3. Open a text field in another app, switch to the Just Speak to It keyboard, and start transcription.
-4. Confirm the containing app records through the iPhone microphone, returns the nonce-matched result through the App Group, and the keyboard inserts the text at the cursor.
+3. Open a text field in another app, switch to the Just Speak to It keyboard, and start transcription. In a normal handoff-only build, no microphone or Speech permission prompt may come from the keyboard.
+4. Confirm the containing app records through the iPhone microphone, returns the nonce-matched result through the App Group, and the keyboard inserts the text at the cursor. If Instant Dictation is not ready, confirm the keyboard shows the reconnect state and leaves the field unchanged.
 5. Confirm stale results are not reused and normal Apple keyboard switching remains available.
 
-A custom keyboard extension cannot access the microphone directly. The supported path is keyboard → containing app → microphone/transcription → App Group handoff → `textDocumentProxy.insertText`.
+Direct extension capture remains an unverified, policy-gated candidate rather
+than an assumed platform capability. Run it only with
+`enable_direct_capture=true` and complete the separate physical matrix. The
+normal supported path is keyboard → containing app → microphone/transcription
+→ App Group handoff → `textDocumentProxy.insertText`.
+
+## Build-based rollback
+
+- Direct-capture rollback: run a new build with `include_keyboard=true` and
+  `enable_direct_capture=false`; verify handoff on hardware.
+- Extension rollback: run a new build with `include_keyboard=false`; verify the
+  archive omits `JustSpeakKeyboard.appex`.
+- There is no runtime switch for an installed build. Record the replacement
+  workflow URL, commit, version/build, processing, tester assignment, physical
+  installation, and observed extension state in issue #661.
 
 ## Completion evidence
 
@@ -72,6 +92,8 @@ Report each state separately:
 
 - PR merged and release commit identified.
 - Release workflow succeeded.
+- Workflow summary recorded keyboard inclusion and direct-capture policy.
+- Archive presence/absence and keyboard App Group entitlement matched policy.
 - App Store Connect processing completed for the exact version/build.
 - Internal tester group assignment confirmed.
 - TestFlight build installed on a physical iPhone.

--- a/Docs/ios-testflight-release.md
+++ b/Docs/ios-testflight-release.md
@@ -66,7 +66,7 @@ The command must exit successfully. The release workflow performs the same exact
 
 1. Install or update the processed build from TestFlight and confirm its version/build in the app.
 2. In iOS Settings, enable **Just Speak to It** under **General** → **Keyboard** → **Keyboards**. Enable Full Access only when the app's current onboarding requires it.
-3. Open a text field in another app, switch to the Just Speak to It keyboard, and start transcription. In a normal handoff-only build, no microphone or Speech permission prompt may come from the keyboard.
+3. Open a text field in another app, switch to the Just Speak to It keyboard, and start transcription. In a normal handoff-only build, the keyboard must not present a microphone or Speech permission prompt. Treat any such prompt as a failure.
 4. Confirm the containing app records through the iPhone microphone, returns the nonce-matched result through the App Group, and the keyboard inserts the text at the cursor. If Instant Dictation is not ready, confirm the keyboard shows the reconnect state and leaves the field unchanged.
 5. Confirm stale results are not reused and normal Apple keyboard switching remains available.
 

--- a/JustSpeakKeyboard/KeyboardDictationEngine.swift
+++ b/JustSpeakKeyboard/KeyboardDictationEngine.swift
@@ -1,6 +1,16 @@
 import AVFoundation
+import Foundation
 import Speech
 import SpeakCore
+
+@MainActor
+protocol KeyboardDictationEngineProtocol: AnyObject {
+    var onEvent: ((UUID, KeyboardDictationMachine.Event) -> Void)? { get set }
+
+    func start(runID: UUID, localeIdentifier: String)
+    func stop(runID: UUID)
+    func cancel(runID: UUID)
+}
 
 /// Captures microphone audio and produces live Apple Speech hypotheses inside
 /// the keyboard extension process.
@@ -12,8 +22,8 @@ import SpeakCore
 /// runs out of process, so the extension's own footprint stays within the
 /// keyboard memory budget — no model weights are loaded here.
 @MainActor
-final class KeyboardDictationEngine {
-    var onEvent: ((KeyboardDictationMachine.Event) -> Void)?
+final class KeyboardDictationEngine: KeyboardDictationEngineProtocol {
+    var onEvent: ((UUID, KeyboardDictationMachine.Event) -> Void)?
 
     private let audioEngine = AVAudioEngine()
     private var recognizer: SFSpeechRecognizer?
@@ -23,7 +33,7 @@ final class KeyboardDictationEngine {
     private var finalizationTimeout: Task<Void, Never>?
     private var lastHypothesis = ""
     private var isStopping = false
-    private var isRunning = false
+    private var activeRunID: UUID?
     private var tapInstalled = false
 
     // MARK: - Preflight state used by the capture-path planner
@@ -52,30 +62,30 @@ final class KeyboardDictationEngine {
 
     // MARK: - Session control
 
-    func start(localeIdentifier: String) {
-        guard !isRunning else { return }
-        isRunning = true
+    func start(runID: UUID, localeIdentifier: String) {
+        guard activeRunID == nil else { return }
+        activeRunID = runID
         isStopping = false
         lastHypothesis = ""
-        Task { [weak self] in
-            await self?.requestPermissionsThenCapture(localeIdentifier: localeIdentifier)
+        Task { [weak self, runID] in
+            await self?.requestPermissionsThenCapture(runID: runID, localeIdentifier: localeIdentifier)
         }
     }
 
     /// Ends audio input gracefully; the final transcript arrives as a
     /// `.finalized` event (with a timeout so the keyboard can never hang).
-    func stop() {
-        guard isRunning, !isStopping else { return }
+    func stop(runID: UUID) {
+        guard activeRunID == runID, !isStopping else { return }
         isStopping = true
         stopAudioOnly()
         request?.endAudio()
-        armFinalizationTimeout()
+        armFinalizationTimeout(runID: runID)
     }
 
     /// Tears everything down without delivering further events.
-    func cancel() {
-        guard isRunning else { return }
-        isRunning = false
+    func cancel(runID: UUID) {
+        guard activeRunID == runID else { return }
+        activeRunID = nil
         finalizationTimeout?.cancel()
         finalizationTimeout = nil
         task?.cancel()
@@ -84,18 +94,19 @@ final class KeyboardDictationEngine {
 
     // MARK: - Startup
 
-    private func requestPermissionsThenCapture(localeIdentifier: String) async {
-        guard isRunning else { return }
+    private func requestPermissionsThenCapture(runID: UUID, localeIdentifier: String) async {
+        guard activeRunID == runID else { return }
         guard await Self.ensureMicrophonePermission() else {
-            fail(.microphoneUnavailable)
+            fail(.microphoneUnavailable, runID: runID)
             return
         }
+        guard activeRunID == runID else { return }
         guard await Self.ensureSpeechPermission() else {
-            fail(.speechRecognitionUnavailable)
+            fail(.speechRecognitionUnavailable, runID: runID)
             return
         }
-        guard isRunning else { return }
-        beginCapture(localeIdentifier: localeIdentifier)
+        guard activeRunID == runID else { return }
+        beginCapture(runID: runID, localeIdentifier: localeIdentifier)
     }
 
     private static func ensureMicrophonePermission() async -> Bool {
@@ -131,10 +142,11 @@ final class KeyboardDictationEngine {
         }
     }
 
-    private func beginCapture(localeIdentifier: String) {
+    private func beginCapture(runID: UUID, localeIdentifier: String) {
+        guard activeRunID == runID else { return }
         guard let recognizer = SFSpeechRecognizer(locale: Locale(identifier: localeIdentifier)),
               recognizer.isAvailable else {
-            fail(.speechRecognitionUnavailable)
+            fail(.speechRecognitionUnavailable, runID: runID)
             return
         }
         self.recognizer = recognizer
@@ -144,14 +156,14 @@ final class KeyboardDictationEngine {
             try session.setCategory(.record, mode: .measurement, options: [.allowBluetoothHFP])
             try session.setActive(true)
         } catch {
-            fail(.microphoneUnavailable)
+            fail(.microphoneUnavailable, runID: runID)
             return
         }
 
         let input = audioEngine.inputNode
         let format = input.outputFormat(forBus: 0)
         guard format.channelCount > 0 else {
-            fail(.microphoneUnavailable)
+            fail(.microphoneUnavailable, runID: runID)
             return
         }
 
@@ -172,32 +184,33 @@ final class KeyboardDictationEngine {
         do {
             try audioEngine.start()
         } catch {
-            fail(.microphoneUnavailable)
+            fail(.microphoneUnavailable, runID: runID)
             return
         }
 
-        task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+        task = recognizer.recognitionTask(with: request) { [weak self, runID] result, error in
             let text = result?.bestTranscription.formattedString
             let isFinal = result?.isFinal ?? false
             let failed = error != nil
             Task { @MainActor in
-                self?.handleRecognition(text: text, isFinal: isFinal, failed: failed)
+                self?.handleRecognition(runID: runID, text: text, isFinal: isFinal, failed: failed)
             }
         }
 
-        observeInterruptions()
-        onEvent?(.captureStarted)
+        observeInterruptions(runID: runID)
+        guard activeRunID == runID else { return }
+        onEvent?(runID, .captureStarted)
     }
 
     // MARK: - Recognition results
 
-    private func handleRecognition(text: String?, isFinal: Bool, failed: Bool) {
-        guard isRunning else { return }
+    private func handleRecognition(runID: UUID, text: String?, isFinal: Bool, failed: Bool) {
+        guard activeRunID == runID else { return }
         if let text, !text.isEmpty {
             lastHypothesis = text
         }
         if isFinal {
-            deliverFinal(text ?? lastHypothesis)
+            deliverFinal(text ?? lastHypothesis, runID: runID)
             return
         }
         if failed {
@@ -205,41 +218,43 @@ final class KeyboardDictationEngine {
             // the best hypothesis so far instead of dropping spoken words; a
             // failure with no words at all surfaces as an interruption.
             if isStopping || !lastHypothesis.isEmpty {
-                deliverFinal(lastHypothesis)
+                deliverFinal(lastHypothesis, runID: runID)
             } else {
-                fail(.audioInterrupted)
+                fail(.audioInterrupted, runID: runID)
             }
             return
         }
         if let text, !text.isEmpty {
-            onEvent?(.hypothesis(text))
+            onEvent?(runID, .hypothesis(text))
         }
     }
 
-    private func deliverFinal(_ transcript: String) {
+    private func deliverFinal(_ transcript: String, runID: UUID) {
+        guard activeRunID == runID else { return }
         finalizationTimeout?.cancel()
         finalizationTimeout = nil
-        isRunning = false
+        activeRunID = nil
         teardown()
-        onEvent?(.finalized(transcript))
+        onEvent?(runID, .finalized(transcript))
     }
 
-    private func fail(_ failure: KeyboardDictationMachine.Failure) {
+    private func fail(_ failure: KeyboardDictationMachine.Failure, runID: UUID) {
+        guard activeRunID == runID else { return }
         finalizationTimeout?.cancel()
         finalizationTimeout = nil
-        isRunning = false
+        activeRunID = nil
         teardown()
-        onEvent?(.captureFailed(failure))
+        onEvent?(runID, .captureFailed(failure))
     }
 
-    private func armFinalizationTimeout() {
+    private func armFinalizationTimeout(runID: UUID) {
         finalizationTimeout?.cancel()
-        finalizationTimeout = Task { [weak self] in
+        finalizationTimeout = Task { [weak self, runID] in
             try? await Task.sleep(for: .seconds(5))
             guard !Task.isCancelled else { return }
-            guard let self, self.isRunning, self.isStopping else { return }
+            guard let self, self.activeRunID == runID, self.isStopping else { return }
             self.task?.cancel()
-            self.deliverFinal(self.lastHypothesis)
+            self.deliverFinal(self.lastHypothesis, runID: runID)
         }
     }
 
@@ -266,17 +281,18 @@ final class KeyboardDictationEngine {
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
-    private func observeInterruptions() {
+    private func observeInterruptions(runID: UUID) {
         guard interruptionObserver == nil else { return }
         interruptionObserver = NotificationCenter.default.addObserver(
             forName: AVAudioSession.interruptionNotification,
             object: AVAudioSession.sharedInstance(),
             queue: .main
-        ) { [weak self] notification in
+        ) { [weak self, runID] notification in
             let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
             guard typeValue == AVAudioSession.InterruptionType.began.rawValue else { return }
             Task { @MainActor in
-                self?.onEvent?(.interrupted)
+                guard let self, self.activeRunID == runID else { return }
+                self.onEvent?(runID, .interrupted)
             }
         }
     }

--- a/JustSpeakKeyboard/KeyboardDocumentSession.swift
+++ b/JustSpeakKeyboard/KeyboardDocumentSession.swift
@@ -180,7 +180,7 @@ private extension KeyboardDocumentSession.Snapshot {
         guard scalarCount > 0,
               let originalBefore = original.beforeInput,
               let currentBefore = beforeInput,
-              Snapshot.scalarExact(afterInput, original.afterInput) else {
+              Self.scalarExact(afterInput, original.afterInput) else {
             return false
         }
         let originalScalars = originalBefore.unicodeScalars

--- a/JustSpeakKeyboard/KeyboardDocumentSession.swift
+++ b/JustSpeakKeyboard/KeyboardDocumentSession.swift
@@ -1,0 +1,176 @@
+import Foundation
+import SpeakCore
+
+/// Owns the bounded host-document region touched by one direct dictation run.
+/// Every replacement is conditional on the cursor context still matching the
+/// previous extension-authored edit.
+@MainActor
+final class KeyboardDocumentSession {
+    struct Snapshot: Equatable {
+        let beforeInput: String?
+        let afterInput: String?
+
+        static func == (lhs: Snapshot, rhs: Snapshot) -> Bool {
+            Self.scalarExact(lhs.beforeInput, rhs.beforeInput)
+                && Self.scalarExact(lhs.afterInput, rhs.afterInput)
+        }
+
+        private static func scalarExact(_ lhs: String?, _ rhs: String?) -> Bool {
+            switch (lhs, rhs) {
+            case let (.some(lhs), .some(rhs)):
+                lhs.unicodeScalars.elementsEqual(rhs.unicodeScalars)
+            case (.none, .none):
+                true
+            default:
+                false
+            }
+        }
+    }
+
+    enum EditResult: Equatable {
+        case applied
+        case anchorLost
+    }
+
+    private let insertText: (String) -> Void
+    private let deleteBackward: () -> Void
+    private let readSnapshot: () -> Snapshot
+
+    private var expectedSnapshot: Snapshot?
+    private var pendingSeparator: String?
+    private var separatorInserted = false
+
+    init(
+        insertText: @escaping (String) -> Void,
+        deleteBackward: @escaping () -> Void,
+        contextBeforeInput: @escaping () -> String?,
+        contextAfterInput: @escaping () -> String?
+    ) {
+        self.insertText = insertText
+        self.deleteBackward = deleteBackward
+        self.readSnapshot = {
+            Snapshot(
+                beforeInput: contextBeforeInput(),
+                afterInput: contextAfterInput()
+            )
+        }
+    }
+
+    func begin() {
+        let snapshot = readSnapshot()
+        expectedSnapshot = snapshot
+        pendingSeparator = KeyboardTranscriptStreamer.leadingSeparator(
+            contextBeforeInput: snapshot.beforeInput
+        )
+        separatorInserted = false
+    }
+
+    func anchorIsCurrent() -> Bool {
+        guard let expectedSnapshot else { return false }
+        return readSnapshot() == expectedSnapshot
+    }
+
+    func apply(_ edit: KeyboardTranscriptEdit) -> EditResult {
+        guard anchorIsCurrent() else { return .anchorLost }
+
+        for _ in 0..<edit.deleteCount {
+            guard deleteOneCharacter() else { return .anchorLost }
+        }
+
+        var insertion = edit.insertion
+        if !insertion.isEmpty, !separatorInserted, let pendingSeparator {
+            insertion = pendingSeparator + insertion
+            separatorInserted = true
+        }
+        if !insertion.isEmpty {
+            insertText(insertion)
+            expectedSnapshot = readSnapshot()
+        }
+        return .applied
+    }
+
+    /// Removes only the session-owned separator. It is called for an empty
+    /// final result; permission/startup failures never insert the separator.
+    func removeSeparatorIfTranscriptIsEmpty() -> EditResult {
+        guard separatorInserted else { return .applied }
+        guard anchorIsCurrent(), expectedSnapshot?.beforeInput?.last == " " else {
+            return .anchorLost
+        }
+        guard deleteOneCharacter() else { return .anchorLost }
+        separatorInserted = false
+        return .applied
+    }
+
+    func invalidate() {
+        expectedSnapshot = nil
+        pendingSeparator = nil
+        separatorInserted = false
+    }
+
+    /// Handles both known `UITextDocumentProxy` behaviours: deleting a whole
+    /// grapheme cluster or deleting one Unicode scalar at a time. Scalar-wise
+    /// progress continues only while the complete bounded context is exact.
+    private func deleteOneCharacter() -> Bool {
+        guard let original = expectedSnapshot,
+              let beforeInput = original.beforeInput,
+              let character = beforeInput.last else {
+            return false
+        }
+
+        let expectedWhole = Snapshot(
+            beforeInput: String(beforeInput.dropLast()),
+            afterInput: original.afterInput
+        )
+        deleteBackward()
+        var current = readSnapshot()
+        if current == expectedWhole {
+            expectedSnapshot = current
+            return true
+        }
+
+        let scalarCount = character.unicodeScalars.count
+        guard scalarCount > 1 else { return false }
+
+        var removedScalars = 1
+        while removedScalars < scalarCount,
+              current == scalarProgressSnapshot(
+                  original: original,
+                  beforeInput: beforeInput,
+                  removedScalars: removedScalars
+              ) {
+            deleteBackward()
+            removedScalars += 1
+            current = readSnapshot()
+            if current == expectedWhole {
+                expectedSnapshot = current
+                return true
+            }
+        }
+
+        // A proven partial scalar deletion can be restored exactly before the
+        // run is paused. Unknown host outcomes are never followed by an insert.
+        if removedScalars < scalarCount,
+           current == scalarProgressSnapshot(
+               original: original,
+               beforeInput: beforeInput,
+               removedScalars: removedScalars
+           ) {
+            let removedSuffix = String(beforeInput.unicodeScalars.suffix(removedScalars))
+            insertText(removedSuffix)
+            current = readSnapshot()
+        }
+        expectedSnapshot = current
+        return false
+    }
+
+    private func scalarProgressSnapshot(
+        original: Snapshot,
+        beforeInput: String,
+        removedScalars: Int
+    ) -> Snapshot {
+        Snapshot(
+            beforeInput: String(beforeInput.unicodeScalars.dropLast(removedScalars)),
+            afterInput: original.afterInput
+        )
+    }
+}

--- a/JustSpeakKeyboard/KeyboardDocumentSession.swift
+++ b/JustSpeakKeyboard/KeyboardDocumentSession.swift
@@ -15,7 +15,7 @@ final class KeyboardDocumentSession {
                 && Self.scalarExact(lhs.afterInput, rhs.afterInput)
         }
 
-        private static func scalarExact(_ lhs: String?, _ rhs: String?) -> Bool {
+        fileprivate static func scalarExact(_ lhs: String?, _ rhs: String?) -> Bool {
             switch (lhs, rhs) {
             case let (.some(lhs), .some(rhs)):
                 lhs.unicodeScalars.elementsEqual(rhs.unicodeScalars)
@@ -39,6 +39,7 @@ final class KeyboardDocumentSession {
     private var expectedSnapshot: Snapshot?
     private var pendingSeparator: String?
     private var separatorInserted = false
+    private var authoredText = ""
 
     init(
         insertText: @escaping (String) -> Void,
@@ -63,6 +64,7 @@ final class KeyboardDocumentSession {
             contextBeforeInput: snapshot.beforeInput
         )
         separatorInserted = false
+        authoredText = ""
     }
 
     func anchorIsCurrent() -> Bool {
@@ -72,9 +74,14 @@ final class KeyboardDocumentSession {
 
     func apply(_ edit: KeyboardTranscriptEdit) -> EditResult {
         guard anchorIsCurrent() else { return .anchorLost }
+        guard edit.deleteCount <= authoredText.count,
+              contextContainsAuthoredSuffix() else {
+            return .anchorLost
+        }
 
         for _ in 0..<edit.deleteCount {
             guard deleteOneCharacter() else { return .anchorLost }
+            authoredText.removeLast()
         }
 
         var insertion = edit.insertion
@@ -84,6 +91,7 @@ final class KeyboardDocumentSession {
         }
         if !insertion.isEmpty {
             insertText(insertion)
+            authoredText += edit.insertion
             expectedSnapshot = readSnapshot()
         }
         return .applied
@@ -105,11 +113,12 @@ final class KeyboardDocumentSession {
         expectedSnapshot = nil
         pendingSeparator = nil
         separatorInserted = false
+        authoredText = ""
     }
 
     /// Handles both known `UITextDocumentProxy` behaviours: deleting a whole
     /// grapheme cluster or deleting one Unicode scalar at a time. Scalar-wise
-    /// progress continues only while the complete bounded context is exact.
+    /// progress continues only while the unchanged context remains provable.
     private func deleteOneCharacter() -> Bool {
         guard let original = expectedSnapshot,
               let beforeInput = original.beforeInput,
@@ -117,44 +126,35 @@ final class KeyboardDocumentSession {
             return false
         }
 
-        let expectedWhole = Snapshot(
-            beforeInput: String(beforeInput.dropLast()),
-            afterInput: original.afterInput
-        )
+        let scalarCount = character.unicodeScalars.count
         deleteBackward()
         var current = readSnapshot()
-        if current == expectedWhole {
+        if current.matchesRemoval(of: scalarCount, from: original) {
             expectedSnapshot = current
             return true
         }
 
-        let scalarCount = character.unicodeScalars.count
-        guard scalarCount > 1 else { return false }
+        guard scalarCount > 1, current.matchesRemoval(of: 1, from: original) else {
+            expectedSnapshot = current
+            return false
+        }
 
         var removedScalars = 1
-        while removedScalars < scalarCount,
-              current == scalarProgressSnapshot(
-                  original: original,
-                  beforeInput: beforeInput,
-                  removedScalars: removedScalars
-              ) {
+        while removedScalars < scalarCount {
             deleteBackward()
             removedScalars += 1
             current = readSnapshot()
-            if current == expectedWhole {
+            if current.matchesRemoval(of: scalarCount, from: original) {
                 expectedSnapshot = current
                 return true
             }
+            guard current.matchesRemoval(of: removedScalars, from: original) else { break }
         }
 
         // A proven partial scalar deletion can be restored exactly before the
         // run is paused. Unknown host outcomes are never followed by an insert.
         if removedScalars < scalarCount,
-           current == scalarProgressSnapshot(
-               original: original,
-               beforeInput: beforeInput,
-               removedScalars: removedScalars
-           ) {
+           current.matchesRemoval(of: removedScalars, from: original) {
             let removedSuffix = String(beforeInput.unicodeScalars.suffix(removedScalars))
             insertText(removedSuffix)
             current = readSnapshot()
@@ -163,14 +163,34 @@ final class KeyboardDocumentSession {
         return false
     }
 
-    private func scalarProgressSnapshot(
-        original: Snapshot,
-        beforeInput: String,
-        removedScalars: Int
-    ) -> Snapshot {
-        Snapshot(
-            beforeInput: String(beforeInput.unicodeScalars.dropLast(removedScalars)),
-            afterInput: original.afterInput
-        )
+    private func contextContainsAuthoredSuffix() -> Bool {
+        guard !authoredText.isEmpty else { return true }
+        guard let beforeInput = expectedSnapshot?.beforeInput else { return false }
+        let visibleCount = min(beforeInput.count, authoredText.count)
+        return beforeInput.suffix(visibleCount).elementsEqual(authoredText.suffix(visibleCount))
+    }
+}
+
+private extension KeyboardDocumentSession.Snapshot {
+    /// Host apps may keep `documentContextBeforeInput` at a fixed bound, so a
+    /// successful delete can reveal older text at the front instead of simply
+    /// shortening the context. The unchanged suffix and after-context still
+    /// prove that the requested number of scalars was removed at the cursor.
+    func matchesRemoval(of scalarCount: Int, from original: Self) -> Bool {
+        guard scalarCount > 0,
+              let originalBefore = original.beforeInput,
+              let currentBefore = beforeInput,
+              Snapshot.scalarExact(afterInput, original.afterInput) else {
+            return false
+        }
+        let originalScalars = originalBefore.unicodeScalars
+        let currentScalars = currentBefore.unicodeScalars
+        guard scalarCount <= originalScalars.count else { return false }
+        let expectedSuffix = originalScalars.dropLast(scalarCount)
+        guard currentScalars.count >= expectedSuffix.count,
+              currentScalars.count <= originalScalars.count else {
+            return false
+        }
+        return currentScalars.suffix(expectedSuffix.count).elementsEqual(expectedSuffix)
     }
 }

--- a/JustSpeakKeyboard/KeyboardHandoffController.swift
+++ b/JustSpeakKeyboard/KeyboardHandoffController.swift
@@ -37,6 +37,7 @@ final class KeyboardHandoffController: ObservableObject {
     private var pollTask: Task<Void, Never>?
     private var insertText: ((String) -> Void)?
     private var profile: KeyboardDictationProfileOption?
+    private var autoStartWhenReady = false
 
     /// Poll cadence while a handoff request is in flight; the keyboard mirrors
     /// interim text from the App Group record at this rate.
@@ -67,10 +68,14 @@ final class KeyboardHandoffController: ObservableObject {
         if requestID == nil {
             requestID = store.activeRecord()?.requestID
         }
+        autoStartWhenReady = autoStart && requestID == nil
+        if requestID == nil {
+            presentation = .idle
+        }
         refreshInstantSession()
         refresh()
         startPolling()
-        if autoStart, requestID == nil, isInstantReady, presentation != .inserted {
+        if autoStartWhenReady, requestID == nil, isInstantReady, presentation != .inserted {
             start()
         } else if requestID == nil, !isInstantReady {
             presentation = .waitingForApp
@@ -88,6 +93,7 @@ final class KeyboardHandoffController: ObservableObject {
         }
         pollTask?.cancel()
         pollTask = nil
+        autoStartWhenReady = false
         liveTranscript = ""
         presentation = .idle
     }
@@ -112,6 +118,7 @@ final class KeyboardHandoffController: ObservableObject {
     }
 
     func start() {
+        autoStartWhenReady = false
         do {
             guard isInstantReady, let currentDocumentIdentifier else {
                 presentation = .waitingForApp
@@ -183,7 +190,7 @@ final class KeyboardHandoffController: ObservableObject {
     private func refresh() {
         refreshInstantSession()
         guard let requestID else {
-            if isInstantReady, presentation == .waitingForApp {
+            if autoStartWhenReady, isInstantReady, presentation == .waitingForApp {
                 start()
                 return
             }

--- a/JustSpeakKeyboard/KeyboardRootView.swift
+++ b/JustSpeakKeyboard/KeyboardRootView.swift
@@ -76,7 +76,7 @@ struct KeyboardRootView: View {
                     .accessibilityHint("Touch and hold to choose another keyboard")
             }
 
-            if let chip = model.languageChipLabel, model.showsLanguageChip {
+            if let chip = model.languageChipLabel, model.showsLanguageChip, !isBlocked {
                 chipButton(
                     label: chip,
                     accessibilityLabel: "Dictation language \(chip). Tap to switch.",
@@ -391,8 +391,8 @@ struct KeyboardRootView: View {
     /// the single control row keeps a full-size mic key on the narrowest
     /// supported iPhone instead of wrapping or truncating.
     private var micCaption: String? {
-        if model.mode == .direct,
-           model.languageChipLabel != nil,
+        if model.languageChipLabel != nil,
+           model.showsLanguageChip,
            model.profileChipLabel != nil {
             return nil
         }

--- a/JustSpeakKeyboard/KeyboardRootView.swift
+++ b/JustSpeakKeyboard/KeyboardRootView.swift
@@ -76,7 +76,7 @@ struct KeyboardRootView: View {
                     .accessibilityHint("Touch and hold to choose another keyboard")
             }
 
-            if let chip = model.languageChipLabel, model.mode == .direct {
+            if let chip = model.languageChipLabel, model.showsLanguageChip {
                 chipButton(
                     label: chip,
                     accessibilityLabel: "Dictation language \(chip). Tap to switch.",

--- a/JustSpeakKeyboard/KeyboardViewController.swift
+++ b/JustSpeakKeyboard/KeyboardViewController.swift
@@ -58,6 +58,9 @@ final class KeyboardViewController: UIInputViewController {
             },
             contextBeforeInput: { [weak self] in
                 self?.textDocumentProxy.documentContextBeforeInput
+            },
+            contextAfterInput: { [weak self] in
+                self?.textDocumentProxy.documentContextAfterInput
             }
         )
     }

--- a/JustSpeakKeyboard/KeyboardViewModel.swift
+++ b/JustSpeakKeyboard/KeyboardViewModel.swift
@@ -2,12 +2,18 @@ import Combine
 import Foundation
 import SpeakCore
 
-/// Top-level keyboard model. Routes the selected mode to the in-extension
-/// Apple Speech engine or the app-owned Instant Dictation handoff, exposing one
-/// surface to the SwiftUI view.
+/// Top-level keyboard model. Plans the capture path for each appearance and
+/// drives either the policy-gated in-extension engine or the Instant Dictation
+/// handoff, exposing one surface to the SwiftUI view.
 @MainActor
 // swiftlint:disable:next type_body_length
 final class KeyboardViewModel: ObservableObject {
+    struct DirectCaptureCapabilities {
+        let microphonePermission: KeyboardCapturePlanner.Permission
+        let speechRecognitionPermission: KeyboardCapturePlanner.Permission
+        let speechRecognizerAvailable: (String) -> Bool
+    }
+
     enum Mode: Equatable {
         case direct
         case handoff
@@ -23,31 +29,58 @@ final class KeyboardViewModel: ObservableObject {
     let handoff: KeyboardHandoffController
 
     private var machine = KeyboardDictationMachine()
-    private let engine: KeyboardDictationEngine
+    private let engine: any KeyboardDictationEngineProtocol
     private let handoffStore: KeyboardHandoffStore
     private let preferences: KeyboardDictationPreferencesStore
+    private let directCapturePolicy: KeyboardCapturePlanner.DirectCapturePolicy
+    private let directCaptureCapabilities: () -> DirectCaptureCapabilities
     private var languageSelection = KeyboardLanguageSelection.automaticOnly
     private var profileSelection = KeyboardProfileSelection.directOnly
     private var handoffForwarder: AnyCancellable?
     private var hasFullAccess = false
+    private var activeRunID: UUID?
+    private var documentSession: KeyboardDocumentSession?
 
     private var currentDocumentIdentifier: UUID?
     private var proxyInsert: ((String) -> Void)?
-    private var proxyDeleteBackward: (() -> Void)?
-    private var contextBeforeInput: (() -> String?)?
 
-    init() {
-        self.engine = KeyboardDictationEngine()
-        self.handoff = KeyboardHandoffController()
-        self.handoffStore = .shared
-        self.preferences = .shared
-        engine.onEvent = { [weak self] event in
-            self?.dispatch(event)
+    init(
+        engine: any KeyboardDictationEngineProtocol = KeyboardDictationEngine(),
+        handoff: KeyboardHandoffController = KeyboardHandoffController(),
+        handoffStore: KeyboardHandoffStore = .shared,
+        preferences: KeyboardDictationPreferencesStore = .shared,
+        directCapturePolicy: KeyboardCapturePlanner.DirectCapturePolicy = KeyboardViewModel.buildDirectCapturePolicy,
+        directCaptureCapabilities: @escaping () -> DirectCaptureCapabilities = {
+            DirectCaptureCapabilities(
+                microphonePermission: KeyboardDictationEngine.microphonePermission(),
+                speechRecognitionPermission: KeyboardDictationEngine.speechRecognitionPermission(),
+                speechRecognizerAvailable: {
+                    KeyboardDictationEngine.recognizerAvailable(localeIdentifier: $0)
+                }
+            )
+        }
+    ) {
+        self.engine = engine
+        self.handoff = handoff
+        self.handoffStore = handoffStore
+        self.preferences = preferences
+        self.directCapturePolicy = directCapturePolicy
+        self.directCaptureCapabilities = directCaptureCapabilities
+        engine.onEvent = { [weak self] runID, event in
+            self?.receiveEngineEvent(runID: runID, event: event)
         }
         // Republish nested handoff changes so the shared root view refreshes.
         handoffForwarder = handoff.objectWillChange.sink { [weak self] _ in
             self?.objectWillChange.send()
         }
+    }
+
+    private static var buildDirectCapturePolicy: KeyboardCapturePlanner.DirectCapturePolicy {
+        #if IOS_KEYBOARD_DIRECT_CAPTURE
+        .enabled
+        #else
+        .disabled
+        #endif
     }
 
     var isCapturing: Bool {
@@ -85,6 +118,12 @@ final class KeyboardViewModel: ObservableObject {
         profileSelection.selectedIdentifier
     }
 
+    /// Language belongs to the selected Local profile, even when rollout
+    /// policy routes that profile through the app-owned handoff.
+    var showsLanguageChip: Bool {
+        profileSelection.route == .directAppleSpeech
+    }
+
     // MARK: - Lifecycle from the input view controller
 
     func activate(
@@ -92,13 +131,18 @@ final class KeyboardViewModel: ObservableObject {
         documentIdentifier: UUID,
         insertText: @escaping (String) -> Void,
         deleteBackward: @escaping () -> Void,
-        contextBeforeInput: @escaping () -> String?
+        contextBeforeInput: @escaping () -> String?,
+        contextAfterInput: @escaping () -> String?
     ) {
         self.hasFullAccess = hasFullAccess
         self.currentDocumentIdentifier = documentIdentifier
         self.proxyInsert = insertText
-        self.proxyDeleteBackward = deleteBackward
-        self.contextBeforeInput = contextBeforeInput
+        self.documentSession = KeyboardDocumentSession(
+            insertText: insertText,
+            deleteBackward: deleteBackward,
+            contextBeforeInput: contextBeforeInput,
+            contextAfterInput: contextAfterInput
+        )
         handoffStore.recordExtensionObservation(hasFullAccess: hasFullAccess)
 
         languageSelection = preferences.selection()
@@ -124,15 +168,7 @@ final class KeyboardViewModel: ObservableObject {
             return
         }
 
-        let path = KeyboardCapturePlanner.path(
-            hasFullAccess: true,
-            sharedContainerAvailable: true,
-            microphonePermission: KeyboardDictationEngine.microphonePermission(),
-            speechRecognitionPermission: KeyboardDictationEngine.speechRecognitionPermission(),
-            speechRecognizerAvailable: KeyboardDictationEngine.recognizerAvailable(
-                localeIdentifier: activeLocaleIdentifier
-            )
-        )
+        let path = plannedCapturePath(hasFullAccess: hasFullAccess)
         switch path {
         case .direct:
             handoff.deactivate()
@@ -157,8 +193,8 @@ final class KeyboardViewModel: ObservableObject {
         dispatch(.dismissed)
         handoff.deactivate()
         proxyInsert = nil
-        proxyDeleteBackward = nil
-        contextBeforeInput = nil
+        documentSession?.invalidate()
+        documentSession = nil
     }
 
     func updateDocumentContext(documentIdentifier: UUID, selectionChanged: Bool) {
@@ -166,10 +202,11 @@ final class KeyboardViewModel: ObservableObject {
         currentDocumentIdentifier = documentIdentifier
         switch mode {
         case .direct:
-            // The keyboard's own streamed insertions raise text/selection
-            // callbacks, so only a genuine document change ends the session.
-            guard changedDocument else { return }
-            if machine.isCapturing {
+            // Extension-authored edits update the session anchor before UIKit
+            // callbacks arrive. Any other caret or host-text mutation makes
+            // the bounded replacement region unprovable and pauses the run.
+            if machine.isCapturing,
+               changedDocument || documentSession?.anchorIsCurrent() != true {
                 dispatch(.targetChanged)
             }
         case .handoff:
@@ -216,12 +253,13 @@ final class KeyboardViewModel: ObservableObject {
     }
 
     func cycleLanguage() {
-        guard mode == .direct, !isBusy,
+        guard profileSelection.route == .directAppleSpeech, !isBusy,
               let next = languageSelection.nextQuickIdentifier else {
             return
         }
         languageSelection = preferences.select(next)
         refreshChips()
+        configureCaptureMode(autoStartHandoff: false)
     }
 
     func cycleProfile() {
@@ -266,70 +304,68 @@ final class KeyboardViewModel: ObservableObject {
         for effect in effects {
             perform(effect)
         }
+        if directState == .failed(.noSpeech) {
+            _ = documentSession?.removeSeparatorIfTranscriptIsEmpty()
+        }
+    }
+
+    private func receiveEngineEvent(runID: UUID, event: KeyboardDictationMachine.Event) {
+        guard activeRunID == runID else { return }
+        dispatch(event)
+        switch event {
+        case .captureFailed, .finalized:
+            if activeRunID == runID {
+                activeRunID = nil
+            }
+        default:
+            break
+        }
     }
 
     private func perform(_ effect: KeyboardDictationMachine.Effect) {
         switch effect {
         case .startCapture:
-            insertLeadingSeparatorIfNeeded()
-            engine.start(localeIdentifier: activeLocaleIdentifier)
+            documentSession?.begin()
+            let runID = UUID()
+            activeRunID = runID
+            engine.start(runID: runID, localeIdentifier: activeLocaleIdentifier)
         case .stopCapture:
-            engine.stop()
+            guard let activeRunID else { return }
+            engine.stop(runID: activeRunID)
         case .cancelCapture:
-            engine.cancel()
+            if let activeRunID {
+                engine.cancel(runID: activeRunID)
+                self.activeRunID = nil
+            }
             fallBackToHandoffIfDirectCaptureIsImpossible()
         case let .applyEdit(edit):
-            apply(edit)
-        }
-    }
-
-    private func apply(_ edit: KeyboardTranscriptEdit) {
-        guard let proxyInsert, let proxyDeleteBackward else { return }
-        for _ in 0..<edit.deleteCount {
-            deleteOneUserPerceivedCharacter(using: proxyDeleteBackward)
-        }
-        if !edit.insertion.isEmpty {
-            proxyInsert(edit.insertion)
-        }
-    }
-
-    /// `KeyboardTranscriptEdit.deleteCount` counts user-perceived characters,
-    /// but `UITextDocumentProxy.deleteBackward()` can remove a single Unicode
-    /// scalar of a composed cluster (an emoji ZWJ sequence, for example),
-    /// leaving a fragment behind. Extra deletes are issued only while the whole
-    /// visible document context matches exactly what a partial, scalar-by-scalar
-    /// deletion would leave; any other outcome — including a host that removed
-    /// the cluster whole, or a truncated context window — stops immediately, so
-    /// this can never eat host text.
-    private func deleteOneUserPerceivedCharacter(using deleteBackward: () -> Void) {
-        guard let contextBefore = contextBeforeInput?(),
-              let cluster = contextBefore.last,
-              cluster.unicodeScalars.count > 1 else {
-            deleteBackward()
-            return
-        }
-        let scalarsInCluster = cluster.unicodeScalars.count
-        var removedScalars = 0
-        while removedScalars < scalarsInCluster {
-            deleteBackward()
-            removedScalars += 1
-            guard removedScalars < scalarsInCluster,
-                  let context = contextBeforeInput?(),
-                  context.unicodeScalars.elementsEqual(
-                      contextBefore.unicodeScalars.dropLast(removedScalars)
-                  ) else {
+            guard documentSession?.apply(edit) == .applied else {
+                dispatch(.targetChanged)
                 return
             }
         }
     }
 
-    private func insertLeadingSeparatorIfNeeded() {
-        guard let separator = KeyboardTranscriptStreamer.leadingSeparator(
-            contextBeforeInput: contextBeforeInput?()
-        ) else {
-            return
+    private func plannedCapturePath(hasFullAccess: Bool) -> KeyboardCapturePlanner.Path {
+        guard directCapturePolicy == .enabled else {
+            return KeyboardCapturePlanner.path(
+                hasFullAccess: hasFullAccess,
+                sharedContainerAvailable: handoffStore.isAvailable,
+                directCapturePolicy: .disabled,
+                microphonePermission: .denied,
+                speechRecognitionPermission: .denied,
+                speechRecognizerAvailable: false
+            )
         }
-        proxyInsert?(separator)
+        let capabilities = directCaptureCapabilities()
+        return KeyboardCapturePlanner.path(
+            hasFullAccess: hasFullAccess,
+            sharedContainerAvailable: handoffStore.isAvailable,
+            directCapturePolicy: .enabled,
+            microphonePermission: capabilities.microphonePermission,
+            speechRecognitionPermission: capabilities.speechRecognitionPermission,
+            speechRecognizerAvailable: capabilities.speechRecognizerAvailable(activeLocaleIdentifier)
+        )
     }
 
     /// After a permission-style failure the direct path cannot recover inside

--- a/JustSpeakKeyboard/KeyboardViewModel.swift
+++ b/JustSpeakKeyboard/KeyboardViewModel.swift
@@ -33,7 +33,7 @@ final class KeyboardViewModel: ObservableObject {
     private let handoffStore: KeyboardHandoffStore
     private let preferences: KeyboardDictationPreferencesStore
     private let directCapturePolicy: KeyboardCapturePlanner.DirectCapturePolicy
-    private let directCaptureCapabilities: () -> DirectCaptureCapabilities
+    private let directCaptureCapabilities: @MainActor () -> DirectCaptureCapabilities
     private var languageSelection = KeyboardLanguageSelection.automaticOnly
     private var profileSelection = KeyboardProfileSelection.directOnly
     private var handoffForwarder: AnyCancellable?
@@ -44,21 +44,32 @@ final class KeyboardViewModel: ObservableObject {
     private var currentDocumentIdentifier: UUID?
     private var proxyInsert: ((String) -> Void)?
 
+    convenience init() {
+        self.init(
+            engine: KeyboardDictationEngine(),
+            handoff: KeyboardHandoffController(),
+            handoffStore: .shared,
+            preferences: .shared,
+            directCapturePolicy: Self.buildDirectCapturePolicy,
+            directCaptureCapabilities: {
+                DirectCaptureCapabilities(
+                    microphonePermission: KeyboardDictationEngine.microphonePermission(),
+                    speechRecognitionPermission: KeyboardDictationEngine.speechRecognitionPermission(),
+                    speechRecognizerAvailable: {
+                        KeyboardDictationEngine.recognizerAvailable(localeIdentifier: $0)
+                    }
+                )
+            }
+        )
+    }
+
     init(
-        engine: any KeyboardDictationEngineProtocol = KeyboardDictationEngine(),
-        handoff: KeyboardHandoffController = KeyboardHandoffController(),
-        handoffStore: KeyboardHandoffStore = .shared,
-        preferences: KeyboardDictationPreferencesStore = .shared,
-        directCapturePolicy: KeyboardCapturePlanner.DirectCapturePolicy = KeyboardViewModel.buildDirectCapturePolicy,
-        directCaptureCapabilities: @escaping () -> DirectCaptureCapabilities = {
-            DirectCaptureCapabilities(
-                microphonePermission: KeyboardDictationEngine.microphonePermission(),
-                speechRecognitionPermission: KeyboardDictationEngine.speechRecognitionPermission(),
-                speechRecognizerAvailable: {
-                    KeyboardDictationEngine.recognizerAvailable(localeIdentifier: $0)
-                }
-            )
-        }
+        engine: any KeyboardDictationEngineProtocol,
+        handoff: KeyboardHandoffController,
+        handoffStore: KeyboardHandoffStore,
+        preferences: KeyboardDictationPreferencesStore,
+        directCapturePolicy: KeyboardCapturePlanner.DirectCapturePolicy,
+        directCaptureCapabilities: @escaping @MainActor () -> DirectCaptureCapabilities
     ) {
         self.engine = engine
         self.handoff = handoff

--- a/Project.swift
+++ b/Project.swift
@@ -124,6 +124,24 @@ if isIOSKeyboardDirectCaptureEnabled {
     iosKeyboardSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) IOS_KEYBOARD_DIRECT_CAPTURE"
 }
 
+let iosKeyboardInfoPlist: InfoPlist = isIOSKeyboardDirectCaptureEnabled
+    ? .file(path: "JustSpeakKeyboard/Info.plist")
+    : .extendingDefault(with: [
+        "CFBundleDisplayName": "Just Speak",
+        "CFBundleShortVersionString": "$(MARKETING_VERSION)",
+        "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
+        "NSExtension": [
+            "NSExtensionAttributes": [
+                "IsASCIICapable": true,
+                "PrefersRightToLeft": false,
+                "PrimaryLanguage": "en-GB",
+                "RequestsOpenAccess": true
+            ],
+            "NSExtensionPointIdentifier": "com.apple.keyboard-service",
+            "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).KeyboardViewController"
+        ]
+    ])
+
 var watchAppSettings: [String: SettingValue] = [
     "CURRENT_PROJECT_VERSION": "1",
     "MARKETING_VERSION": "\(version)"
@@ -313,7 +331,7 @@ let keyboardTarget: Target = .target(
     product: .appExtension,
     bundleId: "com.justspeaktoit.ios.keyboard",
     deploymentTargets: .iOS("17.0"),
-    infoPlist: .file(path: "JustSpeakKeyboard/Info.plist"),
+    infoPlist: iosKeyboardInfoPlist,
     sources: ["JustSpeakKeyboard/**/*.swift"],
     entitlements: .file(path: "JustSpeakKeyboard/JustSpeakKeyboard.entitlements"),
     dependencies: [

--- a/Project.swift
+++ b/Project.swift
@@ -23,12 +23,19 @@ var iosAppSettings: [String: SettingValue] = [
     "MARKETING_VERSION": "\(version)"
 ]
 
-// Build-time feature flags for iOS. Both features are hidden by default.
+// Build-time feature flags for iOS. The keyboard extension and its direct
+// capture path are independent rollout decisions: TestFlight can ship the
+// handoff-only keyboard without touching microphone/Speech permissions in the
+// extension process.
 // `TUIST_IOS_KEYBOARD=1 tuist generate` is the only way to include the custom
 // keyboard extension in the generated project and host app. The matching Swift
 // condition gates app activation and setup UI (see SpeakiOSApp/FeatureFlags.swift).
 let iosKeyboardFlag = (ProcessInfo.processInfo.environment["TUIST_IOS_KEYBOARD"] ?? "").lowercased()
 let isIOSKeyboardEnabled = ["1", "true", "yes"].contains(iosKeyboardFlag)
+let iosKeyboardDirectCaptureFlag = (
+    ProcessInfo.processInfo.environment["TUIST_IOS_KEYBOARD_DIRECT_CAPTURE"] ?? ""
+).lowercased()
+let isIOSKeyboardDirectCaptureEnabled = ["1", "true", "yes"].contains(iosKeyboardDirectCaptureFlag)
 // `TUIST_WATCH_APP=1 tuist generate` includes the Apple Watch companion app
 // and defines `WATCH_APP_FEATURE`, which gates the iPhone-side
 // WatchConnectivity receiver (see SpeakiOSApp/FeatureFlags.swift). Off by
@@ -50,6 +57,11 @@ if isIOSKeyboardEnabled {
     iosActiveCompilationConditions.append("IOS_KEYBOARD_FEATURE")
     iosTestSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) IOS_KEYBOARD_FEATURE"
     iosTestResourceElements.append("JustSpeakKeyboard/JustSpeakKeyboard.entitlements")
+}
+if isIOSKeyboardEnabled, isIOSKeyboardDirectCaptureEnabled {
+    iosActiveCompilationConditions.append("IOS_KEYBOARD_DIRECT_CAPTURE")
+    iosTestSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] =
+        "$(inherited) IOS_KEYBOARD_FEATURE IOS_KEYBOARD_DIRECT_CAPTURE"
 }
 if isWatchAppEnabled {
     iosActiveCompilationConditions.append("WATCH_APP_FEATURE")
@@ -108,6 +120,9 @@ var iosKeyboardSettings: [String: SettingValue] = [
     "MARKETING_VERSION": "\(version)",
     "SKIP_INSTALL": "YES"
 ]
+if isIOSKeyboardDirectCaptureEnabled {
+    iosKeyboardSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) IOS_KEYBOARD_DIRECT_CAPTURE"
+}
 
 var watchAppSettings: [String: SettingValue] = [
     "CURRENT_PROJECT_VERSION": "1",
@@ -353,7 +368,15 @@ let iosTestsTarget: Target = .target(
     product: .unitTests,
     bundleId: "com.justspeaktoit.ios.tests",
     deploymentTargets: .iOS("17.0"),
-    sources: ["Tests/SpeakiOSTests/**"],
+    sources: isIOSKeyboardEnabled
+        ? [
+            "Tests/SpeakiOSTests/**",
+            "JustSpeakKeyboard/KeyboardDictationEngine.swift",
+            "JustSpeakKeyboard/KeyboardDocumentSession.swift",
+            "JustSpeakKeyboard/KeyboardHandoffController.swift",
+            "JustSpeakKeyboard/KeyboardViewModel.swift"
+        ]
+        : ["Tests/SpeakiOSTests/**"],
     resources: .resources(iosTestResourceElements),
     dependencies: [
         .target(name: "SpeakiOS"),

--- a/Sources/SpeakCore/KeyboardDictationMachine.swift
+++ b/Sources/SpeakCore/KeyboardDictationMachine.swift
@@ -4,10 +4,18 @@ import Foundation
 ///
 /// Both paths require Full Access: without it iOS gives the keyboard neither
 /// an audio session nor the shared App Group container, so nothing can run.
-/// With Full Access the keyboard prefers recording in its own process and
-/// falls back to the containing app's Instant Dictation handoff when the
-/// microphone or Apple Speech is unavailable to the extension.
+/// With Full Access the independent direct-capture policy either selects the
+/// containing app's Instant Dictation handoff immediately or permits recording
+/// in the keyboard process, with handoff as the availability fallback.
 public enum KeyboardCapturePlanner {
+    public enum DirectCapturePolicy: Equatable, Sendable {
+        /// Ship the extension in handoff-only mode without reading or requesting
+        /// microphone and Speech permissions in the keyboard process.
+        case disabled
+        /// Permit the extension to attempt direct microphone capture.
+        case enabled
+    }
+
     public enum Permission: Equatable, Sendable {
         case undetermined
         case granted
@@ -28,6 +36,7 @@ public enum KeyboardCapturePlanner {
     public static func path(
         hasFullAccess: Bool,
         sharedContainerAvailable: Bool,
+        directCapturePolicy: DirectCapturePolicy = .enabled,
         microphonePermission: Permission,
         speechRecognitionPermission: Permission,
         speechRecognizerAvailable: Bool
@@ -37,6 +46,9 @@ public enum KeyboardCapturePlanner {
             sharedContainerAvailable: sharedContainerAvailable
         ) {
             return .blocked(reason)
+        }
+        guard directCapturePolicy == .enabled else {
+            return .handoff
         }
         guard speechRecognizerAvailable,
               microphonePermission != .denied,

--- a/Sources/SpeakCore/KeyboardDictationMachine.swift
+++ b/Sources/SpeakCore/KeyboardDictationMachine.swift
@@ -36,7 +36,7 @@ public enum KeyboardCapturePlanner {
     public static func path(
         hasFullAccess: Bool,
         sharedContainerAvailable: Bool,
-        directCapturePolicy: DirectCapturePolicy = .enabled,
+        directCapturePolicy: DirectCapturePolicy = .disabled,
         microphonePermission: Permission,
         speechRecognitionPermission: Permission,
         speechRecognizerAvailable: Bool

--- a/Sources/SpeakiOS/Views/KeyboardSetupView.swift
+++ b/Sources/SpeakiOS/Views/KeyboardSetupView.swift
@@ -6,6 +6,7 @@ import UIKit
 public struct KeyboardSetupView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.iOSKeyboardDirectCaptureEnabled) private var directCaptureEnabled
     @State private var observation: KeyboardExtensionObservation?
     @ObservedObject private var instantDictation = KeyboardInstantDictationCoordinator.shared
 
@@ -22,8 +23,11 @@ public struct KeyboardSetupView: View {
                     Text("Dictate in any app, right from the keyboard")
                         .font(.title2.bold())
                     Text(
-                        "Tap the mic key and your words stream into the text field as you speak — "
-                            + "no app switching. Use the globe key to return to the system keyboard for typing."
+                        directCaptureEnabled
+                            ? "Tap the mic key and your words stream into the text field as you speak — "
+                                + "no app switching. Use the globe key to return to the system keyboard for typing."
+                            : "Tap the mic key to dictate through Just Speak's Instant Dictation handoff — "
+                                + "without leaving the app you're typing in."
                     )
                     .foregroundStyle(.secondary)
                 }
@@ -44,8 +48,11 @@ public struct KeyboardSetupView: View {
                 setupStep(
                     number: 3,
                     title: "Tap the mic and speak",
-                    detail: "In any text field, hold the globe key, pick Just Speak, and tap the mic. "
-                        + "Allow microphone and speech recognition when asked the first time."
+                    detail: directCaptureEnabled
+                        ? "In any text field, hold the globe key, pick Just Speak, and tap the mic. "
+                            + "Allow microphone and speech recognition when asked the first time."
+                        : "Enable Instant Dictation below, then hold the globe key in any text field, "
+                            + "pick Just Speak, and tap the mic."
                 )
 
                 Button {
@@ -79,7 +86,7 @@ public struct KeyboardSetupView: View {
                 .foregroundStyle(.secondary)
             }
 
-            Section("App Mode: Instant Dictation") {
+            Section(directCaptureEnabled ? "App Mode and Fallback" : "Instant Dictation") {
                 statusRow(
                     title: "App-owned microphone",
                     isReady: instantDictation.isReady || instantDictation.isRecording,
@@ -106,10 +113,13 @@ public struct KeyboardSetupView: View {
                 .accessibilityIdentifier("keyboardInstantDictationButton")
 
                 Text(
-                    "Required when the keyboard's App mode uses your selected model and post-processing. "
-                        + "It is also the fallback if local keyboard capture is unavailable. Just Speak keeps "
-                        + "a ready microphone session and handles recording without leaving the app you're "
-                        + "typing in. Idle audio is discarded immediately and never saved or sent."
+                    "App mode always uses Instant Dictation for your selected model and post-processing. "
+                        + (directCaptureEnabled
+                            ? "Local mode also falls back to it when in-keyboard capture is unavailable. "
+                            : "Local mode uses it while direct capture remains off, without requesting "
+                                + "microphone or speech-recognition permission in the keyboard. ")
+                        + "Just Speak keeps a ready microphone session and securely handles each request."
+                        + " Idle audio is discarded immediately and never saved or sent."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -123,22 +133,25 @@ public struct KeyboardSetupView: View {
 
             Section("Why Full Access?") {
                 Label(
-                    "Lets the keyboard run the microphone and Apple speech recognition",
-                    systemImage: "mic.fill"
+                    directCaptureEnabled
+                        ? "Lets the keyboard run the microphone and Apple speech recognition"
+                        : "Lets the keyboard exchange private dictation state with Just Speak",
+                    systemImage: directCaptureEnabled ? "mic.fill" : "arrow.left.arrow.right"
                 )
                 Label(
                     "Shares your language choice and dictation state with the app",
                     systemImage: "gearshape.2"
                 )
                 Label(
-                    "Required by iOS before a keyboard may record or reach the network",
+                    "Required by iOS for the shared App Group and network access",
                     systemImage: "lock.open"
                 )
                 Text(
-                    "The keyboard reads the text just before the cursor only to place dictated words "
-                        + "correctly, and never stores or transmits it. It records only while the mic key "
-                        + "is active, prefers on-device Apple speech, and shares state with Just Speak "
-                        + "solely through the private App Group."
+                    "The keyboard reads bounded text immediately before and after the cursor only to place "
+                        + "dictated words safely, and never stores or transmits that context. "
+                        + (directCaptureEnabled
+                            ? "It records only while the mic key is active and prefers on-device Apple speech."
+                            : "Recording runs in Just Speak through Instant Dictation, not in the keyboard.")
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/Sources/SpeakiOS/Views/KeyboardVisibility.swift
+++ b/Sources/SpeakiOS/Views/KeyboardVisibility.swift
@@ -9,11 +9,21 @@ private struct IOSKeyboardEnabledKey: EnvironmentKey {
     static let defaultValue = false
 }
 
+private struct IOSKeyboardDirectCaptureEnabledKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
 public extension EnvironmentValues {
     /// Whether the custom keyboard extension is included in this app build.
     var iOSKeyboardEnabled: Bool {
         get { self[IOSKeyboardEnabledKey.self] }
         set { self[IOSKeyboardEnabledKey.self] = newValue }
+    }
+
+    /// Whether this build permits direct capture inside the keyboard process.
+    var iOSKeyboardDirectCaptureEnabled: Bool {
+        get { self[IOSKeyboardDirectCaptureEnabledKey.self] }
+        set { self[IOSKeyboardDirectCaptureEnabledKey.self] = newValue }
     }
 }
 #endif

--- a/SpeakiOSApp/FeatureFlags.swift
+++ b/SpeakiOSApp/FeatureFlags.swift
@@ -12,15 +12,21 @@ import Foundation
 /// `SHOW_OPENCLAW_TAB` compilation condition).
 enum FeatureFlags {
     /// Whether the custom keyboard extension (in-keyboard dictation with the
-    /// Instant Dictation handoff as fallback) is enabled. Defaults to `false`
-    /// so App Store and TestFlight builds ship without it; `Project.swift`
-    /// includes the extension and defines `IOS_KEYBOARD_FEATURE` only when
-    /// generated with `TUIST_IOS_KEYBOARD=1`. Internal builds (CI and the
-    /// manual `include_keyboard` release input) turn it on; the physical
-    /// device matrix in `Docs/ios-keyboard-mvp-verification.md` is the gate
-    /// for enabling it in TestFlight.
+    /// Instant Dictation handoff) is included. TestFlight includes it by
+    /// default; `TUIST_IOS_KEYBOARD=0` is the build-based rollback switch.
+    /// Direct capture has a separate gate below.
     static var iOSKeyboardEnabled: Bool {
         #if IOS_KEYBOARD_FEATURE
+        true
+        #else
+        false
+        #endif
+    }
+
+    /// Whether this build permits microphone capture inside the keyboard
+    /// extension. The keyboard can ship independently in handoff-only mode.
+    static var iOSKeyboardDirectCaptureEnabled: Bool {
+        #if IOS_KEYBOARD_DIRECT_CAPTURE
         true
         #else
         false

--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -81,6 +81,10 @@ struct SpeakiOSApp: App {
                 .environmentObject(deepLinkRouter)
                 .environment(\.openClawEnabled, FeatureFlags.openClawTabEnabled)
                 .environment(\.iOSKeyboardEnabled, FeatureFlags.iOSKeyboardEnabled)
+                .environment(
+                    \.iOSKeyboardDirectCaptureEnabled,
+                    FeatureFlags.iOSKeyboardDirectCaptureEnabled
+                )
                 .onOpenURL { url in
                     deepLinkRouter.handle(url)
                 }

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -122,7 +122,7 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(infoPlist.contains("$(PRODUCT_MODULE_NAME).KeyboardViewController"))
     }
 
-    func testIOSKeyboardIsAnExplicitOffByDefaultBuildFeature() throws {
+    func testIOSKeyboardBuild_hasIndependentDirectCapturePolicy() throws {
         let manifest = try String(
             contentsOf: repositoryRoot.appendingPathComponent("Project.swift"),
             encoding: .utf8
@@ -145,6 +145,8 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(manifest.contains("if isIOSKeyboardEnabled {"))
         XCTAssertTrue(manifest.contains("projectTargets.append(keyboardTarget)"))
         XCTAssertTrue(manifest.contains("iosActiveCompilationConditions.append(\"IOS_KEYBOARD_FEATURE\")"))
+        XCTAssertTrue(manifest.contains("environment[\"TUIST_IOS_KEYBOARD_DIRECT_CAPTURE\"] ?? \"\""))
+        XCTAssertTrue(manifest.contains("IOS_KEYBOARD_DIRECT_CAPTURE"))
         XCTAssertTrue(manifest.contains("settings: .settings(base: iosTestSettings)"))
         XCTAssertTrue(
             manifest.contains(
@@ -153,9 +155,11 @@ final class DistributionBuildIdentityTests: XCTestCase {
         )
         XCTAssertTrue(featureFlags.contains("#if IOS_KEYBOARD_FEATURE"))
         XCTAssertTrue(featureFlags.contains("static var iOSKeyboardEnabled: Bool"))
+        XCTAssertTrue(featureFlags.contains("static var iOSKeyboardDirectCaptureEnabled: Bool"))
         XCTAssertTrue(app.contains("guard FeatureFlags.iOSKeyboardEnabled else"))
         XCTAssertTrue(app.contains("KeyboardInstantDictationStore.shared.setEnabled(false)"))
         XCTAssertTrue(settings.contains("if iOSKeyboardEnabled"))
+        XCTAssertTrue(settings.contains("KeyboardDictationPreferencesStore.shared.mirrorAppPreference"))
     }
 
     func testWatchAppBuildFeature_isOffByDefault() throws {
@@ -249,6 +253,10 @@ final class DistributionBuildIdentityTests: XCTestCase {
             contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-ios.yml"),
             encoding: .utf8
         )
+        let autoRelease = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/auto-release.yml"),
+            encoding: .utf8
+        )
 
         XCTAssertTrue(workflow.contains("IOS_KEYBOARD_APPSTORE_PROFILE"))
         XCTAssertTrue(workflow.contains("ios-keyboard-appstore.provisionprofile"))
@@ -272,13 +280,24 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(workflow.contains("iCloud container mismatch"))
         XCTAssertTrue(workflow.contains("iCloud.com.justspeaktoit.ios"))
         XCTAssertTrue(workflow.contains("TUIST_IOS_KEYBOARD: ${{ inputs.include_keyboard && '1' || '0' }}"))
+        XCTAssertTrue(
+            workflow.contains(
+                "TUIST_IOS_KEYBOARD_DIRECT_CAPTURE: ${{ inputs.include_keyboard && inputs.enable_direct_capture"
+            )
+        )
         XCTAssertTrue(workflow.contains("Keyboard feature is off, but JustSpeakKeyboard.appex was embedded"))
 
         let keyboardInputStart = try XCTUnwrap(workflow.range(of: "      include_keyboard:\n")?.lowerBound)
+        let directInputStart = try XCTUnwrap(workflow.range(of: "      enable_direct_capture:\n")?.lowerBound)
         let environmentStart = try XCTUnwrap(workflow.range(of: "\nenv:\n")?.lowerBound)
-        let keyboardInput = workflow[keyboardInputStart..<environmentStart]
-        XCTAssertTrue(keyboardInput.contains("default: false"))
+        let keyboardInput = workflow[keyboardInputStart..<directInputStart]
+        XCTAssertTrue(keyboardInput.contains("default: true"))
         XCTAssertTrue(keyboardInput.contains("type: boolean"))
+
+        let directInput = workflow[directInputStart..<environmentStart]
+        XCTAssertTrue(directInput.contains("default: false"))
+        XCTAssertTrue(autoRelease.contains("-f include_keyboard=true"))
+        XCTAssertTrue(autoRelease.contains("-f enable_direct_capture=false"))
 
         let profileBootstrap = try String(
             contentsOf: repositoryRoot.appendingPathComponent("scripts/create-ios-app-store-profile.rb"),

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -139,7 +139,6 @@ final class DistributionBuildIdentityTests: XCTestCase {
             contentsOf: repositoryRoot.appendingPathComponent("Sources/SpeakiOS/Views/SettingsView.swift"),
             encoding: .utf8
         )
-
         XCTAssertTrue(manifest.contains("environment[\"TUIST_IOS_KEYBOARD\"] ?? \"\""))
         XCTAssertTrue(manifest.contains("let isIOSKeyboardEnabled = [\"1\", \"true\", \"yes\"]"))
         XCTAssertTrue(manifest.contains("if isIOSKeyboardEnabled {"))
@@ -261,7 +260,6 @@ final class DistributionBuildIdentityTests: XCTestCase {
             contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/auto-release.yml"),
             encoding: .utf8
         )
-
         XCTAssertTrue(workflow.contains("IOS_KEYBOARD_APPSTORE_PROFILE"))
         XCTAssertTrue(workflow.contains("ios-keyboard-appstore.provisionprofile"))
         XCTAssertTrue(workflow.contains("com.justspeaktoit.ios.keyboard"))
@@ -292,14 +290,12 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(workflow.contains("Keyboard feature is off, but JustSpeakKeyboard.appex was embedded"))
         XCTAssertTrue(workflow.contains("Handoff-only keyboard unexpectedly declares $usage_key"))
         XCTAssertTrue(workflow.contains("Direct-capture keyboard is missing $usage_key"))
-
         let keyboardInputStart = try XCTUnwrap(workflow.range(of: "      include_keyboard:\n")?.lowerBound)
         let directInputStart = try XCTUnwrap(workflow.range(of: "      enable_direct_capture:\n")?.lowerBound)
         let environmentStart = try XCTUnwrap(workflow.range(of: "\nenv:\n")?.lowerBound)
         let keyboardInput = workflow[keyboardInputStart..<directInputStart]
         XCTAssertTrue(keyboardInput.contains("default: true"))
         XCTAssertTrue(keyboardInput.contains("type: boolean"))
-
         let directInput = workflow[directInputStart..<environmentStart]
         XCTAssertTrue(directInput.contains("default: false"))
         XCTAssertTrue(autoRelease.contains("-f include_keyboard=true"))

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -147,6 +147,9 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(manifest.contains("iosActiveCompilationConditions.append(\"IOS_KEYBOARD_FEATURE\")"))
         XCTAssertTrue(manifest.contains("environment[\"TUIST_IOS_KEYBOARD_DIRECT_CAPTURE\"] ?? \"\""))
         XCTAssertTrue(manifest.contains("IOS_KEYBOARD_DIRECT_CAPTURE"))
+        XCTAssertTrue(manifest.contains("let iosKeyboardInfoPlist: InfoPlist = isIOSKeyboardDirectCaptureEnabled"))
+        XCTAssertTrue(manifest.contains("? .file(path: \"JustSpeakKeyboard/Info.plist\")"))
+        XCTAssertTrue(manifest.contains("infoPlist: iosKeyboardInfoPlist"))
         XCTAssertTrue(manifest.contains("settings: .settings(base: iosTestSettings)"))
         XCTAssertTrue(
             manifest.contains(
@@ -287,6 +290,8 @@ final class DistributionBuildIdentityTests: XCTestCase {
             )
         )
         XCTAssertTrue(workflow.contains("Keyboard feature is off, but JustSpeakKeyboard.appex was embedded"))
+        XCTAssertTrue(workflow.contains("Handoff-only keyboard unexpectedly declares $usage_key"))
+        XCTAssertTrue(workflow.contains("Direct-capture keyboard is missing $usage_key"))
 
         let keyboardInputStart = try XCTUnwrap(workflow.range(of: "      include_keyboard:\n")?.lowerBound)
         let directInputStart = try XCTUnwrap(workflow.range(of: "      enable_direct_capture:\n")?.lowerBound)

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -248,6 +248,7 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(instantCoordinator.contains("iOSHistoryManager.shared.recordTranscription"))
     }
 
+    // swiftlint:disable:next function_body_length
     func testIOSReleaseWorkflowSignsAndValidatesKeyboardExtension() throws {
         let workflow = try String(
             contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-ios.yml"),

--- a/Tests/SpeakCoreTests/KeyboardDictationMachineTests.swift
+++ b/Tests/SpeakCoreTests/KeyboardDictationMachineTests.swift
@@ -69,6 +69,19 @@ final class KeyboardDictationMachineTests: XCTestCase {
         XCTAssertEqual(noRecognizer, .handoff)
     }
 
+    func testPlannerWithDirectCaptureDisabled_selectsHandoffBeforePermissions() {
+        let path = KeyboardCapturePlanner.path(
+            hasFullAccess: true,
+            sharedContainerAvailable: true,
+            directCapturePolicy: .disabled,
+            microphonePermission: .undetermined,
+            speechRecognitionPermission: .undetermined,
+            speechRecognizerAvailable: true
+        )
+
+        XCTAssertEqual(path, .handoff)
+    }
+
     // MARK: - Happy path
 
     func testMicTapRecordsStreamsAndFinishes() {

--- a/Tests/SpeakCoreTests/KeyboardDictationMachineTests.swift
+++ b/Tests/SpeakCoreTests/KeyboardDictationMachineTests.swift
@@ -9,6 +9,7 @@ final class KeyboardDictationMachineTests: XCTestCase {
         let path = KeyboardCapturePlanner.path(
             hasFullAccess: false,
             sharedContainerAvailable: true,
+            directCapturePolicy: .enabled,
             microphonePermission: .granted,
             speechRecognitionPermission: .granted,
             speechRecognizerAvailable: true
@@ -21,6 +22,7 @@ final class KeyboardDictationMachineTests: XCTestCase {
         let path = KeyboardCapturePlanner.path(
             hasFullAccess: true,
             sharedContainerAvailable: false,
+            directCapturePolicy: .enabled,
             microphonePermission: .granted,
             speechRecognitionPermission: .granted,
             speechRecognizerAvailable: true
@@ -33,6 +35,7 @@ final class KeyboardDictationMachineTests: XCTestCase {
         let path = KeyboardCapturePlanner.path(
             hasFullAccess: true,
             sharedContainerAvailable: true,
+            directCapturePolicy: .enabled,
             microphonePermission: .undetermined,
             speechRecognitionPermission: .undetermined,
             speechRecognizerAvailable: true
@@ -45,6 +48,7 @@ final class KeyboardDictationMachineTests: XCTestCase {
         let deniedMic = KeyboardCapturePlanner.path(
             hasFullAccess: true,
             sharedContainerAvailable: true,
+            directCapturePolicy: .enabled,
             microphonePermission: .denied,
             speechRecognitionPermission: .granted,
             speechRecognizerAvailable: true
@@ -52,6 +56,7 @@ final class KeyboardDictationMachineTests: XCTestCase {
         let deniedSpeech = KeyboardCapturePlanner.path(
             hasFullAccess: true,
             sharedContainerAvailable: true,
+            directCapturePolicy: .enabled,
             microphonePermission: .granted,
             speechRecognitionPermission: .denied,
             speechRecognizerAvailable: true
@@ -59,6 +64,7 @@ final class KeyboardDictationMachineTests: XCTestCase {
         let noRecognizer = KeyboardCapturePlanner.path(
             hasFullAccess: true,
             sharedContainerAvailable: true,
+            directCapturePolicy: .enabled,
             microphonePermission: .granted,
             speechRecognitionPermission: .granted,
             speechRecognizerAvailable: false
@@ -70,6 +76,13 @@ final class KeyboardDictationMachineTests: XCTestCase {
     }
 
     func testPlannerWithDirectCaptureDisabled_selectsHandoffBeforePermissions() {
+        let defaultPath = KeyboardCapturePlanner.path(
+            hasFullAccess: true,
+            sharedContainerAvailable: true,
+            microphonePermission: .undetermined,
+            speechRecognitionPermission: .undetermined,
+            speechRecognizerAvailable: true
+        )
         let path = KeyboardCapturePlanner.path(
             hasFullAccess: true,
             sharedContainerAvailable: true,
@@ -78,8 +91,18 @@ final class KeyboardDictationMachineTests: XCTestCase {
             speechRecognitionPermission: .undetermined,
             speechRecognizerAvailable: true
         )
+        let blocked = KeyboardCapturePlanner.path(
+            hasFullAccess: false,
+            sharedContainerAvailable: true,
+            directCapturePolicy: .disabled,
+            microphonePermission: .undetermined,
+            speechRecognitionPermission: .undetermined,
+            speechRecognizerAvailable: true
+        )
 
+        XCTAssertEqual(defaultPath, .handoff)
         XCTAssertEqual(path, .handoff)
+        XCTAssertEqual(blocked, .blocked(.fullAccessRequired))
     }
 
     // MARK: - Happy path

--- a/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
+++ b/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
@@ -453,5 +453,4 @@ final class KeyboardViewModelTests: XCTestCase {
         )
     }
 }
-// swiftlint:enable file_length
 #endif

--- a/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
+++ b/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
@@ -3,6 +3,8 @@ import Foundation
 import SpeakCore
 import XCTest
 
+// swiftlint:disable file_length type_body_length
+
 @MainActor
 final class KeyboardViewModelTests: XCTestCase {
     private final class FakeEngine: KeyboardDictationEngineProtocol {
@@ -69,6 +71,13 @@ final class KeyboardViewModelTests: XCTestCase {
         }
     }
 
+    private struct Harness {
+        let model: KeyboardViewModel
+        let handoffStore: KeyboardHandoffStore
+        let instantStore: KeyboardInstantDictationStore
+        let preferences: KeyboardDictationPreferencesStore
+    }
+
     func testDisabledDirectCapture_plansHandoffWithoutReadingPermissions() {
         let engine = FakeEngine()
         let document = DocumentProxy(before: "Host")
@@ -88,6 +97,117 @@ final class KeyboardViewModelTests: XCTestCase {
         XCTAssertEqual(capabilityReads, 0)
         XCTAssertTrue(engine.startedRunIDs.isEmpty)
         model.deactivate()
+    }
+
+    func testDisabledDirectCapture_localProfileHandsOffExactSnapshotWithoutCapabilityReads() throws {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "Host")
+        var capabilityReads = 0
+        let harness = makeHarness(
+            engine: engine,
+            policy: .disabled,
+            capabilities: {
+                capabilityReads += 1
+                return Self.availableCapabilities
+            },
+            configurePreferences: { preferences in
+                Self.publishProfileCatalogue(preferences)
+                preferences.selectProfile(KeyboardDictationProfileCatalog.directIdentifier)
+            },
+            instantReady: true
+        )
+        let expectedProfile = harness.preferences.profileSelection().selectedProfile
+
+        activate(harness.model, document: document)
+
+        XCTAssertEqual(harness.model.mode, .handoff)
+        XCTAssertEqual(capabilityReads, 0)
+        XCTAssertEqual(try XCTUnwrap(harness.handoffStore.activeRecord()).profile, expectedProfile)
+        XCTAssertTrue(engine.startedRunIDs.isEmpty)
+        harness.model.deactivate()
+    }
+
+    func testAppProfile_handsOffExactSnapshotRegardlessOfDirectCapturePolicy() throws {
+        for policy: KeyboardCapturePlanner.DirectCapturePolicy in [.disabled, .enabled] {
+            let engine = FakeEngine()
+            let document = DocumentProxy(before: "Host")
+            var capabilityReads = 0
+            let harness = makeHarness(
+                engine: engine,
+                policy: policy,
+                capabilities: {
+                    capabilityReads += 1
+                    return Self.availableCapabilities
+                },
+                configurePreferences: Self.publishProfileCatalogue,
+                instantReady: true
+            )
+            let expectedProfile = harness.preferences.profileSelection().selectedProfile
+
+            activate(harness.model, document: document)
+
+            XCTAssertEqual(harness.model.mode, .handoff)
+            XCTAssertEqual(capabilityReads, 0)
+            XCTAssertEqual(try XCTUnwrap(harness.handoffStore.activeRecord()).profile, expectedProfile)
+            XCTAssertTrue(engine.startedRunIDs.isEmpty)
+            harness.model.deactivate()
+        }
+    }
+
+    func testEnabledDirectCapture_localProfileUsesRunScopedDocumentSession() throws {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "Host", after: " tail")
+        let harness = makeHarness(
+            engine: engine,
+            configurePreferences: { preferences in
+                Self.publishProfileCatalogue(preferences)
+                preferences.selectProfile(KeyboardDictationProfileCatalog.directIdentifier)
+            }
+        )
+
+        activate(harness.model, document: document)
+        harness.model.micTapped()
+        let runID = try XCTUnwrap(engine.startedRunIDs.last)
+        engine.emit(.captureStarted, for: runID)
+        engine.emit(.hypothesis("dictated words"), for: runID)
+
+        XCTAssertEqual(harness.model.mode, .direct)
+        XCTAssertEqual(document.text, "Host dictated words tail")
+        XCTAssertNil(harness.handoffStore.activeRecord())
+        harness.model.deactivate()
+    }
+
+    func testIdleProfileAndLanguageSwitch_reconfiguresHandoffWithoutAutoStart() throws {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "Host")
+        var capabilityReads = 0
+        let harness = makeHarness(
+            engine: engine,
+            policy: .disabled,
+            capabilities: {
+                capabilityReads += 1
+                return Self.availableCapabilities
+            },
+            configurePreferences: Self.publishProfileCatalogue
+        )
+
+        activate(harness.model, document: document)
+        harness.model.selectProfile(KeyboardDictationProfileCatalog.directIdentifier)
+        _ = harness.instantStore.start(enabling: true)
+        harness.model.cycleLanguage()
+
+        XCTAssertEqual(harness.model.mode, .handoff)
+        XCTAssertTrue(harness.model.showsLanguageChip)
+        XCTAssertEqual(harness.model.languageChipLabel, "EN-GB")
+        XCTAssertEqual(harness.model.handoff.presentation, .idle)
+        XCTAssertNil(harness.handoffStore.activeRecord())
+        XCTAssertEqual(capabilityReads, 0)
+
+        harness.model.micTapped()
+        let request = try XCTUnwrap(harness.handoffStore.activeRecord())
+        XCTAssertEqual(request.profile?.id, KeyboardDictationProfileCatalog.directIdentifier)
+        XCTAssertEqual(request.profile?.languageIdentifier, "en-GB")
+        harness.model.deactivate()
     }
 
     func testDelayedCallbacks_fromPreviousRunCannotReachNewRun() throws {
@@ -263,6 +383,20 @@ final class KeyboardViewModelTests: XCTestCase {
         speechRecognizerAvailable: { _ in true }
     )
 
+    private static func publishProfileCatalogue(_ preferences: KeyboardDictationPreferencesStore) {
+        preferences.mirrorAppPreference(selectedIdentifier: "en-GB")
+        preferences.mirrorAppPreference(selectedIdentifier: "fr-FR")
+        preferences.publishAppProfileSelection(
+            configuration: KeyboardAppProfileConfiguration(
+                transcriptionMode: .batch,
+                transcriptionModelIdentifier: "openai/gpt-transcribe",
+                languageIdentifier: "fr-FR",
+                postProcessingEnabled: true,
+                postProcessingModelIdentifier: "openrouter/openai/gpt-5-mini"
+            )
+        )
+    }
+
     private func makeModel(
         engine: FakeEngine,
         policy: KeyboardCapturePlanner.DirectCapturePolicy = .enabled,
@@ -270,18 +404,40 @@ final class KeyboardViewModelTests: XCTestCase {
             Self.availableCapabilities
         }
     ) -> KeyboardViewModel {
+        makeHarness(engine: engine, policy: policy, capabilities: capabilities).model
+    }
+
+    private func makeHarness(
+        engine: FakeEngine,
+        policy: KeyboardCapturePlanner.DirectCapturePolicy = .enabled,
+        capabilities: @escaping () -> KeyboardViewModel.DirectCaptureCapabilities = {
+            Self.availableCapabilities
+        },
+        configurePreferences: (KeyboardDictationPreferencesStore) -> Void = { _ in },
+        instantReady: Bool = false
+    ) -> Harness {
         let suiteName = "KeyboardViewModelTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         let handoffStore = KeyboardHandoffStore(defaults: defaults)
         let instantStore = KeyboardInstantDictationStore(defaults: defaults)
         let preferences = KeyboardDictationPreferencesStore(defaults: defaults)
-        return KeyboardViewModel(
+        configurePreferences(preferences)
+        if instantReady {
+            _ = instantStore.start(enabling: true)
+        }
+        let model = KeyboardViewModel(
             engine: engine,
             handoff: KeyboardHandoffController(store: handoffStore, instantSessionStore: instantStore),
             handoffStore: handoffStore,
             preferences: preferences,
             directCapturePolicy: policy,
             directCaptureCapabilities: capabilities
+        )
+        return Harness(
+            model: model,
+            handoffStore: handoffStore,
+            instantStore: instantStore,
+            preferences: preferences
         )
     }
 

--- a/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
+++ b/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
@@ -401,9 +401,7 @@ final class KeyboardViewModelTests: XCTestCase {
     private func makeModel(
         engine: FakeEngine,
         policy: KeyboardCapturePlanner.DirectCapturePolicy = .enabled,
-        capabilities: @escaping () -> KeyboardViewModel.DirectCaptureCapabilities = {
-            Self.availableCapabilities
-        }
+        capabilities: (@MainActor () -> KeyboardViewModel.DirectCaptureCapabilities)? = nil
     ) -> KeyboardViewModel {
         makeHarness(engine: engine, policy: policy, capabilities: capabilities).model
     }
@@ -411,9 +409,7 @@ final class KeyboardViewModelTests: XCTestCase {
     private func makeHarness(
         engine: FakeEngine,
         policy: KeyboardCapturePlanner.DirectCapturePolicy = .enabled,
-        capabilities: @escaping () -> KeyboardViewModel.DirectCaptureCapabilities = {
-            Self.availableCapabilities
-        },
+        capabilities: (@MainActor () -> KeyboardViewModel.DirectCaptureCapabilities)? = nil,
         configurePreferences: (KeyboardDictationPreferencesStore) -> Void = { _ in },
         instantReady: Bool = false
     ) -> Harness {
@@ -432,7 +428,7 @@ final class KeyboardViewModelTests: XCTestCase {
             handoffStore: handoffStore,
             preferences: preferences,
             directCapturePolicy: policy,
-            directCaptureCapabilities: capabilities
+            directCaptureCapabilities: capabilities ?? { Self.availableCapabilities }
         )
         return Harness(
             model: model,

--- a/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
+++ b/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
@@ -32,6 +32,7 @@ final class KeyboardViewModelTests: XCTestCase {
         var before: String
         var after: String
         var deletesScalars = false
+        var contextLimit: Int?
 
         init(before: String, after: String = "") {
             self.before = before
@@ -39,6 +40,11 @@ final class KeyboardViewModelTests: XCTestCase {
         }
 
         var text: String { before + after }
+
+        var contextBeforeInput: String {
+            guard let contextLimit else { return before }
+            return String(before.suffix(contextLimit))
+        }
 
         func insertText(_ text: String) {
             before += text
@@ -193,6 +199,43 @@ final class KeyboardViewModelTests: XCTestCase {
         XCTAssertEqual(model.directState, .recording)
     }
 
+    func testBoundedContext_tailRevisionAppliesWithoutLosingAnchor() throws {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "0123456789")
+        document.contextLimit = 5
+        let model = makeModel(engine: engine)
+        activate(model, document: document)
+        model.micTapped()
+        let runID = try XCTUnwrap(engine.startedRunIDs.last)
+        engine.emit(.captureStarted, for: runID)
+        engine.emit(.hypothesis("alpha"), for: runID)
+
+        engine.emit(.hypothesis("beta"), for: runID)
+
+        XCTAssertEqual(document.text, "0123456789 beta")
+        XCTAssertEqual(model.directState, .recording)
+    }
+
+    func testEditExceedingAuthoredText_isRejectedBeforeDeleting() {
+        let document = DocumentProxy(before: "Host")
+        let session = KeyboardDocumentSession(
+            insertText: document.insertText,
+            deleteBackward: document.deleteBackward,
+            contextBeforeInput: { document.contextBeforeInput },
+            contextAfterInput: { document.after }
+        )
+        session.begin()
+        XCTAssertEqual(
+            session.apply(KeyboardTranscriptEdit(deleteCount: 0, insertion: "dictated")),
+            .applied
+        )
+
+        let result = session.apply(KeyboardTranscriptEdit(deleteCount: 9, insertion: "replacement"))
+
+        XCTAssertEqual(result, .anchorLost)
+        XCTAssertEqual(document.text, "Host dictated")
+    }
+
     func testCanonicallyEquivalentHostMutation_doesNotProveReplacementAnchor() {
         let document = DocumentProxy(before: "Host é")
         let session = KeyboardDocumentSession(
@@ -248,7 +291,7 @@ final class KeyboardViewModelTests: XCTestCase {
             documentIdentifier: Self.documentID,
             insertText: document.insertText,
             deleteBackward: document.deleteBackward,
-            contextBeforeInput: { document.before },
+            contextBeforeInput: { document.contextBeforeInput },
             contextAfterInput: { document.after }
         )
     }

--- a/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
+++ b/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
@@ -1,0 +1,256 @@
+#if IOS_KEYBOARD_FEATURE
+import Foundation
+import SpeakCore
+import XCTest
+
+@MainActor
+final class KeyboardViewModelTests: XCTestCase {
+    private final class FakeEngine: KeyboardDictationEngineProtocol {
+        var onEvent: ((UUID, KeyboardDictationMachine.Event) -> Void)?
+        private(set) var startedRunIDs: [UUID] = []
+        private(set) var stoppedRunIDs: [UUID] = []
+        private(set) var cancelledRunIDs: [UUID] = []
+
+        func start(runID: UUID, localeIdentifier _: String) {
+            startedRunIDs.append(runID)
+        }
+
+        func stop(runID: UUID) {
+            stoppedRunIDs.append(runID)
+        }
+
+        func cancel(runID: UUID) {
+            cancelledRunIDs.append(runID)
+        }
+
+        func emit(_ event: KeyboardDictationMachine.Event, for runID: UUID) {
+            onEvent?(runID, event)
+        }
+    }
+
+    private final class DocumentProxy {
+        var before: String
+        var after: String
+        var deletesScalars = false
+
+        init(before: String, after: String = "") {
+            self.before = before
+            self.after = after
+        }
+
+        var text: String { before + after }
+
+        func insertText(_ text: String) {
+            before += text
+        }
+
+        func deleteBackward() {
+            guard !before.isEmpty else { return }
+            if deletesScalars {
+                var scalars = before.unicodeScalars
+                scalars.removeLast()
+                before = String(scalars)
+            } else {
+                before.removeLast()
+            }
+        }
+
+        func moveCursor(characterOffset: Int) {
+            let text = self.text
+            let index = text.index(text.startIndex, offsetBy: characterOffset)
+            before = String(text[..<index])
+            after = String(text[index...])
+        }
+    }
+
+    func testDisabledDirectCapture_plansHandoffWithoutReadingPermissions() {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "Host")
+        var capabilityReads = 0
+        let model = makeModel(
+            engine: engine,
+            policy: .disabled,
+            capabilities: {
+                capabilityReads += 1
+                return Self.availableCapabilities
+            }
+        )
+
+        activate(model, document: document)
+
+        XCTAssertEqual(model.mode, .handoff)
+        XCTAssertEqual(capabilityReads, 0)
+        XCTAssertTrue(engine.startedRunIDs.isEmpty)
+        model.deactivate()
+    }
+
+    func testDelayedCallbacks_fromPreviousRunCannotReachNewRun() throws {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "Host")
+        let model = makeModel(engine: engine)
+        activate(model, document: document)
+
+        model.micTapped()
+        let runA = try XCTUnwrap(engine.startedRunIDs.last)
+        engine.emit(.captureStarted, for: runA)
+        engine.emit(.hypothesis("first"), for: runA)
+        model.cancelTapped()
+
+        model.micTapped()
+        let runB = try XCTUnwrap(engine.startedRunIDs.last)
+        XCTAssertNotEqual(runA, runB)
+        let beforeDelayedCallbacks = document.text
+
+        engine.emit(.hypothesis("stale revision"), for: runA)
+        engine.emit(.finalized("stale final"), for: runA)
+        engine.emit(.captureFailed(.audioInterrupted), for: runA)
+
+        XCTAssertEqual(document.text, beforeDelayedCallbacks)
+        XCTAssertEqual(model.directState, .starting)
+        XCTAssertFalse(engine.cancelledRunIDs.contains(runB))
+
+        engine.emit(.captureStarted, for: runB)
+        engine.emit(.hypothesis("second"), for: runB)
+        XCTAssertEqual(document.text, "Host first second")
+    }
+
+    func testSameFieldCaretMove_pausesBeforeRevisingUnrelatedText() throws {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "prefix suffix")
+        let model = makeModel(engine: engine)
+        activate(model, document: document)
+        model.micTapped()
+        let runID = try XCTUnwrap(engine.startedRunIDs.last)
+        engine.emit(.captureStarted, for: runID)
+        engine.emit(.hypothesis("alpha beta"), for: runID)
+
+        document.moveCursor(characterOffset: 3)
+        let textAtMutation = document.text
+        model.updateDocumentContext(documentIdentifier: Self.documentID, selectionChanged: true)
+        engine.emit(.hypothesis("revised words"), for: runID)
+
+        XCTAssertEqual(model.directState, .finished)
+        XCTAssertEqual(document.text, textAtMutation)
+        XCTAssertTrue(engine.cancelledRunIDs.contains(runID))
+    }
+
+    func testSameFieldHostEdit_invalidatesReplacementAnchor() throws {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "Host")
+        let model = makeModel(engine: engine)
+        activate(model, document: document)
+        model.micTapped()
+        let runID = try XCTUnwrap(engine.startedRunIDs.last)
+        engine.emit(.captureStarted, for: runID)
+        engine.emit(.hypothesis("alpha beta"), for: runID)
+
+        document.after = " external text"
+        let textAtMutation = document.text
+        model.updateDocumentContext(documentIdentifier: Self.documentID, selectionChanged: false)
+        engine.emit(.hypothesis("revised words"), for: runID)
+
+        XCTAssertEqual(document.text, textAtMutation)
+        XCTAssertTrue(engine.cancelledRunIDs.contains(runID))
+    }
+
+    func testEmptyOrFailedCapture_leavesHostFieldUnchanged() throws {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "Host")
+        let model = makeModel(engine: engine)
+        activate(model, document: document)
+
+        model.micTapped()
+        let failedRun = try XCTUnwrap(engine.startedRunIDs.last)
+        engine.emit(.captureFailed(.microphoneUnavailable), for: failedRun)
+        XCTAssertEqual(document.text, "Host")
+
+        // Reactivate direct mode after the permission-style fallback to model a
+        // fresh build/run whose capture starts but produces no speech.
+        model.deactivate()
+        activate(model, document: document)
+        model.micTapped()
+        let emptyRun = try XCTUnwrap(engine.startedRunIDs.last)
+        engine.emit(.captureStarted, for: emptyRun)
+        engine.emit(.finalized(""), for: emptyRun)
+
+        XCTAssertEqual(document.text, "Host")
+        XCTAssertEqual(model.directState, .failed(.noSpeech))
+    }
+
+    func testComposedTailRevision_preservesHostTextWithScalarDeletingProxy() throws {
+        let engine = FakeEngine()
+        let document = DocumentProxy(before: "Host")
+        document.deletesScalars = true
+        let model = makeModel(engine: engine)
+        activate(model, document: document)
+        model.micTapped()
+        let runID = try XCTUnwrap(engine.startedRunIDs.last)
+        engine.emit(.captureStarted, for: runID)
+        engine.emit(.hypothesis("👨‍👩‍👧‍👦"), for: runID)
+        engine.emit(.hypothesis("🎉"), for: runID)
+
+        XCTAssertEqual(document.text, "Host 🎉")
+        XCTAssertEqual(model.directState, .recording)
+    }
+
+    func testCanonicallyEquivalentHostMutation_doesNotProveReplacementAnchor() {
+        let document = DocumentProxy(before: "Host é")
+        let session = KeyboardDocumentSession(
+            insertText: document.insertText,
+            deleteBackward: document.deleteBackward,
+            contextBeforeInput: { document.before },
+            contextAfterInput: { document.after }
+        )
+        session.begin()
+        document.before = "Host e\u{301}"
+
+        let result = session.apply(KeyboardTranscriptEdit(deleteCount: 1, insertion: "x"))
+
+        XCTAssertEqual(result, .anchorLost)
+        XCTAssertEqual(
+            document.before.unicodeScalars.map(\.value),
+            "Host e\u{301}".unicodeScalars.map(\.value)
+        )
+    }
+
+    private static let documentID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+    private static let availableCapabilities = KeyboardViewModel.DirectCaptureCapabilities(
+        microphonePermission: .granted,
+        speechRecognitionPermission: .granted,
+        speechRecognizerAvailable: { _ in true }
+    )
+
+    private func makeModel(
+        engine: FakeEngine,
+        policy: KeyboardCapturePlanner.DirectCapturePolicy = .enabled,
+        capabilities: @escaping () -> KeyboardViewModel.DirectCaptureCapabilities = {
+            Self.availableCapabilities
+        }
+    ) -> KeyboardViewModel {
+        let suiteName = "KeyboardViewModelTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let handoffStore = KeyboardHandoffStore(defaults: defaults)
+        let instantStore = KeyboardInstantDictationStore(defaults: defaults)
+        let preferences = KeyboardDictationPreferencesStore(defaults: defaults)
+        return KeyboardViewModel(
+            engine: engine,
+            handoff: KeyboardHandoffController(store: handoffStore, instantSessionStore: instantStore),
+            handoffStore: handoffStore,
+            preferences: preferences,
+            directCapturePolicy: policy,
+            directCaptureCapabilities: capabilities
+        )
+    }
+
+    private func activate(_ model: KeyboardViewModel, document: DocumentProxy) {
+        model.activate(
+            hasFullAccess: true,
+            documentIdentifier: Self.documentID,
+            insertText: document.insertText,
+            deleteBackward: document.deleteBackward,
+            contextBeforeInput: { document.before },
+            contextAfterInput: { document.after }
+        )
+    }
+}
+#endif

--- a/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
+++ b/Tests/SpeakiOSTests/KeyboardViewModelTests.swift
@@ -3,9 +3,10 @@ import Foundation
 import SpeakCore
 import XCTest
 
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length
 
 @MainActor
+// swiftlint:disable:next type_body_length
 final class KeyboardViewModelTests: XCTestCase {
     private final class FakeEngine: KeyboardDictationEngineProtocol {
         var onEvent: ((UUID, KeyboardDictationMachine.Event) -> Void)?
@@ -452,4 +453,5 @@ final class KeyboardViewModelTests: XCTestCase {
         )
     }
 }
+// swiftlint:enable file_length
 #endif


### PR DESCRIPTION
## Summary

- keep the custom keyboard included in ordinary TestFlight builds while direct capture remains an independent, compile-time, default-off rollout
- preserve the merged Local/App profile switcher: App always hands off its exact model/language/polish snapshot; Local runs directly only when enabled and otherwise hands off the exact Apple Speech snapshot without reading extension capabilities
- isolate every direct recogniser run with a UUID and own bounded before/after document context so stale callbacks, caret moves, and host edits cannot damage a newer run or unrelated text
- keep Local language switching available while idle even when rollout policy routes execution through Instant Dictation; profile/language changes reconfigure the handoff without starting capture
- align setup, privacy, release, evidence, and build rollback guidance with the persistent keyboard and default-off direct-capture policy

## Verification

- added behavioural coverage for direct-off Local exact handoff with zero capability reads, App exact handoff under either flag state, direct-on Local run/document isolation, and idle profile/language reconfiguration without auto-start
- retained stale callback, bounded-context, composed-character, empty-capture, planner, distribution, and no-secrets App Group coverage
- `git diff --check` passed
- local builds and tests were intentionally not run; GitHub CI is the verification path for this rollout

## Rollout

Normal releases use `include_keyboard=true` and `enable_direct_capture=false`. Direct capture remains gated on the physical-device matrix in #661. That follow-up must record the workflow, commit, version/build, archive and entitlement evidence, App Store Connect processing and assignment, physical installation, device/OS/host matrix, and a peak below 60 MB before making direct capture persistent.

Closes #678
Part of #661


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS keyboard support is now included in TestFlight releases by default.
  * Instant Dictation handoff is the default keyboard capture experience.
  * Direct keyboard capture can be enabled separately for dedicated testing.
  * Improved language selection, cursor handling, and text replacement reliability.
  * Keyboard setup messaging now clearly explains capture modes and permissions.

* **Bug Fixes**
  * Prevented outdated recording results from affecting newer sessions.
  * Improved recovery when document content changes during dictation.

* **Documentation**
  * Updated release, verification, privacy, rollout, and rollback guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->