### PR TITLE
fix(sync): make CloudKit fetch cancellation complete promptly

### DIFF
--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -373,6 +373,7 @@ struct CloudKitKeySyncDependencies {
     let fetchRecord: ((CKRecord.ID, CloudKitKeySyncDatabase) async throws -> CKRecord?)?
     let saveRecord: ((CKRecord, CloudKitKeySyncDatabase) async throws -> CKRecord)?
     let fetchChanges: ((CloudKitKeySyncDatabase, Data?) async throws -> KeySyncFetchResult)?
+    let makeFetchOperation: ((CloudKitKeySyncDatabase, Data?) -> any KeySyncFetchOperationRunning)?
 
     static let live = CloudKitKeySyncDependencies(
         defaults: .standard,
@@ -398,8 +399,82 @@ struct CloudKitKeySyncDependencies {
         setupInfrastructure: nil,
         fetchRecord: nil,
         saveRecord: nil,
-        fetchChanges: nil
+        fetchChanges: nil,
+        makeFetchOperation: nil
     )
+}
+
+/// Seam over `CKFetchRecordZoneChangesOperation` so lifecycle code can cancel an
+/// in-flight fetch and tests can inject an operation that models cancellation.
+protocol KeySyncFetchOperationRunning: AnyObject, Sendable {
+    /// Starts the operation. `completion` fires at most once when the fetch
+    /// finishes; late or repeated invocations are ignored by the caller's gate.
+    func run(completion: @escaping @Sendable (Result<Void, Error>) -> Void)
+    /// Requests prompt teardown of the underlying operation.
+    func cancel()
+}
+
+/// One-shot gate that resumes a fetch continuation exactly once even when
+/// cancellation and CloudKit completion race each other.
+final class KeySyncFetchCompletionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var pendingResult: Result<Void, Error>?
+    private var isFinished = false
+
+    func register(_ continuation: CheckedContinuation<Void, Error>) {
+        let immediateResult: Result<Void, Error>? = lock.withLock {
+            if let pendingResult {
+                self.pendingResult = nil
+                return pendingResult
+            }
+            self.continuation = continuation
+            return nil
+        }
+        if let immediateResult {
+            continuation.resume(with: immediateResult)
+        }
+    }
+
+    func finish(with result: Result<Void, Error>) {
+        let waiting: CheckedContinuation<Void, Error>? = lock.withLock {
+            guard !isFinished else { return nil }
+            isFinished = true
+            if let continuation {
+                self.continuation = nil
+                return continuation
+            }
+            pendingResult = result
+            return nil
+        }
+        waiting?.resume(with: result)
+    }
+}
+
+private final class LiveKeySyncFetchOperation: KeySyncFetchOperationRunning, @unchecked Sendable {
+    private let operation: CKFetchRecordZoneChangesOperation
+    private let database: CKDatabase
+
+    init(operation: CKFetchRecordZoneChangesOperation, database: CKDatabase) {
+        self.operation = operation
+        self.database = database
+    }
+
+    func run(completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
+        operation.fetchRecordZoneChangesResultBlock = { result in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+        database.add(operation)
+    }
+
+    func cancel() {
+        operation.cancel()
+    }
 }
 
 private final class KeySyncFetchAccumulator: @unchecked Sendable {
@@ -1381,13 +1456,54 @@ public final class CloudKitKeySync: ObservableObject {
         return .uploaded
     }
 
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func executeFetchOperation(
         database: CloudKitKeySyncDatabase,
         changeToken: Data?
     ) async throws -> KeySyncFetchResult {
         if let fetchChanges = dependencies.fetchChanges {
             return try await fetchChanges(database, changeToken)
+        }
+        let accumulator = KeySyncFetchAccumulator()
+        let operation = try makeFetchOperation(
+            database: database,
+            changeToken: changeToken,
+            accumulator: accumulator
+        )
+        try await Self.awaitFetchCompletion(of: operation)
+        return try accumulator.result()
+    }
+
+    /// Bridges a fetch operation into async/await. Task cancellation cancels the
+    /// operation and resumes the continuation promptly; the gate guarantees the
+    /// continuation resumes exactly once even when cancellation and CloudKit
+    /// completion race.
+    nonisolated static func awaitFetchCompletion(of operation: any KeySyncFetchOperationRunning) async throws {
+        let gate = KeySyncFetchCompletionGate()
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                gate.register(continuation)
+                operation.run { result in
+                    gate.finish(with: result)
+                }
+                if Task.isCancelled {
+                    operation.cancel()
+                    gate.finish(with: .failure(CancellationError()))
+                }
+            }
+        } onCancel: {
+            operation.cancel()
+            gate.finish(with: .failure(CancellationError()))
+        }
+    }
+
+    private func makeFetchOperation(
+        database: CloudKitKeySyncDatabase,
+        changeToken: Data?,
+        accumulator: KeySyncFetchAccumulator
+    ) throws -> any KeySyncFetchOperationRunning {
+        if let makeFetchOperation = dependencies.makeFetchOperation {
+            return makeFetchOperation(database, changeToken)
         }
         guard let liveDatabase = database.live else {
             throw CloudKitKeySyncError.cloudUnavailable
@@ -1409,8 +1525,6 @@ public final class CloudKitKeySync: ObservableObject {
             configurationsByRecordZoneID: [SyncConfiguration.zoneID: config]
         )
         operation.fetchAllChanges = true
-
-        let accumulator = KeySyncFetchAccumulator()
 
         operation.recordWasChangedBlock = { _, result in
             switch result {
@@ -1438,19 +1552,7 @@ public final class CloudKitKeySync: ObservableObject {
             }
         }
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            operation.fetchRecordZoneChangesResultBlock = { result in
-                switch result {
-                case .success:
-                    continuation.resume()
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-            liveDatabase.add(operation)
-        }
-
-        return try accumulator.result()
+        return LiveKeySyncFetchOperation(operation: operation, database: liveDatabase)
     }
 
     private func fetchRecord(

--- a/Sources/SpeakSync/CloudKitKeySync.swift
+++ b/Sources/SpeakSync/CloudKitKeySync.swift
@@ -422,7 +422,10 @@ final class KeySyncFetchCompletionGate: @unchecked Sendable {
     private var pendingResult: Result<Void, Error>?
     private var isFinished = false
 
-    func register(_ continuation: CheckedContinuation<Void, Error>) {
+    /// Registers the continuation. Returns `true` while the fetch is still
+    /// pending; returns `false` when the gate already finished (the
+    /// continuation is resumed immediately and the operation must not start).
+    func register(_ continuation: CheckedContinuation<Void, Error>) -> Bool {
         let immediateResult: Result<Void, Error>? = lock.withLock {
             if let pendingResult {
                 self.pendingResult = nil
@@ -433,7 +436,9 @@ final class KeySyncFetchCompletionGate: @unchecked Sendable {
         }
         if let immediateResult {
             continuation.resume(with: immediateResult)
+            return false
         }
+        return true
     }
 
     func finish(with result: Result<Void, Error>) {
@@ -1482,7 +1487,12 @@ public final class CloudKitKeySync: ObservableObject {
         try await withTaskCancellationHandler {
             try Task.checkCancellation()
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                gate.register(continuation)
+                guard gate.register(continuation) else {
+                    // Cancellation already resumed the continuation; never
+                    // start the operation whose completion would be discarded.
+                    operation.cancel()
+                    return
+                }
                 operation.run { result in
                     gate.finish(with: result)
                 }

--- a/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
+++ b/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
@@ -409,6 +409,78 @@ final class CloudKitKeySyncTests: XCTestCase {
         XCTAssertEqual(harness.defaults.data(forKey: CloudKitKeySync.syncTokenKey), finalToken)
     }
 
+    func testDisable_PromptlyCancelsStalledProductionFetch() async throws {
+        let fetchOperation = FakeFetchOperation()
+        let harness = makeHarness(fetchOperation: { _, _ in fetchOperation })
+
+        let syncTask = Task { try await harness.sync.syncNow() }
+        try await eventually { fetchOperation.runCount == 1 }
+
+        // The fake never completes on its own and ignores cancel(), modelling a
+        // stalled network operation. Without the cancellation handler this await
+        // would hang on the in-flight fetch.
+        await harness.sync.disable()
+
+        XCTAssertGreaterThanOrEqual(fetchOperation.cancelCount, 1)
+        _ = try? await syncTask.value
+        XCTAssertFalse(harness.defaults.bool(forKey: CloudKitKeySync.enabledKey))
+        XCTAssertNil(harness.defaults.data(forKey: CloudKitKeySync.syncTokenKey))
+    }
+
+    func testFetchCancellation_RacingCompletion_DoesNotDoubleResume() async throws {
+        let fetchOperation = FakeFetchOperation()
+        fetchOperation.completesOnCancel = true
+        let harness = makeHarness(fetchOperation: { _, _ in fetchOperation })
+
+        let syncTask = Task { try await harness.sync.syncNow() }
+        try await eventually { fetchOperation.runCount == 1 }
+
+        // cancel() invokes the CloudKit completion while the cancellation handler
+        // resumes the gate itself; a late completion afterwards must be ignored.
+        // A double resume of the checked continuation would crash the test run.
+        await harness.sync.disable()
+        fetchOperation.complete(with: .success(()))
+        fetchOperation.complete(with: .failure(CKError(.networkFailure)))
+
+        _ = try? await syncTask.value
+        XCTAssertGreaterThanOrEqual(fetchOperation.cancelCount, 1)
+        XCTAssertFalse(harness.defaults.bool(forKey: CloudKitKeySync.enabledKey))
+    }
+
+    func testProductionFetchBridge_CompletesNormally() async throws {
+        let fetchOperation = FakeFetchOperation()
+        let harness = makeHarness(fetchOperation: { _, _ in fetchOperation })
+
+        let syncTask = Task { try await harness.sync.syncNow() }
+        try await eventually { fetchOperation.runCount == 1 }
+        fetchOperation.complete(with: .success(()))
+
+        try await syncTask.value
+
+        XCTAssertEqual(fetchOperation.cancelCount, 0)
+        XCTAssertEqual(fetchOperation.runCount, 1)
+    }
+
+    func testAwaitFetchCompletion_CancelledBeforeStart_NeverRunsOperation() async throws {
+        let fetchOperation = FakeFetchOperation()
+        let task = Task {
+            // Enter the bridge only once cancellation is already observed so the
+            // pre-add check is what rejects the fetch.
+            while !Task.isCancelled { await Task.yield() }
+            try await CloudKitKeySync.awaitFetchCompletion(of: fetchOperation)
+        }
+
+        task.cancel()
+
+        do {
+            try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertEqual(fetchOperation.runCount, 0)
+    }
+
     func testSleeperCancellation_ResumesTheMatchingWaiter() async throws {
         let sleeper = TestSleeper()
         let sleepTask = Task { try await sleeper.sleep(123) }
@@ -440,7 +512,10 @@ private extension CloudKitKeySyncTests {
         let key: SymmetricKey
     }
 
-    func makeHarness(accountName: String = "test-account") -> Harness {
+    func makeHarness(
+        accountName: String = "test-account",
+        fetchOperation: ((CloudKitKeySyncDatabase, Data?) -> any KeySyncFetchOperationRunning)? = nil
+    ) -> Harness {
         let suiteName = "CloudKitKeySyncTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
@@ -452,6 +527,10 @@ private extension CloudKitKeySyncTests {
         let secrets = MemorySecretStorage()
         let state = MemorySecretStorage()
         let key = SymmetricKey(data: Data(repeating: 7, count: 32))
+        // When a fetch-operation seam is injected, leave `fetchChanges` nil so the
+        // production continuation bridge (and its cancellation handling) runs.
+        let fetchChanges: ((CloudKitKeySyncDatabase, Data?) async throws -> KeySyncFetchResult)? =
+            fetchOperation == nil ? { _, token in try await cloud.fetch(token: token) } : nil
         let dependencies = CloudKitKeySyncDependencies(
             defaults: defaults,
             notificationCenter: notifications,
@@ -464,7 +543,8 @@ private extension CloudKitKeySyncTests {
             setupInfrastructure: { _ in },
             fetchRecord: { id, _ in cloud.records[id.recordName] },
             saveRecord: { record, _ in try await cloud.save(record) },
-            fetchChanges: { _, token in try await cloud.fetch(token: token) }
+            fetchChanges: fetchChanges,
+            makeFetchOperation: fetchOperation
         )
         let sync = CloudKitKeySync(
             secureStorage: secrets,
@@ -611,6 +691,42 @@ private final class FakeKeySyncCloud {
             )
         }
         return try fetchResults.removeFirst().get()
+    }
+}
+
+private final class FakeFetchOperation: KeySyncFetchOperationRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedCompletion: ((Result<Void, Error>) -> Void)?
+    private var storedRunCount = 0
+    private var storedCancelCount = 0
+    private var storedCompletesOnCancel = false
+
+    var runCount: Int { lock.withLock { storedRunCount } }
+    var cancelCount: Int { lock.withLock { storedCancelCount } }
+    var completesOnCancel: Bool {
+        get { lock.withLock { storedCompletesOnCancel } }
+        set { lock.withLock { storedCompletesOnCancel = newValue } }
+    }
+
+    func run(completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
+        lock.withLock {
+            storedRunCount += 1
+            storedCompletion = completion
+        }
+    }
+
+    func cancel() {
+        let completion: ((Result<Void, Error>) -> Void)? = lock.withLock {
+            storedCancelCount += 1
+            guard storedCompletesOnCancel else { return nil }
+            return storedCompletion
+        }
+        completion?(.failure(CKError(.operationCancelled)))
+    }
+
+    func complete(with result: Result<Void, Error>) {
+        let completion = lock.withLock { storedCompletion }
+        completion?(result)
     }
 }
 

--- a/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
+++ b/Tests/SpeakSyncTests/CloudKitKeySyncTests.swift
@@ -481,6 +481,37 @@ final class CloudKitKeySyncTests: XCTestCase {
         XCTAssertEqual(fetchOperation.runCount, 0)
     }
 
+    func testCompletionGate_FinishedBeforeRegister_ResumesImmediatelyAndReportsNotPending() async {
+        // Models cancellation firing between Task.checkCancellation() and
+        // gate.register: the bridge must not start the operation afterwards.
+        let gate = KeySyncFetchCompletionGate()
+        gate.finish(with: .failure(CancellationError()))
+
+        var stillPending = true
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                stillPending = gate.register(continuation)
+            }
+            XCTFail("Expected CancellationError")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertFalse(stillPending)
+    }
+
+    func testCompletionGate_RegisterBeforeFinish_ReportsPendingAndResumesOnFinish() async throws {
+        let gate = KeySyncFetchCompletionGate()
+
+        var stillPending = false
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            stillPending = gate.register(continuation)
+            gate.finish(with: .success(()))
+        }
+        XCTAssertTrue(stillPending)
+    }
+
     func testSleeperCancellation_ResumesTheMatchingWaiter() async throws {
         let sleeper = TestSleeper()
         let sleepTask = Task { try await sleeper.sleep(123) }


### PR DESCRIPTION
## Defect

`CloudKitKeySync.disable()` and account-change handling cancel the active sync task and then await it. The production `executeFetchOperation` path bridged `CKFetchRecordZoneChangesOperation` through a checked continuation that ignored task cancellation: cancellation neither cancelled the CloudKit operation nor resumed the continuation, so a stalled network request could make disablement or an account switch hang indefinitely while holding the lifecycle lock. The injected test fetch was cancellation-aware, so existing tests never exercised this boundary.

## Fix

- Extracted the continuation bridge into `CloudKitKeySync.awaitFetchCompletion(of:)`, wrapped in `withTaskCancellationHandler`: cancellation cancels the operation and resumes the continuation promptly with `CancellationError`.
- Added `KeySyncFetchCompletionGate`, a lock-guarded one-shot gate, so cancellation and `fetchRecordZoneChangesResultBlock` racing each other resume the continuation exactly once and never leak it (a pending result is held if cancellation fires before the continuation registers).
- Cancellation is checked before the operation starts (`Task.checkCancellation()`) and immediately after registering completion (`Task.isCancelled`), so cancellation in either setup window cannot leave the operation running.
- Introduced a `KeySyncFetchOperationRunning` seam (`run(completion:)` / `cancel()`), with `LiveKeySyncFetchOperation` wrapping the real operation + `CKDatabase`, and a `makeFetchOperation` dependency so tests can inject a fake operation. The sync-generation guard is preserved: a cancelled fetch throws before `applyFetchedChanges`, and late accumulator callbacks only touch the discarded per-fetch accumulator.

## Tests

- `testDisable_PromptlyCancelsStalledProductionFetch` — fake operation never completes and ignores `cancel()`; `disable()` still returns promptly and the operation was cancelled.
- `testFetchCancellation_RacingCompletion_DoesNotDoubleResume` — `cancel()` fires the CloudKit completion while the handler resumes the gate, plus two late completions; no double resume, no crash.
- `testProductionFetchBridge_CompletesNormally` — normal completion path through the bridge succeeds without cancellation.
- `testAwaitFetchCompletion_CancelledBeforeStart_NeverRunsOperation` — pre-start cancellation check rejects the fetch before the operation is ever started.

Full package suite: 1626 tests, 0 failures. SwiftLint strict with baseline: changed files clean.

Fixes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CloudKit key synchronization cancellation behavior.
  - Prevented duplicate completion handling when cancellation and fetch completion occur simultaneously.
  - Ensured stalled or cancelled fetches finish cleanly without hanging or producing inconsistent results.
  - Improved handling when cancellation occurs before a fetch begins.

- **Tests**
  - Added coverage for normal completion, cancellation scenarios, stalled operations, and cancellation/completion race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->