### PR TITLE
fix(sync): retain macOS history sync and persist acknowledgements

### DIFF
--- a/Sources/SpeakApp/HistoryManager.swift
+++ b/Sources/SpeakApp/HistoryManager.swift
@@ -96,6 +96,13 @@ final class HistoryManager: ObservableObject {
   /// Batch size threshold for triggering flush
   var batchSizeThreshold: Int
 
+  /// Fired after a locally created item is committed, so history sync can
+  /// upload it. Wired by `MacHistorySyncAdapter` at bootstrap.
+  var onItemAppended: ((HistoryItem) -> Void)?
+
+  /// Fired after a local removal, so history sync can delete the remote copy.
+  var onItemRemoved: ((UUID) -> Void)?
+
   /// Flag to track if we're currently flushing
   private var isFlushing = false
 
@@ -334,6 +341,8 @@ final class HistoryManager: ObservableObject {
 
     // Write to WAL instead of directly to disk
     await appendToWAL(WALEntry(operation: .append, item: item))
+
+    onItemAppended?(item)
   }
 
   func update(_ item: HistoryItem) async {
@@ -377,6 +386,7 @@ final class HistoryManager: ObservableObject {
     // Write to WAL instead of directly to disk
     if let diskItem {
       await appendToWAL(WALEntry(operation: .remove, item: diskItem))
+      onItemRemoved?(id)
     }
   }
 

--- a/Sources/SpeakApp/MacHistorySyncAdapter.swift
+++ b/Sources/SpeakApp/MacHistorySyncAdapter.swift
@@ -8,13 +8,25 @@ import os.log
 final class MacHistorySyncAdapter: HistorySyncDelegate {
 
     private let historyManager: HistoryManager
+    private let defaults: UserDefaults
     private var syncedIDs: Set<UUID> = []
     private let syncedIDsKey = "speak.sync.syncedMacHistoryIDs"
     private let log = SpeakLogger.logger(category: "MacHistorySync")
 
-    init(historyManager: HistoryManager) {
+    /// True while a remote change is being applied to the local store, so the
+    /// resulting HistoryManager mutation is not echoed back to CloudKit.
+    private var isApplyingRemoteChange = false
+
+    init(historyManager: HistoryManager, defaults: UserDefaults = .standard) {
         self.historyManager = historyManager
+        self.defaults = defaults
         loadSyncedIDs()
+        historyManager.onItemAppended = { [weak self] item in
+            self?.uploadNewItem(item)
+        }
+        historyManager.onItemRemoved = { [weak self] id in
+            self?.deleteItem(id: id)
+        }
     }
 
     /// Start sync — call after creating the adapter.
@@ -25,6 +37,7 @@ final class MacHistorySyncAdapter: HistorySyncDelegate {
 
     /// Upload a newly created history item.
     func uploadNewItem(_ item: HistoryItem) {
+        guard !isApplyingRemoteChange else { return }
         Task {
             let entry = item.toSyncable()
             do {
@@ -37,6 +50,7 @@ final class MacHistorySyncAdapter: HistorySyncDelegate {
 
     /// Delete an item from CloudKit when removed locally.
     func deleteItem(id: UUID) {
+        guard !isApplyingRemoteChange else { return }
         syncedIDs.remove(id)
         saveSyncedIDs()
         Task {
@@ -54,6 +68,8 @@ final class MacHistorySyncAdapter: HistorySyncDelegate {
     }
 
     func didReceiveRemoteEntry(_ entry: SyncableHistoryEntry) async {
+        isApplyingRemoteChange = true
+        defer { isApplyingRemoteChange = false }
         if let local = historyManager.allItems.first(where: { $0.id == entry.id }) {
             if entry.updatedAt > local.updatedAt {
                 await historyManager.update(HistoryItem.fromSyncable(entry))
@@ -74,6 +90,8 @@ final class MacHistorySyncAdapter: HistorySyncDelegate {
     }
 
     func didDeleteRemoteEntry(id: UUID) async {
+        isApplyingRemoteChange = true
+        defer { isApplyingRemoteChange = false }
         await historyManager.remove(id: id)
         syncedIDs.remove(id)
         saveSyncedIDs()
@@ -87,16 +105,14 @@ final class MacHistorySyncAdapter: HistorySyncDelegate {
     // MARK: - Synced IDs Tracking
 
     private func loadSyncedIDs() {
-        if let strings = UserDefaults.standard.stringArray(
-            forKey: syncedIDsKey
-        ) {
+        if let strings = defaults.stringArray(forKey: syncedIDsKey) {
             syncedIDs = Set(strings.compactMap { UUID(uuidString: $0) })
         }
     }
 
     private func saveSyncedIDs() {
         let strings = syncedIDs.map(\.uuidString)
-        UserDefaults.standard.set(strings, forKey: syncedIDsKey)
+        defaults.set(strings, forKey: syncedIDsKey)
     }
 }
 

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -50,6 +50,11 @@ final class AppEnvironment: ObservableObject {
   @Published var apiKeysScrollTarget: String?
   @Published var sidebarNavigationTarget: SidebarItem?
 
+  /// Bridges HistoryManager mutations to CloudKit history sync. Retained here
+  /// because `HistorySyncEngine` only holds its delegate weakly; without this
+  /// owner the adapter deallocates after bootstrap and sync stops (#685).
+  fileprivate(set) var historySyncAdapter: MacHistorySyncAdapter?
+
   private(set) var statusBarController: StatusBarController?
   /// Voice-edit controller; created by `installVoiceEdit()` in AppEnvironment+VoiceEdit.
   var voiceEdit: VoiceEditController?
@@ -112,9 +117,6 @@ final class AppEnvironment: ObservableObject {
     self.transportServer = transportServer
     self.hudPresenter = hudPresenter
   }
-
-  /// Alias for permissions manager (for API consistency)
-  var permissionsManager: PermissionsManager { permissions }
 
   /// Installs the status bar controller and the observer that keeps it in sync
   /// with the visibility settings. Safe to call more than once; it is
@@ -321,6 +323,9 @@ final class AppEnvironment: ObservableObject {
 }
 
 extension AppEnvironment {
+  /// Alias for permissions manager (for API consistency)
+  var permissionsManager: PermissionsManager { permissions }
+
   fileprivate func switchToQuickVoice(_ index: Int) {
     let favorites = settings.ttsFavoriteVoices
     let arrayIndex = index - 1
@@ -564,6 +569,7 @@ enum WireUp {
     #endif
 
     let syncAdapter = MacHistorySyncAdapter(historyManager: environment.history)
+    environment.historySyncAdapter = syncAdapter
     Task { await syncAdapter.start() }
 
     Task { await secureStorage.preloadTrackedSecrets() }

--- a/Sources/SpeakSync/HistorySyncEngine.swift
+++ b/Sources/SpeakSync/HistorySyncEngine.swift
@@ -157,6 +157,14 @@ public final class HistorySyncEngine: ObservableObject {
         guard state.isCloudAvailable else {
             throw SyncError.cloudUnavailable
         }
+        // Without a delegate the acknowledgement cannot be persisted, so the
+        // entry would upload again after relaunch. Fail before touching the
+        // transport and leave the entry pending.
+        guard delegate != nil else {
+            let syncError = SyncError.delegateUnavailable
+            state.error = syncError
+            throw syncError
+        }
         let result = await transport.upload(entries: [entry])
         await applyUploadResult(result)
         state.pendingUploadCount = delegate?.pendingEntries().count ?? 0

--- a/Tests/SpeakAppTests/HistoryManagerTests.swift
+++ b/Tests/SpeakAppTests/HistoryManagerTests.swift
@@ -292,6 +292,32 @@ final class HistoryManagerTests: XCTestCase {
         XCTAssertEqual(manager.statistics.sessionsWithErrors, 0)
     }
 
+    // MARK: - Mutation observers (history sync wiring)
+
+    func testAppend_firesOnItemAppended() async {
+        let manager = await makeManager()
+        var appended: [UUID] = []
+        manager.onItemAppended = { appended.append($0.id) }
+
+        let item = makeItem()
+        await manager.append(item)
+
+        XCTAssertEqual(appended, [item.id])
+    }
+
+    func testRemove_firesOnItemRemovedOnlyForExistingItems() async {
+        let manager = await makeManager()
+        var removed: [UUID] = []
+        manager.onItemRemoved = { removed.append($0) }
+
+        let item = makeItem()
+        await manager.append(item)
+        await manager.remove(id: item.id)
+        await manager.remove(id: UUID())
+
+        XCTAssertEqual(removed, [item.id], "Removing an unknown ID must not notify sync")
+    }
+
     func testRemoveAll_resetsStatistics() async throws {
         let manager = await makeManager()
         await manager.loadFromDisk()

--- a/Tests/SpeakAppTests/MacHistorySyncAdapterTests.swift
+++ b/Tests/SpeakAppTests/MacHistorySyncAdapterTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import XCTest
+
+import SpeakCore
+import SpeakSync
+
+@testable import SpeakApp
+
+/// FileManager that redirects Application Support to a temporary directory so
+/// `HistoryManager` persists to an isolated location during tests.
+private final class TemporaryApplicationSupportFileManager: FileManager {
+    let supportURL: URL
+
+    init(supportURL: URL) {
+        self.supportURL = supportURL
+        super.init()
+    }
+
+    override func urls(
+        for directory: FileManager.SearchPathDirectory,
+        in domainMask: FileManager.SearchPathDomainMask
+    ) -> [URL] {
+        guard directory == .applicationSupportDirectory else {
+            return super.urls(for: directory, in: domainMask)
+        }
+        return [supportURL]
+    }
+}
+
+/// Covers the adapter's bridging contract from #685: local mutations reach the
+/// sync engine via the HistoryManager observers, remote changes are applied
+/// without echoing back as uploads, and acknowledgements survive a relaunch.
+@MainActor
+final class MacHistorySyncAdapterTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var fileManager: TemporaryApplicationSupportFileManager!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        fileManager = TemporaryApplicationSupportFileManager(supportURL: tempDir)
+        suiteName = "MacHistorySyncAdapterTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        fileManager = nil
+        try await super.tearDown()
+    }
+
+    func testInit_wiresHistoryMutationObservers() async {
+        let manager = await makeManager()
+        XCTAssertNil(manager.onItemAppended)
+        XCTAssertNil(manager.onItemRemoved)
+
+        let adapter = MacHistorySyncAdapter(historyManager: manager, defaults: defaults)
+
+        XCTAssertNotNil(
+            manager.onItemAppended,
+            "Adapter must observe appends so new items upload without a full sync"
+        )
+        XCTAssertNotNil(
+            manager.onItemRemoved,
+            "Adapter must observe removals so remote copies are deleted"
+        )
+        _ = adapter
+    }
+
+    func testRemoteEntry_isStoredAndAcknowledgedWithoutBecomingPending() async {
+        let manager = await makeManager()
+        let adapter = MacHistorySyncAdapter(historyManager: manager, defaults: defaults)
+        let entry = makeEntry(text: "from-another-device")
+
+        await adapter.didReceiveRemoteEntry(entry)
+
+        XCTAssertTrue(
+            manager.allItems.contains { $0.id == entry.id },
+            "Remote entry must be added to local history"
+        )
+        XCTAssertFalse(
+            adapter.pendingEntries().contains { $0.id == entry.id },
+            "A downloaded entry must be acknowledged, not queued for re-upload"
+        )
+    }
+
+    func testAcknowledgements_persistAcrossAdapterRelaunch() async {
+        let manager = await makeManager()
+        let item = makeItem()
+        await manager.append(item)
+
+        let first = MacHistorySyncAdapter(historyManager: manager, defaults: defaults)
+        await first.didAcknowledgeSyncedEntries(ids: [item.id])
+        XCTAssertFalse(first.pendingEntries().contains { $0.id == item.id })
+
+        // A fresh adapter over the same defaults simulates app relaunch: the
+        // acknowledgement must be durable so the item is not uploaded again.
+        let relaunched = MacHistorySyncAdapter(historyManager: manager, defaults: defaults)
+        XCTAssertFalse(
+            relaunched.pendingEntries().contains { $0.id == item.id },
+            "Acknowledged IDs must survive relaunch"
+        )
+    }
+
+    func testRemoteDeletion_removesLocalItem() async {
+        let manager = await makeManager()
+        let adapter = MacHistorySyncAdapter(historyManager: manager, defaults: defaults)
+        let item = makeItem()
+        await manager.append(item)
+        await adapter.didAcknowledgeSyncedEntries(ids: [item.id])
+
+        await adapter.didDeleteRemoteEntry(id: item.id)
+
+        XCTAssertFalse(manager.allItems.contains { $0.id == item.id })
+        XCTAssertFalse(adapter.pendingEntries().contains { $0.id == item.id })
+    }
+
+    // MARK: - Helpers
+
+    private func makeManager() async -> HistoryManager {
+        let manager = HistoryManager(
+            fileManager: fileManager,
+            flushInterval: 3600,
+            batchSizeThreshold: 10_000
+        )
+        await manager.waitUntilLoaded()
+        return manager
+    }
+
+    private func makeEntry(id: UUID = UUID(), text: String) -> SyncableHistoryEntry {
+        SyncableHistoryEntry(
+            id: id,
+            createdAt: Date(timeIntervalSince1970: 1),
+            rawTranscription: text,
+            postProcessedText: nil,
+            model: "test",
+            duration: 1,
+            wordCount: 1,
+            originPlatform: "ios",
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+    }
+
+    private func makeItem(id: UUID = UUID()) -> HistoryItem {
+        HistoryItem(
+            id: id,
+            createdAt: Date(),
+            modelsUsed: ["apple/local/SFSpeechRecognizer"],
+            rawTranscription: "raw transcript",
+            postProcessedTranscription: nil,
+            recordingDuration: 5,
+            cost: nil,
+            audioFileURL: nil,
+            networkExchanges: [],
+            events: [],
+            phaseTimestamps: PhaseTimestamps(
+                recordingStarted: nil,
+                recordingEnded: nil,
+                transcriptionStarted: nil,
+                transcriptionEnded: nil,
+                postProcessingStarted: nil,
+                postProcessingEnded: nil,
+                outputDelivered: nil
+            ),
+            trigger: HistoryTrigger(
+                gesture: .singleTap,
+                hotKeyDescription: "Fn",
+                outputMethod: .clipboard,
+                destinationApplication: nil
+            ),
+            personalCorrections: nil,
+            errors: []
+        )
+    }
+}

--- a/Tests/SpeakAppTests/WireUpBootstrapTests.swift
+++ b/Tests/SpeakAppTests/WireUpBootstrapTests.swift
@@ -50,6 +50,18 @@ final class WireUpBootstrapTests: XCTestCase {
         XCTAssertNotNil(env.transportServer)
     }
 
+    @MainActor
+    func testBootstrap_retainsHistorySyncAdapter() {
+        // HistorySyncEngine holds its delegate weakly; the environment must be
+        // the adapter's strong owner or history sync silently dies after the
+        // initial start() task completes (#685).
+        let env = WireUp.bootstrap(options: makeWireUpTestOptions())
+        XCTAssertNotNil(
+            env.historySyncAdapter,
+            "Bootstrap must retain the history sync adapter for the app's lifetime"
+        )
+    }
+
     // MARK: - Wiring Correctness
 
     @MainActor

--- a/Tests/SpeakSyncTests/HistorySyncEngineGuardTests.swift
+++ b/Tests/SpeakSyncTests/HistorySyncEngineGuardTests.swift
@@ -98,6 +98,30 @@ final class HistorySyncEngineGuardTests: XCTestCase {
         XCTAssertEqual(transport.fetchCount, 0)
     }
 
+    func testUploadWithoutDelegate_throwsBeforeTouchingTransport() async {
+        // With no delegate the acknowledgement could never be persisted, so a
+        // "successful" upload would be re-uploaded after relaunch. The engine
+        // must fail before the transport call and leave the entry pending.
+        let transport = RecordingTransport()
+        let engine = HistorySyncEngine(
+            transport: transport, defaults: defaults, cloudAvailable: true, delegate: nil
+        )
+
+        do {
+            try await engine.upload(entry: makeEntry(text: "orphaned"))
+            XCTFail("Expected delegateUnavailable")
+        } catch SyncError.delegateUnavailable {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(transport.uploadedBatches.count, 0)
+        guard case .some(SyncError.delegateUnavailable) = engine.state.error as? SyncError else {
+            XCTFail("Expected delegateUnavailable, got \(String(describing: engine.state.error))")
+            return
+        }
+    }
+
     // MARK: - Single-entry upload
 
     func testSingleUploadSuccess_acknowledgesEntryAndClearsError() async throws {


### PR DESCRIPTION
## Defect

`WireUp.bootstrap` created `MacHistorySyncAdapter` as a local variable while `HistorySyncEngine.delegate` is weak. Once the initial `start()` task completed, nothing owned the adapter, so it deallocated and every subsequent sync failed with `delegateUnavailable`. There was also no call site for `uploadNewItem`/`deleteItem`, so history created or deleted during a session never reached CloudKit without a manual full sync.

Separately, `HistorySyncEngine.upload(entry:)` did not require a delegate: a CloudKit upload could succeed with no delegate to persist the acknowledgement, reporting success while leaving the item eligible for re-upload after relaunch.

## Fix

- `AppEnvironment` now retains the adapter (`historySyncAdapter`); the engine's delegate stays weak, so there is no cycle. (Moved the `permissionsManager` alias into an existing `AppEnvironment` extension to stay within the `type_body_length` limit.)
- `HistoryManager` gains `onItemAppended`/`onItemRemoved` observers at the append/remove choke points; the adapter wires them to `uploadNewItem`/`deleteItem` in its init, guarded by an `isApplyingRemoteChange` flag so remote reconciliation is not echoed back to CloudKit as fresh uploads/deletes.
- `HistorySyncEngine.upload(entry:)` fails with `delegateUnavailable` before touching the transport when no delegate is alive, leaving the entry pending instead of falsely reporting success.
- The adapter takes an injectable `UserDefaults` (default `.standard`) so tests can verify acknowledgement persistence in isolation.

## Tests

- `HistorySyncEngineGuardTests.testUploadWithoutDelegate_throwsBeforeTouchingTransport` — missing delegate fails explicitly, transport untouched, entry stays pending.
- `WireUpBootstrapTests.testBootstrap_retainsHistorySyncAdapter` — production bootstrap graph retains the adapter.
- `HistoryManagerTests` — append/remove fire the sync observers; removing an unknown ID does not.
- New `MacHistorySyncAdapterTests` — adapter wires the observers on init; a downloaded remote entry is stored and acknowledged without becoming pending; acknowledgements survive an adapter relaunch over the same defaults; remote deletions remove the local item.

Full `swift test` passes; SwiftLint strict is clean for all changed files.

Fixes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved history synchronization reliability when processing local and remote changes.
  - Prevented remote updates from being uploaded again.
  - Preserved synchronization acknowledgements across app relaunches.
  - Prevented uploads when synchronization is not fully configured, while retaining pending history items.

- **Tests**
  - Added coverage for history change notifications, remote updates and deletions, startup synchronization, and unavailable synchronization configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->