### PR TITLE
fix(mac): enforce captured field identity for text delivery

### DIFF
--- a/Sources/SpeakApp/LiveTextInserter.swift
+++ b/Sources/SpeakApp/LiveTextInserter.swift
@@ -393,21 +393,18 @@ final class LiveTextInserter: ObservableObject { // swiftlint:disable:this type_
     }
   }
 
+  /// The captured field for this session, or `nil` when live insertion must
+  /// defer to standard delivery. `begin(target:)` always captures a target, so
+  /// a missing or cross-process AX element means the capture failed — current
+  /// system focus is deliberately never resolved in its place, because that
+  /// is how live text streams into an unrelated app (issue #707).
   private func getFocusedTextElement() -> AXUIElement? {
-    if let focusedElement = target?.focusedElement {
-      return focusedElement
-    }
-    let systemWideElement = AXUIElementCreateSystemWide()
-    var rawFocused: CFTypeRef?
-    let copyStatus = AXUIElementCopyAttributeValue(
-      systemWideElement, kAXFocusedUIElementAttribute as CFString, &rawFocused
-    )
-
-    guard copyStatus == .success, let rawFocused else {
+    guard let target, let focusedElement = target.focusedElement,
+          target.capturedElementBelongsToCapturedProcess()
+    else {
       return nil
     }
-
-    return unsafeBitCast(rawFocused, to: AXUIElement.self)
+    return focusedElement
   }
 
   /// Verify that text was actually inserted by re-reading the value after a short delay.

--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -39,7 +39,7 @@ struct TextOutputResult {
   let error: Error?
 }
 
-private func currentSystemFocusedElement() -> AXUIElement? {
+func currentSystemFocusedElement() -> AXUIElement? {
   let systemWideElement = AXUIElementCreateSystemWide()
   var rawFocused: CFTypeRef?
   let copyStatus = AXUIElementCopyAttributeValue(
@@ -97,6 +97,51 @@ struct TextOutputTarget {
     }
     return true
   }
+
+  /// Whether the captured AX element belongs to the captured process. An
+  /// AXUIElement is bound to one process for its lifetime, so a mismatch means
+  /// the capture raced an app switch and the element must not be used
+  /// (issue #707).
+  func capturedElementBelongsToCapturedProcess() -> Bool {
+    guard let focusedElement, let processIdentifier else { return false }
+    var elementProcessIdentifier: pid_t = 0
+    guard AXUIElementGetPid(focusedElement, &elementProcessIdentifier) == .success else {
+      return false
+    }
+    return elementProcessIdentifier == processIdentifier
+  }
+
+  /// Field-identity confirmation for keystroke-based delivery (issue #707).
+  enum CapturedFieldConfirmation: Equatable {
+    /// The captured field is the captured process's current focus.
+    case confirmed
+    /// No AX element was captured, so field identity cannot be proven.
+    case fieldUnavailable
+    /// The captured process is not frontmost, or focus moved to a different
+    /// field (for example another conversation in the same app).
+    case fieldChanged
+  }
+
+  /// Confirms that a simulated paste would land in the captured field: the
+  /// captured process must be frontmost and its current focused element must
+  /// be the captured element. PID-directed events reach a process, not a
+  /// field, so without this proof a paste can land in whichever field owns
+  /// focus now (issue #707).
+  func confirmCapturedFieldOwnsFocus(
+    frontmostProcessIdentifier: pid_t? = NSWorkspace.shared.frontmostApplication?.processIdentifier,
+    currentFocus: () -> AXUIElement? = currentSystemFocusedElement
+  ) -> CapturedFieldConfirmation {
+    guard let focusedElement else { return .fieldUnavailable }
+    guard capturedElementBelongsToCapturedProcess(),
+          let frontmostProcessIdentifier,
+          frontmostProcessIdentifier == processIdentifier,
+          let current = currentFocus(),
+          CFEqual(current, focusedElement)
+    else {
+      return .fieldChanged
+    }
+    return .confirmed
+  }
 }
 
 @MainActor
@@ -118,6 +163,8 @@ enum TextOutputError: LocalizedError {
   case clipboardWriteFailed
   case targetApplicationUnavailable
   case pasteShortcutUnavailable
+  case capturedFieldUnavailable
+  case capturedFieldChanged
 
   var errorDescription: String? {
     switch self {
@@ -135,6 +182,12 @@ enum TextOutputError: LocalizedError {
       return "The original app is no longer available. The transcript was kept on the clipboard."
     case .pasteShortcutUnavailable:
       return "Unable to paste into the original app. The transcript was kept on the clipboard."
+    case .capturedFieldUnavailable:
+      return "The field where recording started could not be identified. "
+        + "The transcript was kept on the clipboard."
+    case .capturedFieldChanged:
+      return "The focused field changed since recording started. "
+        + "The transcript was kept on the clipboard."
     }
   }
 }
@@ -162,11 +215,12 @@ struct AccessibilityTextOutput: TextOutputting {
       )
     }
 
-    guard let focusedElement = target?.focusedElement ?? currentSystemFocusedElement() else {
-      return TextOutputResult(
-        method: .none,
-        error: TextOutputError.unableToFindFocusedElement
-      )
+    let focusedElement: AXUIElement
+    switch Self.resolveDeliveryElement(for: target) {
+    case .success(let element):
+      focusedElement = element
+    case .failure(let error):
+      return TextOutputResult(method: .none, error: error)
     }
 
     switch appSettings.accessibilityInsertionMode {
@@ -201,6 +255,28 @@ struct AccessibilityTextOutput: TextOutputting {
     }
   }
 
+  /// A non-nil target is a captured-field contract: when its AX element is
+  /// missing (capture failed) or belongs to another process (the capture
+  /// raced an app switch), never resolve the *current* focus in its place —
+  /// that is how a transcript lands in an unrelated app (issue #707).
+  /// `target == nil` remains the explicit current-focus operation.
+  static func resolveDeliveryElement(
+    for target: TextOutputTarget?
+  ) -> Result<AXUIElement, TextOutputError> {
+    if let target {
+      guard let captured = target.focusedElement else {
+        return .failure(.capturedFieldUnavailable)
+      }
+      guard target.capturedElementBelongsToCapturedProcess() else {
+        return .failure(.capturedFieldChanged)
+      }
+      return .success(captured)
+    }
+    guard let current = currentSystemFocusedElement() else {
+      return .failure(.unableToFindFocusedElement)
+    }
+    return .success(current)
+  }
 }
 
 // @Implement: This implementation should use the clipboard to paste text into the focused app. It should restore the previous pasteboard value (if the app setting output to clipboard is false) It should respect any relevant settings from app settings
@@ -247,6 +323,27 @@ struct PasteTextOutput: TextOutputting {
           method: .clipboard,
           error: TextOutputError.targetApplicationUnavailable
         )
+      }
+      // PID-directed events reach the captured *process*, not the captured
+      // *field*: focus moved to another field in the same app (a different
+      // Slack conversation, say) would receive the paste. Withhold the
+      // keystroke unless the captured field provably still owns focus; the
+      // transcript stays on the clipboard with the reason (issue #707).
+      if let target {
+        switch target.confirmCapturedFieldOwnsFocus() {
+        case .confirmed:
+          break
+        case .fieldUnavailable:
+          return TextOutputResult(
+            method: .clipboard,
+            error: TextOutputError.capturedFieldUnavailable
+          )
+        case .fieldChanged:
+          return TextOutputResult(
+            method: .clipboard,
+            error: TextOutputError.capturedFieldChanged
+          )
+        }
       }
       guard simulatePasteShortcut(destination: destination) else {
         return TextOutputResult(method: .clipboard, error: TextOutputError.pasteShortcutUnavailable)
@@ -396,9 +493,13 @@ struct SmartTextOutput: TextOutputting {
       // TCC before deciding whether direct insertion is available.
       permissionsManager.refresh(.accessibility)
 
-      // Only try accessibility if permission is granted AND there's a focused element
+      // Only try accessibility if permission is granted AND the captured
+      // field (or, with no target, current focus) resolved. A missing or
+      // cross-process captured element falls through to the clipboard path,
+      // whose own field-identity gate decides about the paste keystroke —
+      // never to current focus (issue #707).
       if permissionsManager.status(for: .accessibility).isGranted,
-         let focusedElement = target?.focusedElement ?? currentSystemFocusedElement() {
+         case .success(let focusedElement) = AccessibilityTextOutput.resolveDeliveryElement(for: target) {
 
         // Log element info for debugging
         logFocusedElementInfo(focusedElement)

--- a/Tests/SpeakAppTests/TextOutputTests.swift
+++ b/Tests/SpeakAppTests/TextOutputTests.swift
@@ -120,6 +120,143 @@ final class TextOutputTests: XCTestCase {
   }
   #endif
 
+  // MARK: - Captured field identity (issue #707)
+
+  @MainActor
+  private func makeRunningTarget(focusedElement: AXUIElement?) -> TextOutputTarget {
+    TextOutputTarget(
+      processIdentifier: ProcessInfo.processInfo.processIdentifier,
+      applicationName: "Tests",
+      bundleIdentifier: nil,
+      applicationLaunchDate: nil,
+      focusedElement: focusedElement
+    )
+  }
+
+  @MainActor
+  func testAccessibilityOutput_capturedTargetWithoutElement_NeverUsesCurrentFocus() {
+    let suiteName = "com.speakapp.text-output-tests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+    let output = AccessibilityTextOutput(
+      permissionsManager: PermissionsManager(statusProvider: { _ in .granted }),
+      appSettings: AppSettings(defaults: defaults)
+    )
+
+    let result = output.output(text: "hello", target: makeRunningTarget(focusedElement: nil))
+
+    XCTAssertEqual(result.method, .none)
+    guard case .some(TextOutputError.capturedFieldUnavailable) = result.error else {
+      return XCTFail("Expected capturedFieldUnavailable, got \(String(describing: result.error))")
+    }
+  }
+
+  @MainActor
+  func testAccessibilityOutput_elementFromAnotherProcess_IsRefused() {
+    let suiteName = "com.speakapp.text-output-tests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+    let output = AccessibilityTextOutput(
+      permissionsManager: PermissionsManager(statusProvider: { _ in .granted }),
+      appSettings: AppSettings(defaults: defaults)
+    )
+    // An element bound to a different process than the captured identity: the
+    // capture raced an app switch and must not be delivered into.
+    let foreignElement = AXUIElementCreateApplication(1)
+
+    let result = output.output(text: "hello", target: makeRunningTarget(focusedElement: foreignElement))
+
+    XCTAssertEqual(result.method, .none)
+    guard case .some(TextOutputError.capturedFieldChanged) = result.error else {
+      return XCTFail("Expected capturedFieldChanged, got \(String(describing: result.error))")
+    }
+  }
+
+  @MainActor
+  func testPasteOutput_capturedTargetWithoutElement_WithholdsPasteAndKeepsClipboard() {
+    let suiteName = "com.speakapp.text-output-tests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    let pasteboard = NSPasteboard(name: NSPasteboard.Name(suiteName))
+    defer {
+      pasteboard.clearContents()
+      UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+    let output = PasteTextOutput(
+      permissionsManager: PermissionsManager(statusProvider: { _ in .granted }),
+      appSettings: AppSettings(defaults: defaults),
+      pasteboard: pasteboard
+    )
+
+    let result = output.output(text: "Withheld transcript", target: makeRunningTarget(focusedElement: nil))
+
+    XCTAssertEqual(result.method, .clipboard)
+    guard case .some(TextOutputError.capturedFieldUnavailable) = result.error else {
+      return XCTFail("Expected capturedFieldUnavailable, got \(String(describing: result.error))")
+    }
+    XCTAssertEqual(pasteboard.string(forType: .string), "Withheld transcript")
+  }
+
+  @MainActor
+  func testCapturedElementBelongsToCapturedProcess_matchesOnlyItsOwnProcess() {
+    let ownPid = ProcessInfo.processInfo.processIdentifier
+    let ownElement = AXUIElementCreateApplication(ownPid)
+
+    XCTAssertTrue(makeRunningTarget(focusedElement: ownElement)
+      .capturedElementBelongsToCapturedProcess())
+    XCTAssertFalse(makeRunningTarget(focusedElement: AXUIElementCreateApplication(1))
+      .capturedElementBelongsToCapturedProcess())
+    XCTAssertFalse(makeRunningTarget(focusedElement: nil)
+      .capturedElementBelongsToCapturedProcess())
+  }
+
+  @MainActor
+  func testConfirmCapturedFieldOwnsFocus_requiresFrontmostProcessAndIdenticalField() {
+    let ownPid = ProcessInfo.processInfo.processIdentifier
+    let capturedElement = AXUIElementCreateApplication(ownPid)
+    let target = makeRunningTarget(focusedElement: capturedElement)
+
+    // No element captured: identity cannot be proven.
+    XCTAssertEqual(
+      makeRunningTarget(focusedElement: nil).confirmCapturedFieldOwnsFocus(
+        frontmostProcessIdentifier: ownPid,
+        currentFocus: { capturedElement }
+      ),
+      .fieldUnavailable
+    )
+    // Captured process not frontmost: a paste keystroke would land elsewhere.
+    XCTAssertEqual(
+      target.confirmCapturedFieldOwnsFocus(
+        frontmostProcessIdentifier: 1,
+        currentFocus: { capturedElement }
+      ),
+      .fieldChanged
+    )
+    // Same process, different field (another conversation in the same app).
+    XCTAssertEqual(
+      target.confirmCapturedFieldOwnsFocus(
+        frontmostProcessIdentifier: ownPid,
+        currentFocus: { AXUIElementCreateApplication(1) }
+      ),
+      .fieldChanged
+    )
+    // Focus cannot be read at all: fail closed.
+    XCTAssertEqual(
+      target.confirmCapturedFieldOwnsFocus(
+        frontmostProcessIdentifier: ownPid,
+        currentFocus: { nil }
+      ),
+      .fieldChanged
+    )
+    // The captured field still owns focus in the frontmost captured process.
+    XCTAssertEqual(
+      target.confirmCapturedFieldOwnsFocus(
+        frontmostProcessIdentifier: ownPid,
+        currentFocus: { AXUIElementCreateApplication(ownPid) }
+      ),
+      .confirmed
+    )
+  }
+
   func testHotKeyMonitoringState_displayNames_AreActionable() {
     XCTAssertEqual(HotKeyMonitoringState.active.displayName, "Active")
     XCTAssertEqual(


### PR DESCRIPTION
## Defect

Captured-target delivery could still send transcript text somewhere other than the field active when recording began (#707):

- With a non-nil captured target whose AX element was missing, `AccessibilityTextOutput`, `SmartTextOutput` and `LiveTextInserter` fell back to the *currently* focused system element — switching apps during dictation inserted into an unrelated app.
- The Command-V path posted PID-directed events at the captured *process*, not the captured *field* — moving between Slack/Teams conversations in the same process pasted into the new first responder.

## Fix

- `target == nil` remains the explicit current-focus operation; `target != nil` is now a captured-field contract. `AccessibilityTextOutput.resolveDeliveryElement` refuses a missing element (`capturedFieldUnavailable`) or one bound to a different process (`capturedFieldChanged` — an AXUIElement is process-bound for life, so a mismatch means the capture raced an app switch) and never resolves current focus in their place. `SmartTextOutput` uses the same resolution and falls through to the clipboard path on refusal; `LiveTextInserter` defers to standard delivery instead of resolving current focus.
- Before a simulated paste, `TextOutputTarget.confirmCapturedFieldOwnsFocus` requires the captured process to be frontmost **and** its current focused element to be `CFEqual` to the captured one; unreadable focus fails closed. On refusal the transcript stays on the clipboard and the precise reason surfaces through the existing delivery-result path (HUD + history error), matching the product contract in the issue: automatic insertion requires proof, otherwise clipboard-only with an actionable notification.
- Insertion into a still-valid captured AX element that is no longer focused **is** supported (the AX path targets the field by identity, per #566); only the keystroke path requires live focus.
- Side effect worth noting: with accessibility permission denied on the direct channel, the old code posted a Cmd-V that macOS silently ignored and reported success; it now reports clipboard-only with the reason.

## Tests

New coverage: no-element and cross-process refusals on the AX path; withheld paste keeps the transcript on the clipboard with `capturedFieldUnavailable`; `capturedElementBelongsToCapturedProcess` matrix; full `confirmCapturedFieldOwnsFocus` matrix (unavailable / not-frontmost / different field / unreadable focus / confirmed) via injected frontmost + focus providers. Existing terminated-target, event-destination and streaming-insertion suites unchanged and green. Full suite: 1721 tests, 0 failures; `make lint` clean.

Fixes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW