### PR TITLE
fix(ios): make recording startup cancellable by stop actions

### DIFF
--- a/Sources/SpeakCore/RecordingLifecycleCoordinator.swift
+++ b/Sources/SpeakCore/RecordingLifecycleCoordinator.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Explicit lifecycle of a recording service (issue #701). `starting` is an
+/// active, cancellable operation: a stop that arrives while startup is
+/// suspended retires the pending run instead of no-opping.
+public enum RecordingServiceState: Equatable, Sendable {
+    case idle
+    case starting
+    case recording
+    case stopping
+}
+
+/// The run-identity state machine behind a cancellable recording startup
+/// (issue #701).
+///
+/// A startup run holds a `UUID` identity. Every suspension point in the
+/// service's `startRecording` re-checks `isCurrentStartRun` before publishing
+/// shared state; a stop or cancel during `starting` retires the run, making
+/// the resumed start unwind what it allocated instead of activating the
+/// microphone. Stops can await `awaitStartSettled()` so cancellation is not
+/// fire-and-forget. Cleanup ownership stays with the run that allocated each
+/// resource: a retired old run can neither publish state nor tear down a
+/// newer run's session, because `activate`/`isCurrentStartRun` fail for it.
+@MainActor
+public final class RecordingLifecycleCoordinator {
+    public private(set) var state: RecordingServiceState = .idle
+
+    private var activeStartRunID: UUID?
+    private var settleWaiters: [CheckedContinuation<Void, Never>] = []
+
+    public init() {}
+
+    /// Whether a stop/toggle has an operation to act on: a live recording or
+    /// a startup in flight (which stop will cancel).
+    public var isActive: Bool { state == .starting || state == .recording }
+
+    /// Claims the service for a new startup run. Returns the run's identity,
+    /// or `nil` when the service is not idle (double start).
+    public func beginStart() -> UUID? {
+        guard state == .idle else { return nil }
+        let runID = UUID()
+        activeStartRunID = runID
+        state = .starting
+        return runID
+    }
+
+    /// Whether the given startup run still owns the service. False once a
+    /// stop/cancel retired it or a newer run replaced it.
+    public func isCurrentStartRun(_ runID: UUID) -> Bool {
+        activeStartRunID == runID && state == .starting
+    }
+
+    /// Retires the in-flight startup run (a stop/cancel during `starting`).
+    /// The suspended run observes this at its next identity check and unwinds
+    /// everything it allocated itself.
+    public func retireStartRun() {
+        guard state == .starting else { return }
+        activeStartRunID = nil
+    }
+
+    /// Publishes successful activation for the given run. Returns `false`
+    /// when the run was retired or replaced — the caller must unwind instead
+    /// of going live.
+    public func activate(_ runID: UUID) -> Bool {
+        guard isCurrentStartRun(runID) else { return false }
+        activeStartRunID = nil
+        state = .recording
+        settle()
+        return true
+    }
+
+    /// Settles the state machine after a startup run unwound (cancellation or
+    /// startup failure). Resumes any stops waiting on the cancellation.
+    public func finishStartUnwind() {
+        if state == .starting {
+            activeStartRunID = nil
+            state = .idle
+        }
+        settle()
+    }
+
+    /// Transitions `recording` → `stopping`. Returns `false` when there is no
+    /// live recording to stop.
+    public func beginStopping() -> Bool {
+        guard state == .recording else { return false }
+        state = .stopping
+        return true
+    }
+
+    /// Completes a stop (or a full cancel teardown) back to `idle`.
+    public func finishStopping() {
+        activeStartRunID = nil
+        state = .idle
+        settle()
+    }
+
+    /// Waits until the in-flight startup run has activated or unwound, so a
+    /// stop that cancelled a pending start returns only after no microphone,
+    /// session or activity can remain active.
+    public func awaitStartSettled() async {
+        guard state == .starting else { return }
+        await withCheckedContinuation { continuation in
+            guard state == .starting else {
+                continuation.resume()
+                return
+            }
+            settleWaiters.append(continuation)
+        }
+    }
+
+    private func settle() {
+        guard state != .starting else { return }
+        let waiters = settleWaiters
+        settleWaiters = []
+        for waiter in waiters { waiter.resume() }
+    }
+}

--- a/Sources/SpeakiOS/Activity/AutomationIntents.swift
+++ b/Sources/SpeakiOS/Activity/AutomationIntents.swift
@@ -60,7 +60,7 @@ struct StopDictationIntent: AudioRecordingIntent {
 
     func perform() async throws -> some IntentResult & ReturnsValue<String> {
         let service = await TranscriptionRecordingService.shared
-        guard await service.isRunning else {
+        guard await service.isActive else {
             throw AutomationIntentError.noActiveRecording
         }
         let destination = await AppSettings.shared.hardwareTriggerDestination

--- a/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
+++ b/Sources/SpeakiOS/Activity/TranscriptionIntents.swift
@@ -80,8 +80,10 @@ public struct StartTranscriptionIntent: AudioRecordingIntent, ForegroundContinua
 
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let service = await TranscriptionRecordingService.shared
-        let isRunning = await service.isRunning
-        if isRunning {
+        // `starting` counts: a startup in flight is already an active
+        // operation, not a free slot (issue #701).
+        let isActive = await service.isActive
+        if isActive {
             return .result(dialog: "Recording already in progress.")
         }
         if SharedTranscriptionState.shared.isRecording {
@@ -136,9 +138,11 @@ public struct StartTranscriptionRecordingIntent: AudioRecordingIntent, Foregroun
     /// owned exclusively by `stopRecording(destination:)`.
     public func perform() async throws -> IntentResultContainer<Never, Never, Never, Never> {
         let service = await TranscriptionRecordingService.shared
-        let isRunning = await service.isRunning
+        // A toggle during startup must stop (cancel) the pending run rather
+        // than treating the service as free and double-starting (issue #701).
+        let isActive = await service.isActive
 
-        if isRunning {
+        if isActive {
             let destination = await AppSettings.shared.hardwareTriggerDestination
             await service.stopRecording(destination: destination)
             return .result()
@@ -177,9 +181,10 @@ public struct StopTranscriptionRecordingIntent: AudioRecordingIntent, LiveActivi
 
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let service = await TranscriptionRecordingService.shared
-        let isRunning = await service.isRunning
+        // `starting` is cancellable, not "no active recording" (issue #701).
+        let isActive = await service.isActive
 
-        guard isRunning else {
+        guard isActive else {
             if SharedTranscriptionState.shared.isRecording {
                 return .result(dialog: "A recording is active in the app. Use the in-app stop button.")
             }

--- a/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
+++ b/Sources/SpeakiOS/Services/TranscriptionRecordingService.swift
@@ -12,6 +12,15 @@ import SpeakCore
 public final class TranscriptionRecordingService: ObservableObject {
     public static let shared = TranscriptionRecordingService()
 
+    /// The service's lifecycle state, mirrored from the run-identity
+    /// coordinator after every transition. `isRunning` remains as the
+    /// published `recording`-only view for existing observers.
+    @Published public private(set) var state: RecordingServiceState = .idle
+
+    /// Whether a stop/toggle has an operation to act on: a live recording or
+    /// a startup still in flight (which stop will cancel).
+    public var isActive: Bool { lifecycle.isActive }
+
     @Published public private(set) var isRunning = false
     @Published public private(set) var partialText = ""
     @Published public private(set) var wordCount = 0
@@ -30,9 +39,10 @@ public final class TranscriptionRecordingService: ObservableObject {
     private var startTime: Date?
     private var currentModel: String = ""
     private var sharesLiveTranscript = true
-    /// Guards against concurrent double-starts across the suspension points in
-    /// `startRecording` (key load, transcriber start).
-    private var isStarting = false
+    /// Run-identity state machine for cancellable startup (issue #701); the
+    /// pure mechanics live in SpeakCore so they are testable on every
+    /// platform. `state` mirrors it for observers.
+    private let lifecycle = RecordingLifecycleCoordinator()
     /// Last time the App Group shared state was written for a partial result.
     private var lastSharedStateWriteAt: Date = .distantPast
     private static let sharedStateWriteInterval: TimeInterval = 1.0
@@ -74,9 +84,9 @@ public final class TranscriptionRecordingService: ObservableObject {
         requiresLiveActivity: Bool = true,
         keyboardProfile: KeyboardDictationProfileOption? = nil
     ) async throws {
-        guard !isRunning, !isStarting else { return }
-        isStarting = true
-        defer { isStarting = false }
+        guard let runID = lifecycle.beginStart() else { return }
+        state = lifecycle.state
+        defer { state = lifecycle.state }
 
         let settings = AppSettings.shared
         // AppSettings.init publishes empty API keys and loads the real values
@@ -84,7 +94,12 @@ public final class TranscriptionRecordingService: ObservableObject {
         // Button could read those empty keys and silently fall back to Apple
         // Speech, so wait for the initial load before resolving the model.
         await settings.ensureKeysLoaded()
-        guard !isRunning else { return }
+        // A stop/cancel during the suspension above retires the run; nothing
+        // has been allocated yet, so unwinding only settles the state machine.
+        guard lifecycle.isCurrentStartRun(runID) else {
+            unwindCancelledStart()
+            throw CancellationError()
+        }
 
         lastSessionError = nil
         providerFallbackNotice = nil
@@ -134,19 +149,21 @@ public final class TranscriptionRecordingService: ObservableObject {
             ? activityManager.startActivity(provider: activityProvider)
             : false
         if requiresLiveActivity && !activityStarted && !appIsActive {
-            startTime = nil
-            sharedState.clearRecordingState()
+            unwindCancelledStart()
             throw iOSTranscriptionError.liveActivityUnavailable
         }
 
         #if DEBUG && targetEnvironment(simulator)
         if let transcript = sharedState.simulatorValidationTranscript {
             handlePartialResult(text: transcript)
+            _ = lifecycle.activate(runID)
+            state = lifecycle.state
             isRunning = true
             return
         }
         #endif
 
+        var startedSession: IOSTranscriptionSession?
         do {
             let mode: IOSTranscriptionSession.Mode = usesBatchTranscription
                 ? .batch(retainRecording: retainBatchRecording)
@@ -167,19 +184,42 @@ public final class TranscriptionRecordingService: ObservableObject {
             session.onError = { [weak self] error in
                 self?.handleError(error)
             }
-            transcriptionSession = session
+            startedSession = session
             try await session.start()
-
+            // The session this run allocated is published only while the run
+            // is still current; a stop during start() retires the run, and the
+            // cleanup below tears down exactly what this run owns without
+            // touching any replacement run's session (issue #701).
+            guard lifecycle.activate(runID) else {
+                session.cancel()
+                unwindCancelledStart()
+                throw CancellationError()
+            }
+            transcriptionSession = session
             isRunning = true
         } catch {
-            transcriptionSession?.cancel()
-            startTime = nil
-            transcriptionSession = nil
-            self.sharesLiveTranscript = true
-            sharedState.clearRecordingState()
-            activityManager.endActivity()
+            // Unwind runs for the retired case too: a stop that cancelled this
+            // startup is awaiting settlement, and this run still owns whatever
+            // it allocated. `transcriptionSession` is untouched — it is only
+            // ever assigned after successful activation.
+            startedSession?.cancel()
+            unwindCancelledStart()
             throw error
         }
+    }
+
+    /// Reverts everything a cancelled startup run had published: timing,
+    /// shared App Group recording state and the Live Activity. The run calls
+    /// this itself so ownership never crosses runs.
+    private func unwindCancelledStart() {
+        startTime = nil
+        sharesLiveTranscript = true
+        partialText = ""
+        wordCount = 0
+        sharedState.clearRecordingState()
+        activityManager.endActivity()
+        lifecycle.finishStartUnwind()
+        state = lifecycle.state
     }
 
     /// Stops recording, applies the requested result destination, and returns the result.
@@ -196,10 +236,14 @@ public final class TranscriptionRecordingService: ObservableObject {
         saveToHistory: Bool = true,
         primedActivityMessage: String = "Ready for the Action Button"
     ) async -> TranscriptionResult {
-        // Reentrancy guard: a rapid double-stop (e.g. double Action Button
-        // press) must not produce a second history entry or clobber the
-        // clipboard with stale text. Return an empty no-op result instead.
-        guard isRunning else {
+        // A stop during startup cancels the pending run and waits for it to
+        // unwind (issue #701): retiring `activeStartRunID` makes the suspended
+        // start release everything it allocated instead of activating the
+        // microphone after the user asked to stop.
+        if lifecycle.state == .starting {
+            lifecycle.retireStartRun()
+            await lifecycle.awaitStartSettled()
+            state = lifecycle.state
             return TranscriptionResult(
                 text: "",
                 segments: [],
@@ -211,6 +255,23 @@ public final class TranscriptionRecordingService: ObservableObject {
                 debugInfo: nil
             )
         }
+
+        // Reentrancy guard: a rapid double-stop (e.g. double Action Button
+        // press) must not produce a second history entry or clobber the
+        // clipboard with stale text. Return an empty no-op result instead.
+        guard lifecycle.beginStopping() else {
+            return TranscriptionResult(
+                text: "",
+                segments: [],
+                confidence: nil,
+                duration: 0,
+                modelIdentifier: currentModel,
+                cost: nil,
+                rawPayload: nil,
+                debugInfo: nil
+            )
+        }
+        state = lifecycle.state
         isRunning = false
         let duration = elapsedSeconds
 
@@ -290,6 +351,8 @@ public final class TranscriptionRecordingService: ObservableObject {
         partialText = ""
         wordCount = 0
 
+        lifecycle.finishStopping()
+        state = lifecycle.state
         return result
     }
 
@@ -302,8 +365,14 @@ public final class TranscriptionRecordingService: ObservableObject {
         )
     }
 
-    /// Cancels recording without saving.
+    /// Cancels recording without saving. During startup this retires the
+    /// pending run; the suspended start unwinds its own allocations when it
+    /// resumes (issue #701).
     public func cancelRecording() {
+        if lifecycle.state == .starting {
+            lifecycle.retireStartRun()
+            return
+        }
         transcriptionSession?.cancel()
         transcriptionSession = nil
         sharesLiveTranscript = true
@@ -313,6 +382,8 @@ public final class TranscriptionRecordingService: ObservableObject {
         wordCount = 0
         sharedState.clearRecordingState()
         activityManager.endActivity()
+        lifecycle.finishStopping()
+        state = lifecycle.state
     }
 
     // MARK: - Private
@@ -348,7 +419,7 @@ public final class TranscriptionRecordingService: ObservableObject {
         // the mic stayed hot while the user dictated into a dead session.
         // Tear the session down, preserving the accumulated transcript, and
         // publish the error so the app can surface it on next foreground.
-        guard isRunning else { return }
+        guard lifecycle.state == .recording else { return }
         lastSessionError = error
         Task { [weak self] in
             guard let self, self.isRunning else { return }

--- a/Tests/SpeakCoreTests/RecordingLifecycleCoordinatorTests.swift
+++ b/Tests/SpeakCoreTests/RecordingLifecycleCoordinatorTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+
+@testable import SpeakCore
+
+/// The run-identity state machine behind cancellable recording startup
+/// (issue #701): a stop during `starting` retires the pending run, the
+/// retired run unwinds its own allocations, waiting stops settle only after
+/// that unwind, and a stale run can neither publish state nor disturb a
+/// replacement run.
+@MainActor
+final class RecordingLifecycleCoordinatorTests: XCTestCase {
+    func testHappyPath_startActivateStopReturnsToIdle() {
+        let coordinator = RecordingLifecycleCoordinator()
+        XCTAssertEqual(coordinator.state, .idle)
+        XCTAssertFalse(coordinator.isActive)
+
+        let runID = coordinator.beginStart()
+        XCTAssertNotNil(runID)
+        XCTAssertEqual(coordinator.state, .starting)
+        XCTAssertTrue(coordinator.isActive, "starting must read as an active operation")
+
+        XCTAssertTrue(coordinator.activate(runID!))
+        XCTAssertEqual(coordinator.state, .recording)
+
+        XCTAssertTrue(coordinator.beginStopping())
+        XCTAssertEqual(coordinator.state, .stopping)
+        XCTAssertFalse(coordinator.isActive)
+        coordinator.finishStopping()
+        XCTAssertEqual(coordinator.state, .idle)
+    }
+
+    func testDoubleStart_isRefusedWhileAnyRunIsInFlight() {
+        let coordinator = RecordingLifecycleCoordinator()
+        let first = coordinator.beginStart()
+        XCTAssertNotNil(first)
+        XCTAssertNil(coordinator.beginStart(), "starting must refuse a second run")
+
+        XCTAssertTrue(coordinator.activate(first!))
+        XCTAssertNil(coordinator.beginStart(), "recording must refuse a new run")
+    }
+
+    func testStopDuringStarting_retiresTheRunAndTheRunCannotActivate() {
+        let coordinator = RecordingLifecycleCoordinator()
+        let runID = coordinator.beginStart()!
+
+        // The user stopped while startup was suspended (e.g. Keychain load).
+        coordinator.retireStartRun()
+
+        XCTAssertFalse(coordinator.isCurrentStartRun(runID))
+        XCTAssertFalse(
+            coordinator.activate(runID),
+            "a retired run must not publish recording state"
+        )
+        XCTAssertEqual(coordinator.state, .starting, "the retired run still owns the unwind")
+
+        coordinator.finishStartUnwind()
+        XCTAssertEqual(coordinator.state, .idle)
+    }
+
+    func testAwaitStartSettled_returnsOnlyAfterTheRetiredRunUnwound() async {
+        let coordinator = RecordingLifecycleCoordinator()
+        let runID = coordinator.beginStart()!
+        coordinator.retireStartRun()
+
+        let settled = XCTestExpectation(description: "stop settled")
+        let waiter = Task { @MainActor in
+            await coordinator.awaitStartSettled()
+            XCTAssertNotEqual(coordinator.state, .starting)
+            settled.fulfill()
+        }
+        // Let the waiter suspend before the run unwinds.
+        await Task.yield()
+        XCTAssertFalse(coordinator.isCurrentStartRun(runID))
+
+        coordinator.finishStartUnwind()
+        await fulfillment(of: [settled], timeout: 2)
+        _ = await waiter.value
+        XCTAssertEqual(coordinator.state, .idle)
+    }
+
+    func testAwaitStartSettled_resolvesImmediatelyOutsideStarting() async {
+        let coordinator = RecordingLifecycleCoordinator()
+        await coordinator.awaitStartSettled()
+
+        let runID = coordinator.beginStart()!
+        XCTAssertTrue(coordinator.activate(runID))
+        await coordinator.awaitStartSettled()
+        XCTAssertEqual(coordinator.state, .recording)
+    }
+
+    func testRapidStartStopStart_staleRunCannotTouchTheReplacementRun() {
+        let coordinator = RecordingLifecycleCoordinator()
+        let first = coordinator.beginStart()!
+        coordinator.retireStartRun()
+
+        // No replacement can begin until the retired run has unwound, so a
+        // stale run never coexists with a newer one it could tear down.
+        XCTAssertNil(coordinator.beginStart())
+        coordinator.finishStartUnwind()
+
+        let second = coordinator.beginStart()
+        XCTAssertNotNil(second)
+        XCTAssertNotEqual(first, second)
+
+        // The stale identity has no power over the replacement run.
+        XCTAssertFalse(coordinator.isCurrentStartRun(first))
+        XCTAssertFalse(coordinator.activate(first))
+        XCTAssertEqual(coordinator.state, .starting)
+        XCTAssertTrue(coordinator.isCurrentStartRun(second!))
+        XCTAssertTrue(coordinator.activate(second!))
+        XCTAssertEqual(coordinator.state, .recording)
+    }
+
+    func testStartupFailure_unwindSettlesWaitersAndFreesTheService() async {
+        let coordinator = RecordingLifecycleCoordinator()
+        _ = coordinator.beginStart()!
+
+        let settled = XCTestExpectation(description: "settled after failure")
+        let waiter = Task { @MainActor in
+            await coordinator.awaitStartSettled()
+            settled.fulfill()
+        }
+        await Task.yield()
+
+        // The run's own failure path unwinds; the service is reusable after.
+        coordinator.finishStartUnwind()
+        await fulfillment(of: [settled], timeout: 2)
+        _ = await waiter.value
+        XCTAssertNotNil(coordinator.beginStart())
+    }
+
+    func testBeginStopping_refusedOutsideRecording() {
+        let coordinator = RecordingLifecycleCoordinator()
+        XCTAssertFalse(coordinator.beginStopping())
+
+        _ = coordinator.beginStart()
+        XCTAssertFalse(
+            coordinator.beginStopping(),
+            "a pending start is cancelled via retireStartRun, not stopped"
+        )
+    }
+}


### PR DESCRIPTION
## Defect (#701)

`TranscriptionRecordingService.startRecording()` kept `isRunning == false` while it awaited Keychain loading and `IOSTranscriptionSession.start()`. A stop or toggle in that window hit the double-stop no-op ("No active recording"), and the original start then resumed, activated the microphone and set `isRunning = true` — a recording left running after the user explicitly tried to stop it. The private `isStarting` flag blocked double starts but was invisible to stop intents.

## Fix

- Explicit `idle → starting → recording → stopping` state machine with **run identity**, extracted as `RecordingLifecycleCoordinator` in SpeakCore so the mechanics are CI-testable on every platform (the iOS service file is `#if os(iOS)` and its tests only run on-device/simulator).
- Every suspension point in `startRecording` re-checks `isCurrentStartRun` before publishing shared state; the session is published only through `activate`, which fails for a retired run. A retired run **unwinds its own allocations** — timing, App Group recording state, Live Activity, and the session it created — including when `session.start()` throws after retirement, so cleanup ownership never crosses runs and a stale run can neither publish state nor tear down a replacement run's session.
- A stop during `starting` retires the pending run and **awaits settlement** (`awaitStartSettled`), so when it returns no microphone, session or activity can remain active. `cancelRecording` retires without waiting; the run still unwinds itself.
- Intents observe `starting` as an active, cancellable operation via the new `isActive`: the toggle stops (cancels) a pending start instead of double-starting; Stop Recording cancels it instead of reporting "No active recording"; Start reports "already in progress" during startup. `isRunning` stays published unchanged for existing observers, mirrored from the coordinator.

## Tests

`RecordingLifecycleCoordinatorTests` (8, run on macOS CI): happy path; double-start refusal in starting and recording; stop-during-starting retires the run and `activate` fails for it; `awaitStartSettled` returns only after the retired run unwound; immediate resolution outside `starting`; rapid start-stop-start — no replacement run can begin until the stale run unwound, and the stale identity has no power over the replacement; startup-failure settlement leaves the service reusable; `beginStopping` refused outside `recording`. Full suite: 1724 tests, 0 failures; `make lint` clean; SpeakiOSLib builds.

The device-level acceptance walk (suspend Keychain load → stop → resume; stop during `session.start()`; Live Activity/App Group consistency) maps 1:1 onto coordinator transitions and the run-owned unwind paths; the physical-device pass belongs to the iOS verification matrix.

Fixes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer recording lifecycle states: idle, starting, recording, and stopping.
  * Recording status now reflects sessions that are still starting, preventing conflicting actions.
* **Bug Fixes**
  * Improved handling when recording is cancelled during startup.
  * Prevented duplicate recording starts and ensured stop actions correctly cancel pending starts.
  * Improved cleanup after failed or interrupted recording startup.
* **Improvements**
  * Recording state is now available for more consistent status updates across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->