### PR TITLE
fix(ci): make iOS profile bootstrap concurrency-safe

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -25,6 +25,16 @@ on:
         default: false
         type: boolean
 
+# Serialise runs so overlapping dispatches cannot race App Store Connect
+# portal mutation (bundle ID / capability / profile bootstrap in
+# scripts/create-ios-app-store-profile.rb). cancel-in-progress stays false:
+# a newer dispatch queues behind the in-flight release instead of aborting
+# its upload. GitHub keeps at most one queued run per group, so rapid
+# re-dispatches supersede the previously queued (not running) run.
+concurrency:
+  group: release-ios-portal
+  cancel-in-progress: false
+
 env:
   APP_STORE_CONNECT_KEY_ID: S747NJ9DZY
   # The extension now ships by default, while direct capture remains an

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -411,10 +411,10 @@ final class DistributionBuildIdentityTests: XCTestCase {
             contentsOf: repositoryRoot.appendingPathComponent("scripts/create-ios-app-store-profile.rb"),
             encoding: .utf8
         )
-        XCTAssertTrue(profileBootstrap.contains("path: \"/v1/bundleIds\""))
+        XCTAssertTrue(profileBootstrap.contains("@client.post(\"/v1/bundleIds\""))
         XCTAssertTrue(profileBootstrap.contains("/bundleIdCapabilities\""))
         XCTAssertFalse(profileBootstrap.contains("/bundleIdCapabilities?limit="))
-        XCTAssertTrue(profileBootstrap.contains("path: \"/v1/bundleIdCapabilities\""))
+        XCTAssertTrue(profileBootstrap.contains("@client.post(\"/v1/bundleIdCapabilities\""))
         XCTAssertTrue(profileBootstrap.contains("capabilityType: capability_type"))
         XCTAssertFalse(profileBootstrap.contains("method: Net::HTTP::Delete"))
         XCTAssertFalse(profileBootstrap.contains("profiles.each do |stale_profile|"))

--- a/scripts/create-ios-app-store-profile.rb
+++ b/scripts/create-ios-app-store-profile.rb
@@ -1,4 +1,13 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Ensures the App Store Connect bundle ID, capabilities and App Store
+# provisioning profile exist for an iOS target, then writes the profile to
+# disk. Safe to run concurrently: create conflicts (HTTP 409) from overlapping
+# workers or manual portal edits are resolved by re-fetching the canonical
+# resource with bounded, jittered retries and validating it matches the
+# requested bundle, capability, certificate and active state. Authentication,
+# entitlement and validation failures are never retried as conflicts.
 
 require "base64"
 require "json"
@@ -7,196 +16,397 @@ require "openssl"
 require "optparse"
 require "uri"
 
-options = {
-  api_base: "https://api.appstoreconnect.apple.com",
-  capabilities: [],
-}
+module IOSProfileBootstrap
+  class ApiError < StandardError
+    attr_reader :status, :body
 
-OptionParser.new do |parser|
-  parser.on("--bundle-id IDENTIFIER") { |value| options[:bundle_id] = value }
-  parser.on("--bundle-name NAME") { |value| options[:bundle_name] = value }
-  parser.on("--capability TYPE") { |value| options[:capabilities] << value }
-  parser.on("--certificate-serial SERIAL") { |value| options[:certificate_serial] = value }
-  parser.on("--profile-name NAME") { |value| options[:profile_name] = value }
-  parser.on("--output PATH") { |value| options[:output] = value }
-end.parse!
+    def initialize(message, status: nil, body: nil)
+      super(message)
+      @status = status
+      @body = body
+    end
+  end
 
-required_options = %i[bundle_id certificate_serial profile_name output]
-missing_options = required_options.reject { |key| options[key] && !options[key].empty? }
-abort("Missing required options: #{missing_options.join(', ')}") unless missing_options.empty?
+  # Raised only for HTTP 409: the resource we tried to create already exists
+  # (typically because a concurrent worker or manual portal edit created it).
+  class ConflictError < ApiError; end
 
-key_id = ENV.fetch("APP_STORE_CONNECT_KEY_ID")
-issuer_id = ENV.fetch("APP_STORE_CONNECT_ISSUER_ID")
-key_path = ENV.fetch("APP_STORE_CONNECT_KEY_PATH")
-private_key = OpenSSL::PKey::EC.new(File.read(key_path))
+  # Raised when a fetched resource does not match what was requested, or a
+  # duplicate-reported resource never becomes visible. Never retried.
+  class ValidationError < StandardError; end
 
-def base64url(value)
-  Base64.urlsafe_encode64(value, padding: false)
-end
+  def self.base64url(value)
+    Base64.urlsafe_encode64(value, padding: false)
+  end
 
-header = base64url(JSON.generate(alg: "ES256", kid: key_id, typ: "JWT"))
-issued_at = Time.now.to_i
-payload = base64url(JSON.generate(iss: issuer_id, iat: issued_at, exp: issued_at + 1_200, aud: "appstoreconnect-v1"))
-unsigned_token = "#{header}.#{payload}"
-der_signature = private_key.dsa_sign_asn1(OpenSSL::Digest::SHA256.digest(unsigned_token))
-sequence = OpenSSL::ASN1.decode(der_signature)
-raw_signature = sequence.value.map { |integer| integer.value.to_s(2).rjust(32, "\0") }.join
-token = "#{unsigned_token}.#{base64url(raw_signature)}"
+  def self.jwt_token(key_id:, issuer_id:, private_key:, now: Time.now)
+    header = base64url(JSON.generate(alg: "ES256", kid: key_id, typ: "JWT"))
+    issued_at = now.to_i
+    payload = base64url(JSON.generate(iss: issuer_id, iat: issued_at, exp: issued_at + 1_200, aud: "appstoreconnect-v1"))
+    unsigned_token = "#{header}.#{payload}"
+    der_signature = private_key.dsa_sign_asn1(OpenSSL::Digest::SHA256.digest(unsigned_token))
+    sequence = OpenSSL::ASN1.decode(der_signature)
+    raw_signature = sequence.value.map { |integer| integer.value.to_s(2).rjust(32, "\0") }.join
+    "#{unsigned_token}.#{base64url(raw_signature)}"
+  end
 
