### PR TITLE
fix(mac): gate transcript normalisation by model family

### DIFF
--- a/Sources/SpeakApp/SherpaOnnxLiveController.swift
+++ b/Sources/SpeakApp/SherpaOnnxLiveController.swift
@@ -26,6 +26,9 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
   private var stderrPipe: Pipe?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
   private var currentModel: String?
+  /// The model the running sidecar loaded. Held for the whole session so a
+  /// settings change mid-recording cannot retag the results of this one.
+  private var activeModelID: String?
   private var streamingStartTime: Date?
   private var latestText: String = ""
   private var hasFinished: Bool = false
@@ -66,6 +69,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
     }
 
     let modelID = currentModel ?? appSettings.localStreamingModelSource
+    activeModelID = modelID
     let bundle = try await runtimeManager.ensureReady(sourceID: modelID)
     let process = try makeProcess(bundle: bundle)
     let stdinPipe = Pipe()
@@ -282,7 +286,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
       guard let rawText = event.text?.trimmingCharacters(in: .whitespacesAndNewlines), !rawText.isEmpty else {
         return
       }
-      let text = SherpaOnnxTranscriptNormalizer.normalize(rawText)
+      let text = SherpaOnnxTranscriptNormalizer.normalize(rawText, modelID: activeModelID)
       latestText = text
       let update = LiveTranscriptionUpdate(text: text, isFinal: event.type == "session_final")
       delegate?.liveTranscriber(self, didUpdateWith: update)

--- a/Sources/SpeakApp/SherpaOnnxTranscriptNormalizer.swift
+++ b/Sources/SpeakApp/SherpaOnnxTranscriptNormalizer.swift
@@ -1,10 +1,27 @@
 import Foundation
 
 enum SherpaOnnxTranscriptNormalizer {
-  static func normalize(_ text: String) -> String {
+  /// Rescues the all-caps output of the legacy sherpa-onnx models.
+  ///
+  /// - Parameters:
+  ///   - text: One sidecar partial or final result.
+  ///   - modelID: The model that produced the text. Models with native casing
+  ///     keep their own output; `nil` gets the rescue, which is what the
+  ///     uppercase zipformer models need.
+  static func normalize(_ text: String, modelID: String? = nil) -> String {
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !emitsNativeCasing(modelID: modelID) else { return trimmed }
     guard isUppercaseDominated(trimmed) else { return trimmed }
     return sentenceCase(trimmed.lowercased())
+  }
+
+  /// Whether the model supplies its own casing and punctuation.
+  ///
+  /// Parakeet v3 does, and the rescue below damages it: `HTTP API JSON` becomes
+  /// `Http api json` because the text reads as uppercase-dominated (issue #679).
+  static func emitsNativeCasing(modelID: String?) -> Bool {
+    guard let modelID else { return false }
+    return modelID.lowercased().contains("parakeet")
   }
 
   private static func isUppercaseDominated(_ text: String) -> Bool {

--- a/Tests/SpeakAppTests/SherpaOnnxTranscriptNormalizerTests.swift
+++ b/Tests/SpeakAppTests/SherpaOnnxTranscriptNormalizerTests.swift
@@ -1,8 +1,43 @@
 import XCTest
 
 @testable import SpeakApp
+@testable import SpeakCore
 
 final class SherpaOnnxTranscriptNormalizerTests: XCTestCase {
+    private let parakeetModelID = ParakeetLocalModels.tdtV3Int8SourceID
+    private let zipformerModelID =
+        "local/streaming/huggingface/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26"
+
+    func testNormalize_keepsParakeetAcronyms() {
+        XCTAssertEqual(
+            SherpaOnnxTranscriptNormalizer.normalize("HTTP API JSON", modelID: parakeetModelID),
+            "HTTP API JSON"
+        )
+    }
+
+    func testNormalize_keepsParakeetNativeSentenceCasing() {
+        XCTAssertEqual(
+            SherpaOnnxTranscriptNormalizer.normalize(
+                "  Ship the JSON to Acme Corp.  ",
+                modelID: parakeetModelID
+            ),
+            "Ship the JSON to Acme Corp."
+        )
+    }
+
+    func testNormalize_sentenceCasesUppercaseModelsThatLackNativeCasing() {
+        XCTAssertEqual(
+            SherpaOnnxTranscriptNormalizer.normalize("HELLO WORLD", modelID: zipformerModelID),
+            "Hello world"
+        )
+    }
+
+    func testEmitsNativeCasing_isTrueOnlyForParakeet() {
+        XCTAssertTrue(SherpaOnnxTranscriptNormalizer.emitsNativeCasing(modelID: parakeetModelID))
+        XCTAssertFalse(SherpaOnnxTranscriptNormalizer.emitsNativeCasing(modelID: zipformerModelID))
+        XCTAssertFalse(SherpaOnnxTranscriptNormalizer.emitsNativeCasing(modelID: nil))
+    }
+
     func testNormalize_sentenceCasesUppercaseSherpaOutput() {
         XCTAssertEqual(
             SherpaOnnxTranscriptNormalizer.normalize("HELLO WORLD. THIS IS A LOCAL STREAMING TEST"),


### PR DESCRIPTION
Refs #679 (claim 4 only; the decode/stdin/exit-window rework remains open)
