### PR TITLE
fix(mac): purge stale multipart upload temp files

### DIFF
--- a/Sources/SpeakApp/MistralTranscriptionProvider.swift
+++ b/Sources/SpeakApp/MistralTranscriptionProvider.swift
@@ -12,16 +12,16 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
 
   private let baseURL: URL
   private let session: URLSession
-  private let multipartDirectory: URL
+  private let multipartStaging: MultipartUploadStaging
 
   init(
     session: URLSession = .shared,
     baseURL: URL = URL(string: "https://api.mistral.ai/v1")!,
-    multipartDirectory: URL = FileManager.default.temporaryDirectory
+    multipartStaging: MultipartUploadStaging = .shared
   ) {
     self.session = session
     self.baseURL = baseURL
-    self.multipartDirectory = multipartDirectory
+    self.multipartStaging = multipartStaging
   }
 
   func transcribeFile(
@@ -46,12 +46,12 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
     let modelName = modelID(from: model)
     let uploadBodyURL = try Self.makeMultipartUploadBody(
       sourceURL: url,
-      destinationDirectory: multipartDirectory,
+      staging: multipartStaging,
       boundary: boundary,
       model: modelName,
       language: languageCode(from: language)
     )
-    defer { try? FileManager.default.removeItem(at: uploadBodyURL) }
+    defer { self.multipartStaging.removeUploadBodyFile(at: uploadBodyURL) }
 
     let (data, response) = try await session.upload(for: request, fromFile: uploadBodyURL)
     guard let http = response as? HTTPURLResponse else {
@@ -99,22 +99,14 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
 
   nonisolated static func makeMultipartUploadBody(
     sourceURL: URL,
-    destinationDirectory: URL,
+    staging: MultipartUploadStaging,
     boundary: String,
     model: String,
     language: String?
   ) throws -> URL {
-    let destinationURL = destinationDirectory
-      .appendingPathComponent("mistral-upload-\(UUID().uuidString).multipart")
-    try FileManager.default.createDirectory(
-      at: destinationDirectory,
-      withIntermediateDirectories: true
-    )
+    let destinationURL = try staging.createUploadBodyFile(providerID: "mistral")
 
     do {
-      guard FileManager.default.createFile(atPath: destinationURL.path, contents: nil) else {
-        throw CocoaError(.fileWriteUnknown)
-      }
       let output = try FileHandle(forWritingTo: destinationURL)
       defer { try? output.close() }
 
@@ -141,7 +133,7 @@ struct MistralTranscriptionProvider: TranscriptionProvider {
       try output.write(contentsOf: Data("\r\n--\(boundary)--\r\n".utf8))
       return destinationURL
     } catch {
-      try? FileManager.default.removeItem(at: destinationURL)
+      staging.removeUploadBodyFile(at: destinationURL)
       throw error
     }
   }

--- a/Sources/SpeakApp/MultipartUploadStaging.swift
+++ b/Sources/SpeakApp/MultipartUploadStaging.swift
@@ -1,0 +1,139 @@
+import Foundation
+import SpeakCore
+
+/// Owns the on-disk lifecycle of multipart upload body files (issue #706).
+///
+/// Upload bodies contain raw microphone audio, so they are staged in a dedicated
+/// temporary subdirectory with restrictive permissions, and anything left behind
+/// by a crash, force quit or failed removal is purged once it is safely stale.
+/// Bodies claimed by in-flight uploads are tracked in an in-process registry and
+/// are never purged. Removal failures are logged without file contents and are
+/// retried by the next purge pass.
+final class MultipartUploadStaging: @unchecked Sendable {
+  static let shared = MultipartUploadStaging()
+
+  /// Conservative age after which an unclaimed upload body counts as abandoned.
+  /// In-flight bodies are protected by the claim registry regardless of age.
+  static let defaultStalenessThreshold: TimeInterval = 60 * 60
+
+  private let directory: URL
+  private let stalenessThreshold: TimeInterval
+  private let fileManager = FileManager.default
+  private let lock = NSLock()
+  private var claimedPaths: Set<String> = []
+  private let logger = SpeakLogger.logger(category: "MultipartUploadStaging")
+
+  init(
+    directory: URL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("speak-multipart-uploads", isDirectory: true),
+    stalenessThreshold: TimeInterval = MultipartUploadStaging.defaultStalenessThreshold
+  ) {
+    self.directory = directory
+    self.stalenessThreshold = stalenessThreshold
+  }
+
+  /// Creates an empty upload body file and claims it for the current upload so a
+  /// concurrent purge can never remove it. Callers must hand the URL back to
+  /// `removeUploadBodyFile(at:)` once the upload finishes or fails.
+  func createUploadBodyFile(providerID: String) throws -> URL {
+    // Retry removals that previously failed; the directory only ever holds
+    // in-flight bodies, so the scan is cheap.
+    self.purgeStaleUploads()
+
+    try self.fileManager.createDirectory(
+      at: self.directory,
+      withIntermediateDirectories: true,
+      attributes: [.posixPermissions: 0o700]
+    )
+    let url = self.directory
+      .appendingPathComponent("\(providerID)-upload-\(UUID().uuidString).multipart")
+    self.claim(url)
+    let created = self.fileManager.createFile(
+      atPath: url.path,
+      contents: nil,
+      attributes: [.posixPermissions: 0o600]
+    )
+    guard created else {
+      self.releaseClaim(url)
+      throw CocoaError(.fileWriteUnknown, userInfo: [NSFilePathErrorKey: url.path])
+    }
+    return url
+  }
+
+  /// Removes an upload body and releases its claim. A failed removal is logged
+  /// (never the contents) and retried by a later purge pass once stale.
+  func removeUploadBodyFile(at url: URL) {
+    self.releaseClaim(url)
+    do {
+      try self.fileManager.removeItem(at: url)
+    } catch {
+      guard self.fileManager.fileExists(atPath: url.path) else { return }
+      self.logger.error(
+        """
+        Failed to remove multipart upload body \
+        \(url.lastPathComponent, privacy: .public): \
+        \(error.localizedDescription, privacy: .public)
+        """
+      )
+    }
+  }
+
+  /// Deletes abandoned `*-upload-*.multipart` files older than the staleness
+  /// threshold. Bodies claimed by in-flight uploads are never touched.
+  func purgeStaleUploads(now: Date = Date()) {
+    guard let candidates = try? self.fileManager.contentsOfDirectory(
+      at: self.directory,
+      includingPropertiesForKeys: [.contentModificationDateKey],
+      options: [.skipsHiddenFiles]
+    ) else { return }
+
+    let claimed = self.currentClaims()
+    for url in candidates where Self.isUploadBody(url) && !claimed.contains(Self.claimKey(for: url)) {
+      let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+        .contentModificationDate ?? .distantPast
+      guard now.timeIntervalSince(modified) >= self.stalenessThreshold else { continue }
+      do {
+        try self.fileManager.removeItem(at: url)
+        self.logger.info(
+          "Purged stale multipart upload body \(url.lastPathComponent, privacy: .public)"
+        )
+      } catch {
+        self.logger.error(
+          """
+          Failed to purge stale multipart upload body \
+          \(url.lastPathComponent, privacy: .public): \
+          \(error.localizedDescription, privacy: .public)
+          """
+        )
+      }
+    }
+  }
+
+  private static func isUploadBody(_ url: URL) -> Bool {
+    url.pathExtension == "multipart" && url.lastPathComponent.contains("-upload-")
+  }
+
+  /// `contentsOfDirectory(at:)` resolves symlinks (`/var` → `/private/var`), so
+  /// claims are keyed by the fully resolved path.
+  private static func claimKey(for url: URL) -> String {
+    url.resolvingSymlinksInPath().path
+  }
+
+  private func claim(_ url: URL) {
+    self.lock.lock()
+    defer { self.lock.unlock() }
+    self.claimedPaths.insert(Self.claimKey(for: url))
+  }
+
+  private func releaseClaim(_ url: URL) {
+    self.lock.lock()
+    defer { self.lock.unlock() }
+    self.claimedPaths.remove(Self.claimKey(for: url))
+  }
+
+  private func currentClaims() -> Set<String> {
+    self.lock.lock()
+    defer { self.lock.unlock() }
+    return self.claimedPaths
+  }
+}

--- a/Sources/SpeakApp/MultipartUploadStaging.swift
+++ b/Sources/SpeakApp/MultipartUploadStaging.swift
@@ -18,7 +18,7 @@ final class MultipartUploadStaging: @unchecked Sendable {
 
   private let directory: URL
   private let stalenessThreshold: TimeInterval
-  private let fileManager = FileManager.default
+  private let fileManager: FileManager
   private let lock = NSLock()
   private var claimedPaths: Set<String> = []
   private let logger = SpeakLogger.logger(category: "MultipartUploadStaging")
@@ -26,10 +26,12 @@ final class MultipartUploadStaging: @unchecked Sendable {
   init(
     directory: URL = FileManager.default.temporaryDirectory
       .appendingPathComponent("speak-multipart-uploads", isDirectory: true),
-    stalenessThreshold: TimeInterval = MultipartUploadStaging.defaultStalenessThreshold
+    stalenessThreshold: TimeInterval = MultipartUploadStaging.defaultStalenessThreshold,
+    fileManager: FileManager = .default
   ) {
     self.directory = directory
     self.stalenessThreshold = stalenessThreshold
+    self.fileManager = fileManager
   }
 
   /// Creates an empty upload body file and claims it for the current upload so a
@@ -44,6 +46,12 @@ final class MultipartUploadStaging: @unchecked Sendable {
       at: self.directory,
       withIntermediateDirectories: true,
       attributes: [.posixPermissions: 0o700]
+    )
+    // createDirectory applies attributes only when it creates the directory,
+    // so enforce the restrictive mode on a pre-existing directory as well.
+    try self.fileManager.setAttributes(
+      [.posixPermissions: 0o700],
+      ofItemAtPath: self.directory.path
     )
     let url = self.directory
       .appendingPathComponent("\(providerID)-upload-\(UUID().uuidString).multipart")

--- a/Sources/SpeakApp/SonioxTranscriptionProvider.swift
+++ b/Sources/SpeakApp/SonioxTranscriptionProvider.swift
@@ -82,16 +82,19 @@ struct SonioxTranscriptionProvider: TranscriptionProvider {
     private let baseURL = URL(string: "https://api.soniox.com/v1")!
     private let pollingDelay: Duration
     private let maximumPollingAttempts: Int
+    private let multipartStaging: MultipartUploadStaging
     private let logger = SpeakLogger.logger(category: "SonioxTranscriptionProvider")
 
     init(
         session: URLSession = .shared,
         pollingDelay: Duration = .seconds(2),
-        maximumPollingAttempts: Int = 90
+        maximumPollingAttempts: Int = 90,
+        multipartStaging: MultipartUploadStaging = .shared
     ) {
         self.session = session
         self.pollingDelay = pollingDelay
         self.maximumPollingAttempts = maximumPollingAttempts
+        self.multipartStaging = multipartStaging
     }
 
     func transcribeFile(
@@ -169,10 +172,11 @@ struct SonioxTranscriptionProvider: TranscriptionProvider {
 
         let uploadBodyURL = try Self.makeMultipartUploadBody(
             sourceURL: url,
+            staging: self.multipartStaging,
             boundary: boundary,
             mimeType: self.mimeType(for: url)
         )
-        defer { try? FileManager.default.removeItem(at: uploadBodyURL) }
+        defer { self.multipartStaging.removeUploadBodyFile(at: uploadBodyURL) }
 
         let data = try await self.upload(request, fromFile: uploadBodyURL)
         return try JSONDecoder().decode(SonioxFile.self, from: data)
@@ -180,30 +184,36 @@ struct SonioxTranscriptionProvider: TranscriptionProvider {
 
     private nonisolated static func makeMultipartUploadBody(
         sourceURL: URL,
+        staging: MultipartUploadStaging,
         boundary: String,
         mimeType: String
     ) throws -> URL {
-        let destinationURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("soniox-upload-\(UUID().uuidString).multipart")
-        FileManager.default.createFile(atPath: destinationURL.path, contents: nil)
-        let output = try FileHandle(forWritingTo: destinationURL)
-        defer { try? output.close() }
+        let destinationURL = try staging.createUploadBodyFile(providerID: "soniox")
 
-        let header =
-            "--\(boundary)\r\n"
-            + "Content-Disposition: form-data; name=\"file\"; filename=\"\(sourceURL.lastPathComponent)\"\r\n"
-            + "Content-Type: \(mimeType)\r\n\r\n"
-        try output.write(contentsOf: Data(header.utf8))
+        do {
+            let output = try FileHandle(forWritingTo: destinationURL)
+            defer { try? output.close() }
 
-        let input = try FileHandle(forReadingFrom: sourceURL)
-        defer { try? input.close() }
-        while true {
-            let chunk = try input.read(upToCount: 1024 * 1024) ?? Data()
-            guard !chunk.isEmpty else { break }
-            try output.write(contentsOf: chunk)
+            let header =
+                "--\(boundary)\r\n"
+                + "Content-Disposition: form-data; name=\"file\"; "
+                + "filename=\"\(sourceURL.lastPathComponent)\"\r\n"
+                + "Content-Type: \(mimeType)\r\n\r\n"
+            try output.write(contentsOf: Data(header.utf8))
+
+            let input = try FileHandle(forReadingFrom: sourceURL)
+            defer { try? input.close() }
+            while true {
+                let chunk = try input.read(upToCount: 1024 * 1024) ?? Data()
+                guard !chunk.isEmpty else { break }
+                try output.write(contentsOf: chunk)
+            }
+            try output.write(contentsOf: Data("\r\n--\(boundary)--\r\n".utf8))
+            return destinationURL
+        } catch {
+            staging.removeUploadBodyFile(at: destinationURL)
+            throw error
         }
-        try output.write(contentsOf: Data("\r\n--\(boundary)--\r\n".utf8))
-        return destinationURL
     }
 
     private func createTranscription(

--- a/Sources/SpeakApp/SpeakApp.swift
+++ b/Sources/SpeakApp/SpeakApp.swift
@@ -197,6 +197,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.windows.first?.makeKeyAndOrderFront(nil)
         }
         DispatchQueue.global(qos: .utility).async { _ = AVAudioEngine() } // Sentry JUSTSPEAKTOIT-A
+        // Raw-audio multipart bodies abandoned by a crash or force quit (#706).
+        DispatchQueue.global(qos: .utility).async {
+            MultipartUploadStaging.shared.purgeStaleUploads()
+        }
         checkAndOfferDMGCleanup()
     }
 

--- a/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
+++ b/Tests/SpeakAppTests/MistralTranscriptionProviderTests.swift
@@ -71,7 +71,7 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     let directory = try makeTemporaryDirectory()
     let bodyURL = try MistralTranscriptionProvider.makeMultipartUploadBody(
       sourceURL: audioURL,
-      destinationDirectory: directory,
+      staging: MultipartUploadStaging(directory: directory),
       boundary: "TestBoundary",
       model: "voxtral-mini-latest",
       language: "en"
@@ -96,7 +96,7 @@ final class MistralTranscriptionProviderTests: XCTestCase {
     let directory = try makeTemporaryDirectory()
     let bodyURL = try MistralTranscriptionProvider.makeMultipartUploadBody(
       sourceURL: audioURL,
-      destinationDirectory: directory,
+      staging: MultipartUploadStaging(directory: directory),
       boundary: "TestBoundary",
       model: "voxtral-mini-latest",
       language: nil
@@ -292,12 +292,13 @@ final class MistralTranscriptionProviderTests: XCTestCase {
 
 private func makeProvider(
   multipartDirectory: URL = FileManager.default.temporaryDirectory
+    .appendingPathComponent("speak-multipart-uploads", isDirectory: true)
 ) -> MistralTranscriptionProvider {
   let configuration = URLSessionConfiguration.ephemeral
   configuration.protocolClasses = [MistralMockURLProtocol.self]
   return MistralTranscriptionProvider(
     session: URLSession(configuration: configuration),
-    multipartDirectory: multipartDirectory
+    multipartStaging: MultipartUploadStaging(directory: multipartDirectory)
   )
 }
 

--- a/Tests/SpeakAppTests/MultipartUploadStagingTests.swift
+++ b/Tests/SpeakAppTests/MultipartUploadStagingTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+
+final class MultipartUploadStagingTests: XCTestCase {
+  private var directory: URL!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("multipart-staging-tests-\(UUID().uuidString)", isDirectory: true)
+  }
+
+  override func tearDownWithError() throws {
+    if let directory {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o700],
+        ofItemAtPath: directory.path
+      )
+      try? FileManager.default.removeItem(at: directory)
+    }
+    try super.tearDownWithError()
+  }
+
+  func testCreateUploadBodyFile_createsEmptyRestrictedFileInStagingDirectory() throws {
+    let staging = makeStaging()
+
+    let url = try staging.createUploadBodyFile(providerID: "mistral")
+
+    XCTAssertEqual(url.deletingLastPathComponent().path, directory.path)
+    XCTAssertTrue(url.lastPathComponent.hasPrefix("mistral-upload-"))
+    XCTAssertEqual(url.pathExtension, "multipart")
+    XCTAssertEqual(try Data(contentsOf: url), Data())
+
+    let filePermissions = try posixPermissions(atPath: url.path)
+    XCTAssertEqual(filePermissions, 0o600)
+    let directoryPermissions = try posixPermissions(atPath: directory.path)
+    XCTAssertEqual(directoryPermissions, 0o700)
+  }
+
+  func testCreateUploadBodyFile_throwsWhenFileCannotBeCreated() throws {
+    let staging = makeStaging()
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o500],
+      ofItemAtPath: directory.path
+    )
+
+    XCTAssertThrowsError(try staging.createUploadBodyFile(providerID: "mistral")) { error in
+      XCTAssertEqual((error as? CocoaError)?.code, .fileWriteUnknown)
+    }
+  }
+
+  func testPurge_removesStaleUploadBodies() throws {
+    let staging = makeStaging()
+    let stale = try seedFile(named: "mistral-upload-\(UUID().uuidString).multipart", age: 7_200)
+    let staleSoniox = try seedFile(named: "soniox-upload-\(UUID().uuidString).multipart", age: 7_200)
+
+    staging.purgeStaleUploads()
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: staleSoniox.path))
+  }
+
+  func testPurge_keepsFilesYoungerThanTheStalenessThreshold() throws {
+    let staging = makeStaging()
+    let fresh = try seedFile(named: "mistral-upload-\(UUID().uuidString).multipart", age: 60)
+
+    staging.purgeStaleUploads()
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: fresh.path))
+  }
+
+  func testPurge_ignoresFilesThatAreNotUploadBodies() throws {
+    let staging = makeStaging(stalenessThreshold: 0)
+    let unrelated = try seedFile(named: "notes.txt", age: 7_200)
+    let wrongName = try seedFile(named: "recording.multipart", age: 7_200)
+
+    staging.purgeStaleUploads()
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: unrelated.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: wrongName.path))
+  }
+
+  func testPurge_neverRemovesActiveUploadBodies() throws {
+    let staging = makeStaging(stalenessThreshold: 0)
+
+    let active = try staging.createUploadBodyFile(providerID: "soniox")
+    try backdate(active, by: 7_200)
+
+    staging.purgeStaleUploads()
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: active.path))
+  }
+
+  func testRemoveUploadBodyFile_deletesFileAndReleasesClaimForPurge() throws {
+    let staging = makeStaging(stalenessThreshold: 0)
+    let url = try staging.createUploadBodyFile(providerID: "mistral")
+
+    staging.removeUploadBodyFile(at: url)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+
+    // A released path is fair game again: recreate it out-of-band and confirm
+    // the purge now claims it.
+    try Data("stale".utf8).write(to: url)
+    try backdate(url, by: 7_200)
+    staging.purgeStaleUploads()
+    XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+  }
+
+  func testCreateUploadBodyFile_purgesStaleLeftoversFirst() throws {
+    let staging = makeStaging(stalenessThreshold: 0)
+    let stale = try seedFile(named: "mistral-upload-\(UUID().uuidString).multipart", age: 7_200)
+
+    let url = try staging.createUploadBodyFile(providerID: "mistral")
+    defer { staging.removeUploadBodyFile(at: url) }
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+  }
+
+  // MARK: - Helpers
+
+  private func makeStaging(
+    stalenessThreshold: TimeInterval = MultipartUploadStaging.defaultStalenessThreshold
+  ) -> MultipartUploadStaging {
+    MultipartUploadStaging(directory: directory, stalenessThreshold: stalenessThreshold)
+  }
+
+  private func seedFile(named name: String, age: TimeInterval) throws -> URL {
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let url = directory.appendingPathComponent(name)
+    try Data("leftover".utf8).write(to: url)
+    try backdate(url, by: age)
+    return url
+  }
+
+  private func backdate(_ url: URL, by age: TimeInterval) throws {
+    try FileManager.default.setAttributes(
+      [.modificationDate: Date().addingTimeInterval(-age)],
+      ofItemAtPath: url.path
+    )
+  }
+
+  private func posixPermissions(atPath path: String) throws -> Int {
+    let attributes = try FileManager.default.attributesOfItem(atPath: path)
+    return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
+  }
+}