-def request(api_base:, token:, method:, path:, body: nil)
-  uri = URI.join(api_base, path)
-  request = method.new(uri)
-  request["Authorization"] = "Bearer #{token}"
-  request["Content-Type"] = "application/json"
-  request.body = JSON.generate(body) if body
-  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
-  return response if response.is_a?(Net::HTTPSuccess)
-
-  abort("App Store Connect API #{request.method} #{uri.path} failed (#{response.code}): #{response.body}")
-end
-
-def fetch_collection(api_base:, token:, path:)
-  response = request(api_base: api_base, token: token, method: Net::HTTP::Get, path: path)
-  JSON.parse(response.body).fetch("data")
-end
-
-escaped_bundle_id = URI.encode_www_form_component(options[:bundle_id])
-bundle_ids = fetch_collection(
-  api_base: options[:api_base],
-  token: token,
-  path: "/v1/bundleIds?filter%5Bidentifier%5D=#{escaped_bundle_id}"
-)
-abort("Multiple registered bundle IDs found for #{options[:bundle_id]}") if bundle_ids.length > 1
-
-bundle = bundle_ids.first
-unless bundle
-  bundle_name = options[:bundle_name] || options[:bundle_id]
-  create_body = {
-    data: {
-      type: "bundleIds",
-      attributes: {
-        identifier: options[:bundle_id],
-        name: bundle_name,
-        platform: "IOS",
-      },
-    },
-  }
-  response = request(
-    api_base: options[:api_base],
-    token: token,
-    method: Net::HTTP::Post,
-    path: "/v1/bundleIds",
-    body: create_body
-  )
-  bundle = JSON.parse(response.body).fetch("data")
-  puts "Registered bundle ID #{options[:bundle_id]}"
-else
-  puts "Reusing bundle ID #{options[:bundle_id]}"
-end
-bundle_resource_id = bundle.fetch("id")
-
-unless options[:capabilities].empty?
-  capabilities = fetch_collection(
-    api_base: options[:api_base],
-    token: token,
-    path: "/v1/bundleIds/#{bundle_resource_id}/bundleIdCapabilities"
-  )
-  enabled_capabilities = capabilities.map { |capability| capability.dig("attributes", "capabilityType") }.compact
-
-  options[:capabilities].uniq.each do |capability_type|
-    if enabled_capabilities.include?(capability_type)
-      puts "Reusing #{capability_type} capability for #{options[:bundle_id]}"
-      next
+  # Thin transport: performs one HTTPS request and returns [status, raw_body].
+  # Tests substitute any object responding to call(method:, path:, body:).
+  class HttpTransport
+    def initialize(api_base:, token:)
+      @api_base = api_base
+      @token = token
     end
 
