### PR TITLE
ci: restore pre-merge Release-configuration validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,11 @@ jobs:
           path: ${{ runner.temp }}/snapshot-failures
           if-no-files-found: ignore
 
-      # Release-configuration tests run as the release gate in release-mac.yml;
-      # running them here too effectively doubled test time on 10x-billed macOS runners.
+      # Release-configuration tests run pre-merge in the release-validation job
+      # below (path-filtered to package-affecting changes to control cost on
+      # 10x-billed macOS runners). They are NOT duplicated inside this job:
+      # running both configurations serially in one job doubled its wall time.
+      # release-mac.yml re-runs them post-tag as defence in depth.
 
       - name: Build SpeakCore (App Store flavour)
         # SpeakCore has no package dependencies, so this cheaply compiles the
@@ -81,6 +84,59 @@ jobs:
                 --ignore-filename-regex='\.build|Tests/' 2>/dev/null | head -30 >> $GITHUB_STEP_SUMMARY || true
             fi
           fi
+
+  # Pre-merge Release-configuration gate (#694). A Release-only compile,
+  # optimisation, or test failure must fail the PR that introduces it — the
+  # post-tag run in release-mac.yml is defence in depth, not the first gate.
+  # Cost controls for 10x-billed macOS runners:
+  # - a cheap ubuntu job skips the macOS leg for docs-only changes (a skipped
+  #   job still satisfies a required check, so the gate can be marked required)
+  # - the workflow-level concurrency group cancels superseded runs
+  # - a release-specific .build cache avoids cold dependency builds
+  # - runs only on pull_request: pushes to main were just gated by their PR,
+  #   and tags are re-validated by release-mac.yml.
+  release-paths:
+    name: Detect Release-Relevant Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    outputs:
+      package: ${{ steps.filter.outputs.package }}
+    steps:
+      - name: Filter changed paths
+        # No checkout needed: on pull_request events the action lists changed
+        # files via the GitHub API.
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            package:
+              - 'Package.swift'
+              - 'Package.resolved'
+              - 'Sources/**'
+              - 'Tests/**'
+              - 'Config/**'
+              - '.github/workflows/ci.yml'
+
+  release-validation:
+    name: Build & Test (Release)
+    runs-on: macos-latest
+    timeout-minutes: 45
+    needs: release-paths
+    if: needs.release-paths.outputs.package == 'true'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Cache Swift packages (release)
+        uses: actions/cache@v6
+        with:
+          path: .build
+          key: ${{ runner.os }}-swift-release-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-release-
+
+      - name: Test (Release)
+        run: swift test -c release
 
   build-ios:
     name: Build iOS Library

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -51,7 +51,9 @@ jobs:
 
       - name: Run Tests (Release Config)
         run: |
-          echo "Running tests in release configuration as release gate..."
+          # Defence in depth: the pre-merge gate is the release-validation job
+          # in ci.yml; this re-run protects tags cut from any unvalidated state.
+          echo "Re-running release-configuration tests as post-tag defence in depth..."
           swift test -c release
 
       # Release tests exercise real Keychain migration. Run them before replacing


### PR DESCRIPTION
## Rationale

Pull-request CI only exercised the debug configuration; `swift test -c release` ran solely as the post-tag gate in `release-mac.yml`. A Release-only compile, optimisation, or test failure could therefore merge green and stay latent until an unrelated releasable commit created a tag, at which point the release workflow failed. This PR restores a pre-merge Release gate so the PR that introduces such a failure is the one that goes red — including non-releasing `refactor:`/`chore:` PRs.

## What changed

- **`.github/workflows/ci.yml`**: new `release-paths` (ubuntu) + `release-validation` (macOS) jobs. `release-validation` runs `swift test -c release` — the same command as the post-tag gate — on PRs that touch `Package.swift`, `Package.resolved`, `Sources/**`, `Tests/**`, `Config/**` (read by entitlement/plist tests), or `ci.yml` itself. The stale comment describing the post-tag run as the release gate is replaced.
- **`.github/workflows/release-mac.yml`**: the post-tag `swift test -c release` step is kept, reworded as defence in depth rather than the first gate.

## Cost mitigation (10x-billed macOS runners)

- Docs-only PRs never spin up the macOS runner: a ~seconds ubuntu `dorny/paths-filter` job gates it, and a skipped job still satisfies a required check.
- Runs on `pull_request` only — pushes to `main` were just gated by their PR, and tags re-run the suite in `release-mac.yml`.
- The workflow-level concurrency group (`cancel-in-progress: true`) cancels superseded runs on force-pushes.
- Release-specific `.build` cache (`swift-release-` key, separate from the debug cache) plus a 45-minute timeout.
- Runs as a parallel job rather than appended to the debug job, so PR wall-clock time is unchanged (the old in-job release run that was removed for cost had doubled that job's duration).

## Making the gate required

The acceptance criteria ask for a **required** check. That needs an edit to repo ruleset **20875321** to add `Build & Test (Release)` to the required status checks — only the repo owner can do this; this PR cannot. Because docs-only PRs report the job as *skipped* (not missing), marking it required will not block them.

This change is self-validating: `ci.yml` is in the path filter, so the new job runs on this PR.

Fixes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)