### PR TITLE
fix(speech): derive Speechmatics Automatic language from the system locale

### DIFF
--- a/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SpeechmaticsTranscriptionProvider.swift
@@ -388,9 +388,17 @@ final class SpeechmaticsLiveTranscriber: @unchecked Sendable {
   static func startRecognitionPayload(
     language: String? = nil,
     model: String = "enhanced",
-    sampleRate: Int = 16000
+    sampleRate: Int = 16000,
+    systemLocaleIdentifier: String = Locale.current.identifier
   ) throws -> String {
-    let languageCode = language.map(\.localeLanguageCode) ?? "en"
+    // Speechmatics realtime needs a concrete language, so Automatic (`nil`)
+    // resolves to the system language. A hard-coded `en` here transcribes a
+    // French speaker with the English model (issue #696).
+    let resolved = TranscriptionLanguageCatalog.localeIdentifier(
+      for: TranscriptionLanguageCatalog.normalizedIdentifier(language),
+      systemLocaleIdentifier: systemLocaleIdentifier
+    ).localeLanguageCode
+    let languageCode = resolved.isEmpty ? "en" : resolved
     let payload: [String: Any] = [
       "message": "StartRecognition",
       "audio_format": [

--- a/Tests/SpeakAppTests/SpeechmaticsTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/SpeechmaticsTranscriptionProviderTests.swift
@@ -48,6 +48,41 @@ final class SpeechmaticsTranscriptionProviderTests: XCTestCase {
     XCTAssertEqual(config["max_delay"] as? Double, 0.7)
   }
 
+  func testStartRecognitionPayload_automaticLanguageUsesSystemLocale() throws {
+    let payload = try SpeechmaticsLiveTranscriber.startRecognitionPayload(
+      language: nil,
+      systemLocaleIdentifier: "fr_FR"
+    )
+
+    XCTAssertEqual(try Self.language(inPayload: payload), "fr")
+  }
+
+  func testStartRecognitionPayload_explicitLanguageIgnoresSystemLocale() throws {
+    let payload = try SpeechmaticsLiveTranscriber.startRecognitionPayload(
+      language: "de_DE",
+      systemLocaleIdentifier: "fr_FR"
+    )
+
+    XCTAssertEqual(try Self.language(inPayload: payload), "de")
+  }
+
+  func testStartRecognitionPayload_blankSystemLocaleFallsBackToEnglish() throws {
+    let payload = try SpeechmaticsLiveTranscriber.startRecognitionPayload(
+      language: nil,
+      systemLocaleIdentifier: "   "
+    )
+
+    XCTAssertEqual(try Self.language(inPayload: payload), "en")
+  }
+
+  private static func language(inPayload payload: String) throws -> String {
+    let object = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+    )
+    let config = try XCTUnwrap(object["transcription_config"] as? [String: Any])
+    return try XCTUnwrap(config["language"] as? String)
+  }
+
   func testTranscriptEvent_parsesPartialMetadataTranscript() throws {
     let json = #"""
     {


### PR DESCRIPTION
Closes #696


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic transcription language selection now follows the device’s system language instead of defaulting to English.
  * English remains the fallback when the system language is unavailable or unsupported.
  * Explicitly selected transcription languages continue to take precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->