-    create_body = {
-      data: {
-        type: "bundleIdCapabilities",
-        attributes: {
-          capabilityType: capability_type,
-        },
-        relationships: {
-          bundleId: {
-            data: { type: "bundleIds", id: bundle_resource_id },
+    def call(method:, path:, body: nil)
+      uri = URI.join(@api_base, path)
+      request = method.new(uri)
+      request["Authorization"] = "Bearer #{@token}"
+      request["Content-Type"] = "application/json"
+      request.body = JSON.generate(body) if body
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+      [Integer(response.code), response.body]
+    end
+  end
+
+  # Classifies responses: 2xx parses and returns JSON, 409 raises
+  # ConflictError, anything else raises ApiError (including 401/403 auth and
+  # 400 validation failures, which callers must not treat as conflicts).
+  class Client
+    def initialize(transport:)
+      @transport = transport
+    end
+
+    def request(method:, path:, body: nil)
+      status, raw = @transport.call(method: method, path: path, body: body)
+      if (200..299).cover?(status)
+        return nil if raw.nil? || raw.empty?
+
+        return JSON.parse(raw)
+      end
+
+      message = "App Store Connect API #{method::METHOD} #{path} failed (#{status}): #{raw}"
+      raise ConflictError.new(message, status: status, body: raw) if status == 409
+
+      raise ApiError.new(message, status: status, body: raw)
+    end
+
+    def get(path)
+      request(method: Net::HTTP::Get, path: path)
+    end
+
+    def post(path, body)
+      request(method: Net::HTTP::Post, path: path, body: body)
+    end
+
+    def list(path)
+      get(path).fetch("data")
+    end
+  end
+
+  class Provisioner
+    DEFAULT_MAX_ATTEMPTS = 5
+    BASE_DELAY_SECONDS = 2.0
+
+    def initialize(client:, bundle_id:, profile_name:, certificate_serial:, bundle_name: nil, capabilities: [],
+                   max_attempts: DEFAULT_MAX_ATTEMPTS, sleeper: ->(seconds) { sleep(seconds) },
+                   jitter: -> { rand }, logger: ->(message) { puts message })
+      @client = client
+      @bundle_id = bundle_id
+      @bundle_name = bundle_name || bundle_id
+      @capabilities = capabilities
+      @certificate_serial = certificate_serial
+      @base_profile_name = profile_name
+      @max_attempts = max_attempts
+      @sleeper = sleeper
+      @jitter = jitter
+      @logger = logger
+    end
+
+    # Returns the base64 profileContent for the ensured profile.
+    def provision
+      bundle = ensure_bundle_id
+      bundle_resource_id = bundle.fetch("id")
+      ensure_capabilities(bundle_resource_id)
+      certificate = find_certificate
+      profile = ensure_profile(bundle_resource_id, certificate.fetch("id"))
+      profile_content(profile)
+    end
+
+    def normalized_serial
+      @certificate_serial.delete(":").upcase.sub(/^0+/, "")
+    end
+
+    def profile_name
+      "#{@base_profile_name} #{normalized_serial[-8, 8]}"
+    end
+
+    private
+
+    def log(message)
+      @logger.call(message)
+    end
+
+    def ensure_bundle_id
+      bundle = fetch_bundle
+      if bundle
+        log "Reusing bundle ID #{@bundle_id}"
+        return validate_bundle!(bundle)
+      end
+
+      create_body = {
+        data: {
+          type: "bundleIds",
+          attributes: {
+            identifier: @bundle_id,
+            name: @bundle_name,
+            platform: "IOS",
           },
         },
-      },
+      }
+      begin
+        created = @client.post("/v1/bundleIds", create_body).fetch("data")
+        log "Registered bundle ID #{@bundle_id}"
+        validate_bundle!(created)
+      rescue ConflictError
+        log "Bundle ID #{@bundle_id} already exists (created concurrently); re-fetching"
+        validate_bundle!(refetch("Bundle ID #{@bundle_id}") { fetch_bundle })
+      end
+    end
+
+    def fetch_bundle
+      escaped_bundle_id = URI.encode_www_form_component(@bundle_id)
+      bundles = @client.list("/v1/bundleIds?filter%5Bidentifier%5D=#{escaped_bundle_id}")
+      # The identifier filter matches substrings, so keep only exact matches.
+      matches = bundles.select { |candidate| candidate.dig("attributes", "identifier") == @bundle_id }
+      raise ValidationError, "Multiple registered bundle IDs found for #{@bundle_id}" if matches.length > 1
+
+      matches.first
+    end
+
+    def validate_bundle!(bundle)
+      identifier = bundle.dig("attributes", "identifier")
+      unless identifier == @bundle_id
+        raise ValidationError,
+              "Bundle ID resource #{bundle['id']} has identifier '#{identifier}', expected '#{@bundle_id}'. " \
+              "Check the App Store Connect portal for a conflicting registration."
+      end
+
+      bundle
+    end
+
+    def ensure_capabilities(bundle_resource_id)
+      return if @capabilities.empty?
+
+      enabled = enabled_capabilities(bundle_resource_id)
+      @capabilities.uniq.each do |capability_type|
+        if enabled.include?(capability_type)
+          log "Reusing #{capability_type} capability for #{@bundle_id}"
+          next
+        end
+
+        create_body = {
+          data: {
+            type: "bundleIdCapabilities",
+            attributes: {
+              capabilityType: capability_type,
+            },
+            relationships: {
+              bundleId: {
+                data: { type: "bundleIds", id: bundle_resource_id },
+              },
+            },
+          },
+        }
+        begin
+          @client.post("/v1/bundleIdCapabilities", create_body)
+          log "Enabled #{capability_type} capability for #{@bundle_id}"
+        rescue ConflictError
+          log "#{capability_type} capability already enabled (created concurrently); re-checking"
+          refetch("#{capability_type} capability for #{@bundle_id}") do
+            enabled_capabilities(bundle_resource_id).include?(capability_type) ? capability_type : nil
+          end
+        end
+      end
+    end
+
+    def enabled_capabilities(bundle_resource_id)
+      capabilities = @client.list("/v1/bundleIds/#{bundle_resource_id}/bundleIdCapabilities")
+      capabilities.map { |capability| capability.dig("attributes", "capabilityType") }.compact
+    end
+
+    def find_certificate
+      certificates = @client.list("/v1/certificates?filter%5BcertificateType%5D=DISTRIBUTION,IOS_DISTRIBUTION&limit=200")
+      certificate = certificates.find do |candidate|
+        candidate_serial = candidate.dig("attributes", "serialNumber").to_s.delete(":").upcase.sub(/^0+/, "")
+        candidate_serial == normalized_serial
+      end
+      unless certificate
+        raise ValidationError, "No Apple distribution certificate matched serial #{@certificate_serial}"
+      end
+
+      certificate
+    end
+
+    def ensure_profile(bundle_resource_id, certificate_id)
+      profile = fetch_active_profile
+      if profile
+        log "Reusing provisioning profile #{profile_name}"
+        return validate_profile!(profile, bundle_resource_id, certificate_id)
+      end
+
+      create_body = {
+        data: {
+          type: "profiles",
+          attributes: {
+            name: profile_name,
+            profileType: "IOS_APP_STORE",
+          },
+          relationships: {
+            bundleId: {
+              data: { type: "bundleIds", id: bundle_resource_id },
+            },
+            certificates: {
+              data: [{ type: "certificates", id: certificate_id }],
+            },
+          },
+        },
+      }
+      begin
+        created = @client.post("/v1/profiles", create_body).fetch("data")
+        log "Created provisioning profile #{profile_name}"
+        validate_profile!(created, bundle_resource_id, certificate_id)
+      rescue ConflictError
+        log "Provisioning profile #{profile_name} already exists (created concurrently); re-fetching"
+        profile = refetch("Provisioning profile #{profile_name}") { fetch_active_profile }
+        validate_profile!(profile, bundle_resource_id, certificate_id)
+      end
+    end
+
+    def fetch_active_profile
+      escaped_profile_name = URI.encode_www_form_component(profile_name)
+      profiles = @client.list("/v1/profiles?filter%5Bname%5D=#{escaped_profile_name}&limit=200")
+      profiles.find do |candidate|
+        candidate.dig("attributes", "name") == profile_name &&
+          candidate.dig("attributes", "profileState") == "ACTIVE"
+      end
+    end
+
+    # Fetches the canonical profile record and verifies it matches what this
+    # run requested. A mismatched profile is a genuine configuration problem
+    # (e.g. a stale profile left over from a certificate rotation) and must
+    # fail loudly rather than be silently reused.
+    def validate_profile!(profile, bundle_resource_id, certificate_id)
+      profile_id = profile.fetch("id")
+      detail = @client.get("/v1/profiles/#{profile_id}?include=bundleId,certificates").fetch("data")
+
+      state = detail.dig("attributes", "profileState")
+      unless state == "ACTIVE"
+        raise ValidationError,
+              "Provisioning profile #{profile_name} (#{profile_id}) is #{state || 'in an unknown state'}, expected ACTIVE. " \
+              "Delete or regenerate it in the Apple Developer portal, then rerun this workflow."
+      end
+
+      linked_bundle_id = detail.dig("relationships", "bundleId", "data", "id")
+      unless linked_bundle_id == bundle_resource_id
+        raise ValidationError,
+              "Provisioning profile #{profile_name} (#{profile_id}) is linked to bundle ID resource " \
+              "#{linked_bundle_id || 'none'}, expected #{bundle_resource_id} (#{@bundle_id}). " \
+              "Delete the stale profile in the Apple Developer portal, then rerun this workflow."
+      end
+
+      linked_certificate_ids = Array(detail.dig("relationships", "certificates", "data")).map { |entry| entry["id"] }
+      unless linked_certificate_ids.include?(certificate_id)
+        raise ValidationError,
+              "Provisioning profile #{profile_name} (#{profile_id}) does not include distribution certificate " \
+              "#{certificate_id} (serial #{@certificate_serial}). " \
+              "Delete the stale profile in the Apple Developer portal, then rerun this workflow."
+      end
+
+      detail
+    end
+
+    def profile_content(profile)
+      content = profile.dig("attributes", "profileContent")
+      unless content
+        content = @client.get("/v1/profiles/#{profile.fetch('id')}").dig("data", "attributes", "profileContent")
+      end
+      raise ValidationError, "Apple returned a profile without profileContent" unless content
+
+      content
+    end
+
+    # Bounded, jittered polling for a resource that App Store Connect reported
+    # as a duplicate but which may not be list-visible yet (read-after-write
+    # consistency lag). Only used after a ConflictError.
+    def refetch(description)
+      attempt = 0
+      loop do
+        attempt += 1
+        resource = yield
+        return resource if resource
+
+        if attempt >= @max_attempts
+          raise ValidationError,
+                "#{description} was reported as a duplicate by App Store Connect but did not become visible " \
+                "after #{@max_attempts} attempts. Check the Apple Developer portal and rerun this workflow."
+        end
+
+        delay = BASE_DELAY_SECONDS * attempt + @jitter.call
+        log "#{description} not visible yet (attempt #{attempt}/#{@max_attempts}); retrying in #{delay.round(1)}s"
+        @sleeper.call(delay)
+      end
+    end
+  end
+
+  def self.parse_options(argv)
+    options = {
+      api_base: "https://api.appstoreconnect.apple.com",
+      capabilities: [],
     }
-    request(
-      api_base: options[:api_base],
-      token: token,
-      method: Net::HTTP::Post,
-      path: "/v1/bundleIdCapabilities",
-      body: create_body
+
+    OptionParser.new do |parser|
+      parser.on("--bundle-id IDENTIFIER") { |value| options[:bundle_id] = value }
+      parser.on("--bundle-name NAME") { |value| options[:bundle_name] = value }
+      parser.on("--capability TYPE") { |value| options[:capabilities] << value }
+      parser.on("--certificate-serial SERIAL") { |value| options[:certificate_serial] = value }
+      parser.on("--profile-name NAME") { |value| options[:profile_name] = value }
+      parser.on("--output PATH") { |value| options[:output] = value }
+    end.parse!(argv)
+
+    required_options = %i[bundle_id certificate_serial profile_name output]
+    missing_options = required_options.reject { |key| options[key] && !options[key].empty? }
+    abort("Missing required options: #{missing_options.join(', ')}") unless missing_options.empty?
+
+    options
+  end
+
+  def self.main(argv)
+    options = parse_options(argv)
+
+    key_id = ENV.fetch("APP_STORE_CONNECT_KEY_ID")
+    issuer_id = ENV.fetch("APP_STORE_CONNECT_ISSUER_ID")
+    key_path = ENV.fetch("APP_STORE_CONNECT_KEY_PATH")
+    private_key = OpenSSL::PKey::EC.new(File.read(key_path))
+    token = jwt_token(key_id: key_id, issuer_id: issuer_id, private_key: private_key)
+
+    transport = HttpTransport.new(api_base: options[:api_base], token: token)
+    client = Client.new(transport: transport)
+    provisioner = Provisioner.new(
+      client: client,
+      bundle_id: options[:bundle_id],
+      bundle_name: options[:bundle_name],
+      capabilities: options[:capabilities],
+      certificate_serial: options[:certificate_serial],
+      profile_name: options[:profile_name]
     )
-    puts "Enabled #{capability_type} capability for #{options[:bundle_id]}"
+
+    content = provisioner.provision
+    File.binwrite(options[:output], Base64.decode64(content))
+    puts "Wrote provisioning profile to #{options[:output]}"
+  rescue ApiError, ValidationError => error
+    abort(error.message)
   end
 end
 
-serial = options[:certificate_serial].delete(":").upcase.sub(/^0+/, "")
-certificates = fetch_collection(
-  api_base: options[:api_base],
-  token: token,
-  path: "/v1/certificates?filter%5BcertificateType%5D=DISTRIBUTION,IOS_DISTRIBUTION&limit=200"
-)
-certificate = certificates.find do |candidate|
-  candidate_serial = candidate.dig("attributes", "serialNumber").to_s.delete(":").upcase.sub(/^0+/, "")
-  candidate_serial == serial
-end
-abort("No Apple distribution certificate matched serial #{options[:certificate_serial]}") unless certificate
-
-profile_name = "#{options[:profile_name]} #{serial[-8, 8]}"
-escaped_profile_name = URI.encode_www_form_component(profile_name)
-profiles = fetch_collection(
-  api_base: options[:api_base],
-  token: token,
-  path: "/v1/profiles?filter%5Bname%5D=#{escaped_profile_name}&limit=200"
-)
-
-profile = profiles.find { |candidate| candidate.dig("attributes", "profileState") == "ACTIVE" }
-
-unless profile
-  create_body = {
-    data: {
-      type: "profiles",
-      attributes: {
-        name: profile_name,
-        profileType: "IOS_APP_STORE",
-      },
-      relationships: {
-        bundleId: {
-          data: { type: "bundleIds", id: bundle_resource_id },
-        },
-        certificates: {
-          data: [{ type: "certificates", id: certificate.fetch("id") }],
-        },
-      },
-    },
-  }
-  response = request(
-    api_base: options[:api_base],
-    token: token,
-    method: Net::HTTP::Post,
-    path: "/v1/profiles",
-    body: create_body
-  )
-  profile = JSON.parse(response.body).fetch("data")
-  puts "Created provisioning profile #{profile_name}"
-else
-  puts "Reusing provisioning profile #{profile_name}"
-end
-
-content = profile.dig("attributes", "profileContent")
-unless content
-  response = request(
-    api_base: options[:api_base],
-    token: token,
-    method: Net::HTTP::Get,
-    path: "/v1/profiles/#{profile.fetch('id')}"
-  )
-  content = JSON.parse(response.body).dig("data", "attributes", "profileContent")
-end
-abort("Apple returned a profile without profileContent") unless content
-
-File.binwrite(options[:output], Base64.decode64(content))
-puts "Wrote provisioning profile to #{options[:output]}"
+IOSProfileBootstrap.main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/create-ios-app-store-profile.rb
+++ b/scripts/create-ios-app-store-profile.rb
@@ -176,7 +176,7 @@ module IOSProfileBootstrap
 
     def fetch_bundle
       escaped_bundle_id = URI.encode_www_form_component(@bundle_id)
-      bundles = @client.list("/v1/bundleIds?filter%5Bidentifier%5D=#{escaped_bundle_id}")
+      bundles = @client.list("/v1/bundleIds?filter%5Bidentifier%5D=#{escaped_bundle_id}&limit=200")
       # The identifier filter matches substrings, so keep only exact matches.
       matches = bundles.select { |candidate| candidate.dig("attributes", "identifier") == @bundle_id }
       raise ValidationError, "Multiple registered bundle IDs found for #{@bundle_id}" if matches.length > 1
@@ -231,6 +231,8 @@ module IOSProfileBootstrap
     end
 
     def enabled_capabilities(bundle_resource_id)
+      # Deliberately no limit query parameter on the capability relationship
+      # endpoint; DistributionBuildIdentityTests pins this shape (from #562).
       capabilities = @client.list("/v1/bundleIds/#{bundle_resource_id}/bundleIdCapabilities")
       capabilities.map { |capability| capability.dig("attributes", "capabilityType") }.compact
     end
@@ -278,18 +280,42 @@ module IOSProfileBootstrap
         validate_profile!(created, bundle_resource_id, certificate_id)
       rescue ConflictError
         log "Provisioning profile #{profile_name} already exists (created concurrently); re-fetching"
-        profile = refetch("Provisioning profile #{profile_name}") { fetch_active_profile }
+        profile = refetch_conflicting_profile
         validate_profile!(profile, bundle_resource_id, certificate_id)
       end
     end
 
+    # App Store Connect rejects a duplicate profile name even when the existing
+    # profile is EXPIRED or INVALID, and fetch_active_profile keeps only ACTIVE
+    # profiles, so a stale same-name profile would otherwise surface as a
+    # misleading visibility timeout. Name the stale profile instead.
+    def refetch_conflicting_profile
+      refetch("Provisioning profile #{profile_name}") { fetch_active_profile }
+    rescue ValidationError => error
+      stale = fetch_profile_named
+      stale_state = stale&.dig("attributes", "profileState")
+      raise error if stale.nil? || stale_state == "ACTIVE"
+
+      raise ValidationError,
+            "Provisioning profile #{profile_name} (#{stale['id']}) already exists in state " \
+            "#{stale_state || 'unknown'}, which blocks creating a profile with the same name. " \
+            "Delete the stale profile in the Apple Developer portal, then rerun this workflow."
+    end
+
     def fetch_active_profile
+      fetch_profiles_named.find do |candidate|
+        candidate.dig("attributes", "profileState") == "ACTIVE"
+      end
+    end
+
+    def fetch_profile_named
+      fetch_profiles_named.first
+    end
+
+    def fetch_profiles_named
       escaped_profile_name = URI.encode_www_form_component(profile_name)
       profiles = @client.list("/v1/profiles?filter%5Bname%5D=#{escaped_profile_name}&limit=200")
-      profiles.find do |candidate|
-        candidate.dig("attributes", "name") == profile_name &&
-          candidate.dig("attributes", "profileState") == "ACTIVE"
-      end
+      profiles.select { |candidate| candidate.dig("attributes", "name") == profile_name }
     end
 
     # Fetches the canonical profile record and verifies it matches what this

--- a/scripts/tests/create_ios_app_store_profile_test.rb
+++ b/scripts/tests/create_ios_app_store_profile_test.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+# Tests for scripts/create-ios-app-store-profile.rb conflict handling.
+# Self-contained (minitest is in the Ruby standard distribution); no live
+# credentials or network access are used. Run with:
+#
+#   ruby scripts/tests/create_ios_app_store_profile_test.rb
+
+require "minitest/autorun"
+require_relative "../create-ios-app-store-profile"
+
+module IOSProfileBootstrap
+  # Scripted transport: each expectation is [method, path matcher, status,
+  # body]. Requests are matched in order; an unexpected request fails the test.
+  class FakeTransport
+    Call = Struct.new(:method, :path, :body)
+
+    attr_reader :calls
+
+    def initialize(script)
+      @script = script.dup
+      @calls = []
+    end
+
+    def call(method:, path:, body: nil)
+      @calls << Call.new(method::METHOD, path, body)
+      expected = @script.shift
+      raise "Unexpected request: #{method::METHOD} #{path}" unless expected
+
+      expected_method, matcher, status, response_body = expected
+      unless expected_method == method::METHOD && path.include?(matcher)
+        raise "Expected #{expected_method} #{matcher}, got #{method::METHOD} #{path}"
+      end
+
+      [status, response_body.is_a?(String) ? response_body : JSON.generate(response_body)]
+    end
+
+    def drained?
+      @script.empty?
+    end
+  end
+
+  class ProvisionerTest < Minitest::Test
+    BUNDLE_ID = "com.example.keyboard"
+    BUNDLE_RESOURCE_ID = "B1"
+    CERT_ID = "C1"
+    CERT_SERIAL = "00AB12CD34EF56789"
+    PROFILE_ID = "P1"
+
+    def normalized_serial
+      CERT_SERIAL.delete(":").upcase.sub(/^0+/, "")
+    end
+
+    def profile_name
+      "Example Keyboard App Store #{normalized_serial[-8, 8]}"
+    end
+
+    def build_provisioner(script, capabilities: [], max_attempts: 3)
+      transport = FakeTransport.new(script)
+      @sleeps = []
+      provisioner = Provisioner.new(
+        client: Client.new(transport: transport),
+        bundle_id: BUNDLE_ID,
+        bundle_name: "Example Keyboard",
+        capabilities: capabilities,
+        certificate_serial: CERT_SERIAL,
+        profile_name: "Example Keyboard App Store",
+        max_attempts: max_attempts,
+        sleeper: ->(seconds) { @sleeps << seconds },
+        jitter: -> { 0.5 },
+        logger: ->(_message) {}
+      )
+      [provisioner, transport]
+    end
+
+    def bundle_resource(id: BUNDLE_RESOURCE_ID, identifier: BUNDLE_ID)
+      { "type" => "bundleIds", "id" => id, "attributes" => { "identifier" => identifier } }
+    end
+
+    def certificate_resource
+      { "type" => "certificates", "id" => CERT_ID, "attributes" => { "serialNumber" => CERT_SERIAL } }
+    end
+
+    def profile_resource(id: PROFILE_ID, state: "ACTIVE", content: nil)
+      attributes = { "name" => profile_name, "profileState" => state }
+      attributes["profileContent"] = content if content
+      { "type" => "profiles", "id" => id, "attributes" => attributes }
+    end
+
+    def profile_detail(id: PROFILE_ID, state: "ACTIVE", bundle_ref: BUNDLE_RESOURCE_ID, cert_refs: [CERT_ID],
+                       content: "UFJPRklMRQ==")
+      detail = profile_resource(id: id, state: state, content: content)
+      detail["relationships"] = {
+        "bundleId" => { "data" => { "type" => "bundleIds", "id" => bundle_ref } },
+        "certificates" => { "data" => cert_refs.map { |ref| { "type" => "certificates", "id" => ref } } },
+      }
+      detail
+    end
+
+    def certificate_and_profile_script(profile_steps)
+      [["GET", "/v1/certificates", 200, { "data" => [certificate_resource] }]] + profile_steps
+    end
+
+    def existing_profile_steps
+      [
+        ["GET", "/v1/profiles?filter", 200, { "data" => [profile_resource] }],
+        ["GET", "/v1/profiles/#{PROFILE_ID}?include=bundleId,certificates", 200, { "data" => profile_detail }],
+      ]
+    end
+
+    # Acceptance: two workers observing the same missing bundle converge on the
+    # same resource. Worker A's create succeeds; worker B receives 409 and must
+    # re-fetch worker A's bundle by canonical identifier.
+    def test_bundle_create_conflict_converges_on_existing_resource
+      script = [
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["POST", "/v1/bundleIds", 409, { "errors" => [{ "status" => "409" }] }],
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [bundle_resource] }],
+      ] + certificate_and_profile_script(existing_profile_steps)
+
+      provisioner, transport = build_provisioner(script)
+      content = provisioner.provision
+
+      assert_equal "UFJPRklMRQ==", content
+      assert transport.drained?
+      assert_empty @sleeps
+    end
+
+    def test_winning_worker_creates_bundle_without_conflict
+      script = [
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["POST", "/v1/bundleIds", 201, { "data" => bundle_resource }],
+      ] + certificate_and_profile_script(existing_profile_steps)
+
+      provisioner, transport = build_provisioner(script)
+      assert_equal "UFJPRklMRQ==", provisioner.provision
+      assert transport.drained?
+    end
+
+    # Acceptance: a create conflict followed by delayed list visibility is
+    # retried within a bound (with jittered backoff) and succeeds.
+    def test_conflict_with_delayed_visibility_retries_within_bound
+      script = [
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["POST", "/v1/bundleIds", 409, { "errors" => [] }],
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [bundle_resource] }],
+      ] + certificate_and_profile_script(existing_profile_steps)
+
+      provisioner, transport = build_provisioner(script)
+      assert_equal "UFJPRklMRQ==", provisioner.provision
+      assert transport.drained?
+      assert_equal [2.5, 4.5], @sleeps # BASE_DELAY * attempt + jitter(0.5)
+    end
+
+    def test_conflict_that_never_becomes_visible_fails_within_bound
+      script = [
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["POST", "/v1/bundleIds", 409, { "errors" => [] }],
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+      ]
+
+      provisioner, transport = build_provisioner(script, max_attempts: 3)
+      error = assert_raises(ValidationError) { provisioner.provision }
+      assert_match(/did not become visible/, error.message)
+      assert transport.drained?
+      assert_equal 2, @sleeps.length
+    end
+
+    # Acceptance: authentication failures are not retried as conflicts.
+    def test_auth_failure_is_not_retried_as_conflict
+      script = [
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["POST", "/v1/bundleIds", 401, { "errors" => [{ "status" => "401" }] }],
+      ]
+
+      provisioner, transport = build_provisioner(script)
+      error = assert_raises(ApiError) { provisioner.provision }
+      refute_kind_of ConflictError, error
+      assert_equal 401, error.status
+      assert transport.drained?
+      assert_empty @sleeps
+    end
+
+    def test_capability_conflict_converges
+      script = [
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [bundle_resource] }],
+        ["GET", "/v1/bundleIds/#{BUNDLE_RESOURCE_ID}/bundleIdCapabilities", 200, { "data" => [] }],
+        ["POST", "/v1/bundleIdCapabilities", 409, { "errors" => [] }],
+        ["GET", "/v1/bundleIds/#{BUNDLE_RESOURCE_ID}/bundleIdCapabilities", 200,
+         { "data" => [{ "attributes" => { "capabilityType" => "APP_GROUPS" } }] }],
+      ] + certificate_and_profile_script(existing_profile_steps)
+
+      provisioner, transport = build_provisioner(script, capabilities: ["APP_GROUPS"])
+      assert_equal "UFJPRklMRQ==", provisioner.provision
+      assert transport.drained?
+    end
+
+    def test_profile_conflict_converges_on_concurrently_created_profile
+      profile_steps = [
+        ["GET", "/v1/profiles?filter", 200, { "data" => [] }],
+        ["POST", "/v1/profiles", 409, { "errors" => [] }],
+        ["GET", "/v1/profiles?filter", 200, { "data" => [profile_resource] }],
+        ["GET", "/v1/profiles/#{PROFILE_ID}?include=bundleId,certificates", 200, { "data" => profile_detail }],
+      ]
+      script = [["GET", "/v1/bundleIds?filter", 200, { "data" => [bundle_resource] }]] +
+               certificate_and_profile_script(profile_steps)
+
+      provisioner, transport = build_provisioner(script)
+      assert_equal "UFJPRklMRQ==", provisioner.provision
+      assert transport.drained?
+    end
+
+    # Acceptance: a genuine mismatched resource fails with an actionable error
+    # rather than being silently reused.
+    def test_profile_linked_to_wrong_bundle_fails_with_actionable_error
+      profile_steps = [
+        ["GET", "/v1/profiles?filter", 200, { "data" => [profile_resource] }],
+        ["GET", "/v1/profiles/#{PROFILE_ID}?include=bundleId,certificates", 200,
+         { "data" => profile_detail(bundle_ref: "OTHER") }],
+      ]
+      script = [["GET", "/v1/bundleIds?filter", 200, { "data" => [bundle_resource] }]] +
+               certificate_and_profile_script(profile_steps)
+
+      provisioner, transport = build_provisioner(script)
+      error = assert_raises(ValidationError) { provisioner.provision }
+      assert_match(/linked to bundle ID resource OTHER/, error.message)
+      assert_match(/Delete the stale profile/, error.message)
+      assert transport.drained?
+    end
+
+    def test_profile_missing_certificate_fails_with_actionable_error
+      profile_steps = [
+        ["GET", "/v1/profiles?filter", 200, { "data" => [profile_resource] }],
+        ["GET", "/v1/profiles/#{PROFILE_ID}?include=bundleId,certificates", 200,
+         { "data" => profile_detail(cert_refs: ["STALE_CERT"]) }],
+      ]
+      script = [["GET", "/v1/bundleIds?filter", 200, { "data" => [bundle_resource] }]] +
+               certificate_and_profile_script(profile_steps)
+
+      provisioner, transport = build_provisioner(script)
+      error = assert_raises(ValidationError) { provisioner.provision }
+      assert_match(/does not include distribution certificate #{CERT_ID}/, error.message)
+      assert transport.drained?
+    end
+
+    def test_refetched_bundle_with_wrong_identifier_fails
+      script = [
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [] }],
+        ["POST", "/v1/bundleIds", 201, { "data" => bundle_resource(identifier: "com.example.other") }],
+      ]
+
+      provisioner, transport = build_provisioner(script)
+      error = assert_raises(ValidationError) { provisioner.provision }
+      assert_match(/has identifier 'com.example.other'/, error.message)
+      assert transport.drained?
+    end
+
+    def test_substring_filter_matches_are_ignored
+      lookalike = bundle_resource(id: "B9", identifier: "#{BUNDLE_ID}.extension")
+      script = [
+        ["GET", "/v1/bundleIds?filter", 200, { "data" => [lookalike, bundle_resource] }],
+      ] + certificate_and_profile_script(existing_profile_steps)
+
+      provisioner, transport = build_provisioner(script)
+      assert_equal "UFJPRklMRQ==", provisioner.provision
+      assert transport.drained?
+    end
+  end
+end

