### PR TITLE
fix(mac): make FluidAudio streaming cancellation and backpressure lossless

### DIFF
--- a/Sources/SpeakApp/FluidAudioLiveSupport.swift
+++ b/Sources/SpeakApp/FluidAudioLiveSupport.swift
@@ -1,0 +1,70 @@
+@preconcurrency import AVFoundation
+import FluidAudio
+import Foundation
+
+/// The subset of `StreamingEouAsrManager` the live controller drives. A seam
+/// so behavioural tests can exercise cancellation and backpressure with
+/// delayed model preparation and forced processing errors (issue #715).
+protocol FluidAudioStreamingTranscribing: Sendable {
+  func resetSession() async
+  func streamAudio(_ buffer: AVAudioPCMBuffer) async throws
+  func finishSession() async throws -> String
+  func setPartialTranscriptHandler(_ handler: @escaping @Sendable (String) -> Void) async
+  func setUtteranceHandler(_ handler: @escaping @Sendable (String) -> Void) async
+}
+
+extension StreamingEouAsrManager: FluidAudioStreamingTranscribing {
+  func resetSession() async {
+    await reset()
+  }
+
+  func streamAudio(_ buffer: AVAudioPCMBuffer) async throws {
+    _ = try await process(audioBuffer: buffer)
+  }
+
+  func finishSession() async throws -> String {
+    try await finish()
+  }
+
+  func setPartialTranscriptHandler(_ handler: @escaping @Sendable (String) -> Void) async {
+    await setPartialTranscriptCallback(handler)
+  }
+
+  func setUtteranceHandler(_ handler: @escaping @Sendable (String) -> Void) async {
+    await setEouCallback(handler)
+  }
+}
+
+/// Owns the microphone capture side of a FluidAudio run so tests can replace
+/// the real `AVAudioEngine` with a deterministic fake.
+@MainActor
+protocol FluidAudioAudioCapturing: AnyObject {
+  func start(onBuffer: @escaping @Sendable (AVAudioPCMBuffer) -> Void) async throws
+  func stop()
+}
+
+@MainActor
+final class FluidAudioEngineCapture: FluidAudioAudioCapturing {
+  private var audioEngine: AVAudioEngine?
+
+  func start(onBuffer: @escaping @Sendable (AVAudioPCMBuffer) -> Void) async throws {
+    let audioEngine = AVAudioEngine()
+    self.audioEngine = audioEngine
+    let inputNode = audioEngine.inputNode
+    inputNode.removeTap(onBus: 0)
+    let inputFormat = inputNode.outputFormat(forBus: 0)
+    guard audioInputFormatIsUsable(inputFormat) else {
+      throw TranscriptionManagerError.noUsableAudioInput
+    }
+    inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat) { buffer, _ in
+      onBuffer(buffer)
+    }
+    try await startAudioEngineAfterInputDeviceSettles(audioEngine)
+  }
+
+  func stop() {
+    audioEngine?.stop()
+    audioEngine?.inputNode.removeTap(onBus: 0)
+    audioEngine = nil
+  }
+}

--- a/Sources/SpeakApp/FluidAudioParakeetLiveController.swift
+++ b/Sources/SpeakApp/FluidAudioParakeetLiveController.swift
@@ -4,38 +4,68 @@ import Foundation
 import OSLog
 import SpeakCore
 
+/// Live local streaming via FluidAudio's Parakeet EOU model.
+///
+/// Lifecycle is a run-identity state machine (mirroring the `activeRun`
+/// pattern in `SwitchingLiveTranscriber`): every start mints a run ID before
+/// any awaited work, every later allocation and callback requires that ID to
+/// still be current, and stop retires the ID and awaits owned cleanup. This
+/// guarantees a stop during suspended model preparation prevents microphone
+/// activation, late callbacks from a retired run cannot affect a replacement,
+/// and each run produces exactly one terminal delegate outcome (issue #715).
 @MainActor
 final class FluidAudioParakeetLiveController: LiveTranscriptionController {
+  typealias TranscriberProvider = @MainActor () async throws -> any FluidAudioStreamingTranscribing
+  typealias CaptureProvider = @MainActor () -> any FluidAudioAudioCapturing
+
   weak var delegate: LiveTranscriptionSessionDelegate?
-  private(set) var isRunning = false
+
+  private enum Phase: Equatable {
+    case idle
+    case starting
+    case running
+    case stopping
+  }
+
+  var isRunning: Bool { phase == .running }
 
   private let appSettings: AppSettings
   private let permissionsManager: PermissionsManager
   private let audioDeviceManager: AudioInputDeviceManager
   private let modelManager: FluidAudioModelManager
-  private var audioEngine = AVAudioEngine()
+  private let transcriberProvider: TranscriberProvider?
+  private let captureProvider: CaptureProvider
+
+  private var phase: Phase = .idle
+  private var runID: UUID?
+  private var startTask: Task<Void, any Error>?
+  private var capture: (any FluidAudioAudioCapturing)?
   private var audioPump: FluidAudioBufferPump?
   private var transcriptPump: FluidAudioTranscriptPump?
-  private var transcriber: StreamingEouAsrManager?
+  private var transcriber: (any FluidAudioStreamingTranscribing)?
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
   private var currentLanguage: String?
   private var currentModel = FluidAudioParakeetModel.id
   private var streamingStartTime: Date?
   private var latestText = ""
-  private var processingError: Error?
-  private var isStopping = false
+  private var processingError: (any Error)?
+  private var didDeliverFailure = false
   private let logger = SpeakLogger.logger(category: "FluidAudioLive")
 
   init(
     appSettings: AppSettings,
     permissionsManager: PermissionsManager,
     audioDeviceManager: AudioInputDeviceManager,
-    modelManager: FluidAudioModelManager
+    modelManager: FluidAudioModelManager,
+    transcriberProvider: TranscriberProvider? = nil,
+    captureProvider: @escaping CaptureProvider = { FluidAudioEngineCapture() }
   ) {
     self.appSettings = appSettings
     self.permissionsManager = permissionsManager
     self.audioDeviceManager = audioDeviceManager
     self.modelManager = modelManager
+    self.transcriberProvider = transcriberProvider
+    self.captureProvider = captureProvider
   }
 
   func configure(language: String?, model: String) {
@@ -44,90 +74,161 @@ final class FluidAudioParakeetLiveController: LiveTranscriptionController {
   }
 
   func start() async throws {
-    guard !isRunning, !isStopping else {
+    guard phase == .idle else {
       throw TranscriptionManagerError.liveSessionAlreadyRunning
     }
-    guard await permissionsManager.ensureGranted(.microphone).isGranted else {
-      throw TranscriptionManagerError.microphonePermissionMissing
-    }
-    if let language = currentLanguage,
-      !language.lowercased().hasPrefix("en") {
-      throw FluidAudioModelError.unsupportedLanguage(language)
-    }
-
-    let transcriber = try await modelManager.makeReadyManager()
-    await transcriber.reset()
-
-    let transcriptPump = FluidAudioTranscriptPump()
-    transcriptPump.start { [weak self] event in
-      await self?.handleTranscriptEvent(event)
-    }
-    self.transcriptPump = transcriptPump
-    await configureCallbacks(for: transcriber, transcriptPump: transcriptPump)
-
+    let run = UUID()
+    runID = run
+    phase = .starting
     latestText = ""
     processingError = nil
-    self.transcriber = transcriber
+    didDeliverFailure = false
 
-    let pump = FluidAudioBufferPump()
-    pump.start(manager: transcriber) { [weak self] error in
-      Task { @MainActor [weak self] in
-        self?.handleProcessingError(error)
-      }
+    // Startup runs in an owned task so a concurrent stop can cancel it and
+    // await its unwinding before tearing down whatever it already allocated.
+    let task = Task { @MainActor [weak self] in
+      guard let self else { throw CancellationError() }
+      try await self.performStart(run: run)
     }
-    audioPump = pump
-
-    let session = await audioDeviceManager.beginUsingPreferredInput()
-    activeInputSession = session
-    audioEngine = AVAudioEngine()
-
+    startTask = task
     do {
-      let inputNode = audioEngine.inputNode
-      inputNode.removeTap(onBus: 0)
-      let inputFormat = inputNode.outputFormat(forBus: 0)
-      guard audioInputFormatIsUsable(inputFormat) else {
-        throw TranscriptionManagerError.noUsableAudioInput
-      }
-      inputNode.installTap(onBus: 0, bufferSize: 2048, format: inputFormat) { [weak pump] buffer, _ in
-        pump?.enqueue(buffer)
-      }
-      try await startAudioEngineAfterInputDeviceSettles(audioEngine)
-      streamingStartTime = Date()
-      isRunning = true
+      try await task.value
+      if startTask == task { startTask = nil }
     } catch {
-      await cleanupAfterFailedStart()
+      if startTask == task { startTask = nil }
+      // When phase is `.stopping` a concurrent stop owns the teardown; it is
+      // already awaiting this task and cleans up once we unwind.
+      if runID == run, phase == .starting {
+        await teardownRunResources()
+        retire(run)
+      }
       throw error
     }
   }
 
   func stop() async {
-    guard isRunning, !isStopping else { return }
-    isStopping = true
-    isRunning = false
+    switch phase {
+    case .idle, .stopping:
+      return
+    case .starting:
+      guard let run = runID else { return }
+      phase = .stopping
+      let task = startTask
+      startTask = nil
+      task?.cancel()
+      _ = try? await task?.value
+      await teardownRunResources()
+      retire(run)
+    case .running:
+      guard let run = runID else { return }
+      await stopRunning(run)
+    }
+  }
 
-    audioEngine.stop()
-    audioEngine.inputNode.removeTap(onBus: 0)
-    let droppedBuffers = await audioPump?.finish() ?? 0
-    reportDroppedBuffers(droppedBuffers)
+  // MARK: - Startup
+
+  private func performStart(run: UUID) async throws {
+    guard await permissionsManager.ensureGranted(.microphone).isGranted else {
+      throw TranscriptionManagerError.microphonePermissionMissing
+    }
+    try ensureActive(run)
+    if let language = currentLanguage,
+      !language.lowercased().hasPrefix("en") {
+      throw FluidAudioModelError.unsupportedLanguage(language)
+    }
+
+    // Each resource is published to `self` immediately upon acquisition so a
+    // stop that cancelled this task can tear everything down after awaiting
+    // our unwinding.
+    let transcriber = try await makeTranscriber()
+    self.transcriber = transcriber
+    try ensureActive(run)
+    await transcriber.resetSession()
+    try ensureActive(run)
+
+    let transcriptPump = FluidAudioTranscriptPump()
+    transcriptPump.start { [weak self] event in
+      await self?.handleTranscriptEvent(event, run: run)
+    }
+    self.transcriptPump = transcriptPump
+    await transcriber.setPartialTranscriptHandler { [weak transcriptPump] text in
+      transcriptPump?.enqueue(.partial(text))
+    }
+    await transcriber.setUtteranceHandler { [weak transcriptPump] utterance in
+      transcriptPump?.enqueue(.utteranceBoundary(utterance))
+    }
+    try ensureActive(run)
+
+    let pump = FluidAudioBufferPump()
+    pump.start(
+      process: { buffer in
+        try await transcriber.streamAudio(buffer)
+      },
+      onError: { [weak self] error in
+        Task { @MainActor [weak self] in
+          self?.handleProcessingError(error, run: run)
+        }
+      }
+    )
+    audioPump = pump
+
+    activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+    try ensureActive(run)
+
+    let capture = captureProvider()
+    self.capture = capture
+    try await capture.start { [weak pump] buffer in
+      pump?.enqueue(buffer)
+    }
+    try ensureActive(run)
+    streamingStartTime = Date()
+    phase = .running
+  }
+
+  private func makeTranscriber() async throws -> any FluidAudioStreamingTranscribing {
+    if let transcriberProvider {
+      return try await transcriberProvider()
+    }
+    return try await modelManager.makeReadyManager()
+  }
+
+  /// Startup barrier: throws unless `run` is still the live starting run.
+  private func ensureActive(_ run: UUID) throws {
+    try Task.checkCancellation()
+    guard runID == run, phase == .starting else {
+      throw CancellationError()
+    }
+  }
+
+  // MARK: - Stop
+
+  private func stopRunning(_ run: UUID) async {
+    phase = .stopping
+
+    capture?.stop()
+    capture = nil
+
+    let pumpOutcome = await audioPump?.finish() ?? FluidAudioPumpOutcome()
     audioPump = nil
+    logPressureDiagnostics(pumpOutcome)
 
-    if processingError == nil {
+    if pumpOutcome.processingError == nil, processingError == nil {
       await applyLiveStopGrace(appSettings.liveStopGracePeriod)
     }
 
-    let result = await finishTranscription()
+    let result = await finishTranscription(pumpOutcome: pumpOutcome)
 
     if let transcriber {
-      await transcriber.reset()
+      await transcriber.resetSession()
     }
-    self.transcriber = nil
+    transcriber = nil
     await transcriptPump?.finish()
     transcriptPump = nil
     await endActiveInputSession()
 
     let duration = streamingStartTime.map { Date().timeIntervalSince($0) } ?? 0
     streamingStartTime = nil
-    isStopping = false
+    retire(run)
 
     switch result {
     case .success(let finalText):
@@ -141,80 +242,54 @@ final class FluidAudioParakeetLiveController: LiveTranscriptionController {
         duration: duration,
         modelIdentifier: currentModel,
         cost: nil,
-        rawPayload: nil,
+        rawPayload: Self.lossyAudioPayload(for: pumpOutcome),
         debugInfo: nil
       )
       delegate?.liveTranscriber(self, didFinishWith: transcription)
     case .failure(let error):
-      if processingError == nil {
-        delegate?.liveTranscriber(self, didFail: error)
-      }
+      deliverFailureIfNeeded(error)
     }
   }
 
-  private func configureCallbacks(
-    for transcriber: StreamingEouAsrManager,
-    transcriptPump: FluidAudioTranscriptPump
-  ) async {
-    await transcriber.setPartialTranscriptCallback { [weak transcriptPump] text in
-      transcriptPump?.enqueue(.partial(text))
-    }
-    await transcriber.setEouCallback { [weak transcriptPump] utterance in
-      transcriptPump?.enqueue(.utteranceBoundary(utterance))
-    }
-  }
-
-  private func handleTranscriptEvent(_ event: FluidAudioTranscriptEvent) {
-    switch event {
-    case .partial(let text):
-      latestText = text
-      delegate?.liveTranscriber(self, didUpdatePartial: text)
-    case .utteranceBoundary(let utterance):
-      delegate?.liveTranscriber(self, didDetectUtteranceBoundary: utterance)
-    }
-  }
-
-  private func finishTranscription() async -> Result<String, Error> {
-    if let processingError {
-      return .failure(processingError)
+  private func finishTranscription(pumpOutcome: FluidAudioPumpOutcome) async -> Result<String, any Error> {
+    if let error = processingError ?? pumpOutcome.processingError {
+      return .failure(error)
     }
     guard let transcriber else {
       return .failure(FluidAudioModelError.notInstalled)
     }
     do {
-      return .success(try await transcriber.finish())
+      return .success(try await transcriber.finishSession())
     } catch {
       return .failure(error)
     }
   }
 
-  private func handleProcessingError(_ error: Error) {
-    guard processingError == nil else { return }
-    processingError = error
-    delegate?.liveTranscriber(self, didFail: error)
-  }
-
-  private func cleanupAfterFailedStart() async {
-    audioEngine.stop()
-    audioEngine.inputNode.removeTap(onBus: 0)
-    let droppedBuffers = await audioPump?.finish() ?? 0
-    reportDroppedBuffers(droppedBuffers)
-    audioPump = nil
-    if let transcriber {
-      await transcriber.reset()
+  /// Cleanup for runs that never reached `.running`. Publishes no delegate
+  /// outcome: the start path throws to its caller instead.
+  private func teardownRunResources() async {
+    capture?.stop()
+    capture = nil
+    if let pump = audioPump {
+      audioPump = nil
+      logPressureDiagnostics(await pump.finish())
     }
-    transcriber = nil
-    await transcriptPump?.finish()
-    transcriptPump = nil
+    if let transcriber {
+      self.transcriber = nil
+      await transcriber.resetSession()
+    }
+    if let transcriptPump {
+      self.transcriptPump = nil
+      await transcriptPump.finish()
+    }
     await endActiveInputSession()
-    isRunning = false
-    isStopping = false
     streamingStartTime = nil
   }
 
-  private func reportDroppedBuffers(_ count: Int) {
-    guard count > 0 else { return }
-    logger.warning("Dropped \(count, privacy: .public) FluidAudio input buffers while processing lagged")
+  private func retire(_ run: UUID) {
+    guard runID == run else { return }
+    runID = nil
+    phase = .idle
   }
 
   private func endActiveInputSession() async {
@@ -224,149 +299,77 @@ final class FluidAudioParakeetLiveController: LiveTranscriptionController {
   }
 }
 
-private enum FluidAudioTranscriptEvent: Sendable {
-  case partial(String)
-  case utteranceBoundary(String)
-}
+// MARK: - Callbacks
 
-private final class FluidAudioTranscriptPump: @unchecked Sendable {
-  private let lock = NSLock()
-  private var continuation: AsyncStream<FluidAudioTranscriptEvent>.Continuation?
-  private var consumerTask: Task<Void, Never>?
-
-  func start(onEvent: @escaping @Sendable (FluidAudioTranscriptEvent) async -> Void) {
-    let pair = AsyncStream<FluidAudioTranscriptEvent>.makeStream(bufferingPolicy: .unbounded)
-    lock.lock()
-    continuation = pair.continuation
-    lock.unlock()
-    consumerTask = Task {
-      for await event in pair.stream {
-        await onEvent(event)
-      }
+extension FluidAudioParakeetLiveController {
+  private func handleTranscriptEvent(_ event: FluidAudioTranscriptEvent, run: UUID) {
+    guard runID == run else { return }
+    switch event {
+    case .partial(let text):
+      latestText = text
+      delegate?.liveTranscriber(self, didUpdatePartial: text)
+    case .utteranceBoundary(let utterance):
+      delegate?.liveTranscriber(self, didDetectUtteranceBoundary: utterance)
     }
   }
 
-  func enqueue(_ event: FluidAudioTranscriptEvent) {
-    lock.lock()
-    let continuation = continuation
-    lock.unlock()
-    continuation?.yield(event)
+  /// Prompt mid-run failure notification. Terminal-state authority stays with
+  /// `FluidAudioBufferPump.finish()`, so a stop that races this unstructured
+  /// hop still observes the error; the `didDeliverFailure` flag keeps the
+  /// delegate outcome exactly-once either way.
+  private func handleProcessingError(_ error: any Error, run: UUID) {
+    guard runID == run, processingError == nil else { return }
+    processingError = error
+    deliverFailureIfNeeded(error)
   }
 
-  func finish() async {
-    let continuation = takeContinuation()
-    continuation?.finish()
-    await consumerTask?.value
-    consumerTask = nil
-  }
-
-  private func takeContinuation() -> AsyncStream<FluidAudioTranscriptEvent>.Continuation? {
-    lock.lock()
-    let continuation = continuation
-    self.continuation = nil
-    lock.unlock()
-    return continuation
+  private func deliverFailureIfNeeded(_ error: any Error) {
+    guard !didDeliverFailure else { return }
+    didDeliverFailure = true
+    delegate?.liveTranscriber(self, didFail: error)
   }
 }
 
-private final class FluidAudioBufferPump: @unchecked Sendable {
-  private let lock = NSLock()
-  private var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
-  private var consumerTask: Task<Void, Never>?
-  private var failed = false
-  private var droppedBufferCount = 0
+// MARK: - Lossy-run accounting
 
-  func start(
-    manager: StreamingEouAsrManager,
-    onError: @escaping @Sendable (Error) -> Void
-  ) {
-    let pair = AsyncStream<AVAudioPCMBuffer>.makeStream(bufferingPolicy: .bufferingNewest(32))
-    lock.lock()
-    continuation = pair.continuation
-    failed = false
-    droppedBufferCount = 0
-    lock.unlock()
+extension FluidAudioParakeetLiveController {
+  private struct LossyAudioMarker: Codable {
+    let provider: String
+    let lossyAudio: Bool
+    let droppedBufferCount: Int
+    let droppedAudioSeconds: Double
+    let queuedBufferHighWaterMark: Int
+  }
 
-    consumerTask = Task {
-      do {
-        for await buffer in pair.stream {
-          _ = try await manager.process(audioBuffer: buffer)
-        }
-      } catch {
-        let continuation = markFailed()
-        continuation?.finish()
-        onError(error)
-      }
+  /// Serialised into `TranscriptionResult.rawPayload` when the bounded queue
+  /// discarded captured audio, so a lossy run is never presented as a fully
+  /// healthy transcript (issue #715).
+  private static func lossyAudioPayload(for outcome: FluidAudioPumpOutcome) -> String? {
+    guard outcome.isLossy else { return nil }
+    let marker = LossyAudioMarker(
+      provider: "fluidaudio-parakeet",
+      lossyAudio: true,
+      droppedBufferCount: outcome.droppedBufferCount,
+      droppedAudioSeconds: (outcome.droppedAudioSeconds * 1000).rounded() / 1000,
+      queuedBufferHighWaterMark: outcome.queuedBufferHighWaterMark
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(marker) else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+
+  private func logPressureDiagnostics(_ outcome: FluidAudioPumpOutcome) {
+    if outcome.queuedBufferHighWaterMark > 0 {
+      logger.debug(
+        "FluidAudio queue high-water mark: \(outcome.queuedBufferHighWaterMark, privacy: .public) buffers")
     }
-  }
-
-  func enqueue(_ buffer: AVAudioPCMBuffer) {
-    guard let copiedBuffer = Self.copy(buffer) else { return }
-    lock.lock()
-    let continuation = failed ? nil : continuation
-    lock.unlock()
-    guard let continuation else { return }
-    if case .dropped = continuation.yield(copiedBuffer) {
-      lock.lock()
-      droppedBufferCount += 1
-      lock.unlock()
-    }
-  }
-
-  func finish() async -> Int {
-    let continuation = takeContinuation()
-    continuation?.finish()
-    await consumerTask?.value
-    consumerTask = nil
-    return currentDroppedBufferCount()
-  }
-
-  private func markFailed() -> AsyncStream<AVAudioPCMBuffer>.Continuation? {
-    lock.lock()
-    failed = true
-    let continuation = self.continuation
-    self.continuation = nil
-    lock.unlock()
-    return continuation
-  }
-
-  private func takeContinuation() -> AsyncStream<AVAudioPCMBuffer>.Continuation? {
-    lock.lock()
-    let continuation = self.continuation
-    self.continuation = nil
-    lock.unlock()
-    return continuation
-  }
-
-  private func currentDroppedBufferCount() -> Int {
-    lock.lock()
-    let count = droppedBufferCount
-    lock.unlock()
-    return count
-  }
-
-  private static func copy(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
-    let frameLength = buffer.frameLength
-    guard let copy = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: frameLength) else {
-      return nil
-    }
-    copy.frameLength = frameLength
-    let source = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: buffer.audioBufferList))
-    let destination = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: copy.audioBufferList))
-    for index in 0..<min(source.count, destination.count) {
-      guard let sourceData = source[index].mData, let destinationData = destination[index].mData else {
-        continue
-      }
-      let copiedByteCount = min(
-        Int(source[index].mDataByteSize),
-        Int(destination[index].mDataByteSize)
-      )
-      destinationData.copyMemory(
-        from: sourceData,
-        byteCount: copiedByteCount
-      )
-      destination[index].mDataByteSize = UInt32(copiedByteCount)
-    }
-    return copy
+    guard outcome.isLossy else { return }
+    logger.warning(
+      """
+      Dropped \(outcome.droppedBufferCount, privacy: .public) FluidAudio input buffers \
+      (~\(outcome.droppedAudioSeconds, format: .fixed(precision: 2), privacy: .public)s) \
+      while processing lagged; transcript marked lossy
+      """)
   }
 }

--- a/Sources/SpeakApp/FluidAudioStreamingPumps.swift
+++ b/Sources/SpeakApp/FluidAudioStreamingPumps.swift
@@ -1,0 +1,197 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+/// Terminal accounting for one `FluidAudioBufferPump` run: how much captured
+/// audio the bounded queue discarded under processing pressure and the error
+/// (if any) that terminated the consumer. Returned from `finish()` so the
+/// controller observes the pump's terminal state synchronously instead of
+/// racing an unstructured error callback (issue #715). The diagnostics are
+/// privacy-safe: counts and durations only, never audio or transcript content.
+struct FluidAudioPumpOutcome: Sendable {
+  var droppedBufferCount = 0
+  var droppedAudioSeconds: TimeInterval = 0
+  var queuedBufferHighWaterMark = 0
+  var processingError: (any Error)?
+
+  var isLossy: Bool { droppedBufferCount > 0 }
+}
+
+enum FluidAudioTranscriptEvent: Sendable {
+  case partial(String)
+  case utteranceBoundary(String)
+}
+
+/// Serialises transcript callbacks from the FluidAudio actor onto a single
+/// consumer so delegate delivery stays ordered.
+final class FluidAudioTranscriptPump: @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuation: AsyncStream<FluidAudioTranscriptEvent>.Continuation?
+  private var consumerTask: Task<Void, Never>?
+
+  func start(onEvent: @escaping @Sendable (FluidAudioTranscriptEvent) async -> Void) {
+    let pair = AsyncStream<FluidAudioTranscriptEvent>.makeStream(bufferingPolicy: .unbounded)
+    lock.lock()
+    continuation = pair.continuation
+    lock.unlock()
+    consumerTask = Task {
+      for await event in pair.stream {
+        await onEvent(event)
+      }
+    }
+  }
+
+  func enqueue(_ event: FluidAudioTranscriptEvent) {
+    lock.lock()
+    let continuation = continuation
+    lock.unlock()
+    continuation?.yield(event)
+  }
+
+  func finish() async {
+    let continuation = takeContinuation()
+    continuation?.finish()
+    await consumerTask?.value
+    consumerTask = nil
+  }
+
+  private func takeContinuation() -> AsyncStream<FluidAudioTranscriptEvent>.Continuation? {
+    lock.lock()
+    let continuation = continuation
+    self.continuation = nil
+    lock.unlock()
+    return continuation
+  }
+}
+
+/// Feeds captured microphone buffers to the FluidAudio processor through a
+/// bounded queue. Backpressure accounting (dropped buffers, dropped audio
+/// duration, queue high-water mark) and the consumer's terminal error are all
+/// part of `finish()` so a stop can never observe success before a concurrent
+/// processing failure is visible.
+final class FluidAudioBufferPump: @unchecked Sendable {
+  static let bufferCapacity = 32
+
+  private let lock = NSLock()
+  private var continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+  private var consumerTask: Task<Void, Never>?
+  private var failed = false
+  private var outcome = FluidAudioPumpOutcome()
+
+  func start(
+    process: @escaping @Sendable (AVAudioPCMBuffer) async throws -> Void,
+    onError: @escaping @Sendable (any Error) -> Void
+  ) {
+    let pair = AsyncStream<AVAudioPCMBuffer>.makeStream(
+      bufferingPolicy: .bufferingNewest(Self.bufferCapacity)
+    )
+    lock.lock()
+    continuation = pair.continuation
+    failed = false
+    outcome = FluidAudioPumpOutcome()
+    lock.unlock()
+
+    consumerTask = Task {
+      do {
+        for await buffer in pair.stream {
+          try await process(buffer)
+        }
+      } catch {
+        let continuation = self.recordFailure(error)
+        continuation?.finish()
+        onError(error)
+      }
+    }
+  }
+
+  func enqueue(_ buffer: AVAudioPCMBuffer) {
+    guard let copiedBuffer = Self.copy(buffer) else { return }
+    lock.lock()
+    let continuation = failed ? nil : continuation
+    lock.unlock()
+    guard let continuation else { return }
+    switch continuation.yield(copiedBuffer) {
+    case .enqueued(let remaining):
+      recordOccupancy(Self.bufferCapacity - remaining)
+    case .dropped(let droppedBuffer):
+      recordDrop(of: droppedBuffer)
+    case .terminated:
+      break
+    @unknown default:
+      break
+    }
+  }
+
+  /// Terminates intake, waits for the consumer to drain, and returns the
+  /// pump's terminal outcome including any processing error.
+  func finish() async -> FluidAudioPumpOutcome {
+    let continuation = takeContinuation()
+    continuation?.finish()
+    await consumerTask?.value
+    consumerTask = nil
+    lock.lock()
+    let outcome = outcome
+    lock.unlock()
+    return outcome
+  }
+
+  private func recordOccupancy(_ occupancy: Int) {
+    lock.lock()
+    outcome.queuedBufferHighWaterMark = max(outcome.queuedBufferHighWaterMark, occupancy)
+    lock.unlock()
+  }
+
+  private func recordDrop(of buffer: AVAudioPCMBuffer) {
+    let sampleRate = buffer.format.sampleRate
+    let seconds = sampleRate > 0 ? Double(buffer.frameLength) / sampleRate : 0
+    lock.lock()
+    outcome.droppedBufferCount += 1
+    outcome.droppedAudioSeconds += seconds
+    outcome.queuedBufferHighWaterMark = Self.bufferCapacity
+    lock.unlock()
+  }
+
+  private func recordFailure(_ error: any Error) -> AsyncStream<AVAudioPCMBuffer>.Continuation? {
+    lock.lock()
+    failed = true
+    if outcome.processingError == nil {
+      outcome.processingError = error
+    }
+    let continuation = self.continuation
+    self.continuation = nil
+    lock.unlock()
+    return continuation
+  }
+
+  private func takeContinuation() -> AsyncStream<AVAudioPCMBuffer>.Continuation? {
+    lock.lock()
+    let continuation = self.continuation
+    self.continuation = nil
+    lock.unlock()
+    return continuation
+  }
+
+  private static func copy(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+    let frameLength = buffer.frameLength
+    guard let copy = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: frameLength) else {
+      return nil
+    }
+    copy.frameLength = frameLength
+    let source = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: buffer.audioBufferList))
+    let destination = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: copy.audioBufferList))
+    for index in 0..<min(source.count, destination.count) {
+      guard let sourceData = source[index].mData, let destinationData = destination[index].mData else {
+        continue
+      }
+      let copiedByteCount = min(
+        Int(source[index].mDataByteSize),
+        Int(destination[index].mDataByteSize)
+      )
+      destinationData.copyMemory(
+        from: sourceData,
+        byteCount: copiedByteCount
+      )
+      destination[index].mDataByteSize = UInt32(copiedByteCount)
+    }
+    return copy
+  }
+}

--- a/Tests/SpeakAppTests/FluidAudioLiveTestDoubles.swift
+++ b/Tests/SpeakAppTests/FluidAudioLiveTestDoubles.swift
@@ -1,0 +1,171 @@
+@preconcurrency import AVFoundation
+import Foundation
+import SpeakCore
+
+@testable import SpeakApp
+
+// MARK: - Test doubles
+
+/// Cancellation-aware gate: `wait()` suspends until `open()` (or task
+/// cancellation) and signals entry so tests can order interleavings.
+actor TestGate {
+  private var isOpen = false
+  private var entered = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+  private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    entered = true
+    for waiter in enteredWaiters {
+      waiter.resume()
+    }
+    enteredWaiters = []
+    guard !isOpen else { return }
+    await withTaskCancellationHandler {
+      await withCheckedContinuation { continuation in
+        if isOpen || Task.isCancelled {
+          continuation.resume()
+        } else {
+          waiters.append(continuation)
+        }
+      }
+    } onCancel: {
+      Task { await self.open() }
+    }
+  }
+
+  func open() {
+    isOpen = true
+    for waiter in waiters {
+      waiter.resume()
+    }
+    waiters = []
+  }
+
+  func waitUntilEntered() async {
+    guard !entered else { return }
+    await withCheckedContinuation { enteredWaiters.append($0) }
+  }
+}
+
+final class MockTranscriber: FluidAudioStreamingTranscribing, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _processGate: TestGate?
+  private var _processError: (any Error)?
+  private var _finalText: String
+  private var _processedCount = 0
+  private var _resetCount = 0
+  private var _partialHandler: (@Sendable (String) -> Void)?
+
+  init(finalText: String = "final transcript") {
+    _finalText = finalText
+  }
+
+  var processGate: TestGate? {
+    get { lock.withLock { _processGate } }
+    set { lock.withLock { _processGate = newValue } }
+  }
+
+  var processError: (any Error)? {
+    get { lock.withLock { _processError } }
+    set { lock.withLock { _processError = newValue } }
+  }
+
+  var processedCount: Int { lock.withLock { _processedCount } }
+  var resetCount: Int { lock.withLock { _resetCount } }
+  var partialHandler: (@Sendable (String) -> Void)? { lock.withLock { _partialHandler } }
+
+  func resetSession() async {
+    lock.withLock { _resetCount += 1 }
+  }
+
+  func streamAudio(_ buffer: AVAudioPCMBuffer) async throws {
+    if let gate = processGate {
+      await gate.wait()
+    }
+    if let error = processError {
+      throw error
+    }
+    lock.withLock { _processedCount += 1 }
+  }
+
+  func finishSession() async throws -> String {
+    lock.withLock { _finalText }
+  }
+
+  func setPartialTranscriptHandler(_ handler: @escaping @Sendable (String) -> Void) async {
+    lock.withLock { _partialHandler = handler }
+  }
+
+  func setUtteranceHandler(_ handler: @escaping @Sendable (String) -> Void) async {}
+}
+
+@MainActor
+final class MockCapture: FluidAudioAudioCapturing {
+  private(set) var started = false
+  private(set) var stopCount = 0
+  private var onBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?
+
+  func start(onBuffer: @escaping @Sendable (AVAudioPCMBuffer) -> Void) async throws {
+    started = true
+    self.onBuffer = onBuffer
+  }
+
+  func stop() {
+    stopCount += 1
+    onBuffer = nil
+  }
+
+  func emit(_ buffer: AVAudioPCMBuffer) {
+    onBuffer?(buffer)
+  }
+}
+
+@MainActor
+final class TranscriberBox {
+  private var transcriber: MockTranscriber
+
+  init(_ transcriber: MockTranscriber) {
+    self.transcriber = transcriber
+  }
+
+  func set(_ transcriber: MockTranscriber) {
+    self.transcriber = transcriber
+  }
+
+  func take() -> any FluidAudioStreamingTranscribing {
+    transcriber
+  }
+}
+
+@MainActor
+final class RecordingDelegate: LiveTranscriptionSessionDelegate {
+  private(set) var partials: [String] = []
+  private(set) var finished: [TranscriptionResult] = []
+  private(set) var failures: [any Error] = []
+  private(set) var boundaries: [String] = []
+
+  func liveTranscriber(_ session: any LiveTranscriptionController, didUpdatePartial text: String) {
+    partials.append(text)
+  }
+
+  func liveTranscriber(
+    _ session: any LiveTranscriptionController,
+    didUpdateWith update: LiveTranscriptionUpdate
+  ) {}
+
+  func liveTranscriber(_ session: any LiveTranscriptionController, didFinishWith result: TranscriptionResult) {
+    finished.append(result)
+  }
+
+  func liveTranscriber(_ session: any LiveTranscriptionController, didFail error: any Error) {
+    failures.append(error)
+  }
+
+  func liveTranscriber(
+    _ session: any LiveTranscriptionController,
+    didDetectUtteranceBoundary utterance: String
+  ) {
+    boundaries.append(utterance)
+  }
+}

--- a/Tests/SpeakAppTests/FluidAudioParakeetLiveControllerTests.swift
+++ b/Tests/SpeakAppTests/FluidAudioParakeetLiveControllerTests.swift
@@ -1,0 +1,249 @@
+@preconcurrency import AVFoundation
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// Behavioural tests for issue #715: FluidAudio streaming cancellation and
+/// backpressure must be lossless. Covers stale-run interleaving, structured
+/// error + drop accounting from the buffer pump, and lossy-transcript marking.
+@MainActor
+final class FluidAudioParakeetLiveControllerTests: XCTestCase {
+  private enum TestError: Error {
+    case processing
+  }
+
+  // MARK: - Stale-run interleaving
+
+  func testStopDuringModelPreparation_preventsMicrophoneActivation() async throws {
+    let gate = TestGate()
+    let transcriber = MockTranscriber()
+    let capture = MockCapture()
+    let harness = makeHarness(
+      transcriberProvider: {
+        await gate.wait()
+        return transcriber
+      },
+      capture: capture
+    )
+
+    let startTask = Task { try await harness.controller.start() }
+    await gate.waitUntilEntered()
+    await harness.controller.stop()
+
+    let result = await startTask.result
+    guard case .failure = result else {
+      XCTFail("A start interrupted by stop must throw, not report success")
+      return
+    }
+    XCTAssertFalse(capture.started, "Stop during model preparation must prevent microphone activation")
+    XCTAssertFalse(harness.controller.isRunning)
+    XCTAssertTrue(harness.delegate.finished.isEmpty)
+    XCTAssertTrue(
+      harness.delegate.failures.isEmpty,
+      "A cancelled start throws to its caller; the delegate gets no terminal outcome"
+    )
+
+    // The controller must be reusable for a clean replacement run.
+    await gate.open()
+    try await harness.controller.start()
+    XCTAssertTrue(capture.started)
+    XCTAssertTrue(harness.controller.isRunning)
+    await harness.controller.stop()
+    XCTAssertEqual(harness.delegate.finished.count, 1)
+    XCTAssertTrue(harness.delegate.failures.isEmpty)
+  }
+
+  func testLateCallbacksFromRetiredRun_doNotAffectReplacement() async throws {
+    let capture = MockCapture()
+    let first = MockTranscriber(finalText: "first run")
+    let second = MockTranscriber(finalText: "second run")
+    let box = TranscriberBox(first)
+    let harness = makeHarness(transcriberProvider: { box.take() }, capture: capture)
+
+    try await harness.controller.start()
+    let stalePartialHandler = first.partialHandler
+    await harness.controller.stop()
+    XCTAssertEqual(harness.delegate.finished.count, 1)
+
+    box.set(second)
+    try await harness.controller.start()
+    stalePartialHandler?("stale text from the retired run")
+    await drainAsyncWork()
+    XCTAssertTrue(
+      harness.delegate.partials.isEmpty,
+      "A late partial from a retired run must not reach the delegate"
+    )
+    XCTAssertTrue(harness.controller.isRunning)
+
+    await harness.controller.stop()
+    XCTAssertEqual(harness.delegate.finished.count, 2)
+    XCTAssertEqual(
+      harness.delegate.finished[1].text,
+      "second run",
+      "The retired run's late callback must not leak into the replacement's transcript"
+    )
+    XCTAssertTrue(harness.delegate.failures.isEmpty)
+  }
+
+  // MARK: - Exactly-once terminal outcome
+
+  func testProcessingFailureConcurrentWithStop_deliversExactlyOneFailureAndNoSuccess() async throws {
+    let capture = MockCapture()
+    let transcriber = MockTranscriber()
+    transcriber.processError = TestError.processing
+    let harness = makeHarness(transcriberProvider: { transcriber }, capture: capture)
+
+    try await harness.controller.start()
+    capture.emit(Self.makeBuffer())
+    await harness.controller.stop()
+    await drainAsyncWork()
+
+    XCTAssertEqual(harness.delegate.failures.count, 1, "Exactly one failure must be delivered")
+    XCTAssertTrue(harness.delegate.finished.isEmpty, "No success may follow a processing failure")
+    XCTAssertFalse(harness.controller.isRunning)
+  }
+
+  // MARK: - Buffer pump terminal outcome
+
+  func testBufferPumpFinish_returnsProcessingErrorAndDropAccounting() async throws {
+    let pump = FluidAudioBufferPump()
+    let gate = TestGate()
+    pump.start(
+      process: { _ in
+        await gate.wait()
+        throw TestError.processing
+      },
+      onError: { _ in }
+    )
+
+    // The consumer takes one buffer in flight and blocks on the gate; the
+    // queue then saturates deterministically.
+    pump.enqueue(Self.makeBuffer())
+    await gate.waitUntilEntered()
+    let overflow = 5
+    for _ in 0..<(FluidAudioBufferPump.bufferCapacity + overflow) {
+      pump.enqueue(Self.makeBuffer())
+    }
+
+    await gate.open()
+    let outcome = await pump.finish()
+
+    XCTAssertEqual(outcome.droppedBufferCount, overflow)
+    XCTAssertEqual(
+      outcome.droppedAudioSeconds,
+      Double(overflow) * 2048.0 / 16_000.0,
+      accuracy: 0.001
+    )
+    XCTAssertEqual(outcome.queuedBufferHighWaterMark, FluidAudioBufferPump.bufferCapacity)
+    XCTAssertNotNil(outcome.processingError, "finish() must surface the consumer's terminal error")
+    XCTAssertTrue(outcome.isLossy)
+  }
+
+  // MARK: - Lossy-transcript marking
+
+  func testSaturatedQueue_marksTranscriptLossyWithDropCounts() async throws {
+    let capture = MockCapture()
+    let gate = TestGate()
+    let transcriber = MockTranscriber(finalText: "lossy run text")
+    transcriber.processGate = gate
+    let harness = makeHarness(transcriberProvider: { transcriber }, capture: capture)
+
+    try await harness.controller.start()
+    capture.emit(Self.makeBuffer())
+    await gate.waitUntilEntered()
+    let overflow = 3
+    for _ in 0..<(FluidAudioBufferPump.bufferCapacity + overflow) {
+      capture.emit(Self.makeBuffer())
+    }
+    await gate.open()
+    await harness.controller.stop()
+
+    XCTAssertEqual(harness.delegate.finished.count, 1)
+    XCTAssertTrue(harness.delegate.failures.isEmpty)
+    let result = try XCTUnwrap(harness.delegate.finished.first)
+    XCTAssertEqual(result.text, "lossy run text")
+
+    let payload = try XCTUnwrap(result.rawPayload, "A lossy run must carry an explicit marker")
+    let marker = try JSONDecoder().decode(LossyMarker.self, from: Data(payload.utf8))
+    XCTAssertTrue(marker.lossyAudio)
+    XCTAssertEqual(marker.droppedBufferCount, overflow)
+    XCTAssertGreaterThan(marker.droppedAudioSeconds, 0)
+    XCTAssertEqual(marker.queuedBufferHighWaterMark, FluidAudioBufferPump.bufferCapacity)
+  }
+
+  func testCleanRun_hasNoLossyMarker() async throws {
+    let capture = MockCapture()
+    let transcriber = MockTranscriber(finalText: "clean run text")
+    let harness = makeHarness(transcriberProvider: { transcriber }, capture: capture)
+
+    try await harness.controller.start()
+    capture.emit(Self.makeBuffer())
+    capture.emit(Self.makeBuffer())
+    await harness.controller.stop()
+
+    XCTAssertEqual(harness.delegate.finished.count, 1)
+    let result = try XCTUnwrap(harness.delegate.finished.first)
+    XCTAssertEqual(result.text, "clean run text")
+    XCTAssertNil(result.rawPayload, "A run that preserved all audio must not be marked lossy")
+    XCTAssertTrue(harness.delegate.failures.isEmpty)
+  }
+
+  // MARK: - Helpers
+
+  private struct LossyMarker: Decodable {
+    let provider: String
+    let lossyAudio: Bool
+    let droppedBufferCount: Int
+    let droppedAudioSeconds: Double
+    let queuedBufferHighWaterMark: Int
+  }
+
+  private struct Harness {
+    let controller: FluidAudioParakeetLiveController
+    let delegate: RecordingDelegate
+  }
+
+  private func makeHarness(
+    transcriberProvider: @escaping FluidAudioParakeetLiveController.TranscriberProvider,
+    capture: MockCapture
+  ) -> Harness {
+    let defaults = UserDefaults(suiteName: "fluidaudio-live-tests-\(UUID().uuidString)") ?? .standard
+    let settings = AppSettings(defaults: defaults)
+    settings.liveStopGracePeriod = 0
+    let permissions = PermissionsManager(statusProvider: { _ in .granted })
+    let audioDevices = AudioInputDeviceManager(appSettings: settings)
+    let modelManager = FluidAudioModelManager(
+      modelsDirectory: FileManager.default.temporaryDirectory
+        .appendingPathComponent("fluidaudio-live-tests-\(UUID().uuidString)", isDirectory: true)
+    )
+    let delegate = RecordingDelegate()
+    let controller = FluidAudioParakeetLiveController(
+      appSettings: settings,
+      permissionsManager: permissions,
+      audioDeviceManager: audioDevices,
+      modelManager: modelManager,
+      transcriberProvider: transcriberProvider,
+      captureProvider: { capture }
+    )
+    controller.delegate = delegate
+    return Harness(controller: controller, delegate: delegate)
+  }
+
+  private func drainAsyncWork() async {
+    for _ in 0..<20 {
+      await Task.yield()
+    }
+  }
+
+  private static func makeBuffer(frames: AVAudioFrameCount = 2048) -> AVAudioPCMBuffer {
+    guard
+      let format = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1),
+      let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)
+    else {
+      fatalError("Could not allocate test audio buffer")
+    }
+    buffer.frameLength = frames
+    return buffer
+  }
+}


### PR DESCRIPTION
## Defect

FluidAudio Parakeet live streaming (issue #715, found auditing #561) could silently turn a lossy or failed audio run into a healthy transcript:

- `start()` awaited model preparation with no run identity. A `stop()` during that suspension returned immediately (the controller was not yet "running"), and the suspended startup would later acquire the input device and start the microphone after the user had stopped.
- The audio pump reported its processing error via an unstructured `Task { @MainActor ... }` hop. `stop()` awaited the pump consumer but not that delivery, so it could observe no `processingError`, call `finish()` and publish **success** before the delayed failure arrived — success-then-failure, not exactly-once.
- `.bufferingNewest(32)` discarded the oldest captured buffers when inference lagged; stop only logged the count and still presented the transcript and history entry as complete.

## Fix (local to the FluidAudio controller)

- **Run-identity/phase state machine** (`idle → starting → running → stopping`), mirroring `SwitchingLiveTranscriber`'s `activeRun` pattern: `start()` mints a run ID before any awaited work and runs startup in an owned cancellable task; every later allocation and callback requires the current ID; `stop()` retires the ID, cancels/awaits suspended startup, then awaits owned cleanup. Stop during suspended model preparation now prevents microphone activation; late callbacks from a retired run cannot affect a replacement.
- **Structured pump outcome**: `FluidAudioBufferPump.finish()` now returns `FluidAudioPumpOutcome` (processing error + dropped-buffer count + dropped audio duration + queue high-water mark), so the pump's terminal state is part of stop's decision instead of racing an unstructured callback. The delegate outcome is exactly-once: one failure or one success, never success followed by failure. The prompt mid-run `didFail` notification is kept, deduplicated via a per-run flag and run-ID guard.
- **Lossy-transcript marking**: when the bounded queue dropped captured audio, the delivered `TranscriptionResult` carries an explicit machine-readable marker in `rawPayload` (`lossyAudio`, `droppedBufferCount`, `droppedAudioSeconds`, `queuedBufferHighWaterMark`) and privacy-safe pressure diagnostics (counts/durations only, never content) are logged. A clean run carries no marker.

The shared `LiveTranscriptionController`/finalisation contract is untouched (per coordination with #716); new seams (`FluidAudioStreamingTranscribing`, `FluidAudioAudioCapturing`) are internal to the controller.

## Tests

`Tests/SpeakAppTests/FluidAudioParakeetLiveControllerTests.swift` (+ deterministic doubles in `FluidAudioLiveTestDoubles.swift`):

- stop during suspended model preparation prevents microphone activation, start throws, controller is reusable for a clean replacement run
- late partial callbacks from a retired run cannot reach the delegate or leak into the replacement's transcript
- a processing failure concurrent with stop delivers exactly one failure and no success
- `FluidAudioBufferPump.finish()` returns the processing error plus exact drop accounting under deterministic queue saturation
- a saturated queue marks the transcript lossy with drop counts; a clean run has no lossy marker

Verification: `swift build` clean; full `swift test` — 1633 tests, 0 failures; SwiftLint strict against the repo baseline — no violations in changed files.

Fixes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)