### PR TITLE
fix(mac): refresh Speech Insights when history records change

### DIFF
--- a/Sources/SpeakApp/DashboardView.swift
+++ b/Sources/SpeakApp/DashboardView.swift
@@ -635,7 +635,10 @@ struct DashboardView: View {
 
   private var speechInsightsSection: some View {
     SpeechInsightsSection(model: speechInsights)
-      .task(id: history.statistics) {
+      // Keyed on the history content revision, not `statistics`: statistics
+      // ignore transcript text, so an in-place edit (CloudKit merge, local
+      // reprocess) would otherwise leave the insights stale.
+      .task(id: history.contentRevision) {
         speechInsights.refresh(using: history.allItems)
       }
   }

--- a/Sources/SpeakApp/HistoryManager.swift
+++ b/Sources/SpeakApp/HistoryManager.swift
@@ -55,6 +55,14 @@ final class HistoryManager: ObservableObject {
   @Published private(set) var hasMoreItems: Bool = false
   @Published private(set) var isLoadingMore: Bool = false
 
+  /// Monotonic revision bumped on every mutation of history content (load,
+  /// append, update, remove, clear-all — including CloudKit-driven merges,
+  /// which land through the same mutators). Derived views that depend on
+  /// record *content* (e.g. Speech Insights) should key their refresh on this
+  /// rather than `statistics`, which ignores transcript text and so misses
+  /// in-place edits that leave count/duration/cost unchanged.
+  @Published private(set) var contentRevision: UInt64 = 0
+
   let pageSize: Int
 
   /// Full list of items loaded from disk (for pagination)
@@ -296,6 +304,7 @@ final class HistoryManager: ObservableObject {
       hasMoreItems = sorted.count > pageSize
       cachedStatistics = stats
       statistics = stats
+      contentRevision &+= 1
     } catch {
       log.error("Failed to load history: \(error.localizedDescription, privacy: .public)")
     }
@@ -331,6 +340,7 @@ final class HistoryManager: ObservableObject {
     items = current
 
     updateStatisticsForAppend(item)
+    contentRevision &+= 1
 
     // Write to WAL instead of directly to disk
     await appendToWAL(WALEntry(operation: .append, item: item))
@@ -358,6 +368,7 @@ final class HistoryManager: ObservableObject {
       cachedStatistics = stats
       statistics = stats
     }
+    contentRevision &+= 1
 
     // Write to WAL instead of directly to disk
     await appendToWAL(WALEntry(operation: .update, item: item))
@@ -373,6 +384,7 @@ final class HistoryManager: ObservableObject {
     if let diskItem {
       updateStatisticsForRemove(diskItem)
     }
+    contentRevision &+= 1
 
     // Write to WAL instead of directly to disk
     if let diskItem {
@@ -387,6 +399,7 @@ final class HistoryManager: ObservableObject {
     let stats = Self.calculateStatistics(for: [])
     cachedStatistics = stats
     statistics = stats
+    contentRevision &+= 1
 
     // Write to WAL instead of directly to disk
     await appendToWAL(WALEntry(operation: .removeAll))

--- a/Sources/SpeakApp/SpeechInsightsDashboard.swift
+++ b/Sources/SpeakApp/SpeechInsightsDashboard.swift
@@ -45,6 +45,11 @@ final class SpeechInsightsModel: ObservableObject {
     }
   }
 
+  /// Awaits the most recently scheduled refresh (used by tests).
+  func waitForPendingRefresh() async {
+    await refreshTask?.value
+  }
+
   private func performRefresh(records: [SpeechSessionRecord]) async {
     if summary == nil {
       isComputing = true

--- a/Sources/SpeakCore/SpeechInsights/SpeechInsightsAggregate.swift
+++ b/Sources/SpeakCore/SpeechInsights/SpeechInsightsAggregate.swift
@@ -15,7 +15,10 @@ import Foundation
 public struct SpeechInsightsAggregate: Codable, Sendable, Equatable {
     /// Bump when the stored shape changes; loaders discard mismatched data
     /// and recompute from history.
-    public static let currentSchemaVersion = 1
+    ///
+    /// v2: added `sessionFingerprints` so reconciliation detects in-place
+    /// edits to already-processed sessions.
+    public static let currentSchemaVersion = 2
 
     /// Compact per-session stats retained for time-based metrics (WPM
     /// distribution, filler trend, longest session). Kept sorted by
@@ -51,6 +54,10 @@ public struct SpeechInsightsAggregate: Codable, Sendable, Equatable {
     public var schemaVersion: Int
     /// IDs of every session folded into this aggregate.
     public var processedSessionIDs: Set<UUID>
+    /// Content fingerprint of every processed session, keyed by session ID.
+    /// Lets reconciliation notice when a record was edited in place (text,
+    /// date or duration changed under an existing UUID) and rebuild.
+    public var sessionFingerprints: [UUID: UInt64]
     /// Total spoken words (all surface tokens, fillers included).
     public var totalWordCount: Int
     /// Total filler-phrase occurrences.
@@ -74,6 +81,7 @@ public struct SpeechInsightsAggregate: Codable, Sendable, Equatable {
     public init() {
         schemaVersion = Self.currentSchemaVersion
         processedSessionIDs = []
+        sessionFingerprints = [:]
         totalWordCount = 0
         totalFillerCount = 0
         fillerCounts = [:]

--- a/Sources/SpeakCore/SpeechInsights/SpeechInsightsEngine.swift
+++ b/Sources/SpeakCore/SpeechInsights/SpeechInsightsEngine.swift
@@ -55,16 +55,17 @@ public enum SpeechInsightsEngine {
         configuration: SpeechInsightsConfiguration
     ) {
         aggregate.processedSessionIDs.insert(record.id)
+        aggregate.sessionFingerprints[record.id] = record.contentFingerprint
 
         let tokenized = SpeechTokenizer.tokenize(record.text)
         let surfaces = tokenized.surfaceTokens
 
-        let fillers = SpeechTokenizer.countFillers(
+        let fillers = SpeechTokenizer.matchFillers(
             in: surfaces,
             phrases: configuration.fillerTokenSequences
         )
-        let sessionFillerCount = fillers.values.reduce(0, +)
-        for (phrase, count) in fillers {
+        let sessionFillerCount = fillers.counts.values.reduce(0, +)
+        for (phrase, count) in fillers.counts {
             aggregate.fillerCounts[phrase, default: 0] += count
         }
         aggregate.totalFillerCount += sessionFillerCount
@@ -72,6 +73,7 @@ public enum SpeechInsightsEngine {
 
         let contentWords = contentWords(
             in: tokenized,
+            excludingIndices: fillers.consumedTokenIndices,
             stopwords: configuration.stopwords,
             singleWordFillers: configuration.singleWordFillers
         )
@@ -112,8 +114,10 @@ public enum SpeechInsightsEngine {
     ///
     /// - New sessions are folded in incrementally.
     /// - If any processed session no longer exists in `records` (deletion or
-    ///   retention), or the schema version changed, the aggregate is rebuilt
-    ///   from `records` so removed transcripts stop contributing.
+    ///   retention), was edited in place (content fingerprint changed under an
+    ///   existing UUID — CloudKit merge, local reprocessing), or the schema
+    ///   version changed, the aggregate is rebuilt from `records` so obsolete
+    ///   contributions stop counting.
     public static func reconcile(
         _ aggregate: SpeechInsightsAggregate,
         with records: [SpeechSessionRecord],
@@ -122,9 +126,17 @@ public enum SpeechInsightsEngine {
         guard aggregate.schemaVersion == SpeechInsightsAggregate.currentSchemaVersion else {
             return computeAggregate(from: records, configuration: configuration)
         }
-        let currentIDs = Set(records.map(\.id))
-        guard aggregate.processedSessionIDs.isSubset(of: currentIDs) else {
-            return computeAggregate(from: records, configuration: configuration)
+        let recordsByID = Dictionary(
+            records.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for id in aggregate.processedSessionIDs {
+            guard let record = recordsByID[id],
+                  aggregate.sessionFingerprints[id] == record.contentFingerprint
+            else {
+                // Deleted or edited in place: rebuild from what remains.
+                return computeAggregate(from: records, configuration: configuration)
+            }
         }
         let newRecords = records.filter { !aggregate.processedSessionIDs.contains($0.id) }
         guard !newRecords.isEmpty else { return aggregate }
@@ -133,17 +145,20 @@ public enum SpeechInsightsEngine {
         return updated
     }
 
-    /// Lemmatized content words for one session: filler and stopword tokens
-    /// removed (checking both surface and lemma), single characters and
-    /// digit-only tokens dropped.
+    /// Lemmatized content words for one session: tokens consumed by a matched
+    /// filler phrase (single- or multi-word) excluded, filler and stopword
+    /// tokens removed (checking both surface and lemma), single characters
+    /// and digit-only tokens dropped.
     private static func contentWords(
         in tokenized: SpeechTokenizer.TokenizedText,
+        excludingIndices excluded: Set<Int>,
         stopwords: Set<String>,
         singleWordFillers: Set<String>
     ) -> [String] {
         var words: [String] = []
         words.reserveCapacity(tokenized.lemmas.count)
-        for (surface, lemma) in zip(tokenized.surfaceTokens, tokenized.lemmas) {
+        for (index, (surface, lemma)) in zip(tokenized.surfaceTokens, tokenized.lemmas).enumerated() {
+            if excluded.contains(index) { continue }
             if stopwords.contains(surface) || stopwords.contains(lemma) { continue }
             if singleWordFillers.contains(surface) || singleWordFillers.contains(lemma) { continue }
             if lemma.count < 2 { continue }

--- a/Sources/SpeakCore/SpeechInsights/SpeechSessionRecord.swift
+++ b/Sources/SpeakCore/SpeechInsights/SpeechSessionRecord.swift
@@ -20,6 +20,31 @@ public struct SpeechSessionRecord: Identifiable, Hashable, Sendable {
     /// Transcription model identifier, when known.
     public let modelIdentifier: String?
 
+    /// Stable fingerprint over every aggregation input (`text`, `startedAt`,
+    /// `duration`). Persisted per session in the aggregate so reconciliation
+    /// can detect in-place edits (CloudKit merges, local reprocessing) to a
+    /// record whose UUID was already processed.
+    ///
+    /// Deterministic across launches and devices (FNV-1a, unlike `Hasher`
+    /// which is seeded per process). Extend the folded fields whenever a new
+    /// dimension starts to influence aggregation.
+    public var contentFingerprint: UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325 // FNV-1a offset basis
+        let prime: UInt64 = 0x100_0000_01b3
+        func fold(_ byte: UInt8) {
+            hash = (hash ^ UInt64(byte)) &* prime
+        }
+        for byte in text.utf8 { fold(byte) }
+        fold(0) // field separator
+        withUnsafeBytes(of: startedAt.timeIntervalSince1970.bitPattern.littleEndian) {
+            for byte in $0 { fold(byte) }
+        }
+        withUnsafeBytes(of: duration.bitPattern.littleEndian) {
+            for byte in $0 { fold(byte) }
+        }
+        return hash
+    }
+
     public init(
         id: UUID,
         startedAt: Date,

--- a/Sources/SpeakCore/SpeechInsights/SpeechTokenizer.swift
+++ b/Sources/SpeakCore/SpeechInsights/SpeechTokenizer.swift
@@ -72,7 +72,13 @@ public enum SpeechTokenizer {
         in surfaceTokens: [String],
         phrases: [[String]]
     ) -> FillerMatches {
-        guard !phrases.isEmpty, !surfaceTokens.isEmpty else {
+        // Enforce the documented contract locally: an empty phrase would match
+        // every index without advancing (an infinite loop), and an unsorted
+        // array would let a shorter phrase pre-empt a longer overlapping one.
+        let normalizedPhrases = phrases
+            .filter { !$0.isEmpty }
+            .sorted { $0.count > $1.count }
+        guard !normalizedPhrases.isEmpty, !surfaceTokens.isEmpty else {
             return FillerMatches(counts: [:], consumedTokenIndices: [])
         }
         var counts: [String: Int] = [:]
@@ -80,7 +86,7 @@ public enum SpeechTokenizer {
         var index = 0
         while index < surfaceTokens.count {
             var matched = false
-            for phrase in phrases where phrase.count <= surfaceTokens.count - index {
+            for phrase in normalizedPhrases where phrase.count <= surfaceTokens.count - index {
                 var isMatch = true
                 for (offset, word) in phrase.enumerated()
                 where surfaceTokens[index + offset] != word {

--- a/Sources/SpeakCore/SpeechInsights/SpeechTokenizer.swift
+++ b/Sources/SpeakCore/SpeechInsights/SpeechTokenizer.swift
@@ -47,17 +47,36 @@ public enum SpeechTokenizer {
         return TokenizedText(surfaceTokens: surfaces, lemmas: lemmas)
     }
 
-    /// Counts filler phrases over a surface-token stream.
+    /// Result of matching filler phrases over a surface-token stream: the
+    /// per-phrase counts plus every token index a match consumed, so callers
+    /// can exclude all words of a multi-word filler ("sort of", "you know")
+    /// from content-word statistics, not just single-word fillers.
+    public struct FillerMatches: Sendable, Equatable {
+        public let counts: [String: Int]
+        /// Indices into the matched token array consumed by a filler phrase.
+        public let consumedTokenIndices: Set<Int>
+
+        public init(counts: [String: Int], consumedTokenIndices: Set<Int>) {
+            self.counts = counts
+            self.consumedTokenIndices = consumedTokenIndices
+        }
+    }
+
+    /// Matches filler phrases over a surface-token stream, returning both the
+    /// per-phrase counts and the consumed token indices.
     ///
     /// Matching is greedy and non-overlapping: phrases are tried longest first
     /// and a match consumes its tokens, so "sort of" never also counts "of",
     /// and "you know" wins over any single-word "you" filler entry.
-    public static func countFillers(
+    public static func matchFillers(
         in surfaceTokens: [String],
         phrases: [[String]]
-    ) -> [String: Int] {
-        guard !phrases.isEmpty, !surfaceTokens.isEmpty else { return [:] }
+    ) -> FillerMatches {
+        guard !phrases.isEmpty, !surfaceTokens.isEmpty else {
+            return FillerMatches(counts: [:], consumedTokenIndices: [])
+        }
         var counts: [String: Int] = [:]
+        var consumed: Set<Int> = []
         var index = 0
         while index < surfaceTokens.count {
             var matched = false
@@ -70,6 +89,9 @@ public enum SpeechTokenizer {
                 }
                 if isMatch {
                     counts[phrase.joined(separator: " "), default: 0] += 1
+                    for offset in 0..<phrase.count {
+                        consumed.insert(index + offset)
+                    }
                     index += phrase.count
                     matched = true
                     break
@@ -79,7 +101,16 @@ public enum SpeechTokenizer {
                 index += 1
             }
         }
-        return counts
+        return FillerMatches(counts: counts, consumedTokenIndices: consumed)
+    }
+
+    /// Counts filler phrases over a surface-token stream. Convenience wrapper
+    /// over `matchFillers(in:phrases:)` for callers that only need counts.
+    public static func countFillers(
+        in surfaceTokens: [String],
+        phrases: [[String]]
+    ) -> [String: Int] {
+        matchFillers(in: surfaceTokens, phrases: phrases).counts
     }
 
     /// Builds n-gram counts (space-joined) over a token stream.

--- a/Tests/SpeakAppTests/HistoryManagerTests.swift
+++ b/Tests/SpeakAppTests/HistoryManagerTests.swift
@@ -26,6 +26,7 @@ private final class TemporaryApplicationSupportFileManager: FileManager {
 }
 
 @MainActor
+// swiftlint:disable:next type_body_length
 final class HistoryManagerTests: XCTestCase {
 
     private var tempDir: URL!
@@ -290,6 +291,53 @@ final class HistoryManagerTests: XCTestCase {
         XCTAssertEqual(manager.statistics.totalSpend, 0)
         XCTAssertEqual(manager.statistics.averageSessionLength, 0)
         XCTAssertEqual(manager.statistics.sessionsWithErrors, 0)
+    }
+
+    // MARK: - Content Revision
+
+    func testContentRevision_bumpsOnEveryContentMutation() async throws {
+        let manager = await makeManager()
+        await manager.loadFromDisk()
+        var last = manager.contentRevision
+
+        func assertBumped(_ message: String, file: StaticString = #filePath, line: UInt = #line) {
+            XCTAssertNotEqual(manager.contentRevision, last, message, file: file, line: line)
+            last = manager.contentRevision
+        }
+
+        let item = makeItem(duration: 12)
+        await manager.append(item)
+        assertBumped("append must bump the content revision")
+
+        // An in-place update that leaves every statistics input unchanged
+        // (same duration, cost, errors) must still bump the revision — this is
+        // exactly the case where keying off `statistics` goes stale.
+        let statsBefore = manager.statistics
+        let updated = makeItem(id: item.id, createdAt: item.createdAt, duration: 12)
+        await manager.update(updated)
+        XCTAssertEqual(manager.statistics, statsBefore, "statistics inputs are unchanged")
+        assertBumped("statistics-neutral update must bump the content revision")
+
+        await manager.remove(id: item.id)
+        assertBumped("remove must bump the content revision")
+
+        await manager.append(makeItem(duration: 5))
+        assertBumped("second append must bump the content revision")
+
+        await manager.removeAll()
+        assertBumped("removeAll must bump the content revision")
+
+        await manager.loadFromDisk()
+        assertBumped("reload from disk must bump the content revision")
+    }
+
+    func testContentRevision_unchangedByPaginationOnly() async throws {
+        let manager = await makeManager()
+        await manager.loadFromDisk()
+        await manager.append(makeItem(duration: 3))
+        let before = manager.contentRevision
+        await manager.loadMore()
+        XCTAssertEqual(manager.contentRevision, before)
     }
 
     func testRemoveAll_resetsStatistics() async throws {

--- a/Tests/SpeakAppTests/SpeechInsightsModelTests.swift
+++ b/Tests/SpeakAppTests/SpeechInsightsModelTests.swift
@@ -3,6 +3,27 @@ import XCTest
 import SpeakCore
 @testable import SpeakApp
 
+/// FileManager that redirects Application Support to a temporary directory so
+/// `SpeechInsightsModel` persists its aggregate to an isolated location.
+private final class TemporaryApplicationSupportFileManager: FileManager {
+  let supportURL: URL
+
+  init(supportURL: URL) {
+    self.supportURL = supportURL
+    super.init()
+  }
+
+  override func urls(
+    for directory: FileManager.SearchPathDirectory,
+    in domainMask: FileManager.SearchPathDomainMask
+  ) -> [URL] {
+    guard directory == .applicationSupportDirectory else {
+      return super.urls(for: directory, in: domainMask)
+    }
+    return [supportURL]
+  }
+}
+
 final class SpeechInsightsModelTests: XCTestCase {
   func testSessionRecord_usesRawTranscriptAndMetadata() {
     let created = Date(timeIntervalSince1970: 1_785_888_000)
@@ -45,7 +66,43 @@ final class SpeechInsightsModelTests: XCTestCase {
     XCTAssertEqual(SpeechInsightsModel.sessionRecord(from: item)?.duration, 90)
   }
 
+  // MARK: - Refresh invalidation
+
+  /// Acceptance for #682: replacing only the raw transcript of an existing
+  /// UUID must update the visible summary and the persisted aggregate, and a
+  /// relaunch from disk must agree with the in-memory result.
+  @MainActor
+  func testRefresh_transcriptEditUnderExistingIDUpdatesSummaryAndPersistedAggregate() async throws {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let fileManager = TemporaryApplicationSupportFileManager(supportURL: tempDir)
+
+    let model = SpeechInsightsModel(fileManager: fileManager)
+    let original = makeHistoryItem(raw: "alpha alpha alpha", processed: nil, duration: 30)
+    model.refresh(using: [original])
+    await model.waitForPendingRefresh()
+    XCTAssertEqual(model.summary?.topWords.map(\.term), ["alpha"])
+
+    // Same UUID and metadata, new transcript (CloudKit merge / reprocess).
+    let edited = makeHistoryItem(
+      id: original.id, raw: "bravo bravo", processed: nil, duration: 30
+    )
+    model.refresh(using: [edited])
+    await model.waitForPendingRefresh()
+    XCTAssertEqual(model.summary?.topWords.map(\.term), ["bravo"],
+                   "stale transcript contribution must be replaced")
+
+    // Relaunch: a fresh model loading the persisted aggregate must agree.
+    let relaunched = SpeechInsightsModel(fileManager: fileManager)
+    relaunched.refresh(using: [edited])
+    await relaunched.waitForPendingRefresh()
+    XCTAssertEqual(relaunched.summary, model.summary)
+  }
+
   private func makeHistoryItem(
+    id: UUID = UUID(),
     raw: String?,
     processed: String?,
     duration: TimeInterval,
@@ -54,6 +111,7 @@ final class SpeechInsightsModelTests: XCTestCase {
     recordingEnded: Date? = nil
   ) -> HistoryItem {
     HistoryItem(
+      id: id,
       createdAt: createdAt,
       modelsUsed: ["deepgram/nova-3"],
       modelUsages: [

--- a/Tests/SpeakCoreTests/SpeechInsightsEngineTests.swift
+++ b/Tests/SpeakCoreTests/SpeechInsightsEngineTests.swift
@@ -93,6 +93,52 @@ final class SpeechInsightsEngineTests: XCTestCase {
         XCTAssertNotNil(aggregate.wordCounts["roadmap"])
     }
 
+    func testMultiWordFillers_allConsumedWordsExcludedFromContentAggregates() {
+        // "sort of" / "kind of" count as fillers, and neither "sort" nor
+        // "kind" may leak into top words, weekly/monthly trends or first-seen.
+        let aggregate = SpeechInsightsEngine.computeAggregate(
+            from: [record("sort of sort of budget kind of roadmap", on: now)]
+        )
+        XCTAssertEqual(aggregate.fillerCounts["sort of"], 2)
+        XCTAssertEqual(aggregate.fillerCounts["kind of"], 1)
+        XCTAssertNil(aggregate.wordCounts["sort"])
+        XCTAssertNil(aggregate.wordCounts["kind"])
+        XCTAssertEqual(aggregate.wordCounts["budget"], 1)
+        XCTAssertEqual(aggregate.wordCounts["roadmap"], 1)
+
+        let weekKey = SpeechInsightsAggregate.weekKey(for: now)
+        let monthKey = SpeechInsightsAggregate.monthKey(for: now)
+        XCTAssertNil(aggregate.weeklyWordCounts[weekKey]?["sort"])
+        XCTAssertNil(aggregate.weeklyWordCounts[weekKey]?["kind"])
+        XCTAssertNil(aggregate.monthlyWordCounts[monthKey]?["sort"])
+        XCTAssertNil(aggregate.monthlyWordCounts[monthKey]?["kind"])
+        XCTAssertNil(aggregate.firstSeenByWord["sort"])
+        XCTAssertNil(aggregate.firstSeenByWord["kind"])
+        XCTAssertNotNil(aggregate.firstSeenByWord["budget"])
+    }
+
+    func testMultiWordFillerWords_stillCountWhenUsedOutsideFillerPhrase() {
+        // "sort" and "kind" outside a matched filler span remain real content.
+        let aggregate = SpeechInsightsEngine.computeAggregate(
+            from: [record("please sort every box by kind", on: now)]
+        )
+        XCTAssertTrue(aggregate.fillerCounts.isEmpty)
+        XCTAssertEqual(aggregate.wordCounts["sort"], 1)
+        XCTAssertEqual(aggregate.wordCounts["kind"], 1)
+    }
+
+    func testMultiWordFillers_retainedInPhraseReporting() {
+        // Excluding filler words from content stats must not hide the full
+        // phrase from filler and n-gram reporting.
+        let aggregate = SpeechInsightsEngine.computeAggregate(
+            from: [record("you know the plan sort of works", on: now)]
+        )
+        XCTAssertEqual(aggregate.fillerCounts["you know"], 1)
+        XCTAssertEqual(aggregate.fillerCounts["sort of"], 1)
+        XCTAssertEqual(aggregate.bigramCounts["you know"], 1)
+        XCTAssertEqual(aggregate.bigramCounts["sort of"], 1)
+    }
+
     func testLemmatization_foldsInflectionsIntoOneCount() {
         let aggregate = SpeechInsightsEngine.computeAggregate(
             from: [record("The cats and the cat were sleeping.", on: now)]
@@ -464,12 +510,137 @@ final class SpeechInsightsEngineTests: XCTestCase {
         XCTAssertTrue(reconciled.isEmpty)
     }
 
+    func testReconcile_rebuildsWhenTranscriptChangesUnderExistingID() {
+        // A CloudKit merge or local reprocess replaces only the text: same
+        // UUID, date and duration, so counts-based statistics never move.
+        let stableID = UUID()
+        let original = record("alpha alpha alpha", on: now, id: stableID)
+        let aggregate = SpeechInsightsEngine.computeAggregate(from: [original])
+
+        let edited = record("beta beta", on: now, id: stableID)
+        let reconciled = SpeechInsightsEngine.reconcile(aggregate, with: [edited])
+
+        XCTAssertEqual(reconciled, SpeechInsightsEngine.computeAggregate(from: [edited]))
+        XCTAssertNil(reconciled.wordCounts["alpha"])
+        XCTAssertEqual(reconciled.wordCounts["beta"], 2)
+    }
+
+    func testReconcile_rebuildsWhenStartDateChangesUnderExistingID() {
+        let stableID = UUID()
+        let original = record("alpha", on: date(2026, 7, 20), id: stableID)
+        let aggregate = SpeechInsightsEngine.computeAggregate(from: [original])
+
+        let moved = record("alpha", on: date(2026, 8, 4), id: stableID)
+        let reconciled = SpeechInsightsEngine.reconcile(aggregate, with: [moved])
+
+        XCTAssertEqual(reconciled, SpeechInsightsEngine.computeAggregate(from: [moved]))
+        XCTAssertNil(reconciled.weeklyWordCounts["2026-07-20"])
+        XCTAssertEqual(reconciled.weeklyWordCounts["2026-08-03"]?["alpha"], 1)
+    }
+
+    func testReconcile_rebuildsWhenDurationChangesUnderExistingID() {
+        let stableID = UUID()
+        let original = record(words("alpha", count: 120), on: now, duration: 120, id: stableID)
+        let aggregate = SpeechInsightsEngine.computeAggregate(from: [original])
+
+        let corrected = record(words("alpha", count: 120), on: now, duration: 60, id: stableID)
+        let reconciled = SpeechInsightsEngine.reconcile(aggregate, with: [corrected])
+
+        XCTAssertEqual(reconciled, SpeechInsightsEngine.computeAggregate(from: [corrected]))
+        let summary = SpeechInsightsEngine.summary(for: reconciled, now: now)
+        XCTAssertEqual(summary.pace.averageWPM, 120, accuracy: 0.0001)
+    }
+
+    func testReconcile_unchangedRecordsWithMatchingFingerprintsStayIncremental() {
+        // Same content re-materialised as fresh value instances must not force
+        // a rebuild: fingerprints, not identity, decide.
+        let stableID = UUID()
+        let aggregate = SpeechInsightsEngine.computeAggregate(
+            from: [record("alpha beta", on: now, id: stableID)]
+        )
+        let sameContent = record("alpha beta", on: now, id: stableID)
+        let extra = record("gamma", on: now.addingTimeInterval(60))
+        let reconciled = SpeechInsightsEngine.reconcile(aggregate, with: [sameContent, extra])
+        XCTAssertEqual(
+            reconciled,
+            SpeechInsightsEngine.computeAggregate(from: [sameContent, extra])
+        )
+    }
+
     func testReconcile_recomputesOnSchemaMismatch() {
         let records = sampleRecords()
         var stale = SpeechInsightsEngine.computeAggregate(from: Array(records[0..<2]))
         stale.schemaVersion = 0
         let reconciled = SpeechInsightsEngine.reconcile(stale, with: records)
         XCTAssertEqual(reconciled, SpeechInsightsEngine.computeAggregate(from: records))
+    }
+
+    // MARK: - Content fingerprint
+
+    func testContentFingerprint_isDeterministicAcrossInstances() {
+        let id = UUID()
+        let first = record("alpha beta", on: now, duration: 42, id: id)
+        let second = record("alpha beta", on: now, duration: 42, id: UUID())
+        XCTAssertEqual(first.contentFingerprint, second.contentFingerprint,
+                       "fingerprint covers content only, not identity")
+    }
+
+    func testContentFingerprint_changesWithEachAggregationInput() {
+        let base = record("alpha beta", on: now, duration: 42)
+        XCTAssertNotEqual(
+            base.contentFingerprint,
+            record("alpha gamma", on: now, duration: 42).contentFingerprint
+        )
+        XCTAssertNotEqual(
+            base.contentFingerprint,
+            record("alpha beta", on: now.addingTimeInterval(1), duration: 42).contentFingerprint
+        )
+        XCTAssertNotEqual(
+            base.contentFingerprint,
+            record("alpha beta", on: now, duration: 43).contentFingerprint
+        )
+    }
+
+    func testAggregate_storesFingerprintPerProcessedSession() {
+        let records = sampleRecords()
+        let aggregate = SpeechInsightsEngine.computeAggregate(from: records)
+        XCTAssertEqual(
+            Set(aggregate.sessionFingerprints.keys),
+            aggregate.processedSessionIDs
+        )
+        for record in records {
+            XCTAssertEqual(aggregate.sessionFingerprints[record.id], record.contentFingerprint)
+        }
+    }
+
+    // MARK: - Schema migration
+
+    func testSchemaV1Payload_failsDecodeSoLoadersRecompute() throws {
+        // v1 aggregates have no `sessionFingerprints`; decoding must fail so
+        // persistence loaders fall back to a full recompute from history.
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(SpeechInsightsEngine.computeAggregate(from: sampleRecords()))
+        var json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        json.removeValue(forKey: "sessionFingerprints")
+        json["schemaVersion"] = 1
+        let v1Data = try JSONSerialization.data(withJSONObject: json)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        XCTAssertThrowsError(try decoder.decode(SpeechInsightsAggregate.self, from: v1Data))
+    }
+
+    func testReconcile_recomputesForV1SchemaAggregate() {
+        let records = sampleRecords()
+        var stale = SpeechInsightsEngine.computeAggregate(from: Array(records[0..<2]))
+        stale.schemaVersion = 1
+        stale.sessionFingerprints = [:]
+        let reconciled = SpeechInsightsEngine.reconcile(stale, with: records)
+        XCTAssertEqual(reconciled, SpeechInsightsEngine.computeAggregate(from: records))
+        XCTAssertEqual(reconciled.schemaVersion, SpeechInsightsAggregate.currentSchemaVersion)
     }
 
     // MARK: - Persistence

--- a/Tests/SpeakCoreTests/SpeechTokenizerTests.swift
+++ b/Tests/SpeakCoreTests/SpeechTokenizerTests.swift
@@ -150,6 +150,30 @@ final class SpeechTokenizerTests: XCTestCase {
         )
     }
 
+    func testMatchFillers_ignoresEmptyPhrases() {
+        // An empty phrase must not match (it would otherwise loop forever
+        // without advancing) and must not suppress real phrase matches.
+        let matches = SpeechTokenizer.matchFillers(
+            in: ["um", "hello"],
+            phrases: [[], ["um"]]
+        )
+        XCTAssertEqual(matches.counts, ["um": 1])
+        XCTAssertEqual(matches.consumedTokenIndices, [0])
+
+        let onlyEmpty = SpeechTokenizer.matchFillers(in: ["um"], phrases: [[]])
+        XCTAssertEqual(onlyEmpty, SpeechTokenizer.FillerMatches(counts: [:], consumedTokenIndices: []))
+    }
+
+    func testMatchFillers_sortsUnsortedOverlappingPhrasesLongestFirst() {
+        // Shorter phrase listed first must not pre-empt the longer overlap.
+        let matches = SpeechTokenizer.matchFillers(
+            in: ["you", "know", "what", "happened"],
+            phrases: [["you", "know"], ["you", "know", "what"]]
+        )
+        XCTAssertEqual(matches.counts, ["you know what": 1])
+        XCTAssertEqual(matches.consumedTokenIndices, [0, 1, 2])
+    }
+
     func testCountFillers_matchesMatchFillersCounts() {
         let tokens = ["um", "it", "was", "sort", "of", "fine", "you", "know"]
         XCTAssertEqual(

--- a/Tests/SpeakCoreTests/SpeechTokenizerTests.swift
+++ b/Tests/SpeakCoreTests/SpeechTokenizerTests.swift
@@ -96,6 +96,68 @@ final class SpeechTokenizerTests: XCTestCase {
         XCTAssertEqual(counts["um"], 3)
     }
 
+    // MARK: - Filler matches (consumed token ranges)
+
+    func testMatchFillers_multiWordPhraseConsumesEveryToken() {
+        let tokens = ["it", "was", "sort", "of", "strange", "you", "know"]
+        let matches = SpeechTokenizer.matchFillers(in: tokens, phrases: defaultFillers)
+        XCTAssertEqual(matches.counts["sort of"], 1)
+        XCTAssertEqual(matches.counts["you know"], 1)
+        XCTAssertEqual(matches.consumedTokenIndices, [2, 3, 5, 6])
+    }
+
+    func testMatchFillers_singleWordFillerConsumesItsToken() {
+        let tokens = ["um", "hello", "um"]
+        let matches = SpeechTokenizer.matchFillers(in: tokens, phrases: defaultFillers)
+        XCTAssertEqual(matches.counts["um"], 2)
+        XCTAssertEqual(matches.consumedTokenIndices, [0, 2])
+    }
+
+    func testMatchFillers_repeatedMultiWordPhraseConsumesAllSpans() {
+        let tokens = ["sort", "of", "sort", "of", "planning"]
+        let matches = SpeechTokenizer.matchFillers(in: tokens, phrases: defaultFillers)
+        XCTAssertEqual(matches.counts["sort of"], 2)
+        XCTAssertEqual(matches.consumedTokenIndices, [0, 1, 2, 3])
+        XCTAssertFalse(matches.consumedTokenIndices.contains(4))
+    }
+
+    func testMatchFillers_longestPhraseWinsAndConsumedSpansDoNotOverlap() {
+        let config = SpeechInsightsConfiguration(fillerPhrases: ["you know what", "you know"])
+        let tokens = ["you", "know", "what", "then", "you", "know"]
+        let matches = SpeechTokenizer.matchFillers(in: tokens, phrases: config.fillerTokenSequences)
+        XCTAssertEqual(matches.counts["you know what"], 1)
+        XCTAssertEqual(matches.counts["you know"], 1)
+        XCTAssertEqual(matches.consumedTokenIndices, [0, 1, 2, 4, 5])
+    }
+
+    func testMatchFillers_noMatchesConsumesNothing() {
+        let matches = SpeechTokenizer.matchFillers(
+            in: ["completely", "clean", "sentence"],
+            phrases: defaultFillers
+        )
+        XCTAssertTrue(matches.counts.isEmpty)
+        XCTAssertTrue(matches.consumedTokenIndices.isEmpty)
+    }
+
+    func testMatchFillers_emptyInputs() {
+        XCTAssertEqual(
+            SpeechTokenizer.matchFillers(in: [], phrases: defaultFillers),
+            SpeechTokenizer.FillerMatches(counts: [:], consumedTokenIndices: [])
+        )
+        XCTAssertEqual(
+            SpeechTokenizer.matchFillers(in: ["um"], phrases: []),
+            SpeechTokenizer.FillerMatches(counts: [:], consumedTokenIndices: [])
+        )
+    }
+
+    func testCountFillers_matchesMatchFillersCounts() {
+        let tokens = ["um", "it", "was", "sort", "of", "fine", "you", "know"]
+        XCTAssertEqual(
+            SpeechTokenizer.countFillers(in: tokens, phrases: defaultFillers),
+            SpeechTokenizer.matchFillers(in: tokens, phrases: defaultFillers).counts
+        )
+    }
+
     // MARK: - N-grams
 
     func testNgramCounts_bigrams() {


### PR DESCRIPTION
## Defect

Found reviewing merged #634. Three related staleness/correctness bugs in Speech Insights:

1. **Multi-word filler leakage** — only single-word fillers were excluded from content words, so repeated "sort of"/"kind of" promoted `sort` and `kind` into top words, vocabulary and weekly/monthly trends despite the UI promising top words "minus common filler".
2. **Stale dashboard refresh** — the dashboard `.task` was keyed on `HistoryStatistics`, which omits transcript content; replacing a transcript without changing count/duration/cost/errors never re-ran the refresh.
3. **UUID-only reconciliation** — the aggregate compared only session UUIDs, so an in-place edit (CloudKit merge, local reprocess) to text, date or duration under an existing UUID kept obsolete word/phrase/WPM data in memory and on disk.

## Fix

- `SpeechTokenizer.matchFillers(in:phrases:)` returns per-phrase counts **plus consumed token indices**; the engine excludes every consumed token from content-word aggregates while the full phrase still counts in filler and n-gram reporting. `countFillers` remains as a counts-only wrapper.
- `SpeechSessionRecord.contentFingerprint` — deterministic FNV-1a over every aggregation input (`text`, `startedAt`, `duration`) — is persisted per session in the aggregate (`sessionFingerprints`, schema v1 → v2). `reconcile` rebuilds when any processed session's fingerprint changed (or the session vanished). v1 payloads fail decode and fall back to the existing full-recompute path; a v1-versioned aggregate is likewise rebuilt.
- `HistoryManager.contentRevision` — a published monotonic revision bumped on load/append/update/remove/removeAll (CloudKit merges land through the same mutators) — now keys the dashboard's Speech Insights `.task` instead of `HistoryStatistics`.

## Tests

- Tokenizer: consumed-index matrix — multi-word spans, repeated spans, longest-phrase precedence, single-word fillers, empty inputs, counts parity with `countFillers`.
- Engine: multi-word filler words excluded from all content aggregates but retained in filler/n-gram reporting; standalone "sort"/"kind" still count; fingerprint determinism and per-input sensitivity; reconcile rebuilds on text/date/duration change under an existing UUID (each equal to full recompute); matching fingerprints stay on the incremental path; v1 payload decode failure + v1 reconcile rebuild.
- App: `contentRevision` bumps on every content mutation including a statistics-neutral update, and not on pagination; `SpeechInsightsModel` integration — transcript edit under an existing UUID updates the visible summary and the persisted aggregate agrees after "relaunch".

`swift build` clean; full `swift test` 1649 tests, 0 failures; SwiftLint strict violation set identical to pristine `origin/main` (path-keyed baseline resurfaces the same 468 pre-existing items on both).

Fixes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Speech insights now refresh when transcript content is edited, even when the session remains the same.
  * Changes to session transcripts, dates, or durations are accurately reflected in summaries and trends.
  * Multi-word filler phrases are matched more accurately and excluded from content-word reporting while remaining visible in filler insights.
  * Empty filler entries no longer interfere with insight generation.
  * Updated insights remain consistent after relaunching the app.
* **Improvements**
  * Existing speech-insight data is safely updated to the latest format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->