### PR TITLE
fix(core): keep the transcript when duration metadata fails

### DIFF
--- a/Sources/SpeakCore/OpenRouterAPIClient.swift
+++ b/Sources/SpeakCore/OpenRouterAPIClient.swift
@@ -289,7 +289,7 @@ public actor OpenRouterAPIClient: StreamingChatLLMClient, // swiftlint:disable:t
         }
 
         if allowsLocalFallback(for: cleanedModel) {
-            return try await localTranscriptionFallback(url: url, model: cleanedModel)
+            return await localTranscriptionFallback(url: url, model: cleanedModel)
         }
 
         throw OpenRouterClientError.apiKeyMissing
@@ -595,7 +595,7 @@ public actor OpenRouterAPIClient: StreamingChatLLMClient, // swiftlint:disable:t
             throw OpenRouterClientError.invalidResponse
         }
 
-        return try await buildTranscriptionResult(
+        return await buildTranscriptionResult(
             text: text,
             audioURL: url,
             model: model,
@@ -631,11 +631,9 @@ public actor OpenRouterAPIClient: StreamingChatLLMClient, // swiftlint:disable:t
 
     // MARK: - Local fallbacks
 
-    private func localTranscriptionFallback(url: URL, model: String) async throws
+    private func localTranscriptionFallback(url: URL, model: String) async
         -> TranscriptionResult {
-        let asset = AVURLAsset(url: url)
-        let durationTime = try await asset.load(.duration)
-        let duration = durationTime.seconds
+        let duration = await bestEffortDuration(of: url)
         let text = "Transcription placeholder for \(url.lastPathComponent)"
         let segment = TranscriptionSegment(startTime: 0, endTime: duration, text: text)
         return TranscriptionResult(
@@ -777,10 +775,8 @@ public actor OpenRouterAPIClient: StreamingChatLLMClient, // swiftlint:disable:t
         audioURL: URL,
         model: String,
         payload: Data
-    ) async throws -> TranscriptionResult {
-        let asset = AVURLAsset(url: audioURL)
-        let durationTime = try await asset.load(.duration)
-        let duration = durationTime.seconds
+    ) async -> TranscriptionResult {
+        let duration = await bestEffortDuration(of: audioURL)
         let segments = [TranscriptionSegment(startTime: 0, endTime: duration, text: text)]
 
         return TranscriptionResult(
@@ -793,6 +789,43 @@ public actor OpenRouterAPIClient: StreamingChatLLMClient, // swiftlint:disable:t
             rawPayload: String(data: payload, encoding: .utf8),
             debugInfo: nil
         )
+    }
+
+    /// Reads the recorded length of `audioURL`, and reports `0` when the local
+    /// file gives no usable value.
+    ///
+    /// Duration is enrichment that is added after the provider replies. A
+    /// container that AVFoundation cannot parse, or that holds no duration
+    /// metadata, must not discard a transcript the provider already made — the
+    /// audio is frequently a temporary file that is deleted immediately after,
+    /// so a thrown error loses the speech and the transcript together.
+    ///
+    /// `TranscriptionResult.duration` is a non-optional `TimeInterval`, and all
+    /// consumers already read `0` as "unknown": speech insights skip sessions
+    /// below the minimum length, and the history and recording lists show
+    /// `0:00`. Cost is separate metadata and stays `nil` here. The failure is
+    /// logged so a run with missing durations stays diagnosable.
+    private func bestEffortDuration(of audioURL: URL) async -> TimeInterval {
+        let asset = AVURLAsset(url: audioURL)
+        do {
+            let seconds = try await asset.load(.duration).seconds
+            guard seconds.isFinite, seconds > 0 else {
+                logger.warning(
+                    "Duration metadata for \(audioURL.lastPathComponent, privacy: .public) is not usable; reporting 0"
+                )
+                return 0
+            }
+            return seconds
+        } catch {
+            logger.warning(
+                """
+                Failed to load duration metadata for \
+                \(audioURL.lastPathComponent, privacy: .public): \
+                \(error.localizedDescription, privacy: .public). Keeping the transcript with duration 0
+                """
+            )
+            return 0
+        }
     }
 
     private nonisolated func applyBrandHeaders(_ request: inout URLRequest) {

--- a/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
+++ b/Sources/SpeakiOS/Services/iOSBatchTranscriber.swift
@@ -64,12 +64,22 @@ public final class IOSBatchTranscriber {
         }
         audioSessionManager.deactivate()
         startTime = nil
-        defer {
-            if !retainRecording {
-                AudioRecordingPersistence.deleteRecording(at: recording.url)
-            }
+
+        // A non-retained recording is temporary, but it is still the only copy
+        // of what the user said. Delete it after the transcript is safely in
+        // hand, never on the error path: the keyboard reports the failure to
+        // the user, and the preserved file stays visible in the Recordings
+        // screen, which lists every file in the recordings directory. From
+        // there the user can play it back, retry it, or delete it.
+        let result = try await client.transcribeFile(
+            at: recording.url,
+            model: model,
+            language: language
+        )
+        if !retainRecording {
+            AudioRecordingPersistence.deleteRecording(at: recording.url)
         }
-        return try await client.transcribeFile(at: recording.url, model: model, language: language)
+        return result
     }
 
     public func cancel() {

--- a/Tests/SpeakCoreTests/OpenRouterAPIClientTests.swift
+++ b/Tests/SpeakCoreTests/OpenRouterAPIClientTests.swift
@@ -72,6 +72,69 @@ final class OpenRouterAPIClientTests: XCTestCase {
         )
     }
 
+    /// A provider response that arrived is the user's transcript. Duration is
+    /// enrichment read from the local file afterwards, so a container that
+    /// AVFoundation cannot parse must degrade the duration, not the transcript.
+    func testTranscribeFile_WhenDurationMetadataFails_KeepsTheTranscript() async throws {
+        OpenRouterMockURLProtocol.requestHandler = { request in
+            try makeOpenRouterChatResponse(for: request)
+        }
+
+        let client = OpenRouterAPIClient(
+            apiKeyProvider: { nil },
+            session: makeMockSession(),
+            apiKeyOverride: "test-openrouter-key"
+        )
+        // The bytes are not a readable MPEG-4 container, so `AVURLAsset` fails
+        // to load the duration of this file.
+        let audioURL = try makeAudioFile(extension: "m4a", data: Data("fakeaudiodata".utf8))
+        defer {
+            try? FileManager.default.removeItem(at: audioURL)
+        }
+
+        let result = try await client.transcribeFile(
+            at: audioURL,
+            model: "google/gemini-2.0-flash-001",
+            language: "en_GB"
+        )
+
+        XCTAssertEqual(result.text, "hello world")
+        XCTAssertEqual(result.duration, 0)
+        XCTAssertNotNil(result.rawPayload)
+        // Unknown duration must not invent segment timing.
+        XCTAssertEqual(result.segments.count, 1)
+        XCTAssertEqual(result.segments.first?.startTime, 0)
+        XCTAssertEqual(result.segments.first?.endTime, 0)
+    }
+
+    func testLocalFallback_WhenDurationMetadataFails_KeepsTheTranscript() async throws {
+        OpenRouterMockURLProtocol.requestHandler = { _ in
+            XCTFail("The local fallback must not send a request")
+            throw OpenRouterClientError.invalidResponse
+        }
+
+        let client = OpenRouterAPIClient(
+            apiKeyProvider: { nil },
+            session: makeMockSession(),
+            apiKeyOverride: nil
+        )
+        let audioURL = try makeAudioFile(extension: "m4a", data: Data("fakeaudiodata".utf8))
+        defer {
+            try? FileManager.default.removeItem(at: audioURL)
+        }
+
+        let result = try await client.transcribeFile(
+            at: audioURL,
+            model: "local/whisper",
+            language: "en_GB"
+        )
+
+        XCTAssertTrue(result.text.contains(audioURL.lastPathComponent))
+        XCTAssertEqual(result.duration, 0)
+        XCTAssertEqual(result.segments.count, 1)
+        XCTAssertEqual(result.segments.first?.endTime, 0)
+    }
+
     func testTranscribeFileWithOversizedAudio_ThrowsBeforeEncodingPayload() async throws {
         OpenRouterMockURLProtocol.requestHandler = { _ in
             XCTFail("Oversized audio should be rejected before sending a request")


### PR DESCRIPTION
Closes #692

## What changed

`OpenRouterAPIClient` loaded the duration of the local audio file after the provider answered, and threw if AVFoundation could not read it. A successful transcription was thrown away for a metadata problem. iOS keyboard batch mode passes `retainBatchRecording: false`, and the `defer` in `IOSBatchTranscriber.stop` deleted the recording on the error path as well, so the user lost the transcript and the only copy of the speech.

- `bestEffortDuration(of:)` replaces the throwing duration load at both sites: the remote result and the local fallback. An unreadable, indefinite, or non-finite asset gives 0 seconds and a logged warning, and the segment gets no invented timing.
- `TranscriptionResult.duration` stays a non-optional `TimeInterval`. Every consumer already reads 0 as unknown: speech insights skip sessions below the minimum length, and history and the recordings list show `0:00`. `cost` is separate metadata and stays `nil`.
- `IOSBatchTranscriber.stop` deletes a non-retained recording only after the transcript is in hand. A thrown transcription keeps the file.

## Where a preserved recording goes

The file stays in the recordings directory. `AudioRecordingPersistence.listRecordings()` reads every file in that directory, and the Recordings screen shows the list, so the user can play it back, retry it, or delete it. The failure itself reaches the user through `TranscriptionRecordingService.handleError`, so the preserved file is not silent or orphaned.

## Tests

`OpenRouterAPIClientTests` gets two behavioural cases. Both write bytes that are not a readable MPEG-4 container, so the duration load fails:

- a successful mocked provider response returns the transcript with duration 0 and one segment of `0...0`;
- the local fallback path returns its result with duration 0 and sends no request.

The existing transcription tests in that file called `transcribeFile` with `try?` and dropped the result, because this bug made every one of them throw.
