### PR TITLE
fix(sync): make configuration transfer complete and transactional

### DIFF
--- a/Sources/SpeakCore/ModelCredentialRequirement.swift
+++ b/Sources/SpeakCore/ModelCredentialRequirement.swift
@@ -194,4 +194,22 @@ public enum ModelCredentialResolver {
         "soniox",
         "speechmatics"
     ]
+
+    /// Every API-key identifier the canonical catalogues can require, derived
+    /// from the same definitions the pickers and routing use. This is the
+    /// parity source for surfaces that must cover the whole credential set —
+    /// notably device-to-device configuration transfer (issue #699): a
+    /// provider added to any catalogue appears here automatically, and the
+    /// transfer parity test fails until its transfer capability is defined.
+    public static var allKnownAPIKeyIdentifiers: Set<String> {
+        var identifiers = Set(LiveTranscriptionProviderID.allCases.compactMap(\.apiKeyIdentifier))
+        identifiers.formUnion(directBatchProviderIdentifiers.map { "\($0).apiKey" })
+        // Direct OpenAI batch models, OpenRouter routing, and the voice-output
+        // credentials that use dedicated identifiers.
+        identifiers.insert("openai.apiKey")
+        identifiers.insert("openrouter.apiKey")
+        identifiers.insert("openai.tts.apiKey")
+        identifiers.insert("azure.speech.apiKey")
+        return identifiers
+    }
 }

