### PR TITLE
fix(mac): preserve provider error semantics when consolidating types

### DIFF
--- a/Sources/SpeakCore/TranscriptionProviderRegistry.swift
+++ b/Sources/SpeakCore/TranscriptionProviderRegistry.swift
@@ -52,6 +52,12 @@ public struct TranscriptionProviderMetadata: Sendable, Identifiable {
 
 // MARK: - Provider Error
 
+/// The failure cases that every transcription provider shares.
+///
+/// The descriptions are user-visible: they reach the HUD, the history entry and
+/// the diagnostics report. Keep the established wording. `httpError` keeps the
+/// status code and the response body, because that context is what makes a
+/// provider failure diagnosable.
 public enum TranscriptionProviderError: LocalizedError {
     case apiKeyMissing
     case invalidResponse
@@ -60,11 +66,11 @@ public enum TranscriptionProviderError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .apiKeyMissing:
-            return "API key is missing for the transcription provider."
+            return "API key is required but not provided."
         case .invalidResponse:
-            return "Received an invalid response from the transcription service."
-        case .httpError(let code, let message):
-            return "HTTP error \(code): \(message)"
+            return "The server returned an invalid response."
+        case .httpError(let code, let body):
+            return "Server responded with status \(code): \(body)"
         }
     }
 }