--- a/scripts/tests/create_ios_app_store_profile_test.rb
+++ b/scripts/tests/create_ios_app_store_profile_test.rb
@@ -13,7 +13,7 @@ module IOSProfileBootstrap
   # Scripted transport: each expectation is [method, path matcher, status,
   # body]. Requests are matched in order; an unexpected request fails the test.
   class FakeTransport
-    Call = Struct.new(:method, :path, :body)
+    Call = Struct.new(:http_method, :path, :body)
 
     attr_reader :calls
 
@@ -204,6 +204,43 @@ module IOSProfileBootstrap
         ["GET", "/v1/profiles?filter", 200, { "data" => [] }],
         ["POST", "/v1/profiles", 409, { "errors" => [] }],
         ["GET", "/v1/profiles?filter", 200, { "data" => [profile_resource] }],
+        ["GET", "/v1/profiles/#{PROFILE_ID}?include=bundleId,certificates", 200, { "data" => profile_detail }],
+      ]
+      script = [["GET", "/v1/bundleIds?filter", 200, { "data" => [bundle_resource] }]] +
+               certificate_and_profile_script(profile_steps)
+
+      provisioner, transport = build_provisioner(script)
+      assert_equal "UFJPRklMRQ==", provisioner.provision
+      assert transport.drained?
+    end
+
+    # Acceptance: a stale non-ACTIVE profile that blocks the name is reported
+    # as such, not as a visibility timeout.
+    def test_profile_conflict_with_stale_nonactive_profile_names_the_stale_profile
+      expired = profile_resource(state: "EXPIRED")
+      profile_steps = [
+        ["GET", "/v1/profiles?filter", 200, { "data" => [] }],
+        ["POST", "/v1/profiles", 409, { "errors" => [] }],
+        ["GET", "/v1/profiles?filter", 200, { "data" => [expired] }],
+        ["GET", "/v1/profiles?filter", 200, { "data" => [expired] }],
+        ["GET", "/v1/profiles?filter", 200, { "data" => [expired] }],
+        ["GET", "/v1/profiles?filter", 200, { "data" => [expired] }],
+      ]
+      script = [["GET", "/v1/bundleIds?filter", 200, { "data" => [bundle_resource] }]] +
+               certificate_and_profile_script(profile_steps)
+
+      provisioner, transport = build_provisioner(script, max_attempts: 3)
+      error = assert_raises(ValidationError) { provisioner.provision }
+      assert_match(/already exists in state EXPIRED/, error.message)
+      assert_match(/Delete the stale profile/, error.message)
+      refute_match(/did not become visible/, error.message)
+      assert transport.drained?
+    end
+
+    def test_active_profile_is_selected_when_a_stale_sibling_shares_the_name
+      expired = profile_resource(id: "P0", state: "EXPIRED")
+      profile_steps = [
+        ["GET", "/v1/profiles?filter", 200, { "data" => [expired, profile_resource] }],
         ["GET", "/v1/profiles/#{PROFILE_ID}?include=bundleId,certificates", 200, { "data" => profile_detail }],
       ]
       script = [["GET", "/v1/bundleIds?filter", 200, { "data" => [bundle_resource] }]] +


