### PR TITLE
build: isolate lint tooling from snapshot-test dependency resolution

### DIFF
--- a/.copilot/agents/speak-dev.agent.md
+++ b/.copilot/agents/speak-dev.agent.md
@@ -40,8 +40,8 @@ make rebuild
 # Run tests
 make test
 
-# Lint (strict mode)
-swift package plugin --allow-writing-to-package-directory swiftlint --strict --target SpeakApp
+# Lint (strict mode, isolated Tooling/ graph)
+make lint
 
 # Format
 swift package plugin --allow-writing-to-package-directory swiftformat

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
       prefix: "chore(deps)"
     open-pull-requests-limit: 5
 
+  # Swift Package Manager (isolated lint tooling graph, issue #677)
+  - package-ecosystem: "swift"
+    directory: "/Tooling"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(tooling)"
+    open-pull-requests-limit: 2
+
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Check Package.resolved drift
+        # Resolving the app/test graph must reproduce the checked-in pins;
+        # tooling pins live separately in Tooling/Package.resolved (issue #677).
+        run: git diff --exit-code Package.resolved
+
       - name: Test (Debug)
         run: swift test --enable-code-coverage
 
@@ -185,9 +190,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Cache lint tooling
+        uses: actions/cache@v6
+        with:
+          path: Tooling/.build
+          key: ${{ runner.os }}-tooling-${{ hashFiles('Tooling/Package.resolved') }}
+
+      # SwiftLint resolves through the isolated Tooling/ graph so app/test
+      # dependency changes cannot downgrade the linter (issue #677).
       - name: SwiftLint
