### PR TITLE
fix(release): build the speak CLI per architecture and lipo the slices

### DIFF
--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -420,6 +420,23 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertFalse(profileBootstrap.contains("profiles.each do |stale_profile|"))
     }
 
+    func testSpeakCLIBuildScript_buildsPerArchAndValidatesTheUniversalBinary() throws {
+        let script = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("scripts/build-speak-cli.sh"),
+            encoding: .utf8
+        )
+
+        // A combined dual-arch swift build fails to plan the SwiftFormat
+        // plugin dependency (issue #759); the slices must be built separately
+        // and joined with lipo, and the result must be verified universal.
+        XCTAssertFalse(script.contains("--arch arm64 --arch x86_64"))
+        XCTAssertTrue(script.contains("swift build --product speak --configuration release --arch arm64"))
+        XCTAssertTrue(script.contains("swift build --product speak --configuration release --arch x86_64"))
+        XCTAssertTrue(script.contains("lipo -create"))
+        XCTAssertTrue(script.contains("lipo -archs"))
+        XCTAssertTrue(script.contains("universal speak binary is missing"))
+    }
+
     func testIOSReleaseWorkflowRequiresAnExplicitSemanticVersion() throws {
         let workflow = try String(
             contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-ios.yml"),

--- a/scripts/build-speak-cli.sh
+++ b/scripts/build-speak-cli.sh
@@ -28,17 +28,43 @@ fi
 APP_PATH="$(cd "$APP_PATH" && pwd -P)"
 
 cd "$ROOT_DIR"
-echo "==> Building speak (release, arm64+x86_64)"
-swift build --product speak --configuration release \
-    --arch arm64 --arch x86_64
+# The two slices are built separately and joined with lipo: a single swift
+# build invocation passing both arch flags fails to plan the package graph
+# ("duplicate key found: ID(moduleName: \"CommandLineTool\", packageIdentity:
+# swiftformat)") because the SwiftFormat plugin dependency is modelled once
+# per architecture (issue #759).
+echo "==> Building speak (release, arm64)"
+swift build --product speak --configuration release --arch arm64
+echo "==> Building speak (release, x86_64)"
+swift build --product speak --configuration release --arch x86_64
 
-BINARY_PATH="$(swift build --product speak --configuration release \
-    --arch arm64 --arch x86_64 --show-bin-path)/speak"
+ARM64_BINARY="$(swift build --product speak --configuration release \
+    --arch arm64 --show-bin-path)/speak"
+X86_64_BINARY="$(swift build --product speak --configuration release \
+    --arch x86_64 --show-bin-path)/speak"
 
-if [[ ! -f "$BINARY_PATH" ]]; then
-    echo "error: built binary missing at $BINARY_PATH" >&2
-    exit 1
-fi
+for slice in "$ARM64_BINARY" "$X86_64_BINARY"; do
+    if [[ ! -f "$slice" ]]; then
+        echo "error: built binary missing at $slice" >&2
+        exit 1
+    fi
+done
+
+BINARY_PATH="$(mktemp -d)/speak"
+echo "==> Creating universal binary"
+lipo -create "$ARM64_BINARY" "$X86_64_BINARY" -output "$BINARY_PATH"
+
+# Deterministic validation: the embedded CLI must contain both slices, so a
+# regression back to a single-arch binary fails the release here, not on a
+# user's machine.
+UNIVERSAL_ARCHS="$(lipo -archs "$BINARY_PATH")"
+for required_arch in arm64 x86_64; do
+    if [[ " $UNIVERSAL_ARCHS " != *" $required_arch "* ]]; then
+        echo "error: universal speak binary is missing $required_arch (got: $UNIVERSAL_ARCHS)" >&2
+        exit 1
+    fi
+done
+echo "==> Universal binary contains: $UNIVERSAL_ARCHS"
 
 DESTINATION="$APP_PATH/Contents/MacOS/speak"
 echo "==> Embedding $BINARY_PATH -> $DESTINATION"


### PR DESCRIPTION
## Defect

Every macOS release since the speak CLI embed step landed in #667 has failed at **Embed speak CLI** with:

```
error: duplicate key found: 'ID(moduleName: "CommandLineTool", packageIdentity: swiftformat)'
```

Seven consecutive release runs failed (v2.55 → v2.60.1 tags have no published releases; the last published macOS release is mac-v2.54.0 from 14 August). A single `swift build` invocation passing both arch flags cannot plan the package graph while the SwiftFormat plugin dependency is present — the module is modelled once per architecture and the planner rejects the duplicate identity. Reproduced deterministically on a clean checkout.

## Fix

`scripts/build-speak-cli.sh` now builds each slice with its own single-arch invocation, joins them with `lipo -create`, and fails deterministically if `lipo -archs` does not report both `arm64` and `x86_64` — a regression back to a single-arch binary fails the release step rather than shipping to users. No dependency-graph or workflow changes.

## Verification

- The previous combined invocation reproduces the duplicate-key failure locally.
- The fixed script completes end-to-end locally: both slices build, the universal binary reports `x86_64 arm64`, embeds into a bundle, and `speak --version` runs.
- New `DistributionBuildIdentityTests.testSpeakCLIBuildScript_buildsPerArchAndValidatesTheUniversalBinary` pins the per-arch invocations, the lipo join, and the universal validation (16 tests, 0 failures).

Fixes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW