### PR TITLE
fix(mac): activate local model presets only after installation succeeds

### DIFF
--- a/Sources/SpeakApp/LocalTranscriptionStarterPreset.swift
+++ b/Sources/SpeakApp/LocalTranscriptionStarterPreset.swift
@@ -85,6 +85,26 @@ struct LocalTranscriptionStarterPreset: Identifiable, Equatable {
     }
   }
 
+  /// Routes recordings through this preset.
+  ///
+  /// Call this only when the model is installed. Settings that point at a model
+  /// that is not installed make every recording fail.
+  @MainActor
+  func activate(in settings: AppSettings) {
+    settings.transcriptionMode = .localModel
+    settings.localTranscriptionMode = mode
+
+    switch engine {
+    case .parakeet:
+      settings.localStreamingModelSource = FluidAudioParakeetModel.id
+    case .whisperKit(let model):
+      settings.localTranscriptionModel = model.id
+      if mode == .streaming {
+        settings.localStreamingModelSource = WhisperKitStreamingModel.id(for: model)
+      }
+    }
+  }
+
   static func preferredWhisperKitModel(
     from availableModels: [LocalTranscriptionModel],
     requiresStreaming: Bool

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -53,6 +53,8 @@ struct SettingsView: View {
   @State var huggingFaceModelName: String = "tiny"
   @State var huggingFaceImportError: String?
   @State var isLocalTranscriptionAdvancedExpanded = false
+  /// Tracks the newest starter-preset download so a stale one cannot activate.
+  @State var starterPresetActivationTask: Task<Void, Never>?
   #if !APP_STORE
   @State var streamingHuggingFaceRepoID: String =
     "csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26"

--- a/Sources/SpeakApp/StarterPresetActivation.swift
+++ b/Sources/SpeakApp/StarterPresetActivation.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Sequences the "Configure and Download" action for local-model starter presets.
+///
+/// A preset becomes the active recording configuration only after its model is
+/// ready. While a download runs, the last usable setup stays active. A newer
+/// request supersedes an older one, so a late completion cannot replace the
+/// setup that the user selected last.
+@MainActor
+enum StarterPresetActivation {
+  /// Prepares the model behind a preset, then activates the preset.
+  ///
+  /// - Parameters:
+  ///   - isReady: `true` when the model is already installed.
+  ///   - pending: The activation from a previous request. This function cancels it.
+  ///   - prepare: Downloads and prepares the model. It returns `true` only when
+  ///     the model is ready to use.
+  ///   - activate: Commits the preset as the active recording configuration.
+  /// - Returns: The activation task, or `nil` when the preset activates immediately.
+  @discardableResult
+  static func configureAndDownload(
+    isReady: Bool,
+    supersedes pending: Task<Void, Never>?,
+    prepare: @escaping @MainActor () async -> Bool,
+    activate: @escaping @MainActor () -> Void
+  ) -> Task<Void, Never>? {
+    pending?.cancel()
+
+    guard !isReady else {
+      activate()
+      return nil
+    }
+
+    return Task { @MainActor in
+      let isPrepared = await prepare()
+      guard !Task.isCancelled, isPrepared else { return }
+      activate()
+    }
+  }
+}

--- a/Sources/SpeakApp/Views/Settings/SettingsView+Transcription.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+Transcription.swift
@@ -723,22 +723,31 @@ extension SettingsView {
     }
   }
 
+  /// Stages a preset, then makes it the active setup only after the model is ready.
+  ///
+  /// The previous setup keeps recording while the download runs, so a failed or
+  /// cancelled download leaves the last usable model selected. The row shows the
+  /// failure, which lets the user try again.
   private func configureAndDownload(_ preset: LocalTranscriptionStarterPreset) {
-    settings.transcriptionMode = .localModel
-    settings.localTranscriptionMode = preset.mode
+    starterPresetActivationTask = StarterPresetActivation.configureAndDownload(
+      isReady: starterPresetInstallState(for: preset) == .installed,
+      supersedes: starterPresetActivationTask,
+      prepare: { await installStarterPreset(preset) },
+      activate: { preset.activate(in: settings) }
+    )
+  }
 
+  /// Downloads and prepares the model behind a preset.
+  ///
+  /// - Returns: `true` only when the model manager reports the model as installed.
+  private func installStarterPreset(_ preset: LocalTranscriptionStarterPreset) async -> Bool {
     switch preset.engine {
     case .parakeet:
-      settings.localStreamingModelSource = FluidAudioParakeetModel.id
-      guard fluidAudioModels.installState != .installed else { return }
-      Task { await fluidAudioModels.install() }
+      await fluidAudioModels.install()
+      return fluidAudioModels.installState == .installed
     case .whisperKit(let model):
-      settings.localTranscriptionModel = model.id
-      if preset.mode == .streaming {
-        settings.localStreamingModelSource = WhisperKitStreamingModel.id(for: model)
-      }
-      guard !localModels.isInstalled(model.id) else { return }
-      Task { await localModels.install(model) }
+      await localModels.install(model)
+      return localModels.isInstalled(model.id)
     }
   }
 

--- a/Tests/SpeakAppTests/StarterPresetActivationTests.swift
+++ b/Tests/SpeakAppTests/StarterPresetActivationTests.swift
@@ -1,0 +1,177 @@
+import SpeakCore
+@testable import SpeakApp
+import XCTest
+
+final class StarterPresetActivationTests: XCTestCase {
+  private var suiteNames: [String] = []
+
+  override func tearDown() {
+    for suiteName in suiteNames {
+      UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+    suiteNames = []
+    super.tearDown()
+  }
+
+  @MainActor
+  func testFailedDownload_keepsThePreviousSetupActive() async {
+    let settings = makeSettings(activeModel: "local/whisperkit/small")
+
+    let activation = StarterPresetActivation.configureAndDownload(
+      isReady: false,
+      supersedes: nil,
+      prepare: { false },
+      activate: { self.batchPreset(modelID: "local/whisperkit/large-v3-turbo").activate(in: settings) }
+    )
+    await activation?.value
+
+    XCTAssertEqual(settings.transcriptionMode, .liveNative)
+    XCTAssertEqual(settings.localTranscriptionModel, "local/whisperkit/small")
+  }
+
+  @MainActor
+  func testSuccessfulDownload_activatesThePresetOnce() async {
+    let settings = makeSettings(activeModel: "local/whisperkit/small")
+    var activationCount = 0
+
+    let activation = StarterPresetActivation.configureAndDownload(
+      isReady: false,
+      supersedes: nil,
+      prepare: { true },
+      activate: {
+        activationCount += 1
+        self.batchPreset(modelID: "local/whisperkit/large-v3-turbo").activate(in: settings)
+      }
+    )
+    await activation?.value
+
+    XCTAssertEqual(activationCount, 1)
+    XCTAssertEqual(settings.transcriptionMode, .localModel)
+    XCTAssertEqual(settings.localTranscriptionMode, .batch)
+    XCTAssertEqual(settings.localTranscriptionModel, "local/whisperkit/large-v3-turbo")
+  }
+
+  @MainActor
+  func testInstalledPreset_activatesWithoutADownload() async {
+    let settings = makeSettings(activeModel: "local/whisperkit/small")
+    var didPrepare = false
+
+    let activation = StarterPresetActivation.configureAndDownload(
+      isReady: true,
+      supersedes: nil,
+      prepare: {
+        didPrepare = true
+        return true
+      },
+      activate: { self.batchPreset(modelID: "local/whisperkit/large-v3-turbo").activate(in: settings) }
+    )
+
+    XCTAssertNil(activation)
+    XCTAssertFalse(didPrepare)
+    XCTAssertEqual(settings.localTranscriptionModel, "local/whisperkit/large-v3-turbo")
+  }
+
+  @MainActor
+  func testCancelledDownload_leavesTheActiveSetupUnchanged() async {
+    let settings = makeSettings(activeModel: "local/whisperkit/small")
+    let gate = ActivationGate()
+
+    let activation = StarterPresetActivation.configureAndDownload(
+      isReady: false,
+      supersedes: nil,
+      prepare: {
+        await gate.wait()
+        return true
+      },
+      activate: { self.batchPreset(modelID: "local/whisperkit/large-v3-turbo").activate(in: settings) }
+    )
+    activation?.cancel()
+    gate.open()
+    await activation?.value
+
+    XCTAssertEqual(settings.transcriptionMode, .liveNative)
+    XCTAssertEqual(settings.localTranscriptionModel, "local/whisperkit/small")
+  }
+
+  @MainActor
+  func testOverlappingRequests_letOnlyTheNewestChoiceBecomeActive() async {
+    let settings = makeSettings(activeModel: "local/whisperkit/small")
+    let gate = ActivationGate()
+
+    let firstActivation = StarterPresetActivation.configureAndDownload(
+      isReady: false,
+      supersedes: nil,
+      prepare: {
+        await gate.wait()
+        return true
+      },
+      activate: { self.batchPreset(modelID: "local/whisperkit/tiny").activate(in: settings) }
+    )
+    let secondActivation = StarterPresetActivation.configureAndDownload(
+      isReady: false,
+      supersedes: firstActivation,
+      prepare: { true },
+      activate: { self.batchPreset(modelID: "local/whisperkit/large-v3-turbo").activate(in: settings) }
+    )
+    await secondActivation?.value
+    gate.open()
+    await firstActivation?.value
+
+    XCTAssertEqual(settings.localTranscriptionModel, "local/whisperkit/large-v3-turbo")
+  }
+
+  // MARK: - Helpers
+
+  @MainActor
+  private func makeSettings(activeModel: String) -> AppSettings {
+    let suiteName = "com.speakapp.tests.starterPreset.\(UUID().uuidString)"
+    suiteNames.append(suiteName)
+    let settings = AppSettings(defaults: UserDefaults(suiteName: suiteName)!)
+    settings.transcriptionMode = .liveNative
+    settings.localTranscriptionModel = activeModel
+    return settings
+  }
+
+  private func batchPreset(modelID: String) -> LocalTranscriptionStarterPreset {
+    LocalTranscriptionStarterPreset(
+      id: .whisperKitBatch,
+      mode: .batch,
+      engine: .whisperKit(
+        LocalTranscriptionModel(
+          id: modelID,
+          displayName: "Test Model",
+          modelName: "test-model",
+          engine: .whisperKit,
+          approximateSizeMB: 200,
+          description: "A model for tests.",
+          tags: [.quality],
+          supportsLiveStreaming: false
+        )
+      ),
+      recommendation: "Best quality for finished recordings",
+      detail: "A model for tests.",
+      runtime: "WhisperKit / Core ML",
+      approximateSizeMB: 200
+    )
+  }
+}
+
+/// Holds a simulated download open until the test releases it.
+@MainActor
+private final class ActivationGate {
+  private var continuation: CheckedContinuation<Void, Never>?
+  private var isOpen = false
+
+  func wait() async {
+    guard !isOpen else { return }
+    await withCheckedContinuation { continuation in
+      self.continuation = continuation
+    }
+  }
+
+  func open() {
+    isOpen = true
+    continuation?.resume()
+    continuation = nil
+  }
+}


### PR DESCRIPTION
## Problem

`configureAndDownload` in the local quick-setup card wrote `transcriptionMode`,
`localTranscriptionMode` and the model/source before it started a fire-and-forget
install task, and it ignored the result. A failed or cancelled download therefore
left the persisted settings pointing at a model that is not installed. Every later
recording failed with `.notInstalled`, and the broken setup survived a relaunch.

## Change

- `StarterPresetActivation.configureAndDownload` sequences the action: prepare the
  model first, then activate the preset only when the manager reports it as
  installed. An already installed preset still activates immediately.
- A newer request cancels the previous activation, so a late completion cannot
  replace the setup that the user selected last.
- `LocalTranscriptionStarterPreset.activate(in:)` owns the settings commit, which
  keeps the commit in one place and makes it testable.
- Failure surfacing is unchanged: the row keeps showing "Download failed: …" from
  the manager install state, and the active setup does not change.

## Tests

`Tests/SpeakAppTests/StarterPresetActivationTests.swift` drives success, failure,
cancellation, an already installed preset and two overlapping requests, and asserts
the transcription mode and model that routing uses.

## Verification

- `xcrun swiftc -parse` on the changed files
- `swiftlint lint --strict --baseline .swiftlint-baseline.json` reports no violations

Closes #711


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added starter preset activation for local transcription models, including Parakeet and WhisperKit configurations.
  * Model downloads now complete before applying a selected transcription setup.
  * New activation requests supersede older pending downloads.

* **Bug Fixes**
  * Existing transcription settings remain active if installation is cancelled or fails.
  * Ready presets activate immediately without unnecessary downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->