--- a/Sources/SpeakCore/SettingsSync.swift
+++ b/Sources/SpeakCore/SettingsSync.swift
@@ -310,14 +310,34 @@ public final class ConfigTransferManager: Sendable {
     /// API-key identifiers included in a device-to-device transfer: the union
     /// of the keys either platform can hold, so exporting from one platform
     /// and importing on the other never silently drops a stored credential.
+    ///
+    /// This list is deliberately explicit rather than derived: it is the
+    /// bounded transfer policy (issue #699). A parity test asserts it equals
+    /// `ModelCredentialResolver.allKnownAPIKeyIdentifiers`, so adding a
+    /// provider to any catalogue fails the test until its transfer capability
+    /// is defined here. Dynamically registered identifiers are never exported.
     public static let transferableSecretIdentifiers: [String] = [
+        "assemblyai.apiKey",
+        "azure.speech.apiKey",
+        "cartesia.apiKey",
         "deepgram.apiKey",
-        "openrouter.apiKey",
+        "elevenlabs.apiKey",
+        "gladia.apiKey",
+        "groq.apiKey",
+        "mistral.apiKey",
+        "modulate.apiKey",
         "openai.apiKey",
         "openai.tts.apiKey",
-        "elevenlabs.apiKey",
-        "azure.speech.apiKey"
+        "openrouter.apiKey",
+        "revai.apiKey",
+        "soniox.apiKey",
+        "speechmatics.apiKey",
+        "xai.apiKey"
     ]
+
+    /// Non-secret settings keys a transfer payload may carry. Import refuses
+    /// anything else so a payload cannot write arbitrary defaults.
+    public static let transferableSettingKeys: Set<String> = ["selectedModel"]
 
     /// Collects the transferable secrets currently stored in `storage`,
     /// skipping identifiers that are missing or empty.
@@ -362,7 +382,10 @@ public final class ConfigTransferManager: Sendable {
     public func makeQRCodeImage(payload: String, scale: CGFloat = 10) -> CIImage? {
         let filter = CIFilter.qrCodeGenerator()
         filter.message = Data(payload.utf8)
-        filter.correctionLevel = "M"
+        // Level M for the compatible payload size; a full credential set only
+        // fits at level L (2,953 bytes), which remains reliable for the short
+        // screen-to-camera scan this feature performs (issue #699).
+        filter.correctionLevel = payload.utf8.count > 2_200 ? "L" : "M"
         guard let outputImage = filter.outputImage else { return nil }
         return outputImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
     }
@@ -427,7 +450,35 @@ public final class ConfigTransferManager: Sendable {
             nonce: Data(nonce),
             ciphertext: sealedBox.ciphertext + sealedBox.tag
         )
-        return try envelopeEncoder.encode(envelope).base64EncodedString()
+        let encoded = try envelopeEncoder.encode(envelope)
+        let base64 = encoded.base64EncodedString()
+        // The doubly-encoded form stays the default so older importers keep
+        // working, but it cannot fit a full credential set in one QR code
+        // (issue #699). An oversized payload is emitted as the envelope JSON
+        // itself — QR byte mode carries it directly, authentication is
+        // unchanged, and current importers accept both shapes.
+        if base64.utf8.count > Self.maximumCompatiblePayloadLength,
+           let envelopeJSON = String(bytes: encoded, encoding: .utf8) {
+            return envelopeJSON
+        }
+        return base64
+    }
+
+    /// QR byte capacity at correction level M. Above this the doubly-encoded
+    /// payload cannot be drawn, so export falls back to the raw envelope JSON.
+    static let maximumCompatiblePayloadLength = 2_331
+
+    /// Accepts both payload shapes: the base64-wrapped envelope every version
+    /// understands, and the raw envelope JSON used when a full credential set
+    /// would not fit a QR code otherwise (issue #699).
+    private static func envelopeCandidateData(from encoded: String) -> Data? {
+        if let data = Data(base64Encoded: encoded), !data.isEmpty {
+            return data
+        }
+        if encoded.hasPrefix("{") {
+            return Data(encoded.utf8)
+        }
+        return nil
     }
 
     // MARK: - Import
@@ -436,7 +487,7 @@ public final class ConfigTransferManager: Sendable {
     /// knows whether to ask for a one-time code. Unknown envelope versions are
     /// rejected here rather than being mistaken for a legacy payload.
     public func format(of encoded: String) throws -> ConfigTransferFormat {
-        guard let data = Data(base64Encoded: encoded), !data.isEmpty else {
+        guard let data = Self.envelopeCandidateData(from: encoded) else {
             throw ConfigTransferError.invalidFormat
         }
 
@@ -508,7 +559,7 @@ public final class ConfigTransferManager: Sendable {
 
     /// Parses (but does not decrypt) the envelope, rejecting unknown versions.
     public func decodeEnvelope(_ encoded: String) throws -> ConfigTransferEnvelope {
-        guard let data = Data(base64Encoded: encoded), !data.isEmpty else {
+        guard let data = Self.envelopeCandidateData(from: encoded) else {
             throw ConfigTransferError.invalidFormat
         }
         guard let envelope = try? envelopeDecoder.decode(ConfigTransferEnvelope.self, from: data) else {
@@ -611,6 +662,98 @@ public enum ConfigTransferFormat: Equatable, Sendable {
     case legacy
 }
 
+// MARK: - Transactional import (issue #699)
+
+extension ConfigTransferManager {
+    /// Applies an imported payload transactionally.
+    ///
+    /// Before any mutation the payload is validated against the bounded
+    /// transfer policy and every destination value is read and retained. On a
+    /// failed write, every already-applied secret is rolled back to its
+    /// retained value; if rollback itself fails, the identifiers left in the
+    /// imported state are reported. Settings are applied last (their writes
+    /// cannot fail), so a secret failure never leaves partial settings.
+    ///
+    /// The Keychain offers no multi-item transaction, so an import interrupted
+    /// by process death can leave earlier writes applied; retrying the same
+    /// import re-applies identical values and converges — it can never produce
+    /// a configuration mixing two sources beyond the interrupted one.
+    public func applyImport(
+        payload: ConfigTransferPayload,
+        storage: SecureStorage,
+        defaults: UserDefaults = .standard
+    ) async throws {
+        try Self.validateImport(payload: payload)
+
+        // Retain the destination values for every key that will change. A read
+        // failure other than "not stored" aborts before mutation.
+        var previousValues: [String: String] = [:]
+        for identifier in payload.secrets.keys.sorted() {
+            do {
+                previousValues[identifier] = try await storage.secret(identifier: identifier)
+            } catch SecureStorageError.valueNotFound {
+                continue
+            }
+        }
+
+        var appliedIdentifiers: [String] = []
+        do {
+            for identifier in payload.secrets.keys.sorted() {
+                guard let value = payload.secrets[identifier] else { continue }
+                try await storage.storeSecret(value, identifier: identifier)
+                appliedIdentifiers.append(identifier)
+            }
+        } catch {
+            let stranded = await rollBack(
+                identifiers: appliedIdentifiers,
+                previousValues: previousValues,
+                storage: storage
+            )
+            guard stranded.isEmpty else {
+                throw ConfigTransferError.rollbackFailed(identifiers: stranded)
+            }
+            throw error
+        }
+
+        for (key, value) in payload.settings {
+            defaults.set(value, forKey: key)
+        }
+    }
+
+    /// Refuses anything outside the bounded transfer policy before any write.
+    private static func validateImport(payload: ConfigTransferPayload) throws {
+        for identifier in payload.secrets.keys
+        where !transferableSecretIdentifiers.contains(identifier) {
+            throw ConfigTransferError.unknownSecretIdentifier(identifier)
+        }
+        for key in payload.settings.keys where !transferableSettingKeys.contains(key) {
+            throw ConfigTransferError.unknownSettingKey(key)
+        }
+    }
+
+    /// Restores each applied identifier to its retained value (or removes it
+    /// when it did not exist). Returns the identifiers rollback failed for.
+    private func rollBack(
+        identifiers: [String],
+        previousValues: [String: String],
+        storage: SecureStorage
+    ) async -> [String] {
+        var failures: [String] = []
+        for identifier in identifiers.reversed() {
+            do {
+                if let previous = previousValues[identifier] {
+                    try await storage.storeSecret(previous, identifier: identifier)
+                } else {
+                    try await storage.removeSecret(identifier: identifier)
+                }
+            } catch {
+                failures.append(identifier)
+            }
+        }
+        return failures.sorted()
+    }
+}
+
 public enum ConfigTransferError: LocalizedError, Equatable {
     case invalidFormat
     case payloadExpired
@@ -621,6 +764,9 @@ public enum ConfigTransferError: LocalizedError, Equatable {
     case encryptionFailed
     case randomGenerationFailed
     case qrGenerationFailed
+    case unknownSecretIdentifier(String)
+    case unknownSettingKey(String)
+    case rollbackFailed(identifiers: [String])
 
     public var errorDescription: String? {
         switch self {
@@ -643,6 +789,15 @@ public enum ConfigTransferError: LocalizedError, Equatable {
             return "Failed to generate a secure transfer code. Please try again."
         case .qrGenerationFailed:
             return "Failed to draw the QR code for this configuration."
+        case .unknownSecretIdentifier:
+            return "This configuration contains a credential this version does not recognise. "
+                + "Update both devices, then try again."
+        case .unknownSettingKey:
+            return "This configuration contains a setting this version does not recognise. "
+                + "Update both devices, then try again."
+        case .rollbackFailed:
+            return "The import failed and some credentials could not be restored. "
+                + "Review your API keys in Settings before dictating."
         }
     }
 }

--- a/Sources/SpeakCore/SettingsSync.swift
+++ b/Sources/SpeakCore/SettingsSync.swift
@@ -678,10 +678,16 @@ extension ConfigTransferManager {
     /// by process death can leave earlier writes applied; retrying the same
     /// import re-applies identical values and converges — it can never produce
     /// a configuration mixing two sources beyond the interrupted one.
+    ///
+    /// `liveModelDefaultsKey` mirrors `gatherSettings(defaults:liveModelDefaultsKey:)`:
+    /// the payload always carries the shared `selectedModel` key, and the importing
+    /// platform names the local UserDefaults key it reads its live transcription
+    /// model from, so the selection lands where that platform will find it.
     public func applyImport(
         payload: ConfigTransferPayload,
         storage: SecureStorage,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        liveModelDefaultsKey: String = "selectedModel"
     ) async throws {
         try Self.validateImport(payload: payload)
 
@@ -716,18 +722,32 @@ extension ConfigTransferManager {
         }
 
         for (key, value) in payload.settings {
-            defaults.set(value, forKey: key)
+            let localKey = key == "selectedModel" ? liveModelDefaultsKey : key
+            defaults.set(value, forKey: localKey)
         }
     }
 
     /// Refuses anything outside the bounded transfer policy before any write.
+    ///
+    /// Empty values are refused as well: export never produces them, and
+    /// storing an empty secret would overwrite a working destination credential
+    /// while unregistering its identifier.
     private static func validateImport(payload: ConfigTransferPayload) throws {
-        for identifier in payload.secrets.keys
-        where !transferableSecretIdentifiers.contains(identifier) {
-            throw ConfigTransferError.unknownSecretIdentifier(identifier)
+        for identifier in payload.secrets.keys.sorted() {
+            guard transferableSecretIdentifiers.contains(identifier) else {
+                throw ConfigTransferError.unknownSecretIdentifier(identifier)
+            }
+            if payload.secrets[identifier]?.isEmpty ?? true {
+                throw ConfigTransferError.emptySecretValue(identifier)
+            }
         }
-        for key in payload.settings.keys where !transferableSettingKeys.contains(key) {
-            throw ConfigTransferError.unknownSettingKey(key)
+        for key in payload.settings.keys.sorted() {
+            guard transferableSettingKeys.contains(key) else {
+                throw ConfigTransferError.unknownSettingKey(key)
+            }
+            if payload.settings[key]?.isEmpty ?? true {
+                throw ConfigTransferError.emptySettingValue(key)
+            }
         }
     }
 
@@ -766,6 +786,8 @@ public enum ConfigTransferError: LocalizedError, Equatable {
     case qrGenerationFailed
     case unknownSecretIdentifier(String)
     case unknownSettingKey(String)
+    case emptySecretValue(String)
+    case emptySettingValue(String)
     case rollbackFailed(identifiers: [String])
 
     public var errorDescription: String? {
@@ -795,6 +817,9 @@ public enum ConfigTransferError: LocalizedError, Equatable {
         case .unknownSettingKey:
             return "This configuration contains a setting this version does not recognise. "
                 + "Update both devices, then try again."
+        case .emptySecretValue, .emptySettingValue:
+            return "This configuration contains an empty value and was not applied. "
+                + "Generate a new code on the other device, then try again."
         case .rollbackFailed:
             return "The import failed and some credentials could not be restored. "
                 + "Review your API keys in Settings before dictating."

--- a/Sources/SpeakiOS/Views/ConfigTransferView.swift
+++ b/Sources/SpeakiOS/Views/ConfigTransferView.swift
@@ -304,7 +304,7 @@ struct QRCodeScannerView: View {
             // so imported keys are actually visible in Settings. The shared
             // manager applies the payload transactionally: a failed write
             // rolls every already-applied credential back (issue #699).
-            try await manager.applyImport(
+            try await ConfigTransferManager.shared.applyImport(
                 payload: payload,
                 storage: AppSettings.canonicalCredentialStorage
             )

--- a/Sources/SpeakiOS/Views/ConfigTransferView.swift
+++ b/Sources/SpeakiOS/Views/ConfigTransferView.swift
@@ -301,17 +301,13 @@ struct QRCodeScannerView: View {
 
         do {
             // Write to the canonical credential store the rest of the app reads,
-            // so imported keys are actually visible in Settings.
-            let storage = AppSettings.canonicalCredentialStorage
-
-            for (key, value) in payload.secrets {
-                try await storage.storeSecret(value, identifier: key)
-            }
-
-            // Import settings
-            for (key, value) in payload.settings {
-                UserDefaults.standard.set(value, forKey: key)
-            }
+            // so imported keys are actually visible in Settings. The shared
+            // manager applies the payload transactionally: a failed write
+            // rolls every already-applied credential back (issue #699).
+            try await manager.applyImport(
+                payload: payload,
+                storage: AppSettings.canonicalCredentialStorage
+            )
 
             pendingPayload = nil
             scannedEnvelope = nil

--- a/Tests/SpeakCoreTests/ConfigTransferImportTests.swift
+++ b/Tests/SpeakCoreTests/ConfigTransferImportTests.swift
@@ -199,6 +199,61 @@ final class ConfigTransferImportTests: XCTestCase {
         XCTAssertEqual(identifiers, [], "nothing may be written for a refused payload")
     }
 
+    func testApplyImport_mapsSelectedModelToThePlatformLiveModelKey() async throws {
+        let storage = makeStorage()
+        let payload = ConfigTransferPayload(
+            secrets: [:],
+            settings: ["selectedModel": "deepgram/nova-3-streaming"]
+        )
+
+        try await manager.applyImport(
+            payload: payload,
+            storage: storage,
+            defaults: defaults,
+            liveModelDefaultsKey: "liveTranscriptionModel"
+        )
+
+        XCTAssertEqual(
+            defaults.string(forKey: "liveTranscriptionModel"), "deepgram/nova-3-streaming",
+            "Import must reverse the export-time key normalisation for the importing platform"
+        )
+        XCTAssertNil(defaults.string(forKey: "selectedModel"))
+    }
+
+    func testApplyImport_emptySecret_isRefusedBeforeAnyWrite() async throws {
+        let storage = makeStorage()
+        try await storage.storeSecret("dg-working", identifier: "deepgram.apiKey")
+        let payload = ConfigTransferPayload(
+            secrets: ["deepgram.apiKey": "", "gladia.apiKey": "gl-new"],
+            settings: [:]
+        )
+
+        do {
+            try await manager.applyImport(payload: payload, storage: storage, defaults: defaults)
+            XCTFail("Expected emptySecretValue")
+        } catch let error as ConfigTransferError {
+            XCTAssertEqual(error, .emptySecretValue("deepgram.apiKey"))
+        }
+
+        let deepgram = try await storage.secret(identifier: "deepgram.apiKey")
+        XCTAssertEqual(deepgram, "dg-working", "An empty imported value must not clobber a working credential")
+        let identifiers = await storage.knownIdentifiers()
+        XCTAssertFalse(identifiers.contains("gladia.apiKey"), "Nothing is written when validation fails")
+    }
+
+    func testApplyImport_emptySetting_isRefused() async throws {
+        let storage = makeStorage()
+        let payload = ConfigTransferPayload(secrets: [:], settings: ["selectedModel": ""])
+
+        do {
+            try await manager.applyImport(payload: payload, storage: storage, defaults: defaults)
+            XCTFail("Expected emptySettingValue")
+        } catch let error as ConfigTransferError {
+            XCTAssertEqual(error, .emptySettingValue("selectedModel"))
+        }
+        XCTAssertNil(defaults.string(forKey: "selectedModel"))
+    }
+
     func testApplyImport_unknownSettingKey_isRefusedBeforeAnyWrite() async throws {
         let storage = makeStorage()
         let payload = ConfigTransferPayload(

--- a/Tests/SpeakCoreTests/ConfigTransferImportTests.swift
+++ b/Tests/SpeakCoreTests/ConfigTransferImportTests.swift
@@ -1,0 +1,277 @@
+import Foundation
+import Security
+import XCTest
+
+@testable import SpeakCore
+
+/// Scripted permission checker: each keychain access consumes one decision.
+private final class ScriptedPermissions: KeychainPermissionsChecking, @unchecked Sendable {
+    private let lock = NSLock()
+    private var decisions: [Bool]
+
+    init(decisions: [Bool]) {
+        self.decisions = decisions
+    }
+
+    func ensureKeychainAccess(forService service: String) async -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return decisions.isEmpty ? true : decisions.removeFirst()
+    }
+}
+
+/// Transactional configuration import (issue #699): parity with the canonical
+/// credential catalogue, all-or-nothing application, rollback reporting, and
+/// idempotent retry.
+final class ConfigTransferImportTests: XCTestCase {
+    private let manager = ConfigTransferManager(pbkdf2Iterations: 1_000)
+    private var service: String!
+    private var defaultsSuite: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        service = "com.justspeaktoit.tests.transfer.\(UUID().uuidString.prefix(8))"
+        defaultsSuite = "com.justspeaktoit.tests.transfer.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuite)
+    }
+
+    override func tearDown() {
+        for account in [
+            "speak-app-secrets",
+            "speak-app-secrets.v2",
+            "speak-app-secrets.unsupported-backup"
+        ] {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccount as String: account
+            ]
+            SecItemDelete(query as CFDictionary)
+        }
+        UserDefaults.standard.removePersistentDomain(forName: defaultsSuite)
+        service = nil
+        defaultsSuite = nil
+        defaults = nil
+        super.tearDown()
+    }
+
+    private func makeStorage(decisions: [Bool] = []) -> SecureStorage {
+        SecureStorage(
+            configuration: SecureStorageConfiguration(service: service),
+            permissionsChecker: ScriptedPermissions(decisions: decisions)
+        )
+    }
+
+    // MARK: - Catalogue parity
+
+    func testTransferableSecretIdentifiers_matchTheCanonicalCredentialCatalogue() {
+        // Adding a provider to any catalogue must fail this test until its
+        // transfer capability is defined in transferableSecretIdentifiers.
+        XCTAssertEqual(
+            ConfigTransferManager.transferableSecretIdentifiers.sorted(),
+            ModelCredentialResolver.allKnownAPIKeyIdentifiers.sorted()
+        )
+        XCTAssertEqual(
+            ConfigTransferManager.transferableSecretIdentifiers,
+            ConfigTransferManager.transferableSecretIdentifiers.sorted(),
+            "keep the policy list sorted so diffs stay reviewable"
+        )
+    }
+
+    func testPreviouslyOmittedProviders_areNowTransferable() {
+        let identifiers = Set(ConfigTransferManager.transferableSecretIdentifiers)
+        for required in [
+            "assemblyai.apiKey", "cartesia.apiKey", "gladia.apiKey", "groq.apiKey",
+            "mistral.apiKey", "modulate.apiKey", "revai.apiKey", "soniox.apiKey",
+            "speechmatics.apiKey", "xai.apiKey"
+        ] {
+            XCTAssertTrue(identifiers.contains(required), "\(required) must transfer")
+        }
+    }
+
+    // MARK: - Transactional apply
+
+    func testApplyImport_appliesSecretsAndSettings() async throws {
+        let storage = makeStorage()
+        let payload = ConfigTransferPayload(
+            secrets: ["deepgram.apiKey": "dg-new", "gladia.apiKey": "gl-new"],
+            settings: ["selectedModel": "deepgram/nova-3-streaming"]
+        )
+
+        try await manager.applyImport(payload: payload, storage: storage, defaults: defaults)
+
+        let deepgram = try await storage.secret(identifier: "deepgram.apiKey")
+        let gladia = try await storage.secret(identifier: "gladia.apiKey")
+        XCTAssertEqual(deepgram, "dg-new")
+        XCTAssertEqual(gladia, "gl-new")
+        XCTAssertEqual(defaults.string(forKey: "selectedModel"), "deepgram/nova-3-streaming")
+    }
+
+    func testApplyImport_failedWrite_rollsBackEverySecretAndSkipsSettings() async throws {
+        let seed = makeStorage()
+        try await seed.storeSecret("dg-old", identifier: "deepgram.apiKey")
+
+        // Decisions: load, store deepgram (ok), store gladia (denied),
+        // rollback of deepgram (ok).
+        let storage = makeStorage(decisions: [true, true, false, true])
+        let payload = ConfigTransferPayload(
+            secrets: ["deepgram.apiKey": "dg-new", "gladia.apiKey": "gl-new"],
+            settings: ["selectedModel": "changed"]
+        )
+
+        do {
+            try await manager.applyImport(payload: payload, storage: storage, defaults: defaults)
+            XCTFail("Expected the denied write to fail the import")
+        } catch SecureStorageError.permissionDenied {
+            // Expected: the original failure surfaces once rollback succeeded.
+        }
+
+        let verify = makeStorage()
+        let deepgram = try await verify.secret(identifier: "deepgram.apiKey")
+        XCTAssertEqual(deepgram, "dg-old", "the replaced credential must be restored")
+        let hasGladia = await verify.hasSecret(identifier: "gladia.apiKey")
+        XCTAssertFalse(hasGladia)
+        XCTAssertNil(defaults.string(forKey: "selectedModel"), "settings must not partially apply")
+    }
+
+    func testApplyImport_rollbackFailure_reportsTheStrandedIdentifiers() async throws {
+        // Decisions: load, store deepgram (ok), store gladia (denied),
+        // rollback of deepgram (denied too).
+        let storage = makeStorage(decisions: [true, true, false, false])
+        let payload = ConfigTransferPayload(
+            secrets: ["deepgram.apiKey": "dg-new", "gladia.apiKey": "gl-new"],
+            settings: [:]
+        )
+
+        do {
+            try await manager.applyImport(payload: payload, storage: storage, defaults: defaults)
+            XCTFail("Expected rollbackFailed")
+        } catch let error as ConfigTransferError {
+            XCTAssertEqual(error, .rollbackFailed(identifiers: ["deepgram.apiKey"]))
+        }
+    }
+
+    func testApplyImport_retryAfterFailure_isIdempotentAndComplete() async throws {
+        let seed = makeStorage()
+        try await seed.storeSecret("dg-old", identifier: "deepgram.apiKey")
+
+        let failing = makeStorage(decisions: [true, true, false, true])
+        let payload = ConfigTransferPayload(
+            secrets: ["deepgram.apiKey": "dg-new", "gladia.apiKey": "gl-new"],
+            settings: ["selectedModel": "deepgram/nova-3-streaming"]
+        )
+        do {
+            try await manager.applyImport(payload: payload, storage: failing, defaults: defaults)
+            XCTFail("Expected failure")
+        } catch SecureStorageError.permissionDenied {
+            // Expected.
+        }
+
+        // Retrying the identical import must converge on the full new state.
+        let retry = makeStorage()
+        try await manager.applyImport(payload: payload, storage: retry, defaults: defaults)
+
+        let deepgram = try await retry.secret(identifier: "deepgram.apiKey")
+        let gladia = try await retry.secret(identifier: "gladia.apiKey")
+        XCTAssertEqual(deepgram, "dg-new")
+        XCTAssertEqual(gladia, "gl-new")
+        XCTAssertEqual(defaults.string(forKey: "selectedModel"), "deepgram/nova-3-streaming")
+    }
+
+    // MARK: - Bounded policy
+
+    func testApplyImport_unknownSecretIdentifier_isRefusedBeforeAnyWrite() async throws {
+        let storage = makeStorage()
+        let payload = ConfigTransferPayload(
+            secrets: ["custom-provider.apiKey": "x", "deepgram.apiKey": "dg"],
+            settings: [:]
+        )
+
+        do {
+            try await manager.applyImport(payload: payload, storage: storage, defaults: defaults)
+            XCTFail("Expected unknownSecretIdentifier")
+        } catch let error as ConfigTransferError {
+            XCTAssertEqual(error, .unknownSecretIdentifier("custom-provider.apiKey"))
+        }
+
+        let identifiers = await storage.knownIdentifiers()
+        XCTAssertEqual(identifiers, [], "nothing may be written for a refused payload")
+    }
+
+    func testApplyImport_unknownSettingKey_isRefusedBeforeAnyWrite() async throws {
+        let storage = makeStorage()
+        let payload = ConfigTransferPayload(
+            secrets: ["deepgram.apiKey": "dg"],
+            settings: ["arbitraryDefaultsKey": "boom"]
+        )
+
+        do {
+            try await manager.applyImport(payload: payload, storage: storage, defaults: defaults)
+            XCTFail("Expected unknownSettingKey")
+        } catch let error as ConfigTransferError {
+            XCTAssertEqual(error, .unknownSettingKey("arbitraryDefaultsKey"))
+        }
+
+        let identifiers = await storage.knownIdentifiers()
+        XCTAssertEqual(identifiers, [])
+        XCTAssertNil(defaults.string(forKey: "arbitraryDefaultsKey"))
+    }
+    // MARK: - QR payload budget (issue #699)
+
+    private let code = "A1B2C3D4"
+
+    /// Deterministic high-entropy stand-in for a real API key: repeated
+    /// characters would understate the QR budget.
+    private func syntheticKey(seed: Int, length: Int = 72) -> String {
+        let alphabet = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+        var state = UInt64(seed) &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+        var characters: [Character] = []
+        for _ in 0..<length {
+            state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            characters.append(alphabet[Int(state >> 33) % alphabet.count])
+        }
+        return String(characters)
+    }
+
+    func testGeneratedPayload_forAFullKeySet_stillFitsInAQRCode() throws {
+        // The encrypted envelope is markedly larger than the format it replaces,
+        // so guard the worst realistic case: every transferable key populated
+        // with realistic-entropy values (issue #699 widened the catalogue).
+        let secrets = Dictionary(
+            uniqueKeysWithValues: ConfigTransferManager.transferableSecretIdentifiers.enumerated().map {
+                ($1, syntheticKey(seed: $0))
+            }
+        )
+        let transfer = try manager.makeTransfer(
+            secrets: secrets,
+            settings: ["selectedModel": "deepgram/nova-3-streaming"]
+        )
+        XCTAssertNotNil(manager.makeQRCodeImage(payload: transfer.payload), "Payload too large to encode as a QR code")
+        XCTAssertEqual(try manager.decodePayload(transfer.payload, code: transfer.code).secrets.count, secrets.count)
+    }
+
+    func testGeneratedPayload_smallSet_keepsTheBackwardCompatibleBase64Shape() throws {
+        let encoded = try manager.generatePayload(
+            secrets: ["deepgram.apiKey": syntheticKey(seed: 99)],
+            settings: [:],
+            code: code
+        )
+        XCTAssertNotNil(Data(base64Encoded: encoded), "small payloads must stay importable by older builds")
+        XCTAssertEqual(try manager.format(of: encoded), .encrypted)
+    }
+
+    func testGeneratedPayload_oversizedSet_roundTripsThroughTheEnvelopeJSONShape() throws {
+        let secrets = Dictionary(
+            uniqueKeysWithValues: ConfigTransferManager.transferableSecretIdentifiers.enumerated().map {
+                ($1, syntheticKey(seed: 1_000 + $0, length: 90))
+            }
+        )
+        let encoded = try manager.generatePayload(secrets: secrets, settings: [:], code: code)
+        XCTAssertTrue(encoded.hasPrefix("{"), "oversized payloads carry the envelope JSON directly")
+        XCTAssertEqual(try manager.format(of: encoded), .encrypted)
+        let decoded = try manager.decodePayload(encoded, code: code)
+        XCTAssertEqual(decoded.secrets, secrets)
+        XCTAssertNotNil(manager.makeQRCodeImage(payload: encoded))
+    }
+}

--- a/Tests/SpeakCoreTests/ConfigTransferManagerTests.swift
+++ b/Tests/SpeakCoreTests/ConfigTransferManagerTests.swift
@@ -98,19 +98,6 @@ final class ConfigTransferManagerTests: XCTestCase {
         XCTAssertNotEqual(first.ciphertext, second.ciphertext)
     }
 
-    func testGeneratedPayload_forAFullKeySet_stillFitsInAQRCode() throws {
-        // The encrypted envelope is markedly larger than the format it replaces,
-        // so guard the worst realistic case: every transferable key populated.
-        let secrets = Dictionary(
-            uniqueKeysWithValues: ConfigTransferManager.transferableSecretIdentifiers.map {
-                ($0, String(repeating: "k", count: 72))
-            }
-        )
-        let transfer = try sut.makeTransfer(secrets: secrets, settings: ["selectedModel": "deepgram/nova-3-streaming"])
-        XCTAssertNotNil(sut.makeQRCodeImage(payload: transfer.payload), "Payload too large to encode as a QR code")
-        XCTAssertEqual(try sut.decodePayload(transfer.payload, code: transfer.code).secrets.count, secrets.count)
-    }
-
     func testFormat_encryptedPayload_reportsEncrypted() throws {
         let encoded = try sut.generatePayload(secrets: ["k": "v"], settings: [:], code: code)
         XCTAssertEqual(try sut.format(of: encoded), .encrypted)


### PR DESCRIPTION
## Defects (#699)

- `transferableSecretIdentifiers` listed six identifiers; exports silently dropped AssemblyAI, Cartesia, Gladia, Groq, Mistral, Modulate, Rev.ai, Soniox, Speechmatics and xAI keys while reporting success.
- The iOS import loop overwrote canonical Keychain entries one by one: a later failure left earlier credentials replaced while the UI reported failure — a mixed configuration with the previous values lost.

## Fix

**Complete, catalogue-anchored:** the explicit sixteen-identifier list is the bounded transfer policy; a parity test asserts it equals `ModelCredentialResolver.allKnownAPIKeyIdentifiers`, derived from the same catalogues routing and the pickers use (live providers, direct-batch providers, direct OpenAI, OpenRouter, `openai.tts`, `azure.speech`). Adding a provider anywhere fails the parity test until its transfer capability is defined. Dynamically registered identifiers are never exported, and import refuses unknown secret identifiers or setting keys **before any write**.

**Transactional:** `ConfigTransferManager.applyImport` validates the whole payload, retains every destination value, applies secrets in sorted order, and on failure rolls each applied credential back to its retained value (or removes it) — reporting stranded identifiers via `rollbackFailed` if restoration itself fails. Settings apply last (their writes cannot fail), so a secret failure never leaves partial settings. Retrying an identical import is idempotent and converges even after an interruption. The iOS import view now routes through the shared manager.

**Full-set QR budget:** sixteen realistic-entropy keys exceed every QR capacity in the doubly base64-encoded form (measured 3,048 bytes vs 2,953 max), so an oversized payload is emitted as the envelope JSON itself — same envelope, same AES-GCM authentication, carried directly by QR byte mode at correction L — while small payloads keep the backward-compatible base64 shape (pinned by test). Import accepts both; older builds keep importing every payload that previously fit.

## Tests

Catalogue parity (fails on any new provider until defined), previously omitted providers present, transactional apply, mid-import failure restores the replaced credential and skips settings, rollback-failure reporting, idempotent retry, bounded-policy refusals with zero writes, realistic-entropy full-set QR budget, and payload-shape selection. Full suite: 1726 tests, 0 failures; `make lint` clean; SpeakiOSLib builds.

Fixes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded QR configuration transfers to include all supported API keys and the selected model.
  * Added support for importing both raw JSON and base64-encoded transfer data.
  * Large transfers now use compatible formats with improved QR capacity handling.

* **Bug Fixes**
  * Configuration imports validate content and apply changes transactionally.
  * Failed credential saves roll back automatically.
  * Clear errors are provided for unknown identifiers, empty values, invalid settings, and rollback failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->