### PR TITLE
fix(ios): persist transport device identity across reinstall

### DIFF
--- a/Sources/SpeakCore/DeviceIdentityStore.swift
+++ b/Sources/SpeakCore/DeviceIdentityStore.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Security
+
+// MARK: - Device Identity Storage
+//
+// Backs `DeviceIdentity.deviceId` (TransportProtocol.swift). Split into its
+// own file to keep `TransportProtocol.swift` within the length limit.
+
+/// Persists the single device-identity string that names this install to
+/// paired Macs. The production conformance keeps it in the Keychain so it
+/// survives app deletion/reinstall; tests substitute an in-memory store.
+public protocol DeviceIdentityStoring: Sendable {
+    func loadDeviceId() -> String?
+    func storeDeviceId(_ id: String)
+}
+
+/// Keychain-backed `DeviceIdentityStoring`.
+///
+/// Uses a dedicated service rather than the aggregate `SecureStorage` payload:
+/// `SecureStorage` is an actor (the device ID must stay readable
+/// synchronously) and its legacy-secret migration absorbs and deletes any
+/// standalone account it finds under its own service.
+public struct KeychainDeviceIdentityStore: DeviceIdentityStoring {
+    private let service: String
+    private let account: String
+
+    public init(
+        service: String = "com.speak.ios.device-identity",
+        account: String = "speak-device-id"
+    ) {
+        self.service = service
+        self.account = account
+    }
+
+    public func loadDeviceId() -> String? {
+        var query = baseQuery()
+        query[kSecReturnData as String] = true
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let id = String(data: data, encoding: .utf8),
+              !id.isEmpty
+        else {
+            return nil
+        }
+        return id
+    }
+
+    /// Best-effort: a Keychain failure must never block identification, so
+    /// callers fall back to the UserDefaults mirror written alongside.
+    public func storeDeviceId(_ id: String) {
+        let data = Data(id.utf8)
+        let status = SecItemUpdate(
+            baseQuery() as CFDictionary,
+            [kSecValueData as String: data] as CFDictionary
+        )
+        guard status == errSecItemNotFound else { return }
+
+        var addQuery = baseQuery()
+        addQuery[kSecValueData as String] = data
+        // Readable after first unlock, and *not* synchronizable: the identity
+        // names this physical device, so it must never follow the user's
+        // iCloud Keychain onto another device.
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    private func baseQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+    }
+}

--- a/Sources/SpeakCore/TransportProtocol.swift
+++ b/Sources/SpeakCore/TransportProtocol.swift
@@ -310,17 +310,18 @@ public final class PairingManager: @unchecked Sendable {
 
 /// Provides consistent device identification.
 public struct DeviceIdentity {
+    static let deviceIdDefaultsKey = "speakDeviceId"
+
     public static var deviceId: String {
         #if os(iOS)
-        // Keep any previously persisted ID so existing pairings survive.
-        if let id = UserDefaults.standard.string(forKey: "speakDeviceId") {
-            return id
-        }
-        // Prefer identifierForVendor: stable across reinstalls while any app
-        // from the same vendor remains installed, unlike a random UUID.
-        let id = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
-        UserDefaults.standard.set(id, forKey: "speakDeviceId")
-        return id
+        return mobileDeviceId(
+            store: KeychainDeviceIdentityStore(),
+            defaults: .standard,
+            // Prefer identifierForVendor: stable while any app from the same
+            // vendor remains installed, unlike a random UUID. Either way the
+            // value is captured once and then served from the Keychain.
+            makeDeviceId: { UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString }
+        )
         #else
         // On macOS, use hardware UUID
         let platformExpert = IOServiceGetMatchingService(
@@ -339,6 +340,35 @@ public struct DeviceIdentity {
         }
         return UUID().uuidString
         #endif
+    }
+
+    /// Resolves the mobile device ID, most durable source first:
+    ///
+    /// 1. Keychain — survives app deletion/reinstall.
+    /// 2. UserDefaults — the pre-Keychain location; migrated into the Keychain
+    ///    on first read so existing pairings keep their identity.
+    /// 3. Freshly generated — persisted to the Keychain and mirrored to
+    ///    UserDefaults (rollback to older builds keeps the same ID, and the
+    ///    mirror is the fallback if the Keychain write failed).
+    ///
+    /// Platform-neutral (the iOS-only part is generating the default ID above)
+    /// so tests can inject every collaborator.
+    static func mobileDeviceId(
+        store: any DeviceIdentityStoring,
+        defaults: UserDefaults,
+        makeDeviceId: () -> String
+    ) -> String {
+        if let id = store.loadDeviceId() {
+            return id
+        }
+        if let legacy = defaults.string(forKey: deviceIdDefaultsKey) {
+            store.storeDeviceId(legacy)
+            return legacy
+        }
+        let id = makeDeviceId()
+        store.storeDeviceId(id)
+        defaults.set(id, forKey: deviceIdDefaultsKey)
+        return id
     }
 
     public static var deviceName: String {

--- a/Tests/SpeakCoreTests/DeviceIdentityTests.swift
+++ b/Tests/SpeakCoreTests/DeviceIdentityTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import SpeakCore
+
+final class DeviceIdentityTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var store: InMemoryDeviceIdentityStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "DeviceIdentityTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+        store = InMemoryDeviceIdentityStore()
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        store = nil
+        super.tearDown()
+    }
+
+    private func resolve(makeDeviceId: @escaping () -> String = { "generated-id" }) -> String {
+        DeviceIdentity.mobileDeviceId(store: store, defaults: defaults, makeDeviceId: makeDeviceId)
+    }
+
+    // MARK: - Fresh install
+
+    func testFreshInstallGeneratesAndPersistsToKeychainAndDefaults() {
+        let id = resolve()
+
+        XCTAssertEqual(id, "generated-id")
+        XCTAssertEqual(store.loadDeviceId(), "generated-id")
+        XCTAssertEqual(defaults.string(forKey: DeviceIdentity.deviceIdDefaultsKey), "generated-id")
+    }
+
+    func testRepeatedResolutionIsStableAndGeneratesOnlyOnce() {
+        var generatorCalls = 0
+        let makeDeviceId: () -> String = {
+            generatorCalls += 1
+            return "generated-\(generatorCalls)"
+        }
+
+        let first = resolve(makeDeviceId: makeDeviceId)
+        let second = resolve(makeDeviceId: makeDeviceId)
+
+        XCTAssertEqual(first, "generated-1")
+        XCTAssertEqual(second, first)
+        XCTAssertEqual(generatorCalls, 1)
+    }
+
+    // MARK: - Migration from UserDefaults
+
+    func testExistingDefaultsValueIsMigratedIntoKeychain() {
+        defaults.set("legacy-id", forKey: DeviceIdentity.deviceIdDefaultsKey)
+
+        let id = resolve()
+
+        XCTAssertEqual(id, "legacy-id", "Upgrading an existing install must keep its paired device ID")
+        XCTAssertEqual(store.loadDeviceId(), "legacy-id")
+    }
+
+    // MARK: - Reinstall
+
+    func testKeychainValueSurvivesClearedDefaults() {
+        store.storeDeviceId("keychain-id")
+        // Reinstall wipes UserDefaults; the Keychain item remains.
+
+        let id = resolve(makeDeviceId: {
+            XCTFail("A retained Keychain identity must not be regenerated")
+            return "unexpected"
+        })
+
+        XCTAssertEqual(id, "keychain-id")
+    }
+
+    func testKeychainWinsOverStaleDefaultsValue() {
+        store.storeDeviceId("keychain-id")
+        defaults.set("stale-defaults-id", forKey: DeviceIdentity.deviceIdDefaultsKey)
+
+        XCTAssertEqual(resolve(), "keychain-id")
+    }
+
+    // MARK: - Keychain loss
+
+    func testLosingBothStoresMintsANewIdentity() {
+        // Explicit reset: with no surviving identity the device presents a new
+        // ID, so the Mac treats it as unpaired and the normal pairing flow
+        // re-establishes trust.
+        let id = resolve()
+
+        XCTAssertEqual(id, "generated-id")
+        XCTAssertEqual(store.loadDeviceId(), "generated-id")
+    }
+
+    func testDefaultsMirrorKeepsIdentityStableWhenKeychainWritesFail() {
+        store.failsWrites = true
+
+        let first = resolve(makeDeviceId: { "generated-1" })
+        let second = resolve(makeDeviceId: { "generated-2" })
+
+        XCTAssertEqual(first, "generated-1")
+        XCTAssertEqual(second, first, "The UserDefaults mirror is the fallback when the Keychain is unwritable")
+    }
+}
+
+/// In-memory `DeviceIdentityStoring` seam for tests.
+private final class InMemoryDeviceIdentityStore: DeviceIdentityStoring, @unchecked Sendable {
+    var failsWrites = false
+    private var storedId: String?
+
+    func loadDeviceId() -> String? {
+        storedId
+    }
+
+    func storeDeviceId(_ id: String) {
+        guard !failsWrites else { return }
+        storedId = id
+    }
+}


### PR DESCRIPTION
## Defect

The iOS transport device ID (`speakDeviceId`) lived only in UserDefaults, which is deleted with the app, and `identifierForVendor` rotates once every app from the vendor has been removed. Reinstalling in the common single-app case minted a new ID and orphaned the Mac's prior pairing entry. Scoped per the triage comment on the issue: this is a reinstall-UX fix, not a security change — authentication remains the pairing code.

## Fix

- New `KeychainDeviceIdentityStore` (`Sources/SpeakCore/DeviceIdentityStore.swift`) persists the ID in a dedicated Keychain item so it survives app deletion/reinstall. It deliberately uses its own service rather than the aggregate `SecureStorage` payload: `SecureStorage` is an actor (the ID must stay readable synchronously) and its legacy-secret migration absorbs and deletes standalone accounts under its own service. The item is not synchronizable — the identity names one physical device.
- `DeviceIdentity.deviceId` now resolves most-durable-source first: Keychain → legacy UserDefaults value (migrated into the Keychain on first read so existing pairings keep their identity) → freshly generated ID, persisted to the Keychain and mirrored to UserDefaults for rollback safety and as a fallback when the Keychain is unwritable.
- If both stores are lost, the device presents a new ID; the Mac then treats it as unpaired and the normal pairing flow re-establishes trust.
- Resolution logic (`DeviceIdentity.mobileDeviceId`) is platform-neutral with an injectable `DeviceIdentityStoring` seam for tests.

## Tests

`Tests/SpeakCoreTests/DeviceIdentityTests.swift` (7 tests) covers: fresh install generates and persists once; upgrade migrates the UserDefaults value into the Keychain; reinstall (defaults cleared, Keychain retained) keeps the same ID without regenerating; Keychain wins over stale defaults; full reset mints a new identity; defaults mirror keeps the ID stable when Keychain writes fail.

Verified: `swift build`, full `swift test` (1629 tests, 0 failures), SwiftLint strict (changed files clean; only pre-existing baselined violations remain), and `tuist generate` + `xcodebuild` SpeakiOS simulator build succeeded.

Fixes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Device identity is now securely stored in the iOS Keychain.
  - Existing device identities are migrated automatically, preserving identity across app reinstalls.
  - Newly generated identities are persisted for consistent reuse.

- **Bug Fixes**
  - Added fallback handling to keep device identity stable when secure storage is unavailable.
  - Improved validation of stored identity values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->