### PR TITLE
fix(mac): preserve balanced hotkey holds through recovery

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -102,6 +102,10 @@ let package = Package(
             dependencies: ["SpeakCore"]
         ),
         .testTarget(
+            name: "SpeakHotKeysTests",
+            dependencies: ["SpeakHotKeys"]
+        ),
+        .testTarget(
             name: "SpeakSyncTests",
             dependencies: ["SpeakSync"]
         ),

--- a/Sources/SpeakApp/HotKeyManager.swift
+++ b/Sources/SpeakApp/HotKeyManager.swift
@@ -162,6 +162,7 @@ final class HotKeyManager: ObservableObject {
 	}
 
 	func stopMonitoring() {
+		cancelScheduledRecovery()
 		permissionRequestTask?.cancel()
 		permissionRequestTask = nil
 		monitoringRequested = false
@@ -181,7 +182,12 @@ final class HotKeyManager: ObservableObject {
 		engine.stop()
 	}
 
+	/// Tears the engine down and rearms it with the current binding.
+	///
+	/// A hold that is in progress ends with a balanced `holdEnd`, so a recording
+	/// that started on hold never survives the reconnect.
 	func reconnectMonitoring() {
+		cancelScheduledRecovery()
 		guard monitoringRequested else {
 			startMonitoring()
 			return
@@ -203,6 +209,7 @@ final class HotKeyManager: ObservableObject {
 
 	/// Restart monitoring with the current hotkey from settings.
 	func restartWithCurrentHotKey() {
+		cancelScheduledRecovery()
 		let shouldRestart = monitoringRequested
 		engine.stop()
 		if shouldRestart {
@@ -234,15 +241,26 @@ final class HotKeyManager: ObservableObject {
 		monitoringState = .active
 	}
 
+	/// Rearms monitoring a moment after a lifecycle event.
+	///
+	/// Only the newest request may rearm. A manual reconnect or a binding change
+	/// cancels a pending recovery, so a stale lifecycle event cannot reset a newer
+	/// detector.
 	private func scheduleRecovery(reason: String) {
 		guard monitoringRequested else { return }
 		recoveryTask?.cancel()
 		recoveryTask = Task { @MainActor [weak self] in
 			try? await Task.sleep(for: .milliseconds(500))
 			guard !Task.isCancelled, let self, self.monitoringRequested else { return }
+			self.recoveryTask = nil
 			self.log.info("Rearming global hotkey after \(reason, privacy: .public)")
 			self.reconnectMonitoring()
 		}
+	}
+
+	private func cancelScheduledRecovery() {
+		recoveryTask?.cancel()
+		recoveryTask = nil
 	}
 
 	@discardableResult

--- a/Sources/SpeakHotKeys/GestureDetector.swift
+++ b/Sources/SpeakHotKeys/GestureDetector.swift
@@ -79,17 +79,31 @@ public final class GestureDetector {
     lastReleaseUptime = now
   }
 
+  /// Whether a hold is in progress: `holdStart` fired and `holdEnd` is still due.
+  public var isHoldInProgress: Bool { holdFired }
+
   /// Reset all state (e.g. when switching hotkey mode).
-  public func reset() {
+  ///
+  /// A hold that is in progress ends first with a balanced `holdEnd`. Teardown
+  /// removes the monitoring backend, so the matching key-up can no longer arrive.
+  /// Without the balanced end, the recording that `holdStart` started keeps the
+  /// microphone open until the user stops it by hand.
+  public func reset(source: String = "reset") {
     holdTimer?.cancel()
     holdTimer = nil
     pendingSingleTapWorkItem?.cancel()
     pendingSingleTapWorkItem = nil
+    let hadHoldInProgress = holdFired
     isKeyDown = false
     holdFired = false
     lastReleaseUptime = 0
     lastDoubleTapFireTime = 0
     doubleTapCooldownDeadline = 0
+
+    if hadHoldInProgress {
+      log.info("Ending an in-progress hold because the detector was reset")
+      fire(.holdEnd, source: source)
+    }
   }
 
   // MARK: - Private

--- a/Sources/SpeakHotKeys/HotKeyEngine.swift
+++ b/Sources/SpeakHotKeys/HotKeyEngine.swift
@@ -91,13 +91,16 @@ public final class HotKeyEngine: ObservableObject {
   }
 
   /// Stop all monitoring.
+  ///
+  /// A hold that is in progress ends with a balanced `holdEnd`, so listeners
+  /// never keep a hold-started recording open after the backend goes away.
   public func stop() {
     fnBackend.stop()
     carbonBackend.stop()
-    gestureDetector.reset()
     isMonitoring = false
     isKeyDown = false
     activeHotKey = nil
+    gestureDetector.reset(source: "engine stop")
   }
 
   /// Update timing configuration.

--- a/Tests/SpeakHotKeysTests/GestureDetectorTests.swift
+++ b/Tests/SpeakHotKeysTests/GestureDetectorTests.swift
@@ -1,0 +1,109 @@
+#if os(macOS)
+import XCTest
+
+@testable import SpeakHotKeys
+
+@MainActor
+final class GestureDetectorTests: XCTestCase {
+  private let configuration = HotKeyConfiguration(holdThreshold: 0.02, doubleTapWindow: 0.05)
+
+  func testHoldThenRelease_firesABalancedPair() async {
+    let recorder = GestureRecorder()
+    let detector = makeDetector(recorder: recorder)
+
+    detector.keyDown(source: "test")
+    await recorder.waitForHoldStart(in: self)
+    detector.keyUp(source: "test")
+
+    XCTAssertEqual(recorder.gestures, [.holdStart, .holdEnd])
+    XCTAssertFalse(detector.isHoldInProgress)
+  }
+
+  func testResetDuringHold_firesTheMissingHoldEnd() async {
+    let recorder = GestureRecorder()
+    let detector = makeDetector(recorder: recorder)
+
+    detector.keyDown(source: "test")
+    await recorder.waitForHoldStart(in: self)
+    detector.reset()
+
+    XCTAssertEqual(recorder.gestures, [.holdStart, .holdEnd])
+    XCTAssertFalse(detector.isHoldInProgress)
+  }
+
+  func testKeyUpAfterAResetDuringHold_firesNoSecondEnd() async {
+    let recorder = GestureRecorder()
+    let detector = makeDetector(recorder: recorder)
+
+    detector.keyDown(source: "test")
+    await recorder.waitForHoldStart(in: self)
+    detector.reset()
+    detector.keyUp(source: "test")
+
+    XCTAssertEqual(recorder.gestures, [.holdStart, .holdEnd])
+  }
+
+  func testResetWhileIdle_firesNoGesture() {
+    let recorder = GestureRecorder()
+    let detector = makeDetector(recorder: recorder)
+
+    detector.reset()
+
+    XCTAssertEqual(recorder.gestures, [])
+  }
+
+  func testResetBeforeTheHoldThreshold_firesNoGesture() {
+    let recorder = GestureRecorder()
+    let detector = makeDetector(recorder: recorder)
+
+    detector.keyDown(source: "test")
+    detector.reset()
+
+    XCTAssertEqual(recorder.gestures, [])
+  }
+
+  func testEngineStopDuringHold_firesTheMissingHoldEnd() async {
+    let engine = HotKeyEngine(configuration: configuration)
+    let recorder = GestureRecorder()
+    engine.register(gesture: .holdStart) { recorder.record(.holdStart) }
+    engine.register(gesture: .holdEnd) { recorder.record(.holdEnd) }
+
+    engine.gestureDetector.keyDown(source: "test")
+    await recorder.waitForHoldStart(in: self)
+    engine.stop()
+
+    XCTAssertEqual(recorder.gestures, [.holdStart, .holdEnd])
+    XCTAssertFalse(engine.isKeyDown)
+  }
+
+  // MARK: - Helpers
+
+  private func makeDetector(recorder: GestureRecorder) -> GestureDetector {
+    let detector = GestureDetector(configuration: configuration)
+    detector.onGesture = { recorder.record($0.gesture) }
+    return detector
+  }
+}
+
+/// Collects the gestures a detector emits, and waits for the first hold start.
+@MainActor
+private final class GestureRecorder {
+  private(set) var gestures: [HotKeyGesture] = []
+  private var holdStartExpectation: XCTestExpectation?
+
+  func record(_ gesture: HotKeyGesture) {
+    gestures.append(gesture)
+    if gesture == .holdStart {
+      holdStartExpectation?.fulfill()
+      holdStartExpectation = nil
+    }
+  }
+
+  func waitForHoldStart(in testCase: XCTestCase) async {
+    guard !gestures.contains(.holdStart) else { return }
+    let expectation = testCase.expectation(description: "hold start")
+    holdStartExpectation = expectation
+    await testCase.fulfillment(of: [expectation], timeout: 1)
+  }
+}
+#endif


### PR DESCRIPTION
## Problem

Activation, wake and unlock recovery waits 500ms and then tears the hotkey engine
down and rearms it. Teardown reset the `GestureDetector`, which cleared `isKeyDown`
and `holdFired`. A hold that was in progress therefore lost its `holdEnd`: the
key-up that followed hit the `guard isKeyDown` in `keyUp()` and did nothing.
Hold-to-talk is the default mode, so the recording that `holdStart` began never
terminated and the microphone stayed open.

## Change

- `GestureDetector.reset(source:)` ends an in-progress hold with a balanced
  `holdEnd` before it clears state. Teardown removes the monitoring backend, so
  the matching key-up can no longer arrive. A dropped hold now stops the
  recording instead of leaving it running.
- `HotKeyEngine.stop()` clears its published state first, then resets the
  detector, so every teardown path emits the balanced end.
- `HotKeyManager` cancels a pending recovery when the user reconnects by hand,
  when the binding changes and when monitoring stops. A stale lifecycle event can
  no longer reset a newer detector.
- `GestureDetector.isHoldInProgress` exposes the hold state that these decisions
  depend on.

## Tests

`SpeakHotKeys` had no tests. This adds the `SpeakHotKeysTests` target with
`Tests/SpeakHotKeysTests/GestureDetectorTests.swift`, which covers a normal
balanced hold, a reset during a hold (the regression), the late key-up after that
reset, a reset before the hold threshold, a reset while idle, and an engine stop
during a hold.

## Not included

The bounded failsafe for a key-up that the backend loses while monitoring stays
up is not part of this change. It needs a maximum hold duration, which is a
product decision that can cut a long dictation short.

## Verification

- `xcrun swiftc -parse` on the changed files
- `swiftlint lint --strict --baseline .swiftlint-baseline.json` reports no violations

Closes #708
