### PR TITLE
fix(release): exclude iOS-only commits from mac release notes

### DIFF
--- a/Tests/ReleaseNotesTests/release-notes.test.mjs
+++ b/Tests/ReleaseNotesTests/release-notes.test.mjs
@@ -1,11 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
     appcastBuildNumber,
     buildPrompt,
+    collectReleaseContext,
+    commitPlatform,
     cumulativeSparkleHTML,
     deterministicNotes,
     fetchPublishedSparkleReleases,
+    filterCommitsForTrack,
     generateReleaseNotes,
     markdownToHTML,
     parseCommits,
@@ -74,6 +81,62 @@ test("generator falls back without an API key", async () => {
     assert.equal(result.usedFallback, true);
     assert.match(result.notes, /### New and improved/);
     assert.match(result.notes, /fallback=deterministic/);
+});
+
+test("commit platform classification reads Conventional Commit scopes", () => {
+    assert.equal(commitPlatform("feat(ios): add keyboard themes"), "ios");
+    assert.equal(commitPlatform("fix(mac)!: rework the updater"), "mac");
+    assert.equal(commitPlatform("perf(macos): faster launch"), "mac");
+    assert.equal(commitPlatform("feat(mac,ios): shared history"), "shared");
+    assert.equal(commitPlatform("fix: unscoped shared change"), "shared");
+    assert.equal(commitPlatform("chore(deps): bump Sparkle"), "shared");
+    assert.equal(commitPlatform("Merge branch 'main'"), "shared");
+});
+
+test("track filtering drops only the other platform's commits", () => {
+    const commits = [
+        { sha: "a", subject: "feat(mac): menu bar polish" },
+        { sha: "b", subject: "fix(ios): keyboard crash" },
+        { sha: "c", subject: "feat: shared transcription engine" },
+        { sha: "d", subject: "perf(mac,ios): faster model load" },
+    ];
+    assert.deepEqual(filterCommitsForTrack(commits, "mac").map((commit) => commit.sha), ["a", "c", "d"]);
+    assert.deepEqual(filterCommitsForTrack(commits, "ios").map((commit) => commit.sha), ["b", "c", "d"]);
+    assert.deepEqual(filterCommitsForTrack(commits, "legacy"), commits);
+});
+
+test("mac release context excludes iOS-only commits from the prompt and fallback notes", () => {
+    const repo = mkdtempSync(join(tmpdir(), "release-notes-test-"));
+    const git = (...args) => execFileSync(
+        "git",
+        ["-c", "user.name=Test", "-c", "user.email=test@example.com", ...args],
+        { cwd: repo, encoding: "utf8" }
+    );
+    try {
+        git("init", "--initial-branch=main");
+        writeFileSync(join(repo, "file.txt"), "one\n");
+        git("add", "file.txt");
+        git("commit", "-m", "chore: initial import");
+        git("tag", "mac-v1.0.0");
+        writeFileSync(join(repo, "file.txt"), "two\n");
+        git("commit", "-am", "feat(mac): add dictation window");
+        writeFileSync(join(repo, "file.txt"), "three\n");
+        git("commit", "-am", "feat(ios): add keyboard themes");
+        writeFileSync(join(repo, "file.txt"), "four\n");
+        git("commit", "-am", "fix: stop dropping the final word");
+        git("tag", "mac-v1.1.0");
+
+        const releaseContext = collectReleaseContext({ tag: "mac-v1.1.0", cwd: repo });
+        assert.equal(releaseContext.previousTag, "mac-v1.0.0");
+        assert.deepEqual(releaseContext.commits.map((commit) => commit.subject), [
+            "feat(mac): add dictation window",
+            "fix: stop dropping the final word",
+        ]);
+        assert.doesNotMatch(buildPrompt(releaseContext), /keyboard themes/);
+        assert.doesNotMatch(deterministicNotes(releaseContext), /keyboard themes/);
+    } finally {
+        rmSync(repo, { recursive: true, force: true });
+    }
 });
 
 test("release tracks keep macOS, iOS, and legacy histories separate", () => {

--- a/scripts/release-notes-lib.mjs
+++ b/scripts/release-notes-lib.mjs
@@ -3,6 +3,23 @@ import { execFileSync } from "node:child_process";
 export const DEFAULT_MODEL = "gpt-5.6-luna";
 export const DEFAULT_REASONING_EFFORT = "medium";
 
+export const commitPlatform = (subject) => {
+    const match = String(subject ?? "").match(/^[a-z]+\(([^)]*)\)!?:/i);
+    if (!match) return "shared";
+    const scopes = match[1].toLowerCase().split(/[\s,/]+/).filter(Boolean);
+    const targetsIOS = scopes.includes("ios");
+    const targetsMac = scopes.includes("mac") || scopes.includes("macos");
+    if (targetsIOS && !targetsMac) return "ios";
+    if (targetsMac && !targetsIOS) return "mac";
+    return "shared";
+};
+
+export const filterCommitsForTrack = (commits, track) => {
+    if (track !== "mac" && track !== "ios") return commits;
+    const excluded = track === "mac" ? "ios" : "mac";
+    return commits.filter((commit) => commitPlatform(commit.subject) !== excluded);
+};
+
 const sectionForSubject = (subject) => {
     const match = subject.match(/^(feat|fix|perf|refactor|docs|build|ci|test|chore)(?:\([^)]*\))?!?:\s*(.*)$/i);
     if (!match) {
@@ -318,7 +335,7 @@ export const collectReleaseContext = ({ tag, previousTag, cwd = process.cwd(), r
 
     const range = resolvedPreviousTag ? `${resolvedPreviousTag}..${tag}` : tag;
     const rawLog = runGit(["log", "--reverse", "--format=%H%x1f%s%x1f%b%x1e", range], cwd);
-    const commits = parseCommits(rawLog);
+    const commits = filterCommitsForTrack(parseCommits(rawLog), releaseTrack(tag));
     const fileSummary = resolvedPreviousTag
         ? runGit(["diff", "--stat", "--summary", `${resolvedPreviousTag}..${tag}`], cwd)
         : runGit(["show", "--stat", "--summary", "--format=", tag], cwd);


### PR DESCRIPTION
## Defect

The macOS release-note generator (`scripts/release-notes-lib.mjs`) collected every commit between `mac-v*` tags with no platform filtering. Because `feat(ios):`/`fix(ios):` commits also trigger the macOS release workflow, iOS-only changes were fed to both the model prompt and the deterministic fallback, so published mac notes advertised iOS-only functionality (e.g. the mac-v2.46.0 body was mostly iOS keyboard content).

## Fix

- `commitPlatform(subject)` parses the Conventional Commit scope into `ios` / `mac` / `shared`. Only explicit platform scopes count (`ios`, `mac`, `macos`); combined scopes (`mac,ios`), non-platform scopes (`deps`, `core`, ...), and unscoped or non-conventional subjects classify as `shared`.
- `filterCommitsForTrack(commits, track)` drops the opposite platform's commits: `mac` releases exclude iOS-only commits, and the inverse rule for `ios` releases is defined now so the library stays correct when iOS publication is automated. Legacy/other tracks are untouched.
- `collectReleaseContext` applies the filter via `releaseTrack(tag)`, so the model context (`buildPrompt`) and the fallback (`deterministicNotes`) both see only relevant commits.

The HTML attribute-escaping half of #689 was already fixed by #653 (quote escaping in `escapeHTML` with a regression test), per the triage comment; this PR implements only the remaining filtering half.

## Tests

`node --test Tests/ReleaseNotesTests/*.test.mjs` — 24 pass, including three new tests:

- scope classification across ios/mac/macos/combined/non-platform/unscoped/non-conventional subjects
- track filtering keeps shared and same-platform commits for both mac and ios tracks and leaves legacy ranges alone
- an end-to-end fixture repo with mac, iOS, and unscoped commits between two `mac-v*` tags, asserting the iOS commit is absent from `collectReleaseContext`, the model prompt, and the fallback notes

Fixes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)