### PR TITLE
fix(watch): survive app updates when recovering an interrupted recording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         # The watch app target only exists when generated with
         # TUIST_WATCH_APP=1 (it needs its own provisioning profile for release
         # signing, so it is excluded from release builds). Build it unsigned
-        # here so the flagged target cannot rot. Cheap: six small source files
+        # here so the flagged target cannot rot. Cheap: five small source files
         # plus two shared core files.
         run: |
           set -o pipefail

--- a/JustSpeakWatch/WatchAudioRecorder.swift
+++ b/JustSpeakWatch/WatchAudioRecorder.swift
@@ -30,6 +30,7 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
     private var recorder: AVAudioRecorder?
     private var currentID = UUID()
     private var isFinalising = false
+    private var finalisationTask: Task<Void, Never>?
     private var didRecoverInterruptedCapture = false
 
     init(
@@ -56,10 +57,10 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
         return base.appendingPathComponent("Captures", isDirectory: true)
     }
 
+    /// Derived from the capture id, never persisted: the container path changes
+    /// across an app update or a restore, so a stored path would break recovery.
     static func fileURL(for id: UUID) -> URL {
-        capturesDirectory
-            .appendingPathComponent(id.uuidString)
-            .appendingPathExtension("m4a")
+        WatchActiveCapture.fileURL(for: id, in: capturesDirectory)
     }
 
     private static var activeCaptureMarkerURL: URL {
@@ -77,6 +78,18 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
     func start() async {
         guard !isRecording else { return }
         lastError = nil
+
+        // A stop keeps the marker on disk while it inspects the finished asset.
+        // Wait for that work instead of reading the marker as an unrecovered
+        // capture, which made a fast stop-then-start look like a failure.
+        if let finalisationTask {
+            await finalisationTask.value
+        }
+        guard !isFinalising else {
+            lastError = "The previous recording is still finishing."
+            return
+        }
+        guard !isRecording else { return }
 
         await recoverInterruptedCapture()
         guard activeCaptureRegistry.load() == nil else {
@@ -103,7 +116,7 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
 
             let id = UUID()
             let url = Self.fileURL(for: id)
-            let capture = WatchActiveCapture(id: id, fileURL: url, startedAt: Date())
+            let capture = WatchActiveCapture(id: id, startedAt: Date())
             preparedCapture = capture
             // Mono 16 kHz AAC: compact voice-quality audio that keeps
             // WatchConnectivity transfers small (~250 KB per minute).
@@ -133,7 +146,7 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
             if let preparedCapture,
                activeCaptureRegistry.load()?.id != preparedCapture.id
             {
-                try? FileManager.default.removeItem(at: preparedCapture.fileURL)
+                try? FileManager.default.removeItem(at: Self.fileURL(for: preparedCapture.id))
             }
             recorder = nil
             isRecording = false
@@ -167,7 +180,9 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
             return
         }
 
-        let inspection = await inspectAudio(at: capture.fileURL)
+        // The path comes from the id, so a marker written before an app update
+        // still finds its audio in the new container.
+        let inspection = await inspectAudio(at: Self.fileURL(for: capture.id))
         let finalisation = WatchRecordingFinaliser.finalise(
             capture: capture,
             reason: .runtimeInvalidated(reason: "Recording ended while the watch app was unavailable."),
@@ -184,11 +199,7 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
         guard !isFinalising, isRecording, let recorder else { return }
         isFinalising = true
         let capture = activeCaptureRegistry.load()
-            ?? WatchActiveCapture(
-                id: currentID,
-                fileURL: Self.fileURL(for: currentID),
-                startedAt: startedAt ?? Date()
-            )
+            ?? WatchActiveCapture(id: currentID, startedAt: startedAt ?? Date())
         // Preserve the live value for a user stop. System-driven delegate
         // callbacks may already see zero, so asset inspection below remains
         // the authoritative fallback.
@@ -199,28 +210,38 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
         startedAt = nil
         runtime.end()
 
-        let inspection = await inspectAudio(at: capture.fileURL)
-        let finalisation = WatchRecordingFinaliser.finalise(
-            capture: capture,
-            reason: reason,
-            recorderDuration: recorderDuration,
-            inspection: inspection
-        )
-        complete(finalisation, recovery: false)
-        isFinalising = false
+        // The remaining work suspends. Hold it in a task so `start()` can wait
+        // for the marker to be reconciled rather than trip over it.
+        let task = Task { @MainActor in
+            defer { self.isFinalising = false }
+            let inspection = await self.inspectAudio(at: Self.fileURL(for: capture.id))
+            let finalisation = WatchRecordingFinaliser.finalise(
+                capture: capture,
+                reason: reason,
+                recorderDuration: recorderDuration,
+                inspection: inspection
+            )
+            self.complete(finalisation, recovery: false)
+        }
+        finalisationTask = task
+        await task.value
+        if finalisationTask == task { finalisationTask = nil }
     }
 
     private func complete(_ finalisation: WatchRecordingFinalisation, recovery: Bool) {
         lastError = finalisation.outcome.message
+        let audioURL = Self.fileURL(for: finalisation.capture.id)
 
         switch finalisation.outcome.disposition {
         case .discard:
             do {
-                if FileManager.default.fileExists(atPath: finalisation.capture.fileURL.path) {
-                    try FileManager.default.removeItem(at: finalisation.capture.fileURL)
+                if FileManager.default.fileExists(atPath: audioURL.path) {
+                    try FileManager.default.removeItem(at: audioURL)
                 }
                 try activeCaptureRegistry.clear(matching: finalisation.capture.id)
-                if recovery {
+                // Only fall back to the generic wording. A reason from the
+                // policy tells the user more than "could not be recovered".
+                if recovery, lastError == nil {
                     lastError = "An interrupted recording could not be recovered."
                 }
             } catch {
@@ -235,7 +256,7 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
                     store.enqueue(
                         FinishedRecording(
                             id: finalisation.capture.id,
-                            url: finalisation.capture.fileURL,
+                            url: audioURL,
                             createdAt: finalisation.capture.startedAt,
                             duration: finalisation.duration
                         )

--- a/Sources/SpeakCore/WatchRecordingLifecycle.swift
+++ b/Sources/SpeakCore/WatchRecordingLifecycle.swift
@@ -16,15 +16,40 @@ import Foundation
 
 /// Durable identity for a recording that has started but has not yet reached
 /// the transfer queue.
+///
+/// Identity only, deliberately: an absolute file path does not survive an app
+/// update or a restore, because the container directory is different in the new
+/// installation. A marker written before the update would then point at a dead
+/// path, the audio would look unplayable, and a recoverable recording would be
+/// discarded while its file stayed behind forever. The path is derived from the
+/// id instead — see `fileURL(in:)`.
 public struct WatchActiveCapture: Codable, Equatable, Sendable {
     public let id: UUID
-    public let fileURL: URL
     public let startedAt: Date
 
-    public init(id: UUID, fileURL: URL, startedAt: Date) {
+    public init(id: UUID, startedAt: Date) {
         self.id = id
-        self.fileURL = fileURL
         self.startedAt = startedAt
+    }
+
+    /// Markers written by earlier versions also hold a `fileURL`. Naming the
+    /// keys keeps that stale value out of the decoded capture.
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case startedAt
+    }
+
+    /// Where the audio for this capture lives inside `directory`.
+    public func fileURL(in directory: URL) -> URL {
+        Self.fileURL(for: id, in: directory)
+    }
+
+    /// The one place that builds a capture path, so the recorder and recovery
+    /// can never disagree about it.
+    public static func fileURL(for id: UUID, in directory: URL) -> URL {
+        directory
+            .appendingPathComponent(id.uuidString)
+            .appendingPathExtension("m4a")
     }
 }
 

--- a/Tests/SpeakCoreTests/WatchRecordingLifecycleTests.swift
+++ b/Tests/SpeakCoreTests/WatchRecordingLifecycleTests.swift
@@ -5,11 +5,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
     private let usableDuration: TimeInterval = 42
 
     private var capture: WatchActiveCapture {
-        WatchActiveCapture(
-            id: UUID(),
-            fileURL: URL(fileURLWithPath: "/tmp/watch-capture.m4a"),
-            startedAt: Date(timeIntervalSince1970: 1_700_000_000)
-        )
+        WatchActiveCapture(id: UUID(), startedAt: Date(timeIntervalSince1970: 1_700_000_000))
     }
 
     // MARK: - Runtime loss keeps the partial capture
@@ -171,7 +167,6 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let originalRegistry = WatchActiveCaptureRegistry(fileURL: markerURL)
         let activeCapture = WatchActiveCapture(
             id: UUID(),
-            fileURL: directory.appendingPathComponent("capture.m4a"),
             startedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )
         try originalRegistry.persist(activeCapture)
@@ -193,6 +188,67 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         try FileManager.default.removeItem(at: directory)
     }
 
+    // MARK: - Recovery across an app update
+
+    func testCaptureAudioPath_isDerivedFromTheIdentity() {
+        let directory = URL(fileURLWithPath: "/containers/current/Captures", isDirectory: true)
+        let capture = WatchActiveCapture(id: UUID(), startedAt: Date())
+
+        let derived = capture.fileURL(in: directory)
+
+        XCTAssertEqual(derived, directory.appendingPathComponent("\(capture.id.uuidString).m4a"))
+        XCTAssertEqual(derived, WatchActiveCapture.fileURL(for: capture.id, in: directory))
+    }
+
+    func testRecoveredCapture_findsItsAudioInANewContainerAfterAnAppUpdate() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let markerURL = directory.appendingPathComponent("active-capture.json")
+        let capture = WatchActiveCapture(id: UUID(), startedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        try WatchActiveCaptureRegistry(fileURL: markerURL).persist(capture)
+
+        // An app update moves the container. The marker must not send recovery
+        // to the old path, or the audio is read as unplayable and thrown away.
+        let containerBeforeUpdate = URL(fileURLWithPath: "/containers/A1/Captures", isDirectory: true)
+        let containerAfterUpdate = URL(fileURLWithPath: "/containers/B2/Captures", isDirectory: true)
+        let recovered = try XCTUnwrap(WatchActiveCaptureRegistry(fileURL: markerURL).load())
+
+        XCTAssertEqual(recovered, capture)
+        XCTAssertEqual(recovered.fileURL(in: containerAfterUpdate).lastPathComponent, "\(capture.id.uuidString).m4a")
+        XCTAssertNotEqual(
+            recovered.fileURL(in: containerAfterUpdate),
+            recovered.fileURL(in: containerBeforeUpdate)
+        )
+        try FileManager.default.removeItem(at: directory)
+    }
+
+    func testMarkerWrittenByAnEarlierVersion_loadsAndIgnoresItsStoredPath() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let markerURL = directory.appendingPathComponent("active-capture.json")
+        let id = UUID()
+        let legacyMarker = """
+        {
+          "id": "\(id.uuidString)",
+          "fileURL": "file:///containers/A1/Captures/\(id.uuidString).m4a",
+          "startedAt": "2023-11-14T22:13:20Z"
+        }
+        """
+        try Data(legacyMarker.utf8).write(to: markerURL, options: .atomic)
+
+        let recovered = try XCTUnwrap(WatchActiveCaptureRegistry(fileURL: markerURL).load())
+
+        XCTAssertEqual(recovered.id, id)
+        XCTAssertEqual(recovered.startedAt, Date(timeIntervalSince1970: 1_700_000_000))
+        let container = URL(fileURLWithPath: "/containers/B2/Captures", isDirectory: true)
+        XCTAssertEqual(
+            recovered.fileURL(in: container),
+            container.appendingPathComponent("\(id.uuidString).m4a")
+        )
+        try FileManager.default.removeItem(at: directory)
+    }
+
     func testFailedQueuePersistence_leavesActiveCaptureMarkerForNextLaunch() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -200,7 +256,6 @@ final class WatchRecordingLifecycleTests: XCTestCase {
         let registry = WatchActiveCaptureRegistry(fileURL: markerURL)
         let activeCapture = WatchActiveCapture(
             id: UUID(),
-            fileURL: directory.appendingPathComponent("capture.m4a"),
             startedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )
         try registry.persist(activeCapture)
@@ -222,11 +277,7 @@ final class WatchRecordingLifecycleTests: XCTestCase {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let markerURL = directory.appendingPathComponent("active-capture.json")
         let registry = WatchActiveCaptureRegistry(fileURL: markerURL)
-        let activeCapture = WatchActiveCapture(
-            id: UUID(),
-            fileURL: directory.appendingPathComponent("capture.m4a"),
-            startedAt: Date()
-        )
+        let activeCapture = WatchActiveCapture(id: UUID(), startedAt: Date())
         try registry.persist(activeCapture)
 
         let enqueued = try registry.clearAfterSuccessfulEnqueue(matching: activeCapture.id) { true }


### PR DESCRIPTION
Post-merge review fixes for the watch recording-runtime work in #669. Refs #659.

## Recovery survived a relaunch, but not an app update

`WatchActiveCapture` persisted the absolute `fileURL` of the capture audio. The app container path changes on an app update or a restore, so a marker written before the update pointed into a container that no longer exists. Recovery then found no file, `inspectAudio` returned `.unplayable`, the capture was discarded, and the real m4a stayed in the new container with nothing left to reclaim it.

The marker now holds identity only — `id` and `startedAt` — and the audio path is derived from the id at load time. The file name has always been `<id>.m4a`, so `WatchActiveCapture.fileURL(for:in:)` is now the single place that builds a capture path; `WatchAudioRecorder.fileURL(for:)` calls it. Markers written by earlier versions still decode: explicit `CodingKeys` drop their stored path and the fresh one is derived.

## A fast stop-then-start reported the wrong thing

`finish()` suspends at `await inspectAudio` with `isRecording` already false and the marker still on disk. A start in that window hit the `activeCaptureRegistry.load() == nil` guard and told the user "The previous recording is still waiting to be recovered." — which is not what happened.

`finish()` now holds its suspending tail in a task. `start()` waits for that task, so the usual case simply records, and a start that arrives while a different finalisation is in flight gets the accurate "The previous recording is still finishing."

## Smaller items

- `complete(_:recovery:)` replaced `finalisation.outcome.message` with the generic "An interrupted recording could not be recovered." on every discarded recovery. The specific reason from the end policy is kept when there is one.
- `.github/workflows/ci.yml` said the watch target is "six small source files"; `JustSpeakWatch/` holds five.

## Tests

`WatchRecordingLifecycleTests` gains coverage for the path derivation, for a recovered marker resolving into a new container after an app update, and for a legacy marker that still carries a `fileURL`.

## Verification

- `xcrun swiftc -parse` on all changed Swift files: clean.
- `swiftlint --strict --baseline .swiftlint-baseline.json`: 0 violations in 483 files.
- Build and test run in CI.
