### PR TITLE
fix(ios): centre the launch waveform mark

### DIFF
--- a/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/LaunchMark-dark.svg
+++ b/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/LaunchMark-dark.svg
@@ -2,12 +2,12 @@
   <circle cx="56" cy="56" r="52" fill="#2B211C"/>
   <circle cx="56" cy="56" r="51.5" stroke="#523728"/>
   <g fill="#FF9C73">
-    <rect x="25" y="46" width="6" height="20" rx="3"/>
-    <rect x="35" y="38" width="6" height="36" rx="3"/>
-    <rect x="45" y="30" width="6" height="52" rx="3"/>
-    <rect x="55" y="22" width="6" height="68" rx="3"/>
-    <rect x="65" y="30" width="6" height="52" rx="3"/>
-    <rect x="75" y="38" width="6" height="36" rx="3"/>
-    <rect x="85" y="46" width="6" height="20" rx="3"/>
+    <rect x="23" y="46" width="6" height="20" rx="3"/>
+    <rect x="33" y="38" width="6" height="36" rx="3"/>
+    <rect x="43" y="30" width="6" height="52" rx="3"/>
+    <rect x="53" y="22" width="6" height="68" rx="3"/>
+    <rect x="63" y="30" width="6" height="52" rx="3"/>
+    <rect x="73" y="38" width="6" height="36" rx="3"/>
+    <rect x="83" y="46" width="6" height="20" rx="3"/>
   </g>
 </svg>

--- a/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/LaunchMark.svg
+++ b/SpeakiOSApp/Assets.xcassets/LaunchMark.imageset/LaunchMark.svg
@@ -2,12 +2,12 @@
   <circle cx="56" cy="56" r="52" fill="#FFF3E9"/>
   <circle cx="56" cy="56" r="51.5" stroke="#F4D7C1"/>
   <g fill="#925B3A">
-    <rect x="25" y="46" width="6" height="20" rx="3"/>
-    <rect x="35" y="38" width="6" height="36" rx="3"/>
-    <rect x="45" y="30" width="6" height="52" rx="3"/>
-    <rect x="55" y="22" width="6" height="68" rx="3"/>
-    <rect x="65" y="30" width="6" height="52" rx="3"/>
-    <rect x="75" y="38" width="6" height="36" rx="3"/>
-    <rect x="85" y="46" width="6" height="20" rx="3"/>
+    <rect x="23" y="46" width="6" height="20" rx="3"/>
+    <rect x="33" y="38" width="6" height="36" rx="3"/>
+    <rect x="43" y="30" width="6" height="52" rx="3"/>
+    <rect x="53" y="22" width="6" height="68" rx="3"/>
+    <rect x="63" y="30" width="6" height="52" rx="3"/>
+    <rect x="73" y="38" width="6" height="36" rx="3"/>
+    <rect x="83" y="46" width="6" height="20" rx="3"/>
   </g>
 </svg>

--- a/Tests/SpeakAppTests/IOSLaunchScreenTests.swift
+++ b/Tests/SpeakAppTests/IOSLaunchScreenTests.swift
@@ -9,6 +9,12 @@ final class IOSLaunchScreenTests: XCTestCase {
             .deletingLastPathComponent()
     }
 
