### PR TITLE
fix(core): make lexicon loading and promotion durable

### DIFF
--- a/Sources/SpeakApp/AutoCorrectionTracker.swift
+++ b/Sources/SpeakApp/AutoCorrectionTracker.swift
@@ -34,7 +34,7 @@ final class AutoCorrectionTracker: ObservableObject {
   /// Maximum monitoring duration
   private let maxMonitorDuration: TimeInterval = 30.0
 
-  init(store: AutoCorrectionStore, lexiconService: PersonalLexiconService, appSettings: AppSettings) {
+  init(store: AutoCorrectionStoring, lexiconService: PersonalLexiconService, appSettings: AppSettings) {
     self.engine = AutoCorrectionEngine(
       store: store,
       lexiconService: lexiconService,
@@ -96,23 +96,28 @@ final class AutoCorrectionTracker: ObservableObject {
   }
 
   /// Manually promote a candidate to a correction rule.
-  func promoteCandidate(_ candidate: AutoCorrectionCandidate) async {
-    await engine.promoteCandidate(candidate)
+  /// Throws if the rule or candidate list could not be durably saved; the
+  /// candidate is retained for retry in that case.
+  func promoteCandidate(_ candidate: AutoCorrectionCandidate) async throws {
+    try await engine.promoteCandidate(candidate)
   }
 
   /// Dismiss a candidate (user doesn't want this correction).
-  func dismissCandidate(id: UUID) {
-    engine.dismissCandidate(id: id)
+  /// Throws if the dismissal could not be persisted.
+  func dismissCandidate(id: UUID) async throws {
+    try await engine.dismissCandidate(id: id)
   }
 
   /// Remove a candidate entirely.
-  func removeCandidate(id: UUID) {
-    engine.removeCandidate(id: id)
+  /// Throws if the removal could not be persisted.
+  func removeCandidate(id: UUID) async throws {
+    try await engine.removeCandidate(id: id)
   }
 
   /// Clear all candidates.
-  func clearAllCandidates() {
-    engine.clearAllCandidates()
+  /// Throws if the store could not be emptied.
+  func clearAllCandidates() async throws {
+    try await engine.clearAllCandidates()
   }
 
   // MARK: - Private Methods
@@ -142,6 +147,12 @@ final class AutoCorrectionTracker: ObservableObject {
       return
     }
 
-    await engine.recordEdit(original: insertedText, edited: currentString, app: insertionApp)
+    do {
+      try await engine.recordEdit(original: insertedText, edited: currentString, app: insertionApp)
+    } catch {
+      // Background monitoring has no UI surface; the engine has already
+      // retained any unpromoted candidate for retry, so log and move on.
+      log.error("Failed to record edit durably: \(error.localizedDescription, privacy: .public)")
+    }
   }
 }

--- a/Sources/SpeakApp/PersonalCorrectionsView.swift
+++ b/Sources/SpeakApp/PersonalCorrectionsView.swift
@@ -210,7 +210,13 @@ struct PersonalCorrectionsView: View {
                 Spacer()
                 if autoCorrectionTracker.candidates.count > 0 {
                   Button("Clear All", role: .destructive) {
-                    autoCorrectionTracker.clearAllCandidates()
+                    Task {
+                      do {
+                        try await autoCorrectionTracker.clearAllCandidates()
+                      } catch {
+                        alertMessage = error.localizedDescription
+                      }
+                    }
                   }
                   .font(.caption)
                   .buttonStyle(.borderless)
@@ -293,7 +299,11 @@ struct PersonalCorrectionsView: View {
     HStack(spacing: 8) {
       Button {
         Task {
-          await autoCorrectionTracker.promoteCandidate(candidate)
+          do {
+            try await autoCorrectionTracker.promoteCandidate(candidate)
+          } catch {
+            alertMessage = error.localizedDescription
+          }
         }
       } label: {
         Image(systemName: "checkmark.circle")
@@ -303,7 +313,13 @@ struct PersonalCorrectionsView: View {
       .accessibilityLabel("Add as correction rule: \(candidate.original) to \(candidate.corrected)")
 
       Button {
-        autoCorrectionTracker.dismissCandidate(id: candidate.id)
+        Task {
+          do {
+            try await autoCorrectionTracker.dismissCandidate(id: candidate.id)
+          } catch {
+            alertMessage = error.localizedDescription
+          }
+        }
       } label: {
         Image(systemName: "xmark.circle")
       }
@@ -470,28 +486,38 @@ struct PersonalCorrectionsView: View {
           .foregroundStyle(.secondary)
       }
 
-      HStack(spacing: 12) {
-        Button("Edit") {
-          draft = RuleDraft(rule: rule)
-          showAdvancedOptions = draft.requiresAdvancedOptions
-          focusedField = .canonical
-        }
-        .buttonStyle(.bordered)
-        Button("Delete", role: .destructive) {
-          Task { await lexicon.deleteRule(id: rule.id) }
-        }
-        .buttonStyle(.bordered)
-        Spacer()
-        Text("Updated \(rule.updatedAt.formatted(date: .abbreviated, time: .shortened))")
-          .font(.caption2)
-          .foregroundStyle(.tertiary)
-      }
+      ruleRowActions(rule)
     }
     .padding(density.isCompact ? density.cardPadding : 20)
     .background(
       RoundedRectangle(cornerRadius: density.isCompact ? 8 : 22, style: .continuous)
         .fill(Color(nsColor: .controlBackgroundColor))
     )
+  }
+
+  private func ruleRowActions(_ rule: PersonalLexiconRule) -> some View {
+    HStack(spacing: 12) {
+      Button("Edit") {
+        draft = RuleDraft(rule: rule)
+        showAdvancedOptions = draft.requiresAdvancedOptions
+        focusedField = .canonical
+      }
+      .buttonStyle(.bordered)
+      Button("Delete", role: .destructive) {
+        Task {
+          do {
+            try await lexicon.deleteRule(id: rule.id)
+          } catch {
+            alertMessage = error.localizedDescription
+          }
+        }
+      }
+      .buttonStyle(.bordered)
+      Spacer()
+      Text("Updated \(rule.updatedAt.formatted(date: .abbreviated, time: .shortened))")
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+    }
   }
 
   private var previewSection: some View {

--- a/Sources/SpeakCore/AutoCorrectionEngine.swift
+++ b/Sources/SpeakCore/AutoCorrectionEngine.swift
@@ -1,6 +1,16 @@
 import Foundation
 import os.log
 
+/// Persistence contract for auto-correction candidates. Abstracted so
+/// behavioural tests can inject delayed or failing stores.
+public protocol AutoCorrectionStoring: Sendable {
+  func load() async throws -> [AutoCorrectionCandidate]
+  func save(_ candidates: [AutoCorrectionCandidate]) async throws
+  func deleteAll() async throws
+}
+
+extension AutoCorrectionStore: AutoCorrectionStoring {}
+
 /// Platform-neutral core of auto-correction learning: manages correction
 /// candidates, counts repeated corrections, and promotes them to
 /// PersonalLexiconRules once a threshold is reached.
@@ -11,10 +21,15 @@ import os.log
 public final class AutoCorrectionEngine: ObservableObject {
   @Published public private(set) var candidates: [AutoCorrectionCandidate] = []
 
-  private let store: AutoCorrectionStore
+  private let store: AutoCorrectionStoring
   private let lexiconService: PersonalLexiconService
   private let promotionThreshold: () -> Int
   private let log = SpeakLogger.logger(category: "AutoCorrectionEngine")
+
+  /// Tail of the serial operation chain. The initial load is the first link,
+  /// so every mutation awaits it and a slow load can never overwrite state
+  /// mutated immediately after initialisation.
+  private var operationTail: Task<Void, Never>?
 
   /// - Parameters:
   ///   - store: Persistence for correction candidates.
@@ -23,7 +38,7 @@ public final class AutoCorrectionEngine: ObservableObject {
   ///     it is auto-promoted to a rule (read at evaluation time so settings
   ///     changes take effect immediately).
   public init(
-    store: AutoCorrectionStore,
+    store: AutoCorrectionStoring,
     lexiconService: PersonalLexiconService,
     promotionThreshold: @escaping () -> Int
   ) {
@@ -31,17 +46,26 @@ public final class AutoCorrectionEngine: ObservableObject {
     self.lexiconService = lexiconService
     self.promotionThreshold = promotionThreshold
 
-    Task { [weak self] in
+    operationTail = Task { @MainActor [weak self] in
       await self?.loadCandidates()
     }
   }
 
   // MARK: - Public API
 
+  /// Await completion of the initial load (and any queued operations).
+  public func waitUntilLoaded() async {
+    try? await enqueue { }
+  }
+
   /// Record a user edit of previously inserted transcription text.
   /// Word-level changes are extracted and tracked as correction candidates;
   /// repeated corrections are auto-promoted to lexicon rules.
-  public func recordEdit(original: String, edited: String, app: String?) async {
+  ///
+  /// Throws if the candidate snapshot could not be persisted, or if a
+  /// threshold promotion failed (in which case the candidate is retained so
+  /// the promotion can be retried later).
+  public func recordEdit(original: String, edited: String, app: String?) async throws {
     guard !original.isEmpty, edited != original else {
       log.debug("Text unchanged, no corrections detected")
       return
@@ -56,43 +80,106 @@ public final class AutoCorrectionEngine: ObservableObject {
 
     log.info("Detected \(changes.count, privacy: .public) potential corrections")
 
-    for change in changes {
-      await processChange(change, app: app)
+    try await enqueue {
+      var promotionError: Error?
+      for change in changes {
+        do {
+          try await self.processChange(change, app: app)
+        } catch {
+          // Promotion failed: the candidate stays pending for retry.
+          promotionError = error
+        }
+      }
+      try await self.persistCandidates()
+      if let promotionError {
+        throw promotionError
+      }
     }
   }
 
   /// Manually promote a candidate to a correction rule.
-  public func promoteCandidate(_ candidate: AutoCorrectionCandidate) async {
-    await createRuleFromCandidate(candidate)
-    removeCandidate(id: candidate.id)
+  /// The candidate is removed only once the lexicon rule is durably saved;
+  /// on failure it is retained and the error is rethrown.
+  public func promoteCandidate(_ candidate: AutoCorrectionCandidate) async throws {
+    try await enqueue {
+      try await self.createRuleFromCandidate(candidate)
+      let previous = self.candidates
+      self.candidates.removeAll { $0.id == candidate.id }
+      do {
+        try await self.persistCandidates()
+      } catch {
+        // The rule is durable but the candidate list is not; restore the
+        // in-memory state to mirror disk and surface the failure.
+        self.candidates = previous
+        throw error
+      }
+    }
   }
 
   /// Dismiss a candidate (user doesn't want this correction).
-  public func dismissCandidate(id: UUID) {
-    guard let index = candidates.firstIndex(where: { $0.id == id }) else { return }
-    candidates[index].dismissed = true
-    Task { await persistCandidates() }
+  /// Rolls the dismissal back and rethrows if it could not be persisted.
+  public func dismissCandidate(id: UUID) async throws {
+    try await enqueue {
+      guard let index = self.candidates.firstIndex(where: { $0.id == id }) else { return }
+      let previous = self.candidates
+      self.candidates[index].dismissed = true
+      do {
+        try await self.persistCandidates()
+      } catch {
+        self.candidates = previous
+        throw error
+      }
+    }
   }
 
   /// Remove a candidate entirely.
-  public func removeCandidate(id: UUID) {
-    candidates.removeAll { $0.id == id }
-    Task { await persistCandidates() }
+  /// Rolls the removal back and rethrows if it could not be persisted.
+  public func removeCandidate(id: UUID) async throws {
+    try await enqueue {
+      let previous = self.candidates
+      self.candidates.removeAll { $0.id == id }
+      do {
+        try await self.persistCandidates()
+      } catch {
+        self.candidates = previous
+        throw error
+      }
+    }
   }
 
   /// Clear all candidates.
-  public func clearAllCandidates() {
-    candidates.removeAll()
-    Task {
+  /// Rolls the clear back and rethrows if the store could not be emptied.
+  public func clearAllCandidates() async throws {
+    try await enqueue {
+      let previous = self.candidates
+      self.candidates.removeAll()
       do {
-        try await store.deleteAll()
+        try await self.store.deleteAll()
       } catch {
-        log.error("Failed to delete candidates: \(error.localizedDescription, privacy: .public)")
+        self.candidates = previous
+        self.log.error("Failed to delete candidates: \(error.localizedDescription, privacy: .public)")
+        throw error
       }
     }
   }
 
   // MARK: - Private Methods
+
+  /// Run `operation` after every previously queued operation (including the
+  /// initial load) has finished, serialising load/mutate/save.
+  private func enqueue<T: Sendable>(
+    _ operation: @escaping @MainActor () async throws -> T
+  ) async throws -> T {
+    let previous = operationTail
+    let task = Task { @MainActor () throws -> T in
+      await previous?.value
+      return try await operation()
+    }
+    operationTail = Task { @MainActor in
+      _ = try? await task.value
+    }
+    return try await task.value
+  }
 
   private func loadCandidates() async {
     do {
@@ -104,15 +191,19 @@ public final class AutoCorrectionEngine: ObservableObject {
     }
   }
 
-  private func persistCandidates() async {
+  private func persistCandidates() async throws {
     do {
       try await store.save(candidates)
     } catch {
       log.error("Failed to save candidates: \(error.localizedDescription, privacy: .public)")
+      throw error
     }
   }
 
-  private func processChange(_ change: WordChange, app: String?) async {
+  /// Update in-memory candidates for one word change. Throws only when a
+  /// threshold promotion fails to save its lexicon rule; the candidate is
+  /// retained (with its incremented count) in that case.
+  private func processChange(_ change: WordChange, app: String?) async throws {
     let matchKey = "\(change.original.lowercased())→\(change.corrected.lowercased())"
 
     // Check if we already have this candidate
@@ -125,7 +216,8 @@ public final class AutoCorrectionEngine: ObservableObject {
       // Check if ready to promote
       if candidates[index].seenCount >= promotionThreshold() {
         log.info("Promoting correction to rule")
-        await createRuleFromCandidate(candidates[index])
+        // Remove the candidate only after the rule is durably saved.
+        try await createRuleFromCandidate(candidates[index])
         candidates.remove(at: index)
       }
     } else {
@@ -145,11 +237,9 @@ public final class AutoCorrectionEngine: ObservableObject {
         "New correction candidate: '\(change.original, privacy: .public)' → '\(change.corrected, privacy: .public)'"
       )
     }
-
-    await persistCandidates()
   }
 
-  private func createRuleFromCandidate(_ candidate: AutoCorrectionCandidate) async {
+  private func createRuleFromCandidate(_ candidate: AutoCorrectionCandidate) async throws {
     do {
       _ = try await lexiconService.addRule(
         displayName: candidate.corrected,
@@ -168,6 +258,7 @@ public final class AutoCorrectionEngine: ObservableObject {
       )
     } catch {
       log.error("Failed to create rule: \(error.localizedDescription, privacy: .public)")
+      throw error
     }
   }
 }

--- a/Sources/SpeakCore/AutoCorrectionModels.swift
+++ b/Sources/SpeakCore/AutoCorrectionModels.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// A candidate correction detected from user edits after transcription insertion.
 /// When seen multiple times, candidates are promoted to PersonalLexiconRules.
-public struct AutoCorrectionCandidate: Identifiable, Codable, Equatable {
+public struct AutoCorrectionCandidate: Identifiable, Codable, Equatable, Sendable {
   public let id: UUID
   public var original: String        // The word(s) from transcription that was corrected
   public var corrected: String       // What the user changed it to
@@ -132,7 +132,7 @@ public struct WordChange: Equatable, Hashable {
 // MARK: - Rule Source
 
 /// Indicates how a PersonalLexiconRule was created.
-public enum PersonalLexiconRuleSource: String, Codable {
+public enum PersonalLexiconRuleSource: String, Codable, Sendable {
   case manual     // User created manually
   case automatic  // Auto-promoted from correction candidate
 }

--- a/Sources/SpeakCore/PersonalLexiconModels.swift
+++ b/Sources/SpeakCore/PersonalLexiconModels.swift
@@ -3,8 +3,8 @@ import Foundation
 // MARK: - Domain Models
 
 // Personal lexicon rules capture canonical spellings and contextual hints for corrections.
-public struct PersonalLexiconRule: Identifiable, Codable, Equatable {
-  public enum Activation: String, Codable, CaseIterable {
+public struct PersonalLexiconRule: Identifiable, Codable, Equatable, Sendable {
+  public enum Activation: String, Codable, CaseIterable, Sendable {
     case automatic
     case requireContextMatch
     case manual
@@ -90,7 +90,7 @@ public struct PersonalLexiconContext: Equatable {
   public static let empty = PersonalLexiconContext(tags: [], destinationApplication: nil, recentTranscriptWindow: "")
 }
 
-public enum PersonalLexiconConfidence: String, Codable, CaseIterable {
+public enum PersonalLexiconConfidence: String, Codable, CaseIterable, Sendable {
   case high
   case medium
   case low

--- a/Sources/SpeakCore/PersonalLexiconService.swift
+++ b/Sources/SpeakCore/PersonalLexiconService.swift
@@ -1,27 +1,47 @@
 import Foundation
 import os.log
 
+/// Persistence contract for the personal lexicon. Abstracted so behavioural
+/// tests can inject delayed or failing stores.
+public protocol PersonalLexiconStoring: Sendable {
+  func load() async throws -> [PersonalLexiconRule]
+  func save(_ rules: [PersonalLexiconRule]) async throws
+}
+
+extension PersonalLexiconStore: PersonalLexiconStoring {}
+
 @MainActor
 public final class PersonalLexiconService: ObservableObject {
   @Published public private(set) var rules: [PersonalLexiconRule] = [] {
     didSet { regexCache.removeAll() }
   }
 
-  private let store: PersonalLexiconStore
+  private let store: PersonalLexiconStoring
   private let log = SpeakLogger.logger(category: "PersonalLexicon")
   private var regexCache: [String: NSRegularExpression] = [:]
 
-  public init(store: PersonalLexiconStore) {
+  /// Tail of the serial operation chain. The initial load is the first link,
+  /// so every mutation awaits it and load/mutate/save never interleave.
+  private var operationTail: Task<Void, Never>?
+
+  public init(store: PersonalLexiconStoring) {
     self.store = store
-    Task { [weak self] in
+    operationTail = Task { @MainActor [weak self] in
       await self?.loadInitialRules()
     }
   }
 
+  /// Await completion of the initial load (and any queued operations).
+  public func waitUntilLoaded() async {
+    try? await enqueue { }
+  }
+
   public func refresh() async {
     do {
-      let loaded = try await store.load()
-      rules = Self.normalised(rules: loaded)
+      try await enqueue {
+        let loaded = try await self.store.load()
+        self.rules = Self.normalised(rules: loaded)
+      }
     } catch {
       log.error("Failed to refresh lexicon: \(error.localizedDescription, privacy: .public)")
     }
@@ -57,18 +77,17 @@ public final class PersonalLexiconService: ObservableObject {
     }
 
     rule = rule.updatingTimestamps()
+    let newRule = rule
 
-    rules.append(rule)
-    rules = Self.normalised(rules: rules)
-    await persistSnapshot()
+    try await enqueue {
+      try await self.mutateAndPersist { current in
+        current.append(newRule)
+      }
+    }
     return rule
   }
 
   public func updateRule(_ rule: PersonalLexiconRule) async throws {
-    guard let index = rules.firstIndex(where: { $0.id == rule.id }) else {
-      throw PersonalLexiconServiceError.unknownRule
-    }
-
     let sanitisedRule = rule.sanitised().updatingTimestamps()
     guard !sanitisedRule.canonical.isEmpty else {
       throw PersonalLexiconServiceError.invalidCanonical
@@ -77,21 +96,30 @@ public final class PersonalLexiconService: ObservableObject {
       throw PersonalLexiconServiceError.missingAlias
     }
 
-    rules[index] = sanitisedRule
-    rules = Self.normalised(rules: rules)
-    await persistSnapshot()
+    try await enqueue {
+      guard let index = self.rules.firstIndex(where: { $0.id == rule.id }) else {
+        throw PersonalLexiconServiceError.unknownRule
+      }
+      try await self.mutateAndPersist { current in
+        current[index] = sanitisedRule
+      }
+    }
   }
 
-  public func deleteRule(id: UUID) async {
-    rules.removeAll { $0.id == id }
-    await persistSnapshot()
+  public func deleteRule(id: UUID) async throws {
+    try await enqueue {
+      try await self.mutateAndPersist { current in
+        current.removeAll { $0.id == id }
+      }
+    }
   }
 
-  public func moveRules(from offsets: IndexSet, to destination: Int) async {
-    var mutable = rules
-    mutable.move(fromOffsets: offsets, toOffset: destination)
-    rules = mutable
-    await persistSnapshot()
+  public func moveRules(from offsets: IndexSet, to destination: Int) async throws {
+    try await enqueue {
+      try await self.mutateAndPersist(normalise: false) { current in
+        current.move(fromOffsets: offsets, toOffset: destination)
+      }
+    }
   }
 
   public func apply(to text: String, context: PersonalLexiconContext) -> PersonalLexiconApplicationResult {
@@ -156,23 +184,50 @@ public final class PersonalLexiconService: ObservableObject {
     rules.filter { $0.shouldAutoApply(in: context) }
   }
 
-  private func loadInitialRules() async {
+  // MARK: - Serialised persistence
+
+  /// Run `operation` after every previously queued operation (including the
+  /// initial load) has finished. Operations therefore never observe a
+  /// half-loaded store and an older load can never replace newer changes.
+  private func enqueue<T: Sendable>(
+    _ operation: @escaping @MainActor () async throws -> T
+  ) async throws -> T {
+    let previous = operationTail
+    let task = Task { @MainActor () throws -> T in
+      await previous?.value
+      return try await operation()
+    }
+    operationTail = Task { @MainActor in
+      _ = try? await task.value
+    }
+    return try await task.value
+  }
+
+  /// Apply `mutation` optimistically, persist the result, and roll the
+  /// in-memory state back if the save fails so memory always mirrors disk.
+  private func mutateAndPersist(
+    normalise: Bool = true,
+    _ mutation: (inout [PersonalLexiconRule]) -> Void
+  ) async throws {
+    let previous = rules
+    var mutated = previous
+    mutation(&mutated)
+    rules = normalise ? Self.normalised(rules: mutated) : mutated
     do {
-      let loaded = try await store.load()
-      await MainActor.run {
-        self.rules = Self.normalised(rules: loaded)
-      }
+      try await store.save(rules)
     } catch {
-      log.error("Failed to load lexicon: \(error.localizedDescription, privacy: .public)")
+      rules = previous
+      log.error("Failed to persist lexicon: \(error.localizedDescription, privacy: .public)")
+      throw error
     }
   }
 
-  private func persistSnapshot() async {
-    let snapshot = rules
+  private func loadInitialRules() async {
     do {
-      try await store.save(snapshot)
+      let loaded = try await store.load()
+      rules = Self.normalised(rules: loaded)
     } catch {
-      log.error("Failed to persist lexicon: \(error.localizedDescription, privacy: .public)")
+      log.error("Failed to load lexicon: \(error.localizedDescription, privacy: .public)")
     }
   }
 

--- a/Tests/SpeakCoreTests/AutoCorrectionEngineTests.swift
+++ b/Tests/SpeakCoreTests/AutoCorrectionEngineTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+import SpeakCore
+
+@MainActor
+final class AutoCorrectionEngineTests: XCTestCase {
+  func testRecordEditImmediatelyAfterInitPreservesExistingCandidates() async throws {
+    let existing = AutoCorrectionCandidate(original: "wrold", corrected: "world")
+    let store = ControllableAutoCorrectionStore(
+      initialCandidates: [existing],
+      loadDelayNanoseconds: 100_000_000
+    )
+    let engine = makeEngine(store: store)
+
+    // Mutate immediately, before the delayed load has completed.
+    try await engine.recordEdit(original: "teh cat", edited: "the cat", app: nil)
+
+    XCTAssertEqual(
+      Set(engine.candidates.map(\.matchKey)),
+      ["wrold→world", "teh→the"],
+      "Pre-populated candidates must survive an edit recorded before the load finishes"
+    )
+    let persisted = await store.savedCandidates
+    XCTAssertEqual(Set((persisted ?? []).map(\.matchKey)), ["wrold→world", "teh→the"])
+  }
+
+  func testPromotionRemovesCandidateOnlyAfterDurableRuleSave() async throws {
+    let candidate = AutoCorrectionCandidate(original: "teh", corrected: "the", seenCount: 1)
+    let store = ControllableAutoCorrectionStore(initialCandidates: [candidate])
+    let lexiconStore = ControllableLexiconStore(initialRules: [])
+    let engine = makeEngine(store: store, lexiconStore: lexiconStore, threshold: 2)
+    await engine.waitUntilLoaded()
+
+    try await engine.recordEdit(original: "teh cat", edited: "the cat", app: nil)
+
+    XCTAssertTrue(engine.candidates.isEmpty, "Candidate should be removed after promotion")
+    let rules = await lexiconStore.savedRules
+    XCTAssertEqual(rules?.map(\.canonical), ["the"], "Promoted rule must be durably saved")
+    let persisted = await store.savedCandidates
+    XCTAssertEqual(persisted, [], "Candidate removal must be persisted")
+  }
+
+  func testFailedLexiconSaveKeepsPromotionCandidateForRetry() async throws {
+    let candidate = AutoCorrectionCandidate(original: "teh", corrected: "the", seenCount: 1)
+    let store = ControllableAutoCorrectionStore(initialCandidates: [candidate])
+    let lexiconStore = ControllableLexiconStore(initialRules: [], failSaves: true)
+    let engine = makeEngine(store: store, lexiconStore: lexiconStore, threshold: 2)
+    await engine.waitUntilLoaded()
+
+    do {
+      try await engine.recordEdit(original: "teh cat", edited: "the cat", app: nil)
+      XCTFail("recordEdit should surface the failed promotion")
+    } catch {
+      // Expected
+    }
+
+    XCTAssertEqual(engine.candidates.map(\.matchKey), ["teh→the"], "Candidate must be retained for retry")
+    XCTAssertEqual(engine.candidates.first?.seenCount, 2, "Increment should still be recorded")
+    let rules = await lexiconStore.savedRules
+    XCTAssertNil(rules, "No rule may be reported saved when the lexicon save failed")
+    let persisted = await store.savedCandidates
+    XCTAssertEqual(persisted?.map(\.matchKey), ["teh→the"], "Retained candidate must stay persisted")
+  }
+
+  func testManualPromotionFailureRetainsCandidate() async throws {
+    let candidate = AutoCorrectionCandidate(original: "teh", corrected: "the", seenCount: 3)
+    let store = ControllableAutoCorrectionStore(initialCandidates: [candidate])
+    let lexiconStore = ControllableLexiconStore(initialRules: [], failSaves: true)
+    let engine = makeEngine(store: store, lexiconStore: lexiconStore)
+    await engine.waitUntilLoaded()
+
+    do {
+      try await engine.promoteCandidate(candidate)
+      XCTFail("promoteCandidate should rethrow the failed lexicon save")
+    } catch {
+      // Expected
+    }
+
+    XCTAssertEqual(
+      engine.candidates.map(\.id),
+      [candidate.id],
+      "Candidate must remain pending after a failed promotion"
+    )
+  }
+
+  func testFailedDismissRollsBack() async throws {
+    let candidate = AutoCorrectionCandidate(original: "teh", corrected: "the")
+    let store = ControllableAutoCorrectionStore(initialCandidates: [candidate])
+    let engine = makeEngine(store: store)
+    await engine.waitUntilLoaded()
+
+    await store.setFailSaves(true)
+    do {
+      try await engine.dismissCandidate(id: candidate.id)
+      XCTFail("dismissCandidate should rethrow the persistence failure")
+    } catch {
+      // Expected
+    }
+
+    XCTAssertEqual(engine.candidates.first?.dismissed, false, "Dismissal must be rolled back on save failure")
+  }
+
+  func testFailedClearAllRollsBack() async throws {
+    let candidate = AutoCorrectionCandidate(original: "teh", corrected: "the")
+    let store = ControllableAutoCorrectionStore(initialCandidates: [candidate], failDeleteAll: true)
+    let engine = makeEngine(store: store)
+    await engine.waitUntilLoaded()
+
+    do {
+      try await engine.clearAllCandidates()
+      XCTFail("clearAllCandidates should rethrow the persistence failure")
+    } catch {
+      // Expected
+    }
+
+    XCTAssertEqual(engine.candidates.map(\.id), [candidate.id], "Clear must be rolled back on delete failure")
+  }
+
+  // MARK: - Helpers
+
+  private func makeEngine(
+    store: ControllableAutoCorrectionStore,
+    lexiconStore: ControllableLexiconStore = ControllableLexiconStore(initialRules: []),
+    threshold: Int = 3
+  ) -> AutoCorrectionEngine {
+    AutoCorrectionEngine(
+      store: store,
+      lexiconService: PersonalLexiconService(store: lexiconStore),
+      promotionThreshold: { threshold }
+    )
+  }
+}
+
+// MARK: - Test doubles
+
+/// In-memory auto-correction store whose load can be delayed and whose saves
+/// can be made to fail, for durability tests.
+actor ControllableAutoCorrectionStore: AutoCorrectionStoring {
+  struct SaveFailure: Error {}
+
+  private let initialCandidates: [AutoCorrectionCandidate]
+  private let loadDelayNanoseconds: UInt64
+  private var failSaves: Bool
+  private let failDeleteAll: Bool
+  private(set) var savedCandidates: [AutoCorrectionCandidate]?
+
+  init(
+    initialCandidates: [AutoCorrectionCandidate],
+    loadDelayNanoseconds: UInt64 = 0,
+    failSaves: Bool = false,
+    failDeleteAll: Bool = false
+  ) {
+    self.initialCandidates = initialCandidates
+    self.loadDelayNanoseconds = loadDelayNanoseconds
+    self.failSaves = failSaves
+    self.failDeleteAll = failDeleteAll
+  }
+
+  func setFailSaves(_ fail: Bool) {
+    failSaves = fail
+  }
+
+  func load() async throws -> [AutoCorrectionCandidate] {
+    if loadDelayNanoseconds > 0 {
+      try await Task.sleep(nanoseconds: loadDelayNanoseconds)
+    }
+    return savedCandidates ?? initialCandidates
+  }
+
+  func save(_ candidates: [AutoCorrectionCandidate]) async throws {
+    if failSaves {
+      throw SaveFailure()
+    }
+    savedCandidates = candidates
+  }
+
+  func deleteAll() async throws {
+    if failDeleteAll {
+      throw SaveFailure()
+    }
+    savedCandidates = []
+  }
+}

--- a/Tests/SpeakCoreTests/PersonalLexiconServiceTests.swift
+++ b/Tests/SpeakCoreTests/PersonalLexiconServiceTests.swift
@@ -72,6 +72,90 @@ final class PersonalLexiconServiceTests: XCTestCase {
     XCTAssertEqual(result.suggestions.first?.confidence, .low)
   }
 
+  // MARK: - Durability
+
+  func testMutationImmediatelyAfterInitDoesNotOverwriteSlowLoad() async throws {
+    let existing = PersonalLexiconRule(
+      displayName: "Existing",
+      canonical: "Existing",
+      aliases: ["Existng"],
+      activation: .automatic,
+      contextTags: [],
+      confidence: .high,
+      notes: nil
+    )
+    let store = ControllableLexiconStore(initialRules: [existing], loadDelayNanoseconds: 100_000_000)
+    let service = PersonalLexiconService(store: store)
+
+    // Mutate immediately, before the delayed load has completed.
+    _ = try await service.addRule(
+      displayName: "New",
+      canonical: "New",
+      aliases: ["Nwe"],
+      activation: .automatic,
+      contextTags: [],
+      confidence: .high,
+      notes: nil
+    )
+
+    XCTAssertEqual(
+      Set(service.rules.map(\.canonical)),
+      ["Existing", "New"],
+      "Pre-populated rules must survive a mutation issued before the load finishes"
+    )
+    let persisted = await store.savedRules
+    XCTAssertEqual(Set((persisted ?? []).map(\.canonical)), ["Existing", "New"])
+  }
+
+  func testFailedSaveRollsBackAddedRule() async throws {
+    let store = ControllableLexiconStore(initialRules: [], failSaves: true)
+    let service = PersonalLexiconService(store: store)
+    await service.waitUntilLoaded()
+
+    do {
+      _ = try await service.addRule(
+        displayName: "Susy",
+        canonical: "Susy",
+        aliases: ["Susie"],
+        activation: .automatic,
+        contextTags: [],
+        confidence: .high,
+        notes: nil
+      )
+      XCTFail("addRule should rethrow the persistence failure")
+    } catch {
+      // Expected
+    }
+
+    XCTAssertTrue(service.rules.isEmpty, "Optimistic mutation must be rolled back on save failure")
+  }
+
+  func testFailedSaveRollsBackDeletion() async throws {
+    let rule = PersonalLexiconRule(
+      displayName: "Keep",
+      canonical: "Keep",
+      aliases: ["Kepe"],
+      activation: .automatic,
+      contextTags: [],
+      confidence: .high,
+      notes: nil
+    )
+    let store = ControllableLexiconStore(initialRules: [rule])
+    let service = PersonalLexiconService(store: store)
+    await service.waitUntilLoaded()
+    XCTAssertEqual(service.rules.count, 1)
+
+    await store.setFailSaves(true)
+    do {
+      try await service.deleteRule(id: rule.id)
+      XCTFail("deleteRule should rethrow the persistence failure")
+    } catch {
+      // Expected
+    }
+
+    XCTAssertEqual(service.rules.map(\.id), [rule.id], "Deletion must be rolled back on save failure")
+  }
+
   private func makeService() -> (PersonalLexiconService, URL) {
     let tempRoot = FileManager.default.temporaryDirectory
       .appendingPathComponent("personal-lexicon-tests-\(UUID().uuidString)", isDirectory: true)
@@ -79,5 +163,46 @@ final class PersonalLexiconServiceTests: XCTestCase {
     let store = PersonalLexiconStore(fileManager: .default, baseDirectory: tempRoot)
     let service = PersonalLexiconService(store: store)
     return (service, tempRoot)
+  }
+}
+
+// MARK: - Test doubles
+
+/// In-memory lexicon store whose load can be delayed and whose saves can be
+/// made to fail, for durability tests.
+actor ControllableLexiconStore: PersonalLexiconStoring {
+  struct SaveFailure: Error {}
+
+  private let initialRules: [PersonalLexiconRule]
+  private let loadDelayNanoseconds: UInt64
+  private var failSaves: Bool
+  private(set) var savedRules: [PersonalLexiconRule]?
+
+  init(
+    initialRules: [PersonalLexiconRule],
+    loadDelayNanoseconds: UInt64 = 0,
+    failSaves: Bool = false
+  ) {
+    self.initialRules = initialRules
+    self.loadDelayNanoseconds = loadDelayNanoseconds
+    self.failSaves = failSaves
+  }
+
+  func setFailSaves(_ fail: Bool) {
+    failSaves = fail
+  }
+
+  func load() async throws -> [PersonalLexiconRule] {
+    if loadDelayNanoseconds > 0 {
+      try await Task.sleep(nanoseconds: loadDelayNanoseconds)
+    }
+    return savedRules ?? initialRules
+  }
+
+  func save(_ rules: [PersonalLexiconRule]) async throws {
+    if failSaves {
+      throw SaveFailure()
+    }
+    savedRules = rules
   }
 }


### PR DESCRIPTION
## Defect

`PersonalLexiconService` and `AutoCorrectionEngine` kicked off their initial load in unawaited init tasks. With a pre-populated store, an `addRule` or `recordEdit` issued immediately after init mutated the still-empty in-memory array and could persist it before the load finished, overwriting existing rules/candidates. `persistSnapshot()` also swallowed save errors, so promotion reported success on an unwritable disk: the candidate was removed and saved while the rule was never written — after relaunch neither existed.

## Fix

- **Readiness boundary + serialisation**: each service now funnels load/mutate/save through a serial operation chain whose first link is the initial load. Every mutation awaits the load, operations never interleave, and an older load can never replace newer in-memory changes. A `waitUntilLoaded()` hook exposes the boundary.
- **Durable mutations**: lexicon `addRule`/`updateRule`/`deleteRule`/`moveRules` now propagate save failures and roll the optimistic in-memory mutation back, so memory always mirrors disk.
- **Atomic promotion**: a promotion candidate is removed only after the lexicon rule is durably saved. On a failed lexicon save the candidate is retained (with its incremented seen count persisted) and the failure is surfaced, so it stays visibly pending/retryable. Manual `promoteCandidate` behaves the same.
- **Same contract for dismiss/remove/clear**: these now await persistence, roll back on failure, and rethrow instead of using unobserved `Task { … }` saves.
- **Callers**: `PersonalCorrectionsView` surfaces failures through its existing alert; `AutoCorrectionTracker`'s background monitoring path logs them (no UI surface). Store parameters are now the new `PersonalLexiconStoring`/`AutoCorrectionStoring` protocols (the concrete actors conform), and the candidate/rule models are `Sendable`.

## Tests

New behavioural tests using delayed and failing fake stores (`ControllableLexiconStore`, `ControllableAutoCorrectionStore`):

- mutation immediately after init preserves pre-populated rules/candidates once the slow load lands
- failed lexicon save rolls back `addRule`/`deleteRule` and rethrows
- threshold promotion with a failing lexicon store retains the candidate (incremented count persisted) and reports failure; success path removes it only after the durable rule save
- failed dismiss/clear-all roll back

`swift build` clean, full `swift test` suite passes (1631 tests), SwiftLint strict against the repo baseline introduces no new violations (net −1: a `function_body_length` debt entry was removed).

Fixes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Auto-correction candidates and personal lexicon changes now save reliably and support retry after temporary failures.
  - Failed saves automatically roll back changes to prevent data loss.
  - Personal lexicon loading and updates are coordinated for more consistent results.

- **Bug Fixes**
  - Added clear, localized error messages when saving, deleting, promoting, or dismissing items fails.
  - Candidates remain available when promotion or persistence fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->