### PR DESCRIPTION
## Defect

`scripts/create-ios-app-store-profile.rb` performs read-then-create for the bundle ID, capability and provisioning profile with no workflow serialisation and no conflict recovery. Two overlapping TestFlight runs (or a manual portal edit racing a run) can both observe a missing resource; one creates it and the other gets a 409 from App Store Connect, which the generic `request` helper turned into an `abort` — killing an otherwise-valid release. Found while auditing merged PR #562.

## Fix

**Workflow serialisation** — `.github/workflows/release-ios.yml` gains:

```yaml
concurrency:
  group: release-ios-portal
  cancel-in-progress: false
```

Queue-vs-cancel choice: **queue without cancellation**. A release upload must never be aborted by a newer dispatch, so an in-flight run always completes and later dispatches wait. (GitHub keeps at most one *queued* run per group, so a rapid re-dispatch supersedes a previously queued — never a running — run.) Only this workflow mutates portal provisioning resources; `release-appstore.yml` (Mac App Store) only consumes a stored profile secret and uploads, so it needs no group.

**Script idempotence** — the script is restructured into `HttpTransport` / `Client` / `Provisioner` (the old ~line-46 `request` helper is now `Client#request` over an injectable transport, so response sequences are testable without live credentials):

- HTTP 409 raises a typed `ConflictError`; all other non-2xx (401/403 auth, 400 validation, entitlement errors) raise `ApiError` and are **never** retried as conflicts.
- On conflict, the provisioner re-fetches by canonical identifier (bundle identifier / capability type / profile name) with **bounded jittered retries** (5 attempts, `2s * attempt + jitter`) to cover delayed list visibility, then fails actionably if the duplicate never appears.
- The converged-on (or reused) profile is validated against the request: `ACTIVE` state, linked to the expected bundle ID resource, and includes the expected distribution certificate — a stale/mismatched profile now fails with an instruction to delete it in the portal instead of being silently reused.
- ASC's substring-matching identifier/name filters are narrowed to exact matches before use.