-        run: |
-          swift package --disable-dependency-cache plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json
+        run: make lint
+
+      - name: Check tooling Package.resolved drift
+        run: git diff --exit-code Tooling/Package.resolved
 
       - name: Test release-notes generator
         run: node --test Tests/ReleaseNotesTests/*.test.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,9 +112,11 @@ The iOS app is built via Xcode but sources come from Swift packages:
 
 ### Linting
 ```bash
-swift package plugin --allow-writing-to-package-directory swiftlint --strict --target SpeakApp
+make lint                                          # strict SwiftLint against the baseline
+./scripts/swiftlint.sh lint --strict Sources/SpeakApp  # lint a subset
 swift package plugin --allow-writing-to-package-directory swiftformat --target SpeakApp
 ```
+- SwiftLint resolves through the isolated `Tooling/` graph (pinned in `Tooling/Package.resolved`) so app/test dependency changes cannot downgrade the linter; upgrade it intentionally with `make update-tooling`.
 - CI SwiftLint also runs with `.swiftlint-baseline.json`; the baseline is line-number-sensitive, so prefer exact-line inline suppressions when unblocking lint to avoid baseline drift.
 
 ## MCP Tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,8 @@ We use Conventional Commits:
 ### Linting
 
 ```bash
-# Run SwiftLint
-swift package plugin --allow-writing-to-package-directory swiftlint --strict
+# Run SwiftLint (resolves the isolated Tooling/ graph, pinned in Tooling/Package.resolved)
+make lint
 
 # Run SwiftFormat
 swift package plugin --allow-writing-to-package-directory swiftformat

--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,17 @@ install-verify: release ## Build release, install to /Applications, launch and v
 preflight: test-all verify ## Full pre-release check (tests + launch verification)
 
 .PHONY: lint
-lint: ## Run strict SwiftLint against the checked-in debt baseline
-	swift package plugin --allow-writing-to-package-directory swiftlint --strict --baseline .swiftlint-baseline.json
+lint: ## Run strict SwiftLint (isolated Tooling graph) against the checked-in debt baseline
+	./scripts/swiftlint.sh lint --strict --baseline .swiftlint-baseline.json
 
 .PHONY: format
 format: ## Auto-fix formatting and lint violations where possible
 	swift package plugin --allow-writing-to-package-directory swiftformat --recursive
-	swift package plugin --allow-writing-to-package-directory swiftlint --fix --format
+	./scripts/swiftlint.sh lint --fix --format
+
+.PHONY: update-tooling
+update-tooling: ## Intentionally upgrade the lint toolchain pinned in Tooling/Package.resolved
+	swift package --package-path Tooling update
 
 .PHONY: verify-checksums
 verify-checksums: ## Verify binary XCFramework and package checksums

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,24 +10,6 @@
       }
     },
     {
-      "identity" : "collectionconcurrencykit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
-      "state" : {
-        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-        "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "cryptoswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
-      "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
-      }
-    },
-    {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
@@ -43,15 +25,6 @@
       "state" : {
         "revision" : "d27a0ddf0cd1bc90ab038f5781fddc39b894430e",
         "version" : "9.25.0"
-      }
-    },
-    {
-      "identity" : "sourcekitten",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/SourceKitten.git",
-      "state" : {
-        "revision" : "731ffe6a35344a19bab00cdca1c952d5b4fee4d8",
-        "version" : "0.37.2"
       }
     },
     {
@@ -109,15 +82,6 @@
       }
     },
     {
-      "identity" : "swift-filename-matcher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ileitch/swift-filename-matcher",
-      "state" : {
-        "revision" : "eef5ac0b6b3cdc64b3039b037bed2def8a1edaeb",
-        "version" : "2.0.1"
-      }
-    },
-    {
       "identity" : "swift-jinja",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
@@ -140,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "15bf440e9a1e105996ae66a1446e91ffe0b3f8e9",
-        "version" : "604.0.0-prerelease-2025-12-15"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
@@ -163,48 +127,12 @@
       }
     },
     {
-      "identity" : "swiftlint",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/SwiftLint.git",
-      "state" : {
-        "revision" : "9120756b6e20e483c35433c41a4c4a9d32fc898b",
-        "version" : "0.63.1"
-      }
-    },
-    {
-      "identity" : "swiftytexttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
-      "state" : {
-        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swxmlhash",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/drmohundro/SWXMLHash.git",
-      "state" : {
-        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
-        "version" : "7.0.2"
-      }
-    },
-    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
         "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
         "version" : "1.11.0"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "d41ba4e7164c0838c6d48351f7575f7f762151fe",
-        "version" : "6.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,11 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.0"),
+        // SwiftLint intentionally lives in Tooling/Package.swift, not here: it
+        // pins an exact swift-syntax version that conflicts with
+        // swift-snapshot-testing's constraint, and sharing one graph let a test
+        // dependency silently downgrade the linter (issue #677). Run it via
+        // `make lint` / scripts/swiftlint.sh.
         .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.53.6"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.3.0"),

--- a/Tooling/Package.resolved
+++ b/Tooling/Package.resolved
@@ -1,0 +1,95 @@
+{
+  "pins" : [
+    {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "821fc0eaa7c07fc98df1e9d3d43371cace697644",
+        "version" : "0.38.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-filename-matcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ileitch/swift-filename-matcher",
+      "state" : {
+        "revision" : "eef5ac0b6b3cdc64b3039b037bed2def8a1edaeb",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "a8b1c535647243d603b6772e7e8306c993a0c188",
+        "version" : "605.0.0-prerelease-2026-06-26"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint.git",
+      "state" : {
+        "revision" : "fd768ba9a0e8a4f96d550d98de6c4cf2af565cf1",
+        "version" : "0.65.0"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tooling/Package.swift
+++ b/Tooling/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// Lint tooling graph, resolved independently of the application/test graph in
+// the repository root. SwiftLint pins an exact swift-syntax version, while
+// swift-snapshot-testing (root Package.swift) constrains swift-syntax
+// differently; sharing one graph let an unrelated test dependency silently
+// downgrade the linter (issue #677). Keeping SwiftLint here gives it its own
+// resolution, recorded in Tooling/Package.resolved.
+//
+// To upgrade the lint toolchain intentionally, run:
+//
+//     swift package --package-path Tooling update
+//
+// and commit the resulting Tooling/Package.resolved. CI fails if resolving
+// this graph drifts from the checked-in pin.
+let package = Package(
+    name: "SpeakTooling",
+    dependencies: [
+        .package(url: "https://github.com/realm/SwiftLint.git", from: "0.65.0")
+    ]
+)

--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Runs SwiftLint from the isolated tooling graph (Tooling/Package.swift).
+#
+# Lint tooling deliberately does not share the application/test dependency
+# graph: swift-snapshot-testing constrains swift-syntax in a way that silently
+# downgraded SwiftLint when both lived in one graph (issue #677). Resolving
+# Tooling/ separately keeps the linter at the version pinned in
+# Tooling/Package.resolved regardless of app/test dependency changes.
+#
+# All arguments are forwarded to the swiftlint binary, and swiftlint runs from
+# the repository root so relative paths in .swiftlint.yml and the path-keyed
+# .swiftlint-baseline.json keep working.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Resolve the tooling graph; this also downloads the SwiftLint binary
+# artifact bundle into Tooling/.build/artifacts.
+swift package --package-path Tooling resolve
+
+case "$(uname -s)" in
+    Darwin) platform_dir="macos" ;;
+    Linux) platform_dir="linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" ;;
+    *) echo "swiftlint.sh: unsupported platform $(uname -s)" >&2; exit 1 ;;
+esac
+
+swiftlint_bin="$(find Tooling/.build/artifacts -type f -perm -u+x \
+    -path "*/SwiftLintBinary.artifactbundle/$platform_dir/*" -name swiftlint | head -n 1)"
+
+if [ -z "$swiftlint_bin" ]; then
+    echo "swiftlint.sh: SwiftLint binary not found under Tooling/.build/artifacts" >&2
+    exit 1
+fi
+
+exec "$swiftlint_bin" "$@"


### PR DESCRIPTION
## Defect

Lint tooling and application/test dependencies shared one SwiftPM graph. SwiftLint pins an exact `swift-syntax` version (0.65.0 → `605.0.0-prerelease-2026-06-26`), while `swift-snapshot-testing` constrains `swift-syntax` differently, so adding snapshot testing (#630) silently downgraded the resolved linter to SwiftLint 0.63.1 / swift-syntax 604. The broad `from: 0.55.0` constraint accepted the downgrade, leaving lint diagnostics dependent on whichever resolution path last touched `Package.resolved` instead of an explicit toolchain contract.

## Fix

- **`Tooling/Package.swift`** — new dependency-only mini-package holding the SwiftLint dependency (`from: 0.65.0`), with its own authoritative `Tooling/Package.resolved` pinning SwiftLint 0.65.0 / swift-syntax 605.0.0-prerelease-2026-06-26. Intentional upgrades are documented in the manifest and wrapped as `make update-tooling` (`swift package --package-path Tooling update`).
- **Root `Package.swift`** — drops the SwiftLint dependency (with a comment pointing at the tooling graph); the app/test graph no longer contains SwiftLint or its transitive subtree (sourcekitten, yams, cryptoswift, …). Snapshot tests keep resolving through the root graph unchanged.
- **`scripts/swiftlint.sh`** — resolves the tooling graph (which downloads the SwiftLint binary artifact bundle), locates the platform binary under `Tooling/.build/artifacts`, and executes it from the repo root so `.swiftlint.yml` and the path-keyed `.swiftlint-baseline.json` keep working. Replaces the `swift package plugin swiftlint` invocation, which would otherwise run in the tooling package's directory and break the baseline's relative paths.
- **`Makefile`** — `make lint` / `make format` route SwiftLint through the script; new `make update-tooling` target.
- **CI (`ci.yml`)** — Lint job runs `make lint` with a cache keyed on `Tooling/Package.resolved` and fails on tooling `Package.resolved` drift; the build job fails on root `Package.resolved` drift after `make build`.
- **Dependabot** — new `swift` ecosystem entry for `/Tooling` (`chore(tooling)` prefix), so linter upgrades arrive as explicit tooling PRs and cannot be undone by app/test dependency changes.
- Docs (`AGENTS.md`, `CONTRIBUTING.md`, `.copilot/agents/speak-dev.agent.md`) updated to the new commands.

## Verification

- `make lint` from a clean worktree resolves the tooling graph, downloads the SwiftLint 0.65.0 artifact bundle, and lints 546 files with the checked-in baseline: **0 violations** (same green profile as before; `./scripts/swiftlint.sh version` → `0.65.0`).
- Re-running `swift package --package-path Tooling resolve` produces no `Tooling/Package.resolved` drift.
- `swift build` and `swift test` on the trimmed root graph pass; root `Package.resolved` loses only SwiftLint's subtree (snapshot-testing and all app dependencies unchanged, swift-syntax now resolved solely by snapshot-testing's constraints).

Fixes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved linting reliability by using an isolated, pinned tooling environment.
  * Added a command to intentionally update linting tools and dependencies.
  * Added weekly automated dependency updates for tooling.

* **CI**
  * Added checks to detect unexpected dependency lockfile changes.
  * Improved linting cache behavior and validation across supported macOS and Linux environments.

* **Documentation**
  * Updated contributor and development instructions for the revised linting workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->