--- a/Tests/SpeakAppTests/MultipartUploadStagingTests.swift
+++ b/Tests/SpeakAppTests/MultipartUploadStagingTests.swift
@@ -40,16 +40,27 @@ final class MultipartUploadStagingTests: XCTestCase {
   }
 
   func testCreateUploadBodyFile_throwsWhenFileCannotBeCreated() throws {
-    let staging = makeStaging()
-    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-    try FileManager.default.setAttributes(
-      [.posixPermissions: 0o500],
-      ofItemAtPath: directory.path
-    )
+    let staging = makeStaging(fileManager: FailingCreateFileManager())
 
     XCTAssertThrowsError(try staging.createUploadBodyFile(providerID: "mistral")) { error in
       XCTAssertEqual((error as? CocoaError)?.code, .fileWriteUnknown)
     }
+  }
+
+  func testCreateUploadBodyFile_repairsLoosePermissionsOnExistingDirectory() throws {
+    // createDirectory applies attributes only on creation, so a staging
+    // directory left behind with loose permissions must be re-restricted.
+    let staging = makeStaging()
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o755],
+      ofItemAtPath: directory.path
+    )
+
+    let url = try staging.createUploadBodyFile(providerID: "mistral")
+    defer { staging.removeUploadBodyFile(at: url) }
+
+    XCTAssertEqual(try posixPermissions(atPath: directory.path), 0o700)
   }
 
   func testPurge_removesStaleUploadBodies() throws {
@@ -124,9 +135,14 @@ final class MultipartUploadStagingTests: XCTestCase {
   // MARK: - Helpers
 
   private func makeStaging(
-    stalenessThreshold: TimeInterval = MultipartUploadStaging.defaultStalenessThreshold
+    stalenessThreshold: TimeInterval = MultipartUploadStaging.defaultStalenessThreshold,
+    fileManager: FileManager = .default
   ) -> MultipartUploadStaging {
-    MultipartUploadStaging(directory: directory, stalenessThreshold: stalenessThreshold)
+    MultipartUploadStaging(
+      directory: directory,
+      stalenessThreshold: stalenessThreshold,
+      fileManager: fileManager
+    )
   }
 
   private func seedFile(named name: String, age: TimeInterval) throws -> URL {
@@ -147,5 +163,17 @@ final class MultipartUploadStagingTests: XCTestCase {
   private func posixPermissions(atPath path: String) throws -> Int {
     let attributes = try FileManager.default.attributesOfItem(atPath: path)
     return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
+  }
+}
+
+/// Models a file-creation failure (e.g. disk full) after directory setup
+/// succeeded, so the surfaced-error seam stays covered deterministically.
+private final class FailingCreateFileManager: FileManager, @unchecked Sendable {
+  override func createFile(
+    atPath path: String,
+    contents data: Data?,
+    attributes attr: [FileAttributeKey: Any]? = nil
+  ) -> Bool {
+    false
   }
 }


### PR DESCRIPTION
## Defect

Mistral and Soniox batch transcription stage a complete raw-audio multipart request body in the shared temp directory and remove it only in a best-effort `defer`. A crash, force quit, power loss or failed removal left that microphone-audio artefact on disk indefinitely — later runs never purged it. Per the triage comment, the Soniox site was weaker still: it ignored the `createFile` return value and had no cleanup on its failure path. (The file-protection / backup-exclusion criteria were dropped in triage as macOS no-ops.)

## Fix

New shared lifecycle owner, `MultipartUploadStaging` (`Sources/SpeakApp/MultipartUploadStaging.swift`), used by both providers:

- Stages upload bodies in a dedicated temp subdirectory (`speak-multipart-uploads`, mode 0700) with 0600 files.
- Purges abandoned `*-upload-*.multipart` bodies older than a conservative 1-hour threshold at app launch and again before each new upload — the latter also retries removals that previously failed.
- Never touches in-flight uploads: bodies are claimed in an in-process registry (keyed by symlink-resolved paths, since `contentsOfDirectory` resolves `/var` → `/private/var`).
- Surfaces `createFile` failure as a thrown `CocoaError` and cleans up the partial body on any write failure (fixes both Soniox defects).
- Logs removal/purge failures privacy-safely (file name only, never contents); failed removals are retried by the next purge pass.

## Tests

- New `MultipartUploadStagingTests` (8 tests): staleness threshold honoured, stale bodies purged, active uploads never purged, foreign files ignored, purge-on-create retry, `createFile` failure surfaced, restrictive permissions, remove-releases-claim.
- `MistralTranscriptionProviderTests` updated to the staging API; existing success/failure temp-file cleanup tests still pass.
- `swift build` clean; full `SpeakAppTests` target: 569 tests, 0 failures. SwiftLint strict against the repo baseline introduces no new violations from these changes.

Fixes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Improved handling of temporary audio upload files with restricted permissions and safer cleanup.
  * Automatically removes stale upload files at app startup while preserving active uploads.
  * Cleans up temporary data after successful or failed uploads.
  * Repairs permissions on existing staging directories to maintain protection.
* **Testing**
  * Added coverage for file permissions, cleanup behavior, failure handling, stale-file removal, and active-upload protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->