### PR TITLE
fix(a11y): align Dashboard recording action semantics

### DIFF
--- a/Sources/SpeakApp/DashboardView.swift
+++ b/Sources/SpeakApp/DashboardView.swift
@@ -73,9 +73,9 @@ struct DashboardView: View {
         .tint(environment.main.state == .recording ? .red : .accentColor)
         .disabled(isBusy)
         .keyboardShortcut(.space, modifiers: [.command])
-        .accessibilityLabel(buttonTitle)
-        .accessibilityHint(recordButtonAccessibilityHint)
-        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(recordButtonAccessibility.label)
+        .accessibilityHint(recordButtonAccessibility.hint)
+        .accessibilityAddTraits(recordButtonAccessibility.traits)
       }
 
       if let preview = livePreviewText, !preview.isEmpty {
@@ -131,9 +131,9 @@ struct DashboardView: View {
         .keyboardShortcut(.space, modifiers: [.command])
         .disabled(isBusy)
         .speakTooltip("Start a new recording instantly or stop the current one—Speak keeps you informed every step of the way.")
-        .accessibilityLabel(buttonTitle)
-        .accessibilityHint(recordButtonAccessibilityHint)
-        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(recordButtonAccessibility.label)
+        .accessibilityHint(recordButtonAccessibility.hint)
+        .accessibilityAddTraits(recordButtonAccessibility.traits)
         .shadow(color: Color.black.opacity(0.25), radius: 18, x: 0, y: 12)
         .animation(.easeInOut(duration: 0.2), value: environment.main.state)
       }
@@ -299,15 +299,8 @@ struct DashboardView: View {
     }
   }
 
-  private var recordButtonAccessibilityHint: String {
-    switch environment.main.state {
-    case .idle, .completed, .failed:
-      return "Starts a new recording"
-    case .recording:
-      return "Stops the current recording"
-    case .processing, .delivering:
-      return ""
-    }
+  private var recordButtonAccessibility: RecordingControlAccessibility {
+    RecordingControlAccessibility(state: environment.main.state)
   }
 
   @ViewBuilder

--- a/Sources/SpeakApp/MainView.swift
+++ b/Sources/SpeakApp/MainView.swift
@@ -88,9 +88,9 @@ struct MainView: View {
       }
       .keyboardShortcut(.space, modifiers: [.command, .shift])
       .speakTooltip("Start or stop a recording from anywhere in Speak. We'll let you know when we're listening.")
-      .accessibilityLabel(accessibilityLabelForRecordButton)
-      .accessibilityHint(accessibilityHintForRecordButton)
-      .accessibilityAddTraits(accessibilityTraitsForRecordButton)
+      .accessibilityLabel(recordButtonAccessibility.label)
+      .accessibilityHint(recordButtonAccessibility.hint)
+      .accessibilityAddTraits(recordButtonAccessibility.traits)
       .accessibilityIdentifier("toolbarRecordToggleButton")
       .disabled(isRecordButtonDisabled)
     }
@@ -145,37 +145,8 @@ struct MainView: View {
     }
   }
 