+    private var launchMarkImageSet: URL {
+        repositoryRoot.appendingPathComponent("SpeakiOSApp/Assets.xcassets/LaunchMark.imageset")
+    }
+
+    private let launchMarkVariants = ["LaunchMark.svg", "LaunchMark-dark.svg"]
+
     func testLaunchScreen_usesAnAdaptiveImageWithoutText() throws {
         let storyboard = try String(
             contentsOf: repositoryRoot.appendingPathComponent("SpeakiOSApp/Resources/LaunchScreen.storyboard"),
@@ -21,20 +27,131 @@ final class IOSLaunchScreenTests: XCTestCase {
     }
 
     func testLaunchMark_hasLightAndDarkVectorVariants() throws {
-        let imageSet = repositoryRoot.appendingPathComponent("SpeakiOSApp/Assets.xcassets/LaunchMark.imageset")
         let contents = try String(
-            contentsOf: imageSet.appendingPathComponent("Contents.json"),
+            contentsOf: launchMarkImageSet.appendingPathComponent("Contents.json"),
             encoding: .utf8
         )
 
         XCTAssertTrue(contents.contains("LaunchMark.svg"))
         XCTAssertTrue(contents.contains("LaunchMark-dark.svg"))
         XCTAssertTrue(contents.contains("preserves-vector-representation"))
-        XCTAssertTrue(
-            FileManager.default.fileExists(atPath: imageSet.appendingPathComponent("LaunchMark.svg").path)
+        for variant in launchMarkVariants {
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: launchMarkImageSet.appendingPathComponent(variant).path),
+                "\(variant) should exist"
+            )
+        }
+    }
+
+    func testLaunchMark_waveformSharesTheCentreOfTheCircleAndTheCanvas() throws {
+        for variant in launchMarkVariants {
+            let geometry = try launchMarkGeometry(ofVariant: variant)
+
+            XCTAssertEqual(
+                geometry.waveformCentreX,
+                geometry.circleCentreX,
+                accuracy: 0.001,
+                "\(variant): the waveform should share the centre of the circle"
+            )
+            XCTAssertEqual(
+                geometry.waveformCentreX,
+                geometry.canvasWidth / 2,
+                accuracy: 0.001,
+                "\(variant): the waveform should share the centre of the canvas"
+            )
+        }
+    }
+
+    func testLaunchMark_waveformKeepsAnOddBarCountWithEqualSpacing() throws {
+        for variant in launchMarkVariants {
+            let geometry = try launchMarkGeometry(ofVariant: variant)
+            let spacings = zip(geometry.bars, geometry.bars.dropFirst()).map { $1.originX - $0.originX }
+
+            XCTAssertEqual(geometry.bars.count % 2, 1, "\(variant): the bar count should stay odd")
+            XCTAssertEqual(Set(spacings).count, 1, "\(variant): the bars should keep equal spacing")
+        }
+    }
+
+    func testLaunchMark_variantsShareIdenticalShapeCoordinates() throws {
+        let shapes = try launchMarkVariants.map { try launchMarkGeometry(ofVariant: $0) }
+
+        XCTAssertEqual(
+            shapes.first,
+            shapes.last,
+            "Only colour should vary between the light and the dark launch mark"
         )
-        XCTAssertTrue(
-            FileManager.default.fileExists(atPath: imageSet.appendingPathComponent("LaunchMark-dark.svg").path)
+    }
+
+    // MARK: - Helpers
+
+    private struct Bar: Equatable {
+        let originX: Double
+        let originY: Double
+        let width: Double
+        let height: Double
+    }
+
+    private struct LaunchMarkGeometry: Equatable {
+        let canvasWidth: Double
+        let circleCentreX: Double
+        let bars: [Bar]
+
+        var waveformCentreX: Double {
+            let leadingEdge = bars.map(\.originX).min() ?? 0
+            let trailingEdge = bars.map { $0.originX + $0.width }.max() ?? 0
+            return (leadingEdge + trailingEdge) / 2
+        }
+    }
+
+    private func launchMarkGeometry(
+        ofVariant variant: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> LaunchMarkGeometry {
+        let markup = try String(
+            contentsOf: launchMarkImageSet.appendingPathComponent(variant),
+            encoding: .utf8
         )
+
+        let canvasWidths = try values(of: "svg", attributes: ["width"], in: markup)
+        let circles = try values(of: "circle", attributes: ["cx"], in: markup)
+        let rects = try values(of: "rect", attributes: ["x", "y", "width", "height"], in: markup)
+
+        let canvasWidth = try XCTUnwrap(
+            canvasWidths.first?.first,
+            "\(variant): no canvas width",
+            file: file,
+            line: line
+        )
+        let circleCentres = Set(circles.compactMap(\.first))
+        XCTAssertEqual(
+            circleCentres.count,
+            1,
+            "\(variant): the circles should share one centre",
+            file: file,
+            line: line
+        )
+        let circleCentreX = try XCTUnwrap(circleCentres.first, "\(variant): no circle", file: file, line: line)
+        XCTAssertFalse(rects.isEmpty, "\(variant): no waveform bars", file: file, line: line)
+
+        return LaunchMarkGeometry(
+            canvasWidth: canvasWidth,
+            circleCentreX: circleCentreX,
+            bars: rects.map { Bar(originX: $0[0], originY: $0[1], width: $0[2], height: $0[3]) }
+        )
+    }
+
+    /// Reads the given numeric attributes from every occurrence of an element.
+    private func values(of element: String, attributes: [String], in markup: String) throws -> [[Double]] {
+        let attributePatterns = attributes.map { "\($0)=\"(-?[0-9.]+)\"" }.joined(separator: "[^>]*?")
+        let expression = try NSRegularExpression(pattern: "<\(element)[^>]*?\(attributePatterns)")
+        let range = NSRange(markup.startIndex..., in: markup)
+
+        return expression.matches(in: markup, range: range).map { match in
+            (1..<match.numberOfRanges).compactMap { index in
+                guard let captured = Range(match.range(at: index), in: markup) else { return nil }
+                return Double(markup[captured])
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

The waveform bars in both launch-mark variants started at x=25 and ended at x=91,
so their midpoint sat at x=58. The surrounding circle and the 112pt canvas centre
on x=56, so the brand mark appeared 2pt to the right on every iOS launch.

## Change

- Each bar moves 2pt to the left in `LaunchMark.svg` and `LaunchMark-dark.svg`:
  x = 23, 33, 43, 53, 63, 73, 83. The bars now span x=23 to x=89, which puts the
  midpoint on x=56. The 10pt spacing, the odd bar count and every colour stay as
  they were.

## Tests

`Tests/SpeakAppTests/IOSLaunchScreenTests.swift` only checked that the assets
exist. It now reads the geometry out of each SVG and asserts, for both variants,
that the waveform shares the centre of the circle and of the canvas, that the bar
count stays odd with equal spacing, and that the light and the dark variant have
identical shape coordinates. A future asset edit that drifts between variants
fails the suite.

## Verification

- `xcrun swiftc -parse` on the changed test file
- `swiftlint lint --strict --baseline .swiftlint-baseline.json` reports no violations

Closes #691


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded launch-screen validation for light and dark appearances.
  * Added checks for vector assets, centered geometry, evenly spaced waveform bars, and matching shapes across variants.
  * Improved automated parsing of launch-screen SVG geometry and attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->