### PR TITLE
fix(ios): verify effective App Group availability at runtime

### DIFF
--- a/Sources/SpeakCore/AppGroupAvailability.swift
+++ b/Sources/SpeakCore/AppGroupAvailability.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Central runtime check for the shared App Group capability.
+///
+/// `UserDefaults(suiteName:)` can return a non-nil object even when the signed
+/// product lacks the App Group entitlement; writes then land outside the
+/// intended shared container and never reach the counterpart process. The
+/// effective capability is therefore verified by probing
+/// `FileManager.containerURL(forSecurityApplicationGroupIdentifier:)`, which
+/// reflects the entitlement of the running binary.
+///
+/// Every App Group construction site shares one failure behaviour: log a
+/// fault and construct the store without defaults, so it reports itself
+/// unavailable (`isAvailable == false`, throwing or no-op writes) instead of
+/// silently operating on divergent shared state.
+public enum AppGroupAvailability {
+    /// Returns the shared defaults suite only when the effective App Group
+    /// capability is present at runtime; `nil` (after logging a fault)
+    /// otherwise.
+    ///
+    /// `containerURL` and `makeDefaults` are injectable for deterministic
+    /// tests; production callers use the defaults.
+    public static func verifiedDefaults(
+        groupIdentifier: String = KeyboardHandoffStore.appGroupIdentifier,
+        containerURL: (String) -> URL? = {
+            FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: $0)
+        },
+        makeDefaults: (String) -> UserDefaults? = { UserDefaults(suiteName: $0) }
+    ) -> UserDefaults? {
+        guard containerURL(groupIdentifier) != nil else {
+            SpeakLogger.logger(category: "AppGroupAvailability").fault(
+                """
+                App Group \(groupIdentifier, privacy: .public) has no container; the signed \
+                product is missing the entitlement. Shared state is disabled.
+                """
+            )
+            return nil
+        }
+        guard let defaults = makeDefaults(groupIdentifier) else {
+            SpeakLogger.logger(category: "AppGroupAvailability").fault(
+                """
+                App Group \(groupIdentifier, privacy: .public) defaults suite could not be \
+                created. Shared state is disabled.
+                """
+            )
+            return nil
+        }
+        return defaults
+    }
+}