CLI flags, env vars, output path, log lines and the profile-name-with-serial-suffix convention are unchanged, so the `release-ios.yml` invocation needs no edits.

## Verification

- `ruby scripts/tests/create_ios_app_store_profile_test.rb` — 11 tests / 40 assertions, all passing. No Ruby test harness exists in the repo, so this is a self-contained stdlib-minitest file with a scripted fake transport (no network, no credentials), deliberately wired into nothing. Covers each acceptance criterion: two workers converging on the same bundle/capability/profile after a 409; conflict + delayed visibility retried within bound (asserting the jittered delays); never-visible duplicate failing after the bound; 401 not retried as a conflict; mismatched bundle/certificate on a profile failing with an actionable error; substring filter matches ignored.
- `ruby -c` clean on script and test; workflow YAML parses.
- CLI smoke test: missing-options abort behaviour unchanged.

Fixes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved iOS provisioning setup with validation for bundle identifiers, provisioning profiles, certificates, capabilities, and active status.
  - Added resilient handling for concurrent resource creation and delayed API visibility.

- **Bug Fixes**
  - Improved error handling for authentication failures, conflicts, mismatched resources, stale relationships, and missing profile content.
  - iOS release runs now avoid canceling active executions while superseding queued runs.

- **Tests**
  - Added comprehensive automated coverage for provisioning success, conflicts, retries, validation, and API failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->