### PR TITLE
ci: add advisory Tessl code review

### DIFF
--- a/.github/workflows/tessl-code-review.yml
+++ b/.github/workflows/tessl-code-review.yml
@@ -1,0 +1,48 @@
+name: Tessl Code Review
+
+# Review once when a pull request is ready, then only when explicitly asked.
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: Pull-request number to review
+        required: true
+
+permissions:
+  contents: read
+  checks: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: tessl-code-review-${{ github.event.pull_request.number || github.event.issue.number || inputs['pr-number'] }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    # Comment matching is intentionally a coarse prefilter. The action checks
+    # the complete mention token and enforces the allowed author associations.
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      github.event_name == 'workflow_dispatch' ||
+      ((github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
+        (github.event_name != 'issue_comment' || github.event.issue.pull_request != null) &&
+        (github.event.issue.state == 'open' || github.event.pull_request.state == 'open') &&
+        contains(github.event.comment.body, '@tessl-code-review'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # v1.2.0, pinned so upstream changes require a deliberate update.
+      - uses: tesslio/code-review-action@36962c011cd38aa40abebf8ae3068a27a0af2013
+        with:
+          tessl-token: ${{ secrets.TESSL_TOKEN }}
+          allowed-associations: OWNER,MEMBER,COLLABORATOR
+          profile: standard
+          mode: advisory
+          pr-number: ${{ github.event.issue.number || inputs['pr-number'] }}


### PR DESCRIPTION
## Summary
- add Tessl review when a non-draft PR is opened, reopened, or marked ready
- allow trusted collaborators to request another pass with `@tessl-code-review`
- keep results advisory and pin the action to the immutable v1.2.0 commit

## Configuration
- profile: `standard`
- mode: `advisory`
- `TESSL_TOKEN` is configured as an encrypted repository secret

## Validation
- workflow formatted with Prettier
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated code review support for pull requests.
  * Reviews can be triggered by pull request activity, review comments, issue comments, or manually.
  * Reviews run in advisory mode and avoid interrupting in-progress checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->