### PR TITLE
fix(core): make AnyCodable genuinely Sendable

### DIFF
--- a/Sources/SpeakCore/AnyCodable.swift
+++ b/Sources/SpeakCore/AnyCodable.swift
@@ -2,39 +2,87 @@ import Foundation
 
 // MARK: - AnyCodable Helper
 
+/// The bounded error domain for `AnyCodable` construction failures.
+public enum AnyCodableError: Error, Equatable, Sendable, CustomStringConvertible {
+    /// The wrapped value is not representable as JSON
+    /// (null, boolean, integer, double, string, array, or object).
+    case unsupportedValue(typeName: String)
+
+    public var description: String {
+        switch self {
+        case .unsupportedValue(let typeName):
+            return "AnyCodable cannot represent value of type \(typeName) as JSON"
+        }
+    }
+}
+
 /// A type-erased Codable wrapper for heterogeneous JSON values.
 ///
-/// `@unchecked` because `value` is typed `Any` and cannot be statically proven
-/// Sendable. Decoding only ever produces immutable value types (`Bool`, `Int`,
-/// `Double`, `String`, `NSNull`, and arrays/dictionaries of those), so decoded
-/// instances are safe to share.
-/// Strict-concurrency follow-up: `init(_ value: Any)` is public, so callers
-/// could still wrap a mutable reference type; consider constraining the
-/// initializer to a closed set of JSON value types.
-public struct AnyCodable: Codable, @unchecked Sendable {
-    public let value: Any
+/// Storage is a closed, recursively `Sendable` JSON value enum, so instances
+/// are genuinely immutable and safe to share across concurrency domains.
+/// Construction canonicalises input eagerly: Foundation containers (including
+/// mutable ones such as `NSMutableDictionary`/`NSMutableArray`) are deep-copied
+/// into value types, and anything that is not JSON-representable is rejected
+/// with ``AnyCodableError`` at construction time rather than trapping or
+/// failing later during encoding.
+public struct AnyCodable: Codable, Equatable, Sendable {
 
-    public init(_ value: Any) {
-        self.value = value
+    /// A closed, recursively Sendable representation of a JSON value.
+    public enum JSONValue: Equatable, Sendable {
+        case null
+        case bool(Bool)
+        case int(Int)
+        case double(Double)
+        case string(String)
+        case array([JSONValue])
+        case object([String: JSONValue])
+    }
+
+    /// The canonical, immutable JSON storage.
+    public let storage: JSONValue
+
+    /// The wrapped value bridged back to loosely typed JSON objects
+    /// (`NSNull`, `Bool`, `Int`, `Double`, `String`, `[Any]`,
+    /// `[String: Any]`), mirroring the historical `value` property.
+    public var value: Any {
+        Self.bridge(storage)
+    }
+
+    /// Wrap an already-canonical JSON value. Never fails.
+    public init(_ storage: JSONValue) {
+        self.storage = storage
+    }
+
+    /// Canonicalise an arbitrary value into JSON storage.
+    ///
+    /// Accepts `nil`/`NSNull`, booleans, integer and floating-point numbers,
+    /// strings, and (recursively) arrays and string-keyed dictionaries of the
+    /// same — including their mutable Foundation counterparts, which are
+    /// deep-copied so later mutation of the original cannot be observed.
+    ///
+    /// - Throws: ``AnyCodableError/unsupportedValue(typeName:)`` for any
+    ///   value that is not JSON-representable.
+    public init(_ value: Any) throws {
+        self.storage = try Self.canonicalise(value)
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
-            self.value = NSNull()
+            self.storage = .null
         } else if let bool = try? container.decode(Bool.self) {
-            self.value = bool
+            self.storage = .bool(bool)
         } else if let int = try? container.decode(Int.self) {
-            self.value = int
+            self.storage = .int(int)
         } else if let double = try? container.decode(Double.self) {
-            self.value = double
+            self.storage = .double(double)
         } else if let string = try? container.decode(String.self) {
-            self.value = string
+            self.storage = .string(string)
         } else if let array = try? container.decode([AnyCodable].self) {
-            self.value = array.map(\.value)
+            self.storage = .array(array.map(\.storage))
         } else if let dict = try? container.decode([String: AnyCodable].self) {
-            self.value = dict.mapValues(\.value)
+            self.storage = .object(dict.mapValues(\.storage))
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -46,27 +94,78 @@ public struct AnyCodable: Codable, @unchecked Sendable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
 
-        switch value {
-        case is NSNull:
+        switch storage {
+        case .null:
             try container.encodeNil()
-        case let bool as Bool:
+        case .bool(let bool):
             try container.encode(bool)
-        case let int as Int:
+        case .int(let int):
             try container.encode(int)
-        case let double as Double:
+        case .double(let double):
             try container.encode(double)
-        case let string as String:
+        case .string(let string):
             try container.encode(string)
+        case .array(let array):
+            try container.encode(array.map(AnyCodable.init(_:)))
+        case .object(let object):
+            try container.encode(object.mapValues(AnyCodable.init(_:)))
+        }
+    }
+
+    // MARK: - Canonicalisation
+
+    private static func canonicalise(_ value: Any) throws -> JSONValue {
+        switch value {
+        case Optional<Any>.none, is NSNull:
+            return .null
+        case let canonical as JSONValue:
+            return canonical
+        case let wrapped as AnyCodable:
+            return wrapped.storage
+        case let number as NSNumber:
+            // Swift Bool/Int/Double (and friends) all bridge through NSNumber
+            // on Darwin, so disambiguate via the underlying CF type instead of
+            // `as?` casts, which would happily turn `true` into `1`.
+            return canonicalise(number)
+        case let string as String:
+            return .string(string)
         case let array as [Any]:
-            try container.encode(array.map { AnyCodable($0) })
-        case let dict as [String: Any]:
-            try container.encode(dict.mapValues { AnyCodable($0) })
+            return .array(try array.map(canonicalise))
+        case let object as [String: Any]:
+            return .object(try object.mapValues(canonicalise))
         default:
-            let context = EncodingError.Context(
-                codingPath: container.codingPath,
-                debugDescription: "Unsupported type: \(type(of: value))"
-            )
-            throw EncodingError.invalidValue(value, context)
+            throw AnyCodableError.unsupportedValue(typeName: String(describing: type(of: value)))
+        }
+    }
+
+    private static func canonicalise(_ number: NSNumber) -> JSONValue {
+        if CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return .bool(number.boolValue)
+        }
+        if !CFNumberIsFloatType(number), let int = Int(exactly: number) {
+            return .int(int)
+        }
+        return .double(number.doubleValue)
+    }
+
+    // MARK: - Bridging
+
+    private static func bridge(_ storage: JSONValue) -> Any {
+        switch storage {
+        case .null:
+            return NSNull()
+        case .bool(let bool):
+            return bool
+        case .int(let int):
+            return int
+        case .double(let double):
+            return double
+        case .string(let string):
+            return string
+        case .array(let array):
+            return array.map(bridge)
+        case .object(let object):
+            return object.mapValues(bridge)
         }
     }
 }

--- a/Tests/SpeakCoreTests/AnyCodableTests.swift
+++ b/Tests/SpeakCoreTests/AnyCodableTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class AnyCodableTests: XCTestCase {
 
     private func roundTrip<T: Equatable>(_ value: Any, as type: T.Type) throws -> T {
-        let encoded = try JSONEncoder().encode(AnyCodable(value))
+        let encoded = try JSONEncoder().encode(try AnyCodable(value))
         let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
         guard let result = decoded.value as? T else {
             XCTFail("Expected \(T.self), got \(Swift.type(of: decoded.value))")
@@ -89,14 +89,14 @@ final class AnyCodableTests: XCTestCase {
     }
 
     func testEncode_null_roundTrips() throws {
-        let encoded = try JSONEncoder().encode(AnyCodable(NSNull()))
+        let encoded = try JSONEncoder().encode(try AnyCodable(NSNull()))
         let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
         XCTAssertTrue(decoded.value is NSNull)
     }
 
     func testEncode_array_roundTrips() throws {
         let arr: [Any] = [1, "two", false]
-        let encoded = try JSONEncoder().encode(AnyCodable(arr))
+        let encoded = try JSONEncoder().encode(try AnyCodable(arr))
         let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
         let result = decoded.value as? [Any]
         XCTAssertNotNil(result)
@@ -106,16 +106,10 @@ final class AnyCodableTests: XCTestCase {
 
     func testEncode_dict_roundTrips() throws {
         let dict: [String: Any] = ["a": 1, "b": "bee"]
-        let encoded = try JSONEncoder().encode(AnyCodable(dict))
+        let encoded = try JSONEncoder().encode(try AnyCodable(dict))
         let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
         let result = decoded.value as? [String: Any]
         XCTAssertEqual(result?["b"] as? String, "bee")
-    }
-
-    func testEncode_unsupportedType_throws() {
-        struct Unsupported {}
-        let codable = AnyCodable(Unsupported())
-        XCTAssertThrowsError(try JSONEncoder().encode(codable), "Encoding unsupported type should throw")
     }
 
     // MARK: - Nested structures
@@ -133,5 +127,114 @@ final class AnyCodableTests: XCTestCase {
         let arr = decoded.value as? [[String: Any]]
         XCTAssertEqual(arr?.count, 2)
         XCTAssertEqual(arr?.first?["id"] as? Int, 1)
+    }
+
+    // MARK: - Construction validation (Sendable invariants)
+
+    func testInit_unsupportedType_throwsAtConstruction() {
+        struct Unsupported {}
+        XCTAssertThrowsError(try AnyCodable(Unsupported())) { error in
+            guard case .unsupportedValue(let typeName)? = error as? AnyCodableError else {
+                XCTFail("Expected AnyCodableError.unsupportedValue, got \(error)")
+                return
+            }
+            XCTAssertTrue(typeName.contains("Unsupported"))
+        }
+    }
+
+    func testInit_unsupportedNestedType_throwsAtConstruction() {
+        let dict: [String: Any] = ["ok": 1, "bad": Date()]
+        XCTAssertThrowsError(try AnyCodable(dict)) { error in
+            XCTAssertTrue(error is AnyCodableError)
+        }
+    }
+
+    func testInit_nilOptional_becomesNull() throws {
+        let value: String? = nil
+        let wrapped = try AnyCodable(value as Any)
+        XCTAssertEqual(wrapped.storage, .null)
+    }
+
+    func testInit_preservesBoolVersusIntDistinction() throws {
+        XCTAssertEqual(try AnyCodable(true).storage, .bool(true))
+        XCTAssertEqual(try AnyCodable(1).storage, .int(1))
+        XCTAssertEqual(try AnyCodable(NSNumber(value: true)).storage, .bool(true))
+        XCTAssertEqual(try AnyCodable(NSNumber(value: 1)).storage, .int(1))
+    }
+
+    func testInit_jsonSerializationOutput_isAccepted() throws {
+        let json = Data(#"{"a": [1, 2.5, true, null, "s"]}"#.utf8)
+        let object = try JSONSerialization.jsonObject(with: json, options: [.mutableContainers])
+        let wrapped = try AnyCodable(object)
+        XCTAssertEqual(
+            wrapped.storage,
+            .object(["a": .array([.int(1), .double(2.5), .bool(true), .null, .string("s")])])
+        )
+    }
+
+    func testEncodedShape_isStableForPrimitives() throws {
+        XCTAssertEqual(try JSONEncoder().encode(try AnyCodable(42)), Data("42".utf8))
+        XCTAssertEqual(try JSONEncoder().encode(try AnyCodable(true)), Data("true".utf8))
+        XCTAssertEqual(try JSONEncoder().encode(try AnyCodable("x")), Data(#""x""#.utf8))
+    }
+
+    // MARK: - Defensive copying of mutable Foundation containers
+
+    func testInit_mutableDictionary_isDeepCopied() throws {
+        let inner = NSMutableArray(array: [1, 2])
+        let original = NSMutableDictionary(dictionary: ["items": inner, "name": "before"])
+
+        let wrapped = try AnyCodable(original)
+
+        original["name"] = "after"
+        inner.add(3)
+
+        XCTAssertEqual(
+            wrapped.storage,
+            .object(["items": .array([.int(1), .int(2)]), "name": .string("before")])
+        )
+    }
+
+    func testInit_mutableArray_isDeepCopied() throws {
+        let original = NSMutableArray(array: ["a"])
+        let wrapped = try AnyCodable(original)
+
+        original.add("b")
+
+        XCTAssertEqual(wrapped.storage, .array([.string("a")]))
+    }
+
+    func testInit_mutableString_isCopied() throws {
+        let original = NSMutableString(string: "hello")
+        let wrapped = try AnyCodable(original)
+
+        original.append(" world")
+
+        XCTAssertEqual(wrapped.storage, .string("hello"))
+    }
+
+    // MARK: - Concurrency
+
+    func testActorTransfer_encodingIsDeterministicWhileOriginalMutates() async throws {
+        let original = NSMutableDictionary(dictionary: ["count": 0])
+        let wrapped = try AnyCodable(original)
+        let expected = try JSONEncoder().encode(wrapped)
+
+        let mutator = Task.detached {
+            for index in 1...500 {
+                original["count"] = index
+            }
+        }
+
+        let encodings = await Task.detached { () -> [Data] in
+            (0..<100).compactMap { _ in try? JSONEncoder().encode(wrapped) }
+        }.value
+
+        await mutator.value
+
+        XCTAssertEqual(encodings.count, 100)
+        for encoded in encodings {
+            XCTAssertEqual(encoded, expected)
+        }
     }
 }


### PR DESCRIPTION
## Defect

`AnyCodable` declared `@unchecked Sendable` while its public `init(_ value: Any)` stored the caller's reference verbatim. Wrapping an `NSMutableDictionary`/`NSMutableArray` and sending the value across an actor boundary let the original be mutated concurrently with encoding/reading — exactly the race strict concurrency is supposed to rule out. Non-JSON values were also accepted silently and only failed later inside `encode(to:)`.

## Fix

- Storage is now a closed, recursively Sendable enum `AnyCodable.JSONValue` (`null`/`bool`/`int`/`double`/`string`/`array`/`object`); the struct is plain `Sendable` (no `@unchecked`) and `Equatable`.
- `init(_ value: Any)` is now `throws`: input is canonicalised eagerly — mutable Foundation containers (`NSMutableDictionary`, `NSMutableArray`, `NSMutableString`) are deep-copied into value types, `NSNumber` bool-vs-int is disambiguated via the underlying CF type, nil optionals become `null` — and anything not JSON-representable is rejected at construction with a bounded `AnyCodableError.unsupportedValue` instead of deferring failure to encoding.
- A non-throwing `init(_ storage: JSONValue)` covers already-canonical values (used by `encode(to:)`).
- The historical `value: Any` accessor remains as a computed bridge (`NSNull`/`Bool`/`Int`/`Double`/`String`/`[Any]`/`[String: Any]`), so the existing consumers in `OpenClawClient`/`OpenClawClientReceive` (which only decode and downcast `value`) compile unchanged, and the Codable round-trip produces the identical JSON shape for existing payloads.

## Tests

- All pre-existing round-trip/decode tests kept (adapted to the throwing init).
- New coverage: unsupported top-level and nested values throw `AnyCodableError` at construction; mutable dictionary/array/string inputs are deep-copied so later mutation of the originals is unobservable; bool vs int distinction preserved for both Swift literals and `NSNumber`; `JSONSerialization` `.mutableContainers` output accepted; encoded byte shape stable for primitives; actor-transfer test encodes repeatedly while the original mutable container is mutated on another task and asserts byte-identical deterministic output.
- `swift build` clean; full `swift test`: 1631 tests, 0 failures. SwiftLint strict with repo baseline: no violations in the changed files.

Fixes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for safely representing and comparing JSON-compatible values.
  * Added clear validation errors when unsupported values are provided.
  * Improved handling of optional values, JSON data, and Foundation collection types.
* **Bug Fixes**
  * Preserved value types more reliably when converting between formats.
  * Prevented changes to mutable input values from affecting stored data.
  * Improved consistency of encoded output, including during concurrent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->