--- a/Sources/SpeakCore/KeyboardDictationPreferences.swift
+++ b/Sources/SpeakCore/KeyboardDictationPreferences.swift
@@ -111,13 +111,17 @@ public final class KeyboardDictationPreferencesStore {
     private let lock = NSLock()
 
     public convenience init() {
-        self.init(defaults: UserDefaults(suiteName: KeyboardHandoffStore.appGroupIdentifier))
+        self.init(defaults: AppGroupAvailability.verifiedDefaults())
     }
 
     /// Injectable for deterministic tests. Passing `nil` models a missing or
     /// inaccessible App Group.
     public init(defaults: UserDefaults?) {
         self.defaults = defaults
+    }
+
+    public var isAvailable: Bool {
+        defaults != nil
     }
 
     // MARK: - Dictation profile

--- a/Sources/SpeakCore/KeyboardHandoff.swift
+++ b/Sources/SpeakCore/KeyboardHandoff.swift
@@ -23,7 +23,7 @@ public final class KeyboardHandoffStore: @unchecked Sendable {
     private let lock = NSLock()
 
     public convenience init() {
-        self.init(defaults: UserDefaults(suiteName: Self.appGroupIdentifier))
+        self.init(defaults: AppGroupAvailability.verifiedDefaults())
     }
 
     /// Injectable for deterministic tests. Passing `nil` models a missing or

--- a/Sources/SpeakCore/KeyboardInstantDictation.swift
+++ b/Sources/SpeakCore/KeyboardInstantDictation.swift
@@ -55,11 +55,17 @@ public final class KeyboardInstantDictationStore: @unchecked Sendable {
     private let lock = NSLock()
 
     public convenience init() {
-        self.init(defaults: UserDefaults(suiteName: KeyboardHandoffStore.appGroupIdentifier))
+        self.init(defaults: AppGroupAvailability.verifiedDefaults())
     }
 
+    /// Injectable for deterministic tests. Passing `nil` models a missing or
+    /// inaccessible App Group.
     public init(defaults: UserDefaults?) {
         self.defaults = defaults
+    }
+
+    public var isAvailable: Bool {
+        defaults != nil
     }
 
     public var isEnabled: Bool {

--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -2,7 +2,6 @@
 import AppIntents
 import SpeakCore
 import UIKit
-import os.log
 
 // App Intent declarations intentionally stay together so Shortcuts metadata and
 // foreground-continuation behavior remain auditable in one place.
@@ -377,14 +376,10 @@ public final class SharedTranscriptionState {
     private let defaults: UserDefaults?
 
     private init() {
-        defaults = UserDefaults(suiteName: Self.appGroupIdentifier)
-        #if DEBUG
-        if defaults == nil {
-            SpeakLogger.logger(category: "SharedTranscriptionState")
-                .fault("App Group \(Self.appGroupIdentifier) unavailable; shared state is disabled.")
-            assertionFailure("App Group \(Self.appGroupIdentifier) unavailable; check entitlements.")
-        }
-        #endif
+        // Verified centrally so a missing effective entitlement fails the same
+        // way here as in every other App Group store: a logged fault and an
+        // unavailable, no-op store.
+        defaults = AppGroupAvailability.verifiedDefaults()
         #if DEBUG && targetEnvironment(simulator)
         if let value = ProcessInfo.processInfo.environment["JUSTSPEAKTOIT_SIMULATOR_TRANSCRIPT"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -405,6 +400,10 @@ public final class SharedTranscriptionState {
         return trimmedValue?.isEmpty == false ? trimmedValue : nil
     }
     #endif
+
+    public var isAvailable: Bool {
+        defaults != nil
+    }
 
     /// The full transcript currently shared with extensions and App Intents.
     public var currentTranscriptText: String { defaults?.string(forKey: "currentTranscriptText") ?? "" }

--- a/Tests/SpeakCoreTests/AppGroupAvailabilityTests.swift
+++ b/Tests/SpeakCoreTests/AppGroupAvailabilityTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+@testable import SpeakCore
+
+final class AppGroupAvailabilityTests: XCTestCase {
+    private var suiteName: String!
+    private var suiteDefaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "AppGroupAvailabilityTests.\(UUID().uuidString)"
+        suiteDefaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        suiteDefaults.removePersistentDomain(forName: suiteName)
+        suiteDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    /// A mis-signed product can construct a suite `UserDefaults` while the
+    /// container probe fails; availability must follow the container.
+    func testReportsUnavailableWithoutContainerEvenWhenSuiteDefaultsExist() {
+        let defaults = AppGroupAvailability.verifiedDefaults(
+            groupIdentifier: suiteName,
+            containerURL: { _ in nil },
+            makeDefaults: { _ in self.suiteDefaults }
+        )
+
+        XCTAssertNil(defaults)
+    }
+
+    func testReturnsSuiteDefaultsWhenContainerExists() {
+        var probedIdentifier: String?
+
+        let defaults = AppGroupAvailability.verifiedDefaults(
+            groupIdentifier: suiteName,
+            containerURL: { identifier in
+                probedIdentifier = identifier
+                return FileManager.default.temporaryDirectory
+            },
+            makeDefaults: { _ in self.suiteDefaults }
+        )
+
+        XCTAssertEqual(probedIdentifier, suiteName)
+        XCTAssertTrue(defaults === suiteDefaults)
+    }
+
+    func testReportsUnavailableWhenSuiteCannotBeCreated() {
+        let defaults = AppGroupAvailability.verifiedDefaults(
+            groupIdentifier: suiteName,
+            containerURL: { _ in FileManager.default.temporaryDirectory },
+            makeDefaults: { _ in nil }
+        )
+
+        XCTAssertNil(defaults)
+    }
+
+    func testProbesTheSharedAppGroupIdentifierByDefault() {
+        var probedIdentifier: String?
+
+        _ = AppGroupAvailability.verifiedDefaults(
+            containerURL: { identifier in
+                probedIdentifier = identifier
+                return nil
+            },
+            makeDefaults: { _ in self.suiteDefaults }
+        )
+
+        XCTAssertEqual(probedIdentifier, KeyboardHandoffStore.appGroupIdentifier)
+    }
+
+    /// The one consistent failure behaviour: every App Group store built
+    /// without verified defaults reports itself unavailable.
+    func testStoresBuiltWithoutVerifiedDefaultsReportUnavailable() {
+        XCTAssertFalse(KeyboardHandoffStore(defaults: nil).isAvailable)
+        XCTAssertFalse(KeyboardInstantDictationStore(defaults: nil).isAvailable)
+        XCTAssertFalse(KeyboardDictationPreferencesStore(defaults: nil).isAvailable)
+    }
+}


### PR DESCRIPTION
## Defect

`UserDefaults(suiteName:)` can return a non-nil object even when the signed product lacks the App Group entitlement, so a mis-signed app or extension passed the availability checks while writes landed outside the shared container, invisible to the counterpart process. On top of that, the four App Group construction sites had three different failure behaviours: the keyboard blocked, `SharedTranscriptionState` asserted in DEBUG, and the preference stores silently no-opped.

Per the triage comment, the release-CI signing criterion is out of scope (already implemented in `release-ios.yml`).

## Fix

- New central helper `AppGroupAvailability.verifiedDefaults()` (Sources/SpeakCore/AppGroupAvailability.swift) probes `FileManager.containerURL(forSecurityApplicationGroupIdentifier:)` — which reflects the entitlement of the running binary — before creating the suite defaults, and logs an actionable fault when the capability is missing.
- All four construction sites now share one failure behaviour — a logged fault plus a store that reports `isAvailable == false` and degrades to throwing/no-op writes:
  - `KeyboardHandoffStore` (keyboard blocking still flows from `isAvailable` via `KeyboardLaunchPolicy`)
  - `KeyboardInstantDictationStore` (gains `isAvailable`)
  - `KeyboardDictationPreferencesStore` (gains `isAvailable`)
  - `SharedTranscriptionState` (DEBUG-only `assertionFailure` replaced by the shared behaviour; gains `isAvailable`)

## Tests

- `Tests/SpeakCoreTests/AppGroupAvailabilityTests.swift` with an injectable container probe and suite factory:
  - reports unavailable when the container probe fails even though `UserDefaults(suiteName:)` is non-nil (the acceptance criterion)
  - returns the suite defaults when the container exists; probes the shared group identifier by default
  - reports unavailable when the suite cannot be created
  - all stores built without verified defaults report `isAvailable == false`
- `swift build` and full `swift test`: 1627 tests, 0 failures (11 pre-existing skips).
- SwiftLint strict with repo baseline: no violations in changed files (the baseline is path-keyed, so running from a worktree resurfaces pre-existing entries in untouched files only; CI runs from the repo root).
- iOS-only path verified: `tuist generate` + `xcodebuild -scheme SpeakiOS -destination 'generic/platform=iOS'` succeeds.

Fixes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when accessing shared app data by verifying App Group availability before use.
  - Prevented failures when the shared container or preferences store is unavailable.

- **New Features**
  - Added availability indicators for keyboard dictation and transcription sharing.
  - Shared preferences now safely report when they cannot be accessed.

- **Tests**
  - Added coverage for available, unavailable, and failed shared storage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->