### PR TITLE
fix(core): preserve repeated standalone transcript finals

### DIFF
--- a/Sources/SpeakApp/SharedClientLiveController.swift
+++ b/Sources/SpeakApp/SharedClientLiveController.swift
@@ -24,6 +24,9 @@ final class SharedClientLiveController: NSObject, LiveTranscriptionController {
   private var activeInputSession: AudioInputDeviceManager.SessionContext?
   private var startedAt: Date?
   private var latestTranscript = ""
+  /// Folds updates by the hosted client's declared final shape (issue #700);
+  /// re-created in start() once the client is known.
+  private var accumulated = TranscriptAccumulator(shape: .cumulativeTranscript)
   private var isStopping = false
 
   init(
@@ -64,6 +67,7 @@ final class SharedClientLiveController: NSObject, LiveTranscriptionController {
     activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
     audioEngine = AVAudioEngine()
     latestTranscript = ""
+    accumulated = TranscriptAccumulator(shape: client.finalShape)
     isStopping = false
     self.client = client
 
@@ -109,7 +113,7 @@ final class SharedClientLiveController: NSObject, LiveTranscriptionController {
       // would double every word the client already streamed.
       if let finalTranscript = await finalizingClient.finishAndWait(),
          latestTranscript != finalTranscript {
-        handleTranscript(finalTranscript, isFinal: true)
+        applyFullTranscript(finalTranscript)
       }
     } else {
       client?.stop()
@@ -148,27 +152,47 @@ final class SharedClientLiveController: NSObject, LiveTranscriptionController {
     return apiKey
   }
 
-  /// Applies a transcript update.
-  ///
-  /// This *replaces* `latestTranscript`, which is right for the cumulative
-  /// providers routed here (xAI resends the whole turn on every event) and for
-  /// the full transcript `finishAndWait()` returns. A provider whose
-  /// `onTranscript` emits standalone segments (Deepgram, ElevenLabs) needs
-  /// `TranscriptAccumulator` here before it can be routed through this
-  /// controller — its live updates would otherwise show only the last segment.
+  /// Applies a transcript update, folded by the hosted client's declared
+  /// final shape (issue #700): cumulative finals replace (xAI restates the
+  /// whole turn on every event), standalone segment finals append — including
+  /// repeated identical text, which is a genuine repeat, so a segment-shaped
+  /// provider routed here can no longer lose earlier segments.
   private func handleTranscript(_ text: String, isFinal: Bool) {
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
-    latestTranscript = trimmed
+    let displayText: String
+    if isFinal {
+      displayText = accumulated.append(final: trimmed)
+    } else {
+      displayText = accumulated.display(withInterim: trimmed)
+    }
+    latestTranscript = displayText
     delegate?.liveTranscriber(self, didUpdateWith: LiveTranscriptionUpdate(
-      text: trimmed,
+      text: displayText,
       isFinal: isFinal,
       confidence: nil
     ))
-    delegate?.liveTranscriber(self, didUpdatePartial: trimmed)
+    delegate?.liveTranscriber(self, didUpdatePartial: displayText)
     if isFinal {
-      delegate?.liveTranscriber(self, didDetectUtteranceBoundary: trimmed)
+      delegate?.liveTranscriber(self, didDetectUtteranceBoundary: displayText)
     }
+  }
+
+  /// Adopts a transcript that is already complete (the `finishAndWait()`
+  /// return) as the whole session transcript — replace, never append, or every
+  /// word the client already streamed would double.
+  private func applyFullTranscript(_ transcript: String) {
+    let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    accumulated.replace(with: trimmed)
+    latestTranscript = accumulated.text
+    delegate?.liveTranscriber(self, didUpdateWith: LiveTranscriptionUpdate(
+      text: accumulated.text,
+      isFinal: true,
+      confidence: nil
+    ))
+    delegate?.liveTranscriber(self, didUpdatePartial: accumulated.text)
+    delegate?.liveTranscriber(self, didDetectUtteranceBoundary: accumulated.text)
   }
 
   private func installAudioTap(
@@ -231,6 +255,7 @@ final class SharedClientLiveController: NSObject, LiveTranscriptionController {
     isRunning = false
     isStopping = false
     latestTranscript = ""
+    accumulated.reset()
     startedAt = nil
     await endActiveInputSession()
   }

--- a/Sources/SpeakCore/AssemblyAILiveClient.swift
+++ b/Sources/SpeakCore/AssemblyAILiveClient.swift
@@ -13,6 +13,9 @@ import os.log
 /// so it can drive the generic iOS transcriber (which captures the latest text).
 /// Conforms to ``StreamingTranscriptionClient``.
 public final class AssemblyAILiveClient: StreamingTranscriptionClient, @unchecked Sendable {
+    /// Final shape: this client emits a cumulative display string assembled from turns.
+    public let finalShape: TranscriptFinalShape = .cumulativeTranscript
+
     private static let beginTimeoutSeconds: Double = 8
     private static let terminationTimeoutSeconds: Double = 3
     private static let preBeginByteLimit = 16_000 * 2 * 5 // 5s of 16kHz PCM16

--- a/Sources/SpeakCore/CartesiaLiveClient.swift
+++ b/Sources/SpeakCore/CartesiaLiveClient.swift
@@ -8,6 +8,9 @@ import os.log
 /// Shared by macOS and iOS: both feed it linear16 mono PCM captured by their own
 /// platform audio layer. Conforms to `StreamingTranscriptionClient`.
 public final class CartesiaLiveClient: StreamingTranscriptionClient, @unchecked Sendable {
+    /// Final shape: each is_final transcript event carries one finalised turn.
+    public let finalShape: TranscriptFinalShape = .standaloneSegments
+
     private static let host = "api.cartesia.ai"
     private static let path = "/stt/turns/websocket"
     private static let apiVersion = "2026-03-01"

--- a/Sources/SpeakCore/DeepgramLiveClient.swift
+++ b/Sources/SpeakCore/DeepgramLiveClient.swift
@@ -13,6 +13,10 @@ import os.log
 ///
 /// Works on both macOS and iOS.
 public final class DeepgramLiveClient: FinalizingStreamingTranscriptionClient, @unchecked Sendable {
+    /// Final shape: v1/listen is_final results and Flux EndOfTurn events each cover
+    /// their own audio span exactly once; nothing is resent.
+    public let finalShape: TranscriptFinalShape = .standaloneSegments
+
     private let apiKey: String
     private let model: String
     private let language: String?
@@ -30,7 +34,7 @@ public final class DeepgramLiveClient: FinalizingStreamingTranscriptionClient, @
     /// Guarded by `stateLock`: the session's full transcript, folded from the
     /// segment finals Deepgram streams. `finishAndWait()` returns this, per the
     /// `FinalizingStreamingTranscriptionClient` contract.
-    private var accumulated = TranscriptAccumulator()
+    private var accumulated = TranscriptAccumulator(shape: .standaloneSegments)
 
     /// Bounded post-stop drain state: after `CloseStream` is sent, the trailing
     /// final transcript is folded in and the full transcript is handed to the

--- a/Sources/SpeakCore/ElevenLabsLiveClient.swift
+++ b/Sources/SpeakCore/ElevenLabsLiveClient.swift
@@ -7,6 +7,9 @@ import os.log
 /// Cross-platform ElevenLabs WebSocket client for live speech-to-text.
 /// Works on both macOS and iOS.
 public final class ElevenLabsLiveClient: FinalizingStreamingTranscriptionClient, @unchecked Sendable {
+    /// Final shape: FINAL_TRANSCRIPT events carry the newly finalised segment only.
+    public let finalShape: TranscriptFinalShape = .standaloneSegments
+
     private let apiKey: String
     private let modelID: String
     private let language: String?
@@ -26,7 +29,7 @@ public final class ElevenLabsLiveClient: FinalizingStreamingTranscriptionClient,
     /// Guarded by `stateLock`: the session's full transcript, folded from the
     /// finals ElevenLabs streams. `finishAndWait()` returns this, per the
     /// `FinalizingStreamingTranscriptionClient` contract.
-    private var accumulated = TranscriptAccumulator()
+    private var accumulated = TranscriptAccumulator(shape: .standaloneSegments)
 
     /// Bounded post-stop drain state: while `finishAndWait()` is pending, the
     /// trailing final is folded in and the full transcript is handed to the

--- a/Sources/SpeakCore/GladiaLiveClient.swift
+++ b/Sources/SpeakCore/GladiaLiveClient.swift
@@ -11,6 +11,9 @@ import os.log
 /// carry `(text, is_final)`, so they map straight onto
 /// ``StreamingTranscriptionClient``. Shared by macOS and iOS.
 public final class GladiaLiveClient: StreamingTranscriptionClient, @unchecked Sendable {
+    /// Final shape: each final transcript event carries one utterance.
+    public let finalShape: TranscriptFinalShape = .standaloneSegments
+
     private static let baseURL = URL(string: "https://api.gladia.io")!
 
     private let apiKey: String

--- a/Sources/SpeakCore/ModulateLiveClient.swift
+++ b/Sources/SpeakCore/ModulateLiveClient.swift
@@ -11,6 +11,9 @@ import os.log
 /// The first audio frame is prefixed with a streaming WAV header, as the API
 /// requires. Conforms to ``StreamingTranscriptionClient``.
 public final class ModulateLiveClient: StreamingTranscriptionClient, @unchecked Sendable {
+    /// Final shape: the done emit joins every utterance seen in the session.
+    public let finalShape: TranscriptFinalShape = .cumulativeTranscript
+
     private static let endpoint = "wss://modulate-developer-apis.com/api/velma-2-stt-streaming"
 
     private let apiKey: String

--- a/Sources/SpeakCore/SonioxLiveClient.swift
+++ b/Sources/SpeakCore/SonioxLiveClient.swift
@@ -10,6 +10,9 @@ import os.log
 /// final is committed on the `finished`/finalize markers. Conforms to
 /// ``StreamingTranscriptionClient``.
 public final class SonioxLiveClient: StreamingTranscriptionClient, @unchecked Sendable {
+    /// Final shape: the final emit is the accumulated final-token text for the session.
+    public let finalShape: TranscriptFinalShape = .cumulativeTranscript
+
     private static let websocketHost = "stt-rt.soniox.com"
     private static let websocketPath = "/transcribe-websocket"
 

--- a/Sources/SpeakCore/StreamingTranscriptionClient.swift
+++ b/Sources/SpeakCore/StreamingTranscriptionClient.swift
@@ -16,6 +16,15 @@ import Foundation
 /// `LiveTranscriptionRoute.sampleRate`), and `stop` tears it down. Transcript
 /// updates and errors are delivered through the closures passed to `start`.
 public protocol StreamingTranscriptionClient: AnyObject {
+    /// How this client's final `onTranscript` events are shaped: standalone
+    /// providers emit each finalised segment exactly once, cumulative
+    /// providers restate the transcript so far. Consumers must fold finals by
+    /// this declaration (`TranscriptAccumulator`), because text equality or
+    /// prefixes cannot distinguish a provider resend from two genuinely
+    /// identical utterances (issue #700). There is deliberately no default:
+    /// every conformer states its provider's documented semantics.
+    var finalShape: TranscriptFinalShape { get }
+
     /// Opens the session.
     /// - Parameters:
     ///   - onTranscript: `(text, isFinal)` for each interim/final transcript.

--- a/Sources/SpeakCore/TranscriptAccumulator.swift
+++ b/Sources/SpeakCore/TranscriptAccumulator.swift
@@ -1,23 +1,45 @@
 import Foundation
 
-/// Assembles a session's full transcript from the *segment* finals that
-/// providers like Deepgram and ElevenLabs emit.
+/// How a streaming provider shapes the *final* transcripts it emits.
 ///
-/// Providers disagree on what a "final" carries: some send only the newly
-/// finalised words (a segment), others resend the whole utterance so far
-/// (cumulative). This merges both shapes with one rule — a final that extends
-/// what we already have replaces it, anything else is appended — so callers get
-/// the same full transcript either way and nothing is doubled or dropped.
+/// Text alone cannot distinguish a provider retry from two semantically
+/// identical utterances ("Yes." followed by "Yes."), so the shape is declared
+/// per client instead of inferred from equality or prefixes (issue #700).
+public enum TranscriptFinalShape: Sendable, Equatable {
+    /// Every final is a newly finalised segment that has not been delivered
+    /// before. Identical consecutive text is a genuine repeat and must append;
+    /// duplicates are dropped only by explicit provider event identity.
+    case standaloneSegments
+
+    /// Every final restates the transcript so far, so each one replaces the
+    /// previous — including revisions that are not strict prefix extensions
+    /// (punctuation, casing or word corrections).
+    case cumulativeTranscript
+}
+
+/// Assembles a session's full transcript from the finals a provider emits.
 ///
-/// This is the single implementation of that rule: the shared clients use it to
-/// honour the `FinalizingStreamingTranscriptionClient` full-transcript contract
-/// and the iOS capture path uses it for its live display text, so the two can't
-/// drift apart.
+/// The provider's declared `TranscriptFinalShape` decides the fold: standalone
+/// segments append (even when their text repeats), cumulative transcripts
+/// replace (even when the revision is not a prefix extension). This is the
+/// single implementation of that rule: the shared clients use it to honour the
+/// `FinalizingStreamingTranscriptionClient` full-transcript contract and both
+/// platform capture paths use it for their live display text, so the
+/// consumers cannot drift apart.
 public struct TranscriptAccumulator: Sendable, Equatable {
+    /// How finals folded by this accumulator are shaped.
+    public let shape: TranscriptFinalShape
+
     /// The full transcript so far. Empty until the first non-blank final.
     public private(set) var text: String = ""
 
-    public init() {}
+    /// Provider event identities already folded, used to drop retransmissions
+    /// of the same event. Only populated when callers supply identities.
+    private var seenEventIDs: Set<String> = []
+
+    public init(shape: TranscriptFinalShape) {
+        self.shape = shape
+    }
 
     public var isEmpty: Bool { self.text.isEmpty }
 
@@ -26,16 +48,25 @@ public struct TranscriptAccumulator: Sendable, Equatable {
     public var transcriptOrNil: String? { self.text.isEmpty ? nil : self.text }
 
     /// Merges one provider final into the transcript and returns the result.
+    ///
+    /// - Parameters:
+    ///   - segment: the final's text. Blank finals are ignored.
+    ///   - eventID: a stable provider event/sequence identity, when the
+    ///     provider has one. A repeated identity is a retransmission and is
+    ///     dropped; without an identity every distinct final event is folded,
+    ///     including ones whose text matches what was already accumulated.
     @discardableResult
-    public mutating func append(final segment: String) -> String {
+    public mutating func append(final segment: String, eventID: String? = nil) -> String {
         let trimmed = segment.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return self.text }
-        if self.text.isEmpty || trimmed == self.text || trimmed.hasPrefix(self.text + " ") {
-            // Cumulative final (or the first one): it already contains
-            // everything we had, so it replaces rather than appends.
+        if let eventID {
+            guard self.seenEventIDs.insert(eventID).inserted else { return self.text }
+        }
+        switch self.shape {
+        case .standaloneSegments:
+            self.text = self.text.isEmpty ? trimmed : self.text + " " + trimmed
+        case .cumulativeTranscript:
             self.text = trimmed
-        } else {
-            self.text += " " + trimmed
         }
         return self.text
     }
@@ -48,12 +79,21 @@ public struct TranscriptAccumulator: Sendable, Equatable {
 
     public mutating func reset() {
         self.text = ""
+        self.seenEventIDs = []
     }
 
-    /// The live display text: everything finalised plus a trailing interim.
+    /// The live display text for an interim update.
+    ///
+    /// Standalone interims extend what is finalised; cumulative interims
+    /// already restate the whole transcript so far and stand alone.
     public func display(withInterim interim: String) -> String {
         let trimmed = interim.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return self.text }
-        return self.text.isEmpty ? trimmed : self.text + " " + trimmed
+        switch self.shape {
+        case .standaloneSegments:
+            return self.text.isEmpty ? trimmed : self.text + " " + trimmed
+        case .cumulativeTranscript:
+            return trimmed
+        }
     }
 }

--- a/Sources/SpeakCore/XAILiveClient.swift
+++ b/Sources/SpeakCore/XAILiveClient.swift
@@ -8,6 +8,9 @@ import os
 /// captions, and no `response.create` event. That means no assistant audio is
 /// generated or played.
 public final class XAILiveClient: FinalizingStreamingTranscriptionClient, @unchecked Sendable {
+    /// Final shape: every transcription event restates the whole turn so far.
+    public let finalShape: TranscriptFinalShape = .cumulativeTranscript
+
     private static let finishTimeoutSeconds: TimeInterval = 3
     private static let preconfigurationByteLimit = 24_000 * 2 * 5
 

--- a/Sources/SpeakiOS/Services/SharedClientLiveTranscriber.swift
+++ b/Sources/SpeakiOS/Services/SharedClientLiveTranscriber.swift
@@ -32,8 +32,9 @@ public final class SharedClientLiveTranscriber: ObservableObject {
     private var client: StreamingTranscriptionClient?
     private let audioEngine = AVAudioEngine()
     private var startTime: Date?
-    /// Finalised text so far, folded from the client's finals.
-    private var accumulated = TranscriptAccumulator()
+    /// Finalised text so far, folded by the hosted client's declared final
+    /// shape once `start()` knows which client is in use (issue #700).
+    private var accumulated = TranscriptAccumulator(shape: .standaloneSegments)
 
     /// Persistent audio recorder — saves audio to disk alongside transcription,
     /// so a session survives the network dropping mid-stream.
@@ -90,6 +91,9 @@ public final class SharedClientLiveTranscriber: ObservableObject {
         try await configureAudioSession()
 
         self.client = client
+        // Fold finals by the client's declared shape: standalone segments
+        // append (identical text repeats included), cumulative finals replace.
+        accumulated = TranscriptAccumulator(shape: client.finalShape)
         client.start(
             onTranscript: { [weak self] text, isFinal in
                 Task { @MainActor in self?.handleTranscript(text: text, isFinal: isFinal) }
@@ -256,9 +260,9 @@ public final class SharedClientLiveTranscriber: ObservableObject {
         // captured after this point becomes outstanding again.
         unansweredAudio.clear()
         if isFinal {
-            // Providers disagree on whether a final is a standalone segment or
-            // the whole utterance so far; `TranscriptAccumulator` folds both
-            // shapes the same way the shared clients do.
+            // Folds by the client's declared final shape: standalone segments
+            // append (repeated identical text is a genuine repeat), cumulative
+            // finals replace (issue #700).
             accumulated.append(final: text)
             finalText = accumulated.text
             partialText = accumulated.text

--- a/Tests/SpeakCoreTests/StreamingClientContractTests.swift
+++ b/Tests/SpeakCoreTests/StreamingClientContractTests.swift
@@ -60,18 +60,39 @@ final class StreamingClientContractTests: XCTestCase {
         XCTAssertNil(transcript)
     }
 
-    func testDeepgram_cumulativeFinalsAreNotDoubled() async {
-        // Arrange: a provider that resends the whole utterance must not be
-        // concatenated with itself.
+    func testDeepgram_repeatedIdenticalStandaloneFinalsAreBothKept() async {
+        // Issue #700: two legitimate standalone finals with identical text are
+        // two utterances, not a resend. Deepgram's is_final results are
+        // segment-shaped, so nothing may be inferred from text equality.
         let client = DeepgramLiveClient(apiKey: "k", model: "nova-3")
 
-        // Act
+        client.parseTranscriptResponse(Self.deepgramFinal("Yes."))
+        client.parseTranscriptResponse(Self.deepgramFinal("Yes."))
+        let transcript = await client.finishAndWait()
+
+        XCTAssertEqual(transcript, "Yes. Yes.")
+    }
+
+    func testDeepgram_prefixExtendingStandaloneFinalsAreBothKept() async {
+        // A later segment that happens to start with the earlier segment's
+        // words is still its own segment; prefix inference must not replace.
+        let client = DeepgramLiveClient(apiKey: "k", model: "nova-3")
+
         client.parseTranscriptResponse(Self.deepgramFinal("Hello"))
         client.parseTranscriptResponse(Self.deepgramFinal("Hello there"))
         let transcript = await client.finishAndWait()
 
-        // Assert
-        XCTAssertEqual(transcript, "Hello there")
+        XCTAssertEqual(transcript, "Hello Hello there")
+    }
+
+    func testDeepgram_blankFinalsAreIgnored() async {
+        let client = DeepgramLiveClient(apiKey: "k", model: "nova-3")
+
+        client.parseTranscriptResponse(Self.deepgramFinal("Hello."))
+        client.parseTranscriptResponse(Self.deepgramFinal("   "))
+        let transcript = await client.finishAndWait()
+
+        XCTAssertEqual(transcript, "Hello.")
     }
 
     // MARK: - ElevenLabs (segment-shaped finals)
@@ -88,6 +109,17 @@ final class StreamingClientContractTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(transcript, "Hello there. This is a test.")
+    }
+
+    func testElevenLabs_repeatedIdenticalStandaloneFinalsAreBothKept() async {
+        // Issue #700: "Yes." followed by "Yes." is two utterances.
+        let client = ElevenLabsLiveClient(apiKey: "k")
+
+        client.parseTranscriptResponse(Self.elevenLabs("Yes.", isFinal: true))
+        client.parseTranscriptResponse(Self.elevenLabs("Yes.", isFinal: true))
+        let transcript = await client.finishAndWait()
+
+        XCTAssertEqual(transcript, "Yes. Yes.")
     }
 
     func testElevenLabs_finishAndWaitWithoutAnySpeechReturnsNil() async {
@@ -165,32 +197,85 @@ final class StreamingClientContractTests: XCTestCase {
         ))
     }
 
-    // MARK: - Accumulator rule
+    // MARK: - Accumulator rule (issue #700)
 
-    func testTranscriptAccumulator_mergesSegmentAndCumulativeFinals() {
-        // Arrange
-        var accumulator = TranscriptAccumulator()
+    func testAccumulator_standaloneShape_appendsEveryFinalIncludingIdenticalText() {
+        var accumulator = TranscriptAccumulator(shape: .standaloneSegments)
 
-        // Act / Assert: segments append…
-        accumulator.append(final: "Hello there.")
-        accumulator.append(final: "Second sentence.")
-        XCTAssertEqual(accumulator.text, "Hello there. Second sentence.")
+        accumulator.append(final: "Yes.")
+        accumulator.append(final: "Yes.")
+        XCTAssertEqual(accumulator.text, "Yes. Yes.")
 
-        // …a cumulative resend replaces…
-        accumulator.append(final: "Hello there. Second sentence. Third.")
-        XCTAssertEqual(accumulator.text, "Hello there. Second sentence. Third.")
+        // Prefix extension is its own segment, never a replacement.
+        accumulator.append(final: "Yes. Absolutely.")
+        XCTAssertEqual(accumulator.text, "Yes. Yes. Yes. Absolutely.")
 
-        // …blank finals are ignored, and the display view adds the interim.
+        // Blank finals are ignored; the display view appends the interim.
         accumulator.append(final: "   ")
-        XCTAssertEqual(accumulator.text, "Hello there. Second sentence. Third.")
+        XCTAssertEqual(accumulator.text, "Yes. Yes. Yes. Absolutely.")
         XCTAssertEqual(
-            accumulator.display(withInterim: "and a"),
-            "Hello there. Second sentence. Third. and a"
+            accumulator.display(withInterim: "and"),
+            "Yes. Yes. Yes. Absolutely. and"
         )
 
         accumulator.reset()
         XCTAssertTrue(accumulator.isEmpty)
         XCTAssertNil(accumulator.transcriptOrNil)
+    }
+
+    func testAccumulator_standaloneShape_dropsRetransmissionsOnlyByEventIdentity() {
+        var accumulator = TranscriptAccumulator(shape: .standaloneSegments)
+
+        accumulator.append(final: "Yes.", eventID: "turn-1")
+        // A retry of the same provider event must not double the words…
+        accumulator.append(final: "Yes.", eventID: "turn-1")
+        XCTAssertEqual(accumulator.text, "Yes.")
+
+        // …while a new event with identical text is a genuine repeat.
+        accumulator.append(final: "Yes.", eventID: "turn-2")
+        XCTAssertEqual(accumulator.text, "Yes. Yes.")
+
+        // Resetting forgets seen identities along with the text.
+        accumulator.reset()
+        accumulator.append(final: "Yes.", eventID: "turn-1")
+        XCTAssertEqual(accumulator.text, "Yes.")
+    }
+
+    func testAccumulator_cumulativeShape_replacesIncludingNonPrefixRevisions() {
+        var accumulator = TranscriptAccumulator(shape: .cumulativeTranscript)
+
+        accumulator.append(final: "hello there")
+        XCTAssertEqual(accumulator.text, "hello there")
+
+        // A cumulative correction that is not a prefix extension (casing and
+        // punctuation revised) replaces rather than appending a duplicate.
+        accumulator.append(final: "Hello there!")
+        XCTAssertEqual(accumulator.text, "Hello there!")
+
+        accumulator.append(final: "Hello there! Second turn.")
+        XCTAssertEqual(accumulator.text, "Hello there! Second turn.")
+
+        // A cumulative interim restates the whole transcript and stands alone.
+        XCTAssertEqual(
+            accumulator.display(withInterim: "Hello there! Second turn. And"),
+            "Hello there! Second turn. And"
+        )
+
+        // Blank finals are ignored.
+        accumulator.append(final: " ")
+        XCTAssertEqual(accumulator.text, "Hello there! Second turn.")
+    }
+
+    func testEveryStreamingClient_declaresItsDocumentedFinalShape() {
+        // The declaration is the contract consumers fold by; pin each one.
+        XCTAssertEqual(DeepgramLiveClient(apiKey: "k", model: "nova-3").finalShape, .standaloneSegments)
+        XCTAssertEqual(ElevenLabsLiveClient(apiKey: "k").finalShape, .standaloneSegments)
+        XCTAssertEqual(GladiaLiveClient(apiKey: "k").finalShape, .standaloneSegments)
+        XCTAssertEqual(CartesiaLiveClient(apiKey: "k").finalShape, .standaloneSegments)
+        XCTAssertEqual(XAILiveClient(apiKey: "k").finalShape, .cumulativeTranscript)
+        XCTAssertEqual(SonioxLiveClient(apiKey: "k").finalShape, .cumulativeTranscript)
+        XCTAssertEqual(AssemblyAILiveClient(apiKey: "k").finalShape, .cumulativeTranscript)
+        XCTAssertEqual(ModulateLiveClient(apiKey: "k").finalShape, .cumulativeTranscript)
     }
 
     // MARK: - Fixtures


### PR DESCRIPTION
## Defect

`TranscriptAccumulator` inferred whether a final was a standalone segment or a cumulative resend from text equality and prefixes. Two legitimate consecutive standalone finals with identical text (`Yes.` followed by `Yes.`) satisfied `trimmed == self.text` and were folded as a resend, so Deepgram and ElevenLabs recordings silently lost the repeated utterance. Text alone cannot distinguish a provider retry from two semantically identical segments (#700).

## Fix

- New `TranscriptFinalShape` (`.standaloneSegments` / `.cumulativeTranscript`), declared explicitly by **every** `StreamingTranscriptionClient` conformer — there is deliberately no protocol default. Grounded per provider: standalone — Deepgram (v1 `is_final` results and Flux `EndOfTurn` each cover their own audio span), ElevenLabs (`FINAL_TRANSCRIPT` carries the newly finalised segment), Gladia (one utterance per final), Cartesia (one finalised turn per event); cumulative — xAI (restates the whole turn), Soniox (accumulated final-token text), AssemblyAI (assembled cumulative display string), Modulate (joined utterances).
- `TranscriptAccumulator` folds by the declared shape: standalone finals **always append**, including identical text; retransmissions are dropped only via an explicit `eventID`; cumulative finals **replace**, including non-prefix revisions (punctuation/casing corrections). Blank finals stay ignored; `reset()` clears seen event identities; `display(withInterim:)` is shape-aware (a cumulative interim restates the whole transcript and stands alone).
- iOS `SharedClientLiveTranscriber` builds its accumulator from `client.finalShape` at start.
- macOS `SharedClientLiveController` folds through the accumulator too — behaviour is identical for its current cumulative xAI tenant, and a segment-shaped provider routed there can no longer show only the newest segment; the `finishAndWait()` full transcript is adopted via `replace` (never append, which would double streamed words).

## Tests

Contract tests updated/added: repeated identical standalone finals kept for Deepgram (`Yes. Yes.`) and ElevenLabs; prefix-extending segments both kept (`Hello` + `Hello there` → `Hello Hello there` — the old inference test asserting replacement is removed as the encoded defect); blank finals ignored; event-identity retry dedupe (same id dropped, new id with identical text kept, reset forgets identities); cumulative non-prefix revisions replace; every conformer's declared shape pinned in one table test. Full suite: 1722 tests, 0 failures; `make lint` clean; SpeakiOSLib builds.

Fixes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW