### PR TITLE
fix(mac): prevent history loss when WAL startup fails

### DIFF
--- a/Sources/SpeakApp/HistoryManager.swift
+++ b/Sources/SpeakApp/HistoryManager.swift
@@ -41,6 +41,45 @@ struct WALEntry: Codable {
   }
 }
 
+extension [WALEntry] {
+  /// Applies the queued operations, in order, to an item list. Shared by WAL
+  /// replay and by the startup merge of mutations queued while storage was
+  /// unavailable (issue #695). Appends are idempotent by item id.
+  func applied(to items: [HistoryItem]) -> [HistoryItem] {
+    var current = items
+    for entry in self {
+      switch entry.operation {
+      case .append:
+        if let item = entry.item, !current.contains(where: { $0.id == item.id }) {
+          current.insert(item, at: 0)
+        }
+      case .update:
+        if let item = entry.item, let index = current.firstIndex(where: { $0.id == item.id }) {
+          current[index] = item
+        }
+      case .remove:
+        if let item = entry.item {
+          current.removeAll { $0.id == item.id }
+        }
+      case .removeAll:
+        current.removeAll()
+      }
+    }
+    return current
+  }
+}
+
+/// Startup persistence state. `failed` means the on-disk history could not be
+/// loaded; the last snapshot is left untouched and every operation that could
+/// replace it is blocked until a retry succeeds (issue #695).
+enum HistoryLoadState: Equatable {
+  case loading
+  case ready
+  case failed(String)
+
+  var isReady: Bool { self == .ready }
+}
+
 @MainActor
 // swiftlint:disable:next type_body_length
 final class HistoryManager: ObservableObject {
@@ -54,6 +93,14 @@ final class HistoryManager: ObservableObject {
   )
   @Published private(set) var hasMoreItems: Bool = false
   @Published private(set) var isLoadingMore: Bool = false
+
+  /// Startup persistence state. While `.failed`, mutations stay queued in
+  /// memory and nothing on disk is replaced; `retryLoad()` re-attempts.
+  @Published private(set) var loadState: HistoryLoadState = .loading
+
+  /// Most recent WAL/flush failure, for the UI. Cleared by the next durable
+  /// write. Never contains transcript text or file paths.
+  @Published private(set) var persistenceError: String?
 
   let pageSize: Int
 
@@ -187,7 +234,17 @@ final class HistoryManager: ObservableObject {
   /// flush bookkeeping; the on-disk append is actor-isolated.
   private func appendToWAL(_ entry: WALEntry) async {
     pendingWrites.append(entry)
-    await walStore.append(entry)
+    // While startup load has failed, nothing may touch the history files: the
+    // entry stays queued in memory and is written after a successful retry.
+    guard loadState.isReady else { return }
+    do {
+      try await walStore.append(entry)
+    } catch {
+      // The mutation is not durable yet; it remains in pendingWrites so the
+      // next flush retries it through the snapshot commit.
+      persistenceError = "History could not be written to disk. It will be retried automatically."
+      log.error("WAL append failed: \(error.localizedDescription, privacy: .public)")
+    }
     if pendingWrites.count >= batchSizeThreshold {
       await flushIfNeeded()
     }
@@ -225,6 +282,10 @@ final class HistoryManager: ObservableObject {
   /// pending writes unflushed. Doing the encode + write synchronously here costs a
   /// short stall during `willTerminate`, but actually persists the data.
   private func flushImmediatelySync() {
+    // A failed startup load means the in-memory view does not contain the
+    // persisted history; writing it here would replace a valid snapshot with
+    // only the newest items (issue #695).
+    guard loadState.isReady else { return }
     guard !pendingWrites.isEmpty, !isFlushing else { return }
     isFlushing = true
     defer { isFlushing = false }
@@ -246,6 +307,8 @@ final class HistoryManager: ObservableObject {
   /// Force immediate flush of all pending writes — now via isolated WAL store
   func flushImmediately() async {
     await waitUntilLoaded()
+    // Never replace the on-disk snapshot from a state that failed to load it.
+    guard loadState.isReady else { return }
     guard !isFlushing else { return }
     isFlushing = true
     defer { isFlushing = false }
@@ -257,8 +320,10 @@ final class HistoryManager: ObservableObject {
     do {
       try await walStore.commitSnapshot(snapshot, flushing: flushedEntries)
       completeFlush(flushedCount: flushedCount)
+      persistenceError = nil
       log.info("Flush complete")
     } catch {
+      persistenceError = "History could not be written to disk. It will be retried automatically."
       log.error("Failed to flush history: \(error.localizedDescription, privacy: .public)")
     }
   }
@@ -292,8 +357,12 @@ final class HistoryManager: ObservableObject {
       } else {
         persisted = try await walStore.loadSnapshot()
       }
+      // Mutations queued while the store was unavailable are replayed on top
+      // of the loaded history, so a retried load keeps both (issue #695). On
+      // first startup the queue is empty and this is the identity.
+      let merged = pendingWrites.applied(to: persisted)
       let (sorted, stats) = await Task.detached(priority: .userInitiated) {
-        let sorted = persisted.sorted { $0.createdAt > $1.createdAt }
+        let sorted = merged.sorted { $0.createdAt > $1.createdAt }
         let stats = Self.calculateStatistics(for: sorted)
         return (sorted, stats)
       }.value
@@ -303,9 +372,30 @@ final class HistoryManager: ObservableObject {
       hasMoreItems = sorted.count > pageSize
       cachedStatistics = stats
       statistics = stats
+      loadState = .ready
+      // Make the queued mutations durable now that the store is reachable.
+      // They remain in pendingWrites either way; flush commits them.
+      for entry in pendingWrites {
+        try? await walStore.append(entry)
+      }
+      if !pendingWrites.isEmpty {
+        await flushIfNeeded()
+      }
     } catch {
+      // Leave the last snapshot and the in-memory queue untouched: readiness
+      // is explicit, not inferred from task completion (issue #695).
+      loadState = .failed(error.localizedDescription)
+      persistenceError = "History could not be loaded from disk. New sessions are kept in memory until retry succeeds."
       log.error("Failed to load history: \(error.localizedDescription, privacy: .public)")
     }
+  }
+
+  /// Re-attempts a failed startup load. Queued mutations are preserved and
+  /// replayed over the loaded history on success.
+  func retryLoad() async {
+    guard case .failed = loadState else { return }
+    loadState = .loading
+    await loadFromDisk()
   }
 
   /// Loads more items for infinite scroll

--- a/Sources/SpeakApp/HistoryView.swift
+++ b/Sources/SpeakApp/HistoryView.swift
@@ -18,6 +18,8 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
   @State private var historyItems: [HistoryItem] = []
   @State private var selectedModelFilter: String? = nil
   @State private var availableModels: [String] = []
+  @State private var persistenceNotice: String?
+  @State private var historyLoadFailed = false
   @State private var historyStats: HistoryStatistics = .init(
     totalSessions: 0,
     cumulativeRecordingDuration: 0,
@@ -148,6 +150,7 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
       ScrollView {
         VStack(alignment: .leading, spacing: density.sectionSpacing) {
           header
+          persistenceBanner
           if isInitialLoad {
             skeletonLoadingView
           } else if filteredItems.isEmpty {
@@ -200,6 +203,14 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
       .onReceive(environment.history.$statistics) { stats in
         withAnimation(.easeInOut(duration: 0.2)) {
           historyStats = stats
+        }
+      }
+      .onReceive(environment.history.$persistenceError) { persistenceNotice = $0 }
+      .onReceive(environment.history.$loadState) { state in
+        if case .failed = state {
+          historyLoadFailed = true
+        } else {
+          historyLoadFailed = false
         }
       }
       .onChange(of: searchText) { _, _ in recomputeFilteredItems() }
@@ -259,6 +270,32 @@ struct HistoryView: View { // swiftlint:disable:this type_body_length
       compactHeader
     } else {
       normalHeader
+    }
+  }
+
+  /// Shown while history persistence is degraded (issue #695): the on-disk
+  /// snapshot is preserved and new sessions stay queued in memory.
+  @ViewBuilder
+  private var persistenceBanner: some View {
+    if let persistenceNotice {
+      HStack(spacing: 8) {
+        Image(systemName: "externaldrive.badge.exclamationmark")
+          .foregroundStyle(.orange)
+          .accessibilityHidden(true)
+        Text(persistenceNotice)
+          .font(.callout)
+          .fixedSize(horizontal: false, vertical: true)
+        Spacer(minLength: 0)
+        if historyLoadFailed {
+          Button("Retry") {
+            Task { await environment.history.retryLoad() }
+          }
+          .accessibilityLabel("Retry loading history")
+        }
+      }
+      .padding(10)
+      .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+      .accessibilityElement(children: .combine)
     }
   }
 

--- a/Sources/SpeakApp/HistoryWALStore.swift
+++ b/Sources/SpeakApp/HistoryWALStore.swift
@@ -32,7 +32,10 @@ actor HistoryWALStore {
 
     // MARK: WAL append
 
-    func append(_ entry: WALEntry) {
+    /// Appends one entry to the WAL. Throws on any encode or I/O failure so the
+    /// caller can refuse to treat the mutation as durable (issue #695); the
+    /// entry stays in the manager's pending queue and is retried by flush.
+    func append(_ entry: WALEntry) throws {
         do {
             var line = try encoder.encode(entry)
             line.append(0x0A)
@@ -41,6 +44,7 @@ actor HistoryWALStore {
             try handle.write(contentsOf: line)
         } catch {
             log.error("Failed to append to WAL: \(error.localizedDescription, privacy: .public)")
+            throw error
         }
     }
 
@@ -60,44 +64,42 @@ actor HistoryWALStore {
     /// Persists a snapshot and removes only the WAL operations represented by it.
     /// Appends queued before or after this actor operation remain in the WAL
     /// unless their entry IDs are explicitly included in `entries`.
+    ///
+    /// The WAL is read and validated *before* the snapshot is replaced, so a
+    /// late WAL read failure cannot leave a partial snapshot behind (#695).
     func commitSnapshot(_ items: [HistoryItem], flushing entries: [WALEntry]) throws {
-        try writeSnapshot(items)
         let flushedIDs = Set(entries.map(\.id))
         let remaining = try loadWALEntries().filter { !flushedIDs.contains($0.id) }
+        try writeSnapshot(items)
         try replaceWAL(with: remaining)
     }
 
     /// Replays and clears the WAL as one actor operation. Keeping the complete
     /// read/merge/write/clear sequence here prevents a concurrent append from
     /// being cleared without first being included in the snapshot.
+    ///
+    /// An unreadable WAL (I/O or permission failure) throws so the manager can
+    /// refuse startup instead of treating it as empty history. A WAL whose
+    /// content decodes to nothing at all is quarantined beside the live file
+    /// and replay falls back to the snapshot — deliberate recovery, distinct
+    /// from an unavailable store (#695).
     func replayWAL() throws -> [HistoryItem]? {
-        let walEntries = try loadWALEntries()
+        guard FileManager.default.fileExists(atPath: walURL.path) else { return nil }
+        try walHandle?.synchronize()
+        let data = try Data(contentsOf: walURL)
+        let decoded = Self.decodeWALContent(from: data, decoder: decoder)
+        if decoded.isFullyUndecodable {
+            try quarantineCorruptWAL()
+            return nil
+        }
+        let walEntries = decoded.entries
         guard !walEntries.isEmpty else {
-            if FileManager.default.fileExists(atPath: walURL.path) {
-                try replaceWAL(with: [])
-            }
+            try replaceWAL(with: [])
             return nil
         }
 
         log.info("Replaying \(walEntries.count) WAL entries")
-        var currentItems = try loadSnapshot()
-        for entry in walEntries {
-            switch entry.operation {
-            case .append:
-                if let item = entry.item, !currentItems.contains(where: { $0.id == item.id }) {
-                    currentItems.insert(item, at: 0)
-                }
-            case .update:
-                if let item = entry.item,
-                   let index = currentItems.firstIndex(where: { $0.id == item.id }) {
-                    currentItems[index] = item
-                }
-            case .remove:
-                if let item = entry.item { currentItems.removeAll { $0.id == item.id } }
-            case .removeAll:
-                currentItems.removeAll()
-            }
-        }
+        let currentItems = walEntries.applied(to: try loadSnapshot())
 
         try writeSnapshot(currentItems)
         try replaceWAL(with: [])
@@ -109,7 +111,7 @@ actor HistoryWALStore {
         guard FileManager.default.fileExists(atPath: walURL.path) else { return [] }
         try walHandle?.synchronize()
         let data = try Data(contentsOf: walURL)
-        return decodeWALEntries(from: data)
+        return Self.decodeWALContent(from: data, decoder: decoder).entries
     }
 
     // MARK: Private
@@ -143,16 +145,46 @@ actor HistoryWALStore {
         try data.write(to: walURL, options: [.atomic])
     }
 
-    private func decodeWALEntries(from data: Data) -> [WALEntry] {
-        if let legacy = try? decoder.decode([WALEntry].self, from: data) { return legacy }
+    /// Result of decoding raw WAL bytes: the recovered entries plus whether the
+    /// file held real content of which nothing decoded (torn tails still count
+    /// as partially decodable; this flag means the whole file is unusable).
+    struct DecodedWALContent {
+        let entries: [WALEntry]
+        let isFullyUndecodable: Bool
+    }
+
+    static func decodeWALContent(from data: Data, decoder: JSONDecoder) -> DecodedWALContent {
+        if let legacy = try? decoder.decode([WALEntry].self, from: data) {
+            return DecodedWALContent(entries: legacy, isFullyUndecodable: false)
+        }
         var entries: [WALEntry] = []
+        var sawContent = false
         for line in data.split(separator: 0x0A) where !line.isEmpty {
+            sawContent = true
             if let entry = try? decoder.decode(WALEntry.self, from: Data(line)) {
                 entries.append(entry)
             } else if let legacy = try? decoder.decode([WALEntry].self, from: Data(line)) {
                 entries.append(contentsOf: legacy)
             }
         }
-        return entries
+        return DecodedWALContent(
+            entries: entries,
+            isFullyUndecodable: sawContent && entries.isEmpty
+        )
+    }
+
+    /// Moves an unusable WAL aside (never deletes it) so startup can proceed
+    /// from the snapshot while the original bytes stay available for support.
+    private func quarantineCorruptWAL() throws {
+        try walHandle?.close()
+        walHandle = nil
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let quarantineURL = walURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("history-wal.corrupt-\(timestamp).json", isDirectory: false)
+        try FileManager.default.moveItem(at: walURL, to: quarantineURL)
+        log.error(
+            "Quarantined undecodable WAL as \(quarantineURL.lastPathComponent, privacy: .public)"
+        )
     }
 }

--- a/Tests/SpeakAppTests/HistoryManagerTests.swift
+++ b/Tests/SpeakAppTests/HistoryManagerTests.swift
@@ -211,12 +211,12 @@ final class HistoryManagerTests: XCTestCase {
         let laterItem = makeItem()
         let flushedEntry = WALEntry(operation: .append, item: flushedItem)
         let laterEntry = WALEntry(operation: .append, item: laterItem)
-        await store.append(flushedEntry)
+        try await store.append(flushedEntry)
 
         async let commit: Void = store.commitSnapshot([flushedItem], flushing: [flushedEntry])
         async let append: Void = store.append(laterEntry)
         try await commit
-        await append
+        try await append
 
         let pending = try await store.loadWALEntries()
         XCTAssertEqual(pending.map(\.id), [laterEntry.id])

--- a/Tests/SpeakAppTests/HistoryPersistenceFailureTests.swift
+++ b/Tests/SpeakAppTests/HistoryPersistenceFailureTests.swift
@@ -1,0 +1,243 @@
+import Foundation
+import XCTest
+
+import SpeakCore
+@testable import SpeakApp
+
+/// FileManager that redirects Application Support to a temporary directory so
+/// `HistoryManager` persists to an isolated location during tests.
+private final class TemporaryApplicationSupportFileManager: FileManager {
+    let supportURL: URL
+
+    init(supportURL: URL) {
+        self.supportURL = supportURL
+        super.init()
+    }
+
+    override func urls(
+        for directory: FileManager.SearchPathDirectory,
+        in domainMask: FileManager.SearchPathDomainMask
+    ) -> [URL] {
+        guard directory == .applicationSupportDirectory else {
+            return super.urls(for: directory, in: domainMask)
+        }
+        return [supportURL]
+    }
+}
+
+/// Startup persistence failure safety (issue #695): a load failure must never
+/// let a partial in-memory view replace the on-disk history, WAL append
+/// failures must be surfaced, and recovery must keep both the original
+/// history and mutations queued while storage was unavailable.
+@MainActor
+final class HistoryPersistenceFailureTests: XCTestCase {
+    private var tempDir: URL!
+    private var fileManager: TemporaryApplicationSupportFileManager!
+
+    private var historyDir: URL {
+        tempDir
+            .appendingPathComponent("SpeakApp", isDirectory: true)
+            .appendingPathComponent("History", isDirectory: true)
+    }
+
+    private var walURL: URL {
+        historyDir.appendingPathComponent("history-wal.json", isDirectory: false)
+    }
+
+    private var storageURL: URL {
+        historyDir.appendingPathComponent("history-log.json", isDirectory: false)
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        fileManager = TemporaryApplicationSupportFileManager(supportURL: tempDir)
+    }
+
+    override func tearDown() async throws {
+        try? setPermissions(0o700, at: historyDir)
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        fileManager = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeManager() async -> HistoryManager {
+        let manager = HistoryManager(
+            fileManager: fileManager,
+            flushInterval: 3600,
+            batchSizeThreshold: 10_000
+        )
+        await manager.waitUntilLoaded()
+        return manager
+    }
+
+    private func makeCoder() -> (JSONEncoder, JSONDecoder) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return (encoder, decoder)
+    }
+
+    private func makeItem(createdAt: Date = Date()) -> HistoryItem {
+        HistoryItem(
+            id: UUID(),
+            createdAt: createdAt,
+            modelsUsed: ["apple/local/SFSpeechRecognizer"],
+            rawTranscription: "raw transcript",
+            postProcessedTranscription: nil,
+            recordingDuration: 10,
+            cost: nil,
+            audioFileURL: nil,
+            networkExchanges: [],
+            events: [],
+            phaseTimestamps: PhaseTimestamps(
+                recordingStarted: nil,
+                recordingEnded: nil,
+                transcriptionStarted: nil,
+                transcriptionEnded: nil,
+                postProcessingStarted: nil,
+                postProcessingEnded: nil,
+                outputDelivered: nil
+            ),
+            trigger: HistoryTrigger(
+                gesture: .singleTap,
+                hotKeyDescription: "Fn",
+                outputMethod: .clipboard,
+                destinationApplication: nil
+            ),
+            personalCorrections: nil,
+            errors: []
+        )
+    }
+
+    private func setPermissions(_ mode: Int, at url: URL) throws {
+        try FileManager.default.setAttributes(
+            [.posixPermissions: mode],
+            ofItemAtPath: url.path
+        )
+    }
+
+    func testUnreadableWAL_failsStartupAndNeverAltersEitherFile() async throws {
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        let (encoder, _) = makeCoder()
+        let existing = [makeItem(createdAt: Date().addingTimeInterval(-20)), makeItem()]
+        try encoder.encode(existing).write(to: storageURL, options: [.atomic])
+        var walData = try encoder.encode(WALEntry(operation: .append, item: makeItem()))
+        walData.append(0x0A)
+        try walData.write(to: walURL, options: [.atomic])
+        let snapshotBytes = try Data(contentsOf: storageURL)
+        try setPermissions(0o000, at: walURL)
+        defer { try? setPermissions(0o644, at: walURL) }
+
+        let manager = await makeManager()
+        guard case .failed = manager.loadState else {
+            return XCTFail("Expected failed load state, got \(manager.loadState)")
+        }
+        XCTAssertNotNil(manager.persistenceError)
+
+        // Attempted mutations while failed must not touch either file.
+        await manager.append(makeItem())
+        await manager.flushImmediately()
+
+        try setPermissions(0o644, at: walURL)
+        XCTAssertEqual(try Data(contentsOf: storageURL), snapshotBytes)
+        XCTAssertEqual(try Data(contentsOf: walURL), walData)
+    }
+
+    func testRetryAfterStorageBecomesReadable_keepsHistoryAndQueuedAppend() async throws {
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        let (encoder, decoder) = makeCoder()
+        let original = makeItem(createdAt: Date().addingTimeInterval(-20))
+        try encoder.encode([original]).write(to: storageURL, options: [.atomic])
+        let walItem = makeItem(createdAt: Date().addingTimeInterval(-10))
+        var walData = try encoder.encode(WALEntry(operation: .append, item: walItem))
+        walData.append(0x0A)
+        try walData.write(to: walURL, options: [.atomic])
+        try setPermissions(0o000, at: walURL)
+        defer { try? setPermissions(0o644, at: walURL) }
+
+        let manager = await makeManager()
+        guard case .failed = manager.loadState else {
+            return XCTFail("Expected failed load state")
+        }
+        let queued = makeItem()
+        await manager.append(queued)
+
+        try setPermissions(0o644, at: walURL)
+        await manager.retryLoad()
+
+        XCTAssertTrue(manager.loadState.isReady)
+        XCTAssertEqual(
+            Set(manager.allItems.map(\.id)),
+            Set([original.id, walItem.id, queued.id]),
+            "original history, replayed WAL entry and the queued append must all survive"
+        )
+
+        await manager.flushImmediately()
+        XCTAssertNil(manager.persistenceError)
+        let persisted = try decoder.decode([HistoryItem].self, from: Data(contentsOf: storageURL))
+        XCTAssertEqual(Set(persisted.map(\.id)), Set([original.id, walItem.id, queued.id]))
+    }
+
+    func testUnreadableSnapshot_failsStartupWithoutInventingEmptyHistory() async throws {
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        let (encoder, _) = makeCoder()
+        try encoder.encode([makeItem()]).write(to: storageURL, options: [.atomic])
+        try setPermissions(0o000, at: storageURL)
+        defer { try? setPermissions(0o644, at: storageURL) }
+
+        let manager = await makeManager()
+        guard case .failed = manager.loadState else {
+            return XCTFail("Expected failed load state")
+        }
+        XCTAssertTrue(manager.allItems.isEmpty)
+    }
+
+    func testFullyUndecodableWAL_isQuarantinedAndSnapshotStillLoads() async throws {
+        try FileManager.default.createDirectory(at: historyDir, withIntermediateDirectories: true)
+        let (encoder, _) = makeCoder()
+        let existing = makeItem()
+        try encoder.encode([existing]).write(to: storageURL, options: [.atomic])
+        let garbage = Data("not json at all\nstill not json\n".utf8)
+        try garbage.write(to: walURL, options: [.atomic])
+
+        let manager = await makeManager()
+
+        XCTAssertTrue(manager.loadState.isReady)
+        XCTAssertEqual(manager.allItems.map(\.id), [existing.id])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: walURL.path))
+        let quarantined = try FileManager.default.contentsOfDirectory(atPath: historyDir.path)
+            .filter { $0.hasPrefix("history-wal.corrupt-") }
+        XCTAssertEqual(quarantined.count, 1)
+        let quarantineURL = historyDir.appendingPathComponent(quarantined[0])
+        XCTAssertEqual(try Data(contentsOf: quarantineURL), garbage)
+    }
+
+    func testWALAppendFailure_surfacesErrorAndFlushMakesItDurable() async throws {
+        let manager = await makeManager()
+        XCTAssertTrue(manager.loadState.isReady)
+
+        // Make the directory unwritable so the WAL append cannot create its file.
+        try setPermissions(0o500, at: historyDir)
+        let item = makeItem()
+        await manager.append(item)
+        XCTAssertNotNil(manager.persistenceError, "a failed WAL append must be surfaced, not logged as success")
+
+        // Once the store is writable again, the periodic flush path makes the
+        // mutation durable and clears the surfaced error.
+        try setPermissions(0o700, at: historyDir)
+        await manager.flushImmediately()
+        XCTAssertNil(manager.persistenceError)
+
+        let (_, decoder) = makeCoder()
+        let persisted = try decoder.decode([HistoryItem].self, from: Data(contentsOf: storageURL))
+        XCTAssertEqual(persisted.map(\.id), [item.id])
+    }
+
+}


### PR DESCRIPTION
## Defect

If WAL replay or snapshot loading threw during `HistoryManager.loadFromDisk`, the error was logged but startup completed with empty in-memory history and `waitUntilLoaded` passed. The next append then flushed a snapshot containing only the new item over the valid `history-log.json` — persistent history loss. `HistoryWALStore.append` also swallowed write errors, so mutations could be reported durable without ever reaching the WAL, and `commitSnapshot` wrote the snapshot before re-reading the WAL, so a late WAL read failure could leave a partial snapshot behind. The termination flush had the same overwrite path.

## Fix

- Startup is modelled as `loading` / `ready` / `failed` (`HistoryLoadState`, published). Readiness is explicit, never inferred from task completion.
- While `failed`: mutations apply in memory and stay queued in `pendingWrites`; `appendToWAL`, `flushImmediately` and the termination flush never touch either file. A banner in History surfaces the state with a Retry button (`retryLoad()`).
- On a successful (re)load, queued mutations are replayed on top of the recovered history via a shared `[WALEntry].applied(to:)` (also now used by WAL replay), then written to the WAL and flushed — original history and queued items both stay durable.
- `HistoryWALStore.append` throws; the manager surfaces the failure (`persistenceError`, published) and the entry remains pending so the next flush commit retries it. Flush success clears the error.
- `commitSnapshot` reads and validates the WAL **before** replacing the snapshot.
- An unreadable WAL or snapshot (I/O/permissions) fails startup instead of being treated as empty history. A WAL whose entire content is undecodable is quarantined beside the live file as `history-wal.corrupt-<ts>.json` (never deleted) and startup proceeds from the snapshot; torn tails keep their existing skip-and-recover behaviour.

## Tests

New `HistoryPersistenceFailureTests` (5): unreadable WAL blocks startup and an attempted append/flush leaves both files byte-identical; retry after storage becomes readable keeps the original history, the replayed WAL entry and the queued append durable; unreadable snapshot fails startup without inventing empty history; fully undecodable WAL is quarantined with its exact bytes and the snapshot still loads; a WAL append failure surfaces `persistenceError` and the next flush makes the item durable and clears it.

Full package suite: 1720 tests, 0 failures (11 skipped). `make lint`: 0 violations.

Fixes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW