### PR TITLE
fix(mac): make capture-health HUD accessible and name-preserving

### DIFF
--- a/Sources/SpeakApp/HUDView.swift
+++ b/Sources/SpeakApp/HUDView.swift
@@ -233,8 +233,15 @@ struct HUDOverlay: View {
     }()
     let micIcon = micWarning ? "mic.slash.fill" : "mic.fill"
     let deviceLabel = health.noInputDevicesAvailable ? "No microphone connected" : health.inputDeviceName
-    HStack(spacing: 6) {
-      HStack(spacing: 4) {
+    // At accessibility text sizes the compact single-line row cannot hold the
+    // enlarged captions, so stack the items vertically and let labels wrap
+    // instead of clipping them.
+    let usesAccessibilityLayout = dynamicTypeSize.isAccessibilitySize
+    let rowLayout = usesAccessibilityLayout
+      ? AnyLayout(VStackLayout(alignment: .leading, spacing: 4))
+      : AnyLayout(HStackLayout(spacing: 6))
+    rowLayout {
+      HStack(alignment: .firstTextBaseline, spacing: 4) {
         Image(systemName: micIcon)
           .font(.system(size: 9, weight: .semibold))
           .foregroundStyle(micColor)
@@ -243,21 +250,23 @@ struct HUDOverlay: View {
         Text(deviceLabel)
           .font(.caption2)
           .foregroundStyle(health.noInputDevicesAvailable ? micColor : .secondary)
-          .lineLimit(1)
+          .lineLimit(usesAccessibilityLayout ? 3 : 1)
           .truncationMode(.tail)
           .help(deviceLabel)
           .accessibilityLabel("Input device: \(deviceLabel)")
       }
 
-      Text(verbatim: "·")
-        .font(.caption2.weight(.semibold))
-        .foregroundStyle(.tertiary)
-        .accessibilityHidden(true)
+      if !usesAccessibilityLayout {
+        Text(verbatim: "·")
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(.tertiary)
+          .accessibilityHidden(true)
+      }
 
       Text(health.providerLabel)
         .font(.caption2.weight(.medium))
         .foregroundStyle(.secondary)
-        .lineLimit(1)
+        .lineLimit(usesAccessibilityLayout ? 3 : 1)
         .truncationMode(.middle)
         .layoutPriority(1)
         .help(health.providerLabel)
@@ -267,7 +276,11 @@ struct HUDOverlay: View {
         .layoutPriority(2)
         .accessibilityLabel("Latency: \(health.latencyTier.displayName)")
     }
-    .frame(height: 18)
+    // Size to content with a compact floor: the row keeps its familiar 18pt
+    // height at standard type sizes but grows (never clips) when Dynamic Type
+    // enlarges the captions.
+    .frame(minHeight: 18)
+    .fixedSize(horizontal: false, vertical: true)
     .accessibilityElement(children: .combine)
   }
 

--- a/Sources/SpeakApp/MainManager+CaptureHealth.swift
+++ b/Sources/SpeakApp/MainManager+CaptureHealth.swift
@@ -181,7 +181,17 @@ extension MainManager {
         return FluidAudioParakeetModel.displayName
       }
       #if !APP_STORE
-      // Use the catalogue's cleaned-up name rather than the raw source ID
+      // Prefer the name stored with the streaming source: the slug-based ID is
+      // lossy (case, punctuation and path components are rewritten), so
+      // re-deriving a label from it can rename a source like "My_ASR.v2".
+      if let sourceName = Self.customStreamingSourceName(
+        for: modelID,
+        in: LocalModelManager.shared.streamingModelSources
+      ) {
+        return sourceName + " (Streaming)"
+      }
+      // Legacy fallback for identifiers with no stored source metadata: use
+      // the catalogue's cleaned-up name rather than the raw source ID
       // (e.g. "sherpa-onnx-streaming-zipformer-en-2023-06-26") so the HUD
       // capture-health label stays readable.
       return ModelCatalog.friendlyName(for: modelID)
@@ -200,4 +210,18 @@ extension MainManager {
     guard let suffixRange else { return displayName }
     return String(displayName[..<suffixRange.lowerBound])
   }
+
+  #if !APP_STORE
+  /// Resolves a custom streaming source identifier back to the model name the
+  /// user configured for it. Returns `nil` when no stored source matches so
+  /// callers can fall back to legacy slug-derived naming.
+  nonisolated static func customStreamingSourceName(
+    for modelID: String,
+    in sources: [LocalStreamingModelSource]
+  ) -> String? {
+    guard let source = sources.first(where: { $0.id == modelID }) else { return nil }
+    let name = source.modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+    return name.isEmpty ? nil : name
+  }
+  #endif
 }

--- a/Tests/SpeakAppTests/CaptureHealthSnapshotTests.swift
+++ b/Tests/SpeakAppTests/CaptureHealthSnapshotTests.swift
@@ -134,4 +134,46 @@ final class CaptureHealthSnapshotTests: XCTestCase {
     manager.updateCaptureHealth(second)
     XCTAssertEqual(manager.captureHealth, second)
   }
+
+  // MARK: - Custom streaming source name resolution (#704)
+
+  #if !APP_STORE
+  func testCustomStreamingSourceName_preservesConfiguredNameExactly() {
+    // The slug-based ID rewrites case and punctuation ("My_ASR.v2" ->
+    // "my-asr-v2"); resolution must return the stored name untouched.
+    let source = LocalStreamingModelSource(repoID: "acme/models", modelName: "My_ASR.v2")
+    XCTAssertNotEqual(ModelCatalog.friendlyName(for: source.id), "My_ASR.v2")
+    XCTAssertEqual(
+      MainManager.customStreamingSourceName(for: source.id, in: [source]),
+      "My_ASR.v2"
+    )
+  }
+
+  func testCustomStreamingSourceName_matchesCorrectSourceAmongMany() {
+    let first = LocalStreamingModelSource(repoID: "acme/models", modelName: "Alpha-EN")
+    let second = LocalStreamingModelSource(repoID: "acme/models", modelName: "Beta-DE")
+    XCTAssertEqual(
+      MainManager.customStreamingSourceName(for: second.id, in: [first, second]),
+      "Beta-DE"
+    )
+  }
+
+  func testCustomStreamingSourceName_unknownID_returnsNilForLegacyFallback() {
+    let source = LocalStreamingModelSource(repoID: "acme/models", modelName: "Alpha-EN")
+    XCTAssertNil(
+      MainManager.customStreamingSourceName(
+        for: "local/streaming/huggingface/other/model",
+        in: [source]
+      )
+    )
+    XCTAssertNil(MainManager.customStreamingSourceName(for: source.id, in: []))
+  }
+
+  func testCustomStreamingSourceName_blankStoredName_returnsNil() {
+    // Sources decoded from legacy metadata may carry an empty name; the
+    // resolver must decline so callers use the slug-derived fallback.
+    let source = LocalStreamingModelSource(repoID: "acme/models", modelName: "   ")
+    XCTAssertNil(MainManager.customStreamingSourceName(for: source.id, in: [source]))
+  }
+  #endif
 }


### PR DESCRIPTION
## Defect

Two problems in the compact HUD capture-health row (found auditing #588):

1. **Clipping at accessibility text sizes** — the row was pinned to `.frame(height: 18)` while its `caption2` labels honour Dynamic Type up to Accessibility 1, so the microphone/device/provider/latency information was vertically clipped for exactly the users who most need it.
2. **Custom streaming source names lost** — provider labels for custom local streaming sources were re-derived from the lossy slug identifier via `ModelCatalog.friendlyName`, so a source configured as `My_ASR.v2` rendered as "My Asr V2".

## Fix

- `Sources/SpeakApp/HUDView.swift`: the health row now sizes to content with a `minHeight: 18` floor (plus `fixedSize(horizontal: false, vertical: true)`), keeping the familiar compact geometry at standard sizes. At `dynamicTypeSize.isAccessibilitySize` it switches via `AnyLayout` to a leading vertical stack, drops the decorative "·" separator, and lets device/provider labels wrap up to three lines instead of clipping. All existing VoiceOver labels and the combined accessibility element are preserved.
- `Sources/SpeakApp/MainManager+CaptureHealth.swift`: streaming provider labels now resolve the source ID back through `LocalModelManager.streamingModelSources` and use the stored `modelName` (new `MainManager.customStreamingSourceName(for:in:)` helper), falling back to slug-derived `ModelCatalog.friendlyName` only when no stored source metadata matches (legacy IDs). Diagnostics keep carrying the raw identifier separately in `transcriptionModel`.

## Tests

- 4 new tests in `Tests/SpeakAppTests/CaptureHealthSnapshotTests.swift` covering the name resolution: exact preservation of `My_ASR.v2` (asserting the old slug path did rewrite it), correct match among multiple sources, nil for unknown/legacy IDs, and nil for blank stored names.
- Full `swift test` passes (all suites, including existing HUD snapshot tests). The recording/failure HUD phases that show this row animate via `TimelineView(.animation)` and are deliberately excluded from the deterministic snapshot suite, so no new snapshots were added.
- SwiftLint strict with the repo baseline: no violations in the touched files.

Fixes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)