--- a/Tests/SpeakAppTests/OpenAITranscriptionProviderErrorTests.swift
+++ b/Tests/SpeakAppTests/OpenAITranscriptionProviderErrorTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+@testable import SpeakCore
+
+/// Locks the user-visible failure text that an OpenAI batch transcription
+/// produces. These descriptions reach the HUD, the history entry and the
+/// diagnostics report, so a change here is a change in product behaviour.
+final class OpenAITranscriptionProviderErrorTests: XCTestCase {
+
+    func testTranscribeFile_httpFailure_reportsTheStatusCodeAndTheBody() async throws {
+        let body = #"{"error":{"message":"Incorrect API key provided","type":"invalid_request_error"}}"#
+        OpenAIErrorMockURLProtocol.responseHandler = { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(body.utf8))
+        }
+        defer { OpenAIErrorMockURLProtocol.responseHandler = nil }
+
+        let error = await transcriptionFailure(apiKey: "bad-key")
+
+        XCTAssertEqual(
+            error?.localizedDescription,
+            "Server responded with status 401: \(body)"
+        )
+    }
+
+    func testTranscribeFile_serverFailure_keepsTheBodyForDiagnostics() async throws {
+        OpenAIErrorMockURLProtocol.responseHandler = { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("upstream timeout".utf8))
+        }
+        defer { OpenAIErrorMockURLProtocol.responseHandler = nil }
+
+        let error = await transcriptionFailure(apiKey: "test-key")
+
+        XCTAssertEqual(
+            error?.localizedDescription,
+            "Server responded with status 500: upstream timeout"
+        )
+    }
+
+    func testTranscribeFile_nonHTTPResponse_reportsAnInvalidResponse() async throws {
+        OpenAIErrorMockURLProtocol.responseHandler = { request in
+            let response = URLResponse(
+                url: try XCTUnwrap(request.url),
+                mimeType: "application/json",
+                expectedContentLength: 0,
+                textEncodingName: nil
+            )
+            return (response, Data())
+        }
+        defer { OpenAIErrorMockURLProtocol.responseHandler = nil }
+
+        let error = await transcriptionFailure(apiKey: "test-key")
+
+        XCTAssertEqual(error?.localizedDescription, "The server returned an invalid response.")
+    }
+
+    func testMissingAPIKey_reportsTheEstablishedWording() {
+        let error: Error = TranscriptionProviderError.apiKeyMissing
+        XCTAssertEqual(error.localizedDescription, "API key is required but not provided.")
+    }
+
+    // MARK: - Helpers
+
+    private func transcriptionFailure(apiKey: String) async -> Error? {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OpenAIErrorMockURLProtocol.self]
+        let provider = OpenAITranscriptionProvider(session: URLSession(configuration: configuration))
+
+        let audioURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openai_error_test_\(UUID().uuidString).m4a")
+        do {
+            try Data("fakeaudiodata".utf8).write(to: audioURL)
+        } catch {
+            XCTFail("Could not write the test audio file: \(error)")
+            return nil
+        }
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        do {
+            _ = try await provider.transcribeFile(
+                at: audioURL,
+                apiKey: apiKey,
+                model: "openai/whisper-1",
+                language: nil
+            )
+            XCTFail("Expected the transcription to fail")
+            return nil
+        } catch {
+            return error
+        }
+    }
+}
+
+// MARK: - Test Infrastructure
+
+private final class OpenAIErrorMockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var responseHandler: (@Sendable (URLRequest) throws -> (URLResponse, Data))?
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.responseHandler else {
+            XCTFail("OpenAIErrorMockURLProtocol.responseHandler was not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/SpeakCoreTests/TranscriptionProviderTests.swift
+++ b/Tests/SpeakCoreTests/TranscriptionProviderTests.swift
@@ -6,58 +6,64 @@ final class TranscriptionProviderErrorTests: XCTestCase {
 
     // MARK: - apiKeyMissing
 
-    func testAPIKeyMissing_errorDescription_isNonEmpty() {
-        let error = TranscriptionProviderError.apiKeyMissing
-        XCTAssertNotNil(error.errorDescription)
-        XCTAssertFalse(error.errorDescription!.isEmpty)
+    func testAPIKeyMissing_errorDescription_usesTheEstablishedWording() {
+        XCTAssertEqual(
+            TranscriptionProviderError.apiKeyMissing.errorDescription,
+            "API key is required but not provided."
+        )
     }
 
-    func testAPIKeyMissing_errorDescription_mentionsAPIKey() {
-        let desc = TranscriptionProviderError.apiKeyMissing.errorDescription!
-        XCTAssertTrue(
-            desc.lowercased().contains("api key"),
-            "Description should mention 'API key': \(desc)"
-        )
+    func testAPIKeyMissing_localizedDescription_matchesTheErrorDescription() {
+        let error = TranscriptionProviderError.apiKeyMissing
+        XCTAssertEqual(error.localizedDescription, error.errorDescription)
     }
 
     // MARK: - invalidResponse
 
-    func testInvalidResponse_errorDescription_isNonEmpty() {
-        let error = TranscriptionProviderError.invalidResponse
-        XCTAssertNotNil(error.errorDescription)
-        XCTAssertFalse(error.errorDescription!.isEmpty)
+    func testInvalidResponse_errorDescription_usesTheEstablishedWording() {
+        XCTAssertEqual(
+            TranscriptionProviderError.invalidResponse.errorDescription,
+            "The server returned an invalid response."
+        )
     }
 
-    func testInvalidResponse_errorDescription_mentionsResponse() {
-        let desc = TranscriptionProviderError.invalidResponse.errorDescription!
-        XCTAssertTrue(
-            desc.lowercased().contains("response"),
-            "Description should mention 'response': \(desc)"
-        )
+    func testInvalidResponse_localizedDescription_matchesTheErrorDescription() {
+        let error = TranscriptionProviderError.invalidResponse
+        XCTAssertEqual(error.localizedDescription, error.errorDescription)
     }
 
     // MARK: - httpError
 
-    func testHTTPError_errorDescription_containsStatusCode() {
-        let error = TranscriptionProviderError.httpError(404, "Not Found")
-        let desc = error.errorDescription!
-        XCTAssertTrue(desc.contains("404"), "Description should contain status code: \(desc)")
-    }
-
-    func testHTTPError_errorDescription_containsMessage() {
-        let error = TranscriptionProviderError.httpError(500, "Internal Server Error")
-        let desc = error.errorDescription!
-        XCTAssertTrue(
-            desc.contains("Internal Server Error"),
-            "Description should contain message: \(desc)"
+    func testHTTPError_errorDescription_keepsTheStatusCodeAndTheBody() {
+        XCTAssertEqual(
+            TranscriptionProviderError.httpError(404, "Not Found").errorDescription,
+            "Server responded with status 404: Not Found"
         )
     }
 
-    func testHTTPError_differentCodes_descriptionReflectsCode() {
-        let error401 = TranscriptionProviderError.httpError(401, "Unauthorized")
-        let error503 = TranscriptionProviderError.httpError(503, "Service Unavailable")
-        XCTAssertTrue(error401.errorDescription!.contains("401"))
-        XCTAssertTrue(error503.errorDescription!.contains("503"))
+    func testHTTPError_errorDescription_keepsAStructuredBodyVerbatim() {
+        let body = #"{"error":{"message":"Invalid API key","type":"invalid_request_error"}}"#
+        let description = TranscriptionProviderError.httpError(401, body).errorDescription
+
+        XCTAssertEqual(description, "Server responded with status 401: \(body)")
+        XCTAssertTrue(description!.contains("401"))
+        XCTAssertTrue(description!.contains("Invalid API key"))
+    }
+
+    func testHTTPError_differentCodes_descriptionReflectsTheCode() {
+        XCTAssertEqual(
+            TranscriptionProviderError.httpError(401, "Unauthorized").errorDescription,
+            "Server responded with status 401: Unauthorized"
+        )
+        XCTAssertEqual(
+            TranscriptionProviderError.httpError(503, "Service Unavailable").errorDescription,
+            "Server responded with status 503: Service Unavailable"
+        )
+    }
+
+    func testHTTPError_localizedDescription_matchesTheErrorDescription() {
+        let error = TranscriptionProviderError.httpError(500, "Internal Server Error")
+        XCTAssertEqual(error.localizedDescription, error.errorDescription)
     }
 }
 


### PR DESCRIPTION
## Problem

Commit a4a1014a (#574) deleted the SpeakApp-local `TranscriptionProviderError` as
an identical duplicate. The wording of the two types was not identical, and the
local type was the one every SpeakApp provider resolved to. A cleanup-only release
therefore changed three user-visible messages:

| Case | Before #574 | After #574 |
| --- | --- | --- |
| `apiKeyMissing` | API key is required but not provided. | API key is missing for the transcription provider. |
| `invalidResponse` | The server returned an invalid response. | Received an invalid response from the transcription service. |
| `httpError` | Server responded with status 401: {body} | HTTP error 401: {body} |

These descriptions reach the HUD, the history entry and the diagnostics report.

## Change

- The shared `SpeakCore.TranscriptionProviderError` carries the established
  wording again. `httpError` keeps the status code and the response body, which
  is the context that makes a provider failure diagnosable.
- A doc comment records that the descriptions are user-visible, so the next
  consolidation does not treat them as free text.

## Tests

- `Tests/SpeakCoreTests/TranscriptionProviderTests.swift` asserts the exact
  description of each case instead of non-emptiness, and checks that a structured
  JSON body survives verbatim in the HTTP case.
- `Tests/SpeakAppTests/OpenAITranscriptionProviderErrorTests.swift` drives the
  OpenAI provider through a 401, a 500 and a non-HTTP response, and asserts the
  description that the failure presents.

## Verification

- `xcrun swiftc -parse` on the changed files
- `swiftlint lint --strict --baseline .swiftlint-baseline.json` reports no violations

Closes #710