-  private var accessibilityLabelForRecordButton: String {
-    switch environment.main.state {
-    case .idle, .completed, .failed:
-      return "Start recording"
-    case .recording:
-      return "Stop recording"
-    case .processing:
-      return "Processing recording"
-    case .delivering:
-      return "Delivering transcription"
-    }
-  }
-
-  private var accessibilityHintForRecordButton: String {
-    switch environment.main.state {
-    case .idle, .completed, .failed:
-      return "Starts a new recording"
-    case .recording:
-      return "Stops recording and processes the transcription"
-    case .processing, .delivering:
-      return ""
-    }
-  }
-
-  private var accessibilityTraitsForRecordButton: AccessibilityTraits {
-    switch environment.main.state {
-    case .idle, .completed, .failed:
-      return [.isButton, .startsMediaSession]
-    case .recording, .processing, .delivering:
-      return .isButton
-    }
+  private var recordButtonAccessibility: RecordingControlAccessibility {
+    RecordingControlAccessibility(state: environment.main.state)
   }
 
   private var isRecordButtonDisabled: Bool {

--- a/Sources/SpeakApp/RecordingControlAccessibility.swift
+++ b/Sources/SpeakApp/RecordingControlAccessibility.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Shared accessibility semantics for every control that toggles recording.
+///
+/// Centralises the label, hint and trait derivation so the Dashboard buttons
+/// and the MainView toolbar control cannot drift apart. Labels are
+/// action-oriented (what activation does), independent of the visible status
+/// copy, and `.startsMediaSession` is applied only in states where activation
+/// begins microphone capture—never when it stops an existing session.
+struct RecordingControlAccessibility: Equatable {
+  let label: String
+  let hint: String
+
+  /// Whether activating the control begins microphone capture.
+  let beginsCapture: Bool
+
+  var traits: AccessibilityTraits {
+    beginsCapture ? [.isButton, .startsMediaSession] : .isButton
+  }
+
+  @MainActor
+  init(state: MainManager.State) {
+    switch state {
+    case .idle, .completed, .failed:
+      label = "Start recording"
+      hint = "Starts a new recording"
+      beginsCapture = true
+    case .recording:
+      label = "Stop recording"
+      hint = "Stops recording and processes the transcription"
+      beginsCapture = false
+    case .processing:
+      label = "Processing recording"
+      hint = ""
+      beginsCapture = false
+    case .delivering:
+      label = "Delivering transcription"
+      hint = ""
+      beginsCapture = false
+    }
+  }
+}

--- a/Tests/SpeakAppTests/RecordingControlAccessibilityTests.swift
+++ b/Tests/SpeakAppTests/RecordingControlAccessibilityTests.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import XCTest
+
+@testable import SpeakApp
+
+/// State-matrix coverage for the shared recording-control accessibility
+/// derivation used by the MainView toolbar button and both Dashboard record
+/// buttons (issue #693).
+final class RecordingControlAccessibilityTests: XCTestCase {
+  @MainActor
+  private func allStates() -> [MainManager.State] {
+    [
+      .idle,
+      .recording,
+      .processing,
+      .delivering,
+      .completed(HistoryItem.placeholder),
+      .failed("Network unavailable")
+    ]
+  }
+
+  @MainActor
+  func testStartableStates_useStartLabelHintAndStartsMediaSession() {
+    let startableStates: [MainManager.State] = [
+      .idle,
+      .completed(HistoryItem.placeholder),
+      .failed("Network unavailable")
+    ]
+    for state in startableStates {
+      let semantics = RecordingControlAccessibility(state: state)
+      XCTAssertEqual(semantics.label, "Start recording", "for state \(state)")
+      XCTAssertEqual(semantics.hint, "Starts a new recording", "for state \(state)")
+      XCTAssertTrue(semantics.beginsCapture, "for state \(state)")
+      XCTAssertEqual(semantics.traits, [.isButton, .startsMediaSession], "for state \(state)")
+    }
+  }
+
+  @MainActor
+  func testRecordingState_announcesStopActionWithoutRelyingOnHints() {
+    let semantics = RecordingControlAccessibility(state: .recording)
+    XCTAssertEqual(semantics.label, "Stop recording")
+    XCTAssertEqual(semantics.hint, "Stops recording and processes the transcription")
+    XCTAssertFalse(semantics.beginsCapture)
+    XCTAssertEqual(semantics.traits, .isButton)
+  }
+
+  @MainActor
+  func testBusyStates_describeProgressWithoutActionHint() {
+    let processing = RecordingControlAccessibility(state: .processing)
+    XCTAssertEqual(processing.label, "Processing recording")
+    XCTAssertEqual(processing.hint, "")
+    XCTAssertEqual(processing.traits, .isButton)
+
+    let delivering = RecordingControlAccessibility(state: .delivering)
+    XCTAssertEqual(delivering.label, "Delivering transcription")
+    XCTAssertEqual(delivering.hint, "")
+    XCTAssertEqual(delivering.traits, .isButton)
+  }
+
+  @MainActor
+  func testStartsMediaSession_appearsOnlyWhenActivationBeginsCapture() {
+    for state in allStates() {
+      let semantics = RecordingControlAccessibility(state: state)
+      XCTAssertEqual(
+        semantics.traits.contains(.startsMediaSession),
+        semantics.beginsCapture,
+        "startsMediaSession must track beginsCapture for state \(state)"
+      )
+      XCTAssertTrue(semantics.traits.contains(.isButton), "for state \(state)")
+    }
+  }
+
+  @MainActor
+  func testEveryState_hasActionOrientedLabelDistinctFromStatusCopy() {
+    for state in allStates() {
+      let semantics = RecordingControlAccessibility(state: state)
+      XCTAssertFalse(semantics.label.isEmpty, "for state \(state)")
+      XCTAssertFalse(
+        semantics.label.contains("…"),
+        "labels must name the action, not progress copy, for state \(state)"
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Defect

The two Dashboard record buttons exposed inaccessible state/action semantics (#693, found while auditing #617):

- While recording, their accessibility label was the visible status copy `Recording…`, so with VoiceOver hints disabled the stop action was undiscoverable.
- In startable states they omitted `.startsMediaSession` (unlike the MainView toolbar control), so VoiceOver speech could continue after activation and be captured at the beginning of the recording.

## Fix

- New `RecordingControlAccessibility` (Sources/SpeakApp/RecordingControlAccessibility.swift) centralises the label/hint/trait derivation for every recording entry point so Dashboard and MainView cannot drift.
- Both Dashboard buttons (compact and normal hero layouts) and the MainView toolbar button now derive their accessibility label, hint and traits from it: action-oriented labels (`Start recording`, `Stop recording`, `Processing recording`, `Delivering transcription`); `.startsMediaSession` only in states where activation begins capture (idle/completed/failed), never in recording/processing/delivering.
- Visible button copy (`Start Recording`, `Recording…`, …) is unchanged — status copy stays independent from accessibility action labels.

## Tests

- `Tests/SpeakAppTests/RecordingControlAccessibilityTests.swift`: state-matrix coverage of all six `MainManager.State` cases — start/stop/busy labels and hints, `.startsMediaSession` present in exactly the startable states, and action-oriented (non-progress) labels everywhere.
- `swift build` clean; full `SpeakAppTests` suite: 561 tests, 0 failures. SwiftLint strict: no violations in touched/new files (remaining reports are pre-existing path-keyed baseline noise).

Fixes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved recording control labels, hints, and traits across dashboard and main views.
  * Recording controls now provide clearer action-oriented feedback for starting, stopping, processing, and delivering recordings.
  * Media-session accessibility traits are applied when recording starts.
* **Tests**
  * Added coverage for recording-control accessibility behavior across all recording states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->