### PR TITLE
build(core): guard exported API compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,3 +263,23 @@ jobs:
 
       - name: Test release-notes generator
         run: node --test Tests/ReleaseNotesTests/*.test.mjs
+
+  api-compatibility:
+    name: Public API compatibility
+    runs-on: macos-latest
+    timeout-minutes: 30
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The baseline treeish must be resolvable locally.
+          fetch-depth: 0
+
+      # Exported library products must not lose or incompatibly change
+      # public symbols in a non-major PR (issue #680). A PR title carrying
+      # the conventional '!' breaking marker declares the major release and
+      # is allowed through with the diff reported.
+      - name: Diagnose breaking public API changes
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: bash scripts/check-api-compatibility.sh "origin/${{ github.base_ref }}"

--- a/Sources/SpeakCore/DeprecatedCompatibility.swift
+++ b/Sources/SpeakCore/DeprecatedCompatibility.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+// MARK: - Deprecated compatibility shims (issue #680)
+//
+// PR #628 removed exported types as dead in-repository code, which was a
+// source-breaking change for external SwiftPM consumers of SpeakCore.
+//
+// Decision per issue #680:
+// - `SpeakErrorMessage` is restored verbatim below as a deprecated shim and
+//   may be removed only in a declared major version. Do not adopt it in new
+//   code.
+// - `PermissionStatus` is NOT restored: its name collides with the app's
+//   live `PermissionStatus` (the collision #628 fixed), and the module also
+//   exports a `SpeakApp` type, so the clash cannot be qualified away. Its
+//   removal is a documented break that shipped with #628 in the v2.4x line;
+//   migrate to the owning platform permission APIs
+//   (`AVCaptureDevice.authorizationStatus`, `SFSpeechRecognizer
+//   .authorizationStatus`). The api-compatibility CI gate now prevents this
+//   class of undeclared removal from recurring.
+
+// MARK: - User-Facing Error Messages
+
+/// Provides actionable error messages for common failure scenarios.
+@available(*, deprecated, message: "Use the owning subsystem's LocalizedError texts; see issue #680.")
+public enum SpeakErrorMessage {
+
+    /// Returns a user-friendly message with actionable steps.
+    public static func userMessage(for error: Error) -> (title: String, message: String, action: String?) {
+        // swiftlint:disable:previous large_tuple
+        // Check for common error types
+        if let urlError = error as? URLError {
+            return handleURLError(urlError)
+        }
+
+        if let secureError = error as? SecureStorageError {
+            return handleSecureStorageError(secureError)
+        }
+
+        // Check error domain/code for system errors
+        let nsError = error as NSError
+
+        // Speech recognition errors
+        if nsError.domain == "kAFAssistantErrorDomain" {
+            return handleSpeechError(nsError)
+        }
+
+        // Audio session errors
+        if nsError.domain == NSOSStatusErrorDomain {
+            return handleAudioError(nsError)
+        }
+
+        // Default
+        return (
+            title: "Something went wrong",
+            message: error.localizedDescription,
+            action: nil
+        )
+    }
+
+    // swiftlint:disable:next large_tuple
+    private static func handleURLError(_ error: URLError) -> (String, String, String?) {
+        switch error.code {
+        case .notConnectedToInternet:
+            return (
+                "No Internet Connection",
+                "Transcription with cloud providers requires an internet connection.",
+                "Check your Wi-Fi or cellular connection, or switch to on-device Apple Speech."
+            )
+        case .timedOut:
+            return (
+                "Connection Timed Out",
+                "The transcription service took too long to respond.",
+                "Check your connection and try again."
+            )
+        case .cannotFindHost, .cannotConnectToHost:
+            return (
+                "Service Unavailable",
+                "Could not connect to the transcription service.",
+                "The service may be down. Try again later or switch providers."
+            )
+        case .secureConnectionFailed:
+            return (
+                "Secure Connection Failed",
+                "Could not establish a secure connection.",
+                "Check your network settings or try a different network."
+            )
+        default:
+            return (
+                "Network Error",
+                error.localizedDescription,
+                "Check your internet connection and try again."
+            )
+        }
+    }
+
+    // swiftlint:disable:next large_tuple
+    private static func handleSecureStorageError(_ error: SecureStorageError) -> (String, String, String?) {
+        switch error {
+        case .permissionDenied:
+            return (
+                "Keychain Access Denied",
+                "Unable to access stored API keys.",
+                "Go to Settings → Privacy & Security → Keychain and ensure Speak has access."
+            )
+        case .valueNotFound:
+            return (
+                "API Key Missing",
+                "No API key found for this service.",
+                "Add your API key in Settings → API Keys."
+            )
+        case .unexpectedStatus:
+            return (
+                "Keychain Error",
+                "An unexpected error occurred accessing secure storage.",
+                "Try restarting the app. If the problem persists, re-enter your API keys."
+            )
+        default:
+            return (
+                "Keychain Error",
+                error.localizedDescription,
+                nil
+            )
+        }
+    }
+
+    // swiftlint:disable:next large_tuple
+    private static func handleSpeechError(_ error: NSError) -> (String, String, String?) {
+        switch error.code {
+        case 1: // Speech not available
+            return (
+                "Speech Recognition Unavailable",
+                "Speech recognition is not available on this device.",
+                "Ensure your device supports speech recognition and you have "
+                    + "an internet connection for first-time setup."
+            )
+        case 4: // Speech recognition denied
+            return (
+                "Speech Permission Required",
+                "Speak needs permission to use speech recognition.",
+                "Go to Settings → Privacy & Security → Speech Recognition and enable for Speak."
+            )
+        case 203: // Recognition request cancelled
+            return (
+                "Transcription Interrupted",
+                "The transcription was interrupted.",
+                "This can happen during calls or when switching apps. Try starting again."
+            )
+        default:
+            return (
+                "Speech Recognition Error",
+                error.localizedDescription,
+                nil
+            )
+        }
+    }
+
+    // swiftlint:disable:next large_tuple
+    private static func handleAudioError(_ error: NSError) -> (String, String, String?) {
+        (
+            "Audio Error",
+            "Could not access the microphone.",
+            "Go to Settings → Privacy & Security → Microphone and ensure Speak has access."
+        )
+    }
+}

--- a/Tests/SpeakCoreTests/PublicAPICompatibilityFixtureTests.swift
+++ b/Tests/SpeakCoreTests/PublicAPICompatibilityFixtureTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+import SpeakCore
+
+/// External-consumer compile fixture (issue #680): code written against the
+/// pre-#628 exported `SpeakCore` API must keep compiling through the
+/// deprecated shims. This file deliberately uses the plain `import` (no
+/// `@testable`) and only the public surface, exactly as an external SwiftPM
+/// consumer would.
+@available(*, deprecated, message: "Exercises deprecated compatibility shims on purpose")
+final class PublicAPICompatibilityFixtureTests: XCTestCase {
+    func testSpeakErrorMessage_userMessage_keepsThePre628CallShape() {
+        let network = SpeakErrorMessage.userMessage(for: URLError(.notConnectedToInternet))
+        XCTAssertFalse(network.title.isEmpty)
+        XCTAssertFalse(network.message.isEmpty)
+        _ = network.action
+
+        let keychain = SpeakErrorMessage.userMessage(for: SecureStorageError.valueNotFound)
+        XCTAssertFalse(keychain.title.isEmpty)
+    }
+
+}

--- a/scripts/check-api-compatibility.sh
+++ b/scripts/check-api-compatibility.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Public-API compatibility gate (issue #680).
+#
+# Diagnoses breaking changes to the exported SwiftPM library products against
+# a baseline treeish (in CI: the PR's base branch). A non-major change that
+# removes or incompatibly alters a public symbol fails here.
+#
+# Intentional update workflow: a PR whose title carries the conventional
+# breaking marker (`type!:` / `type(scope)!:`) declares a major release, so
+# the gate reports the diff but does not fail — auto-release will publish it
+# as a major version and the PR review carries the migration note.
+
+set -uo pipefail
+
+BASELINE="${1:?usage: check-api-compatibility.sh <baseline-treeish>}"
+PR_TITLE="${PR_TITLE:-}"
+
+PRODUCTS=(SpeakCore SpeakSync SpeakiOSLib SpeakHotKeys SpeakAutomationKit)
+
+product_args=()
+for product in "${PRODUCTS[@]}"; do
+    product_args+=(--products "$product")
+done
+
+echo "==> Diagnosing public API against ${BASELINE} for: ${PRODUCTS[*]}"
+output=$(swift package diagnose-api-breaking-changes "$BASELINE" "${product_args[@]}" 2>&1)
+status=$?
+echo "$output"
+
+if [[ $status -eq 0 ]]; then
+    echo "==> Public API is compatible with ${BASELINE}"
+    exit 0
+fi
+
+# The command exits non-zero both for detected breakage and for tooling
+# failures; only treat runs that actually printed findings as breakage.
+if ! grep -q "API breakage" <<< "$output"; then
+    echo "==> swift package diagnose-api-breaking-changes failed to run" >&2
+    exit "$status"
+fi
+
+breaking_title_pattern='^[a-z]+(\([^)]+\))?!:'
+if [[ "$PR_TITLE" =~ $breaking_title_pattern ]]; then
+    echo "==> Breaking API change declared by the PR title's '!' marker;"
+    echo "    allowing under the major-release workflow. Ensure the PR body"
+    echo "    documents the migration path."
+    exit 0
+fi
+
+cat >&2 << 'MSG'
+==> Breaking public API change without a declared major release.
+    Either restore compatibility (a deprecated shim forwarding to the new
+    API), or declare the break by adding the conventional-commit '!' marker
+    to the PR title (e.g. `refactor!: ...`) with a migration note in the PR
+    body. See issue #680.
+MSG
+exit 1


### PR DESCRIPTION
## Problem (#680)

#628 removed public `SpeakErrorMessage` and `PermissionStatus` from the exported `SpeakCore` product in a `refactor:` release — a source break for external SwiftPM consumers — and the repository had no public-API baseline to distinguish a removable implementation detail from an exported contract.

## Fix

**CI gate** — a new `api-compatibility` job runs `swift package diagnose-api-breaking-changes` against the PR's base branch for every exported library product (`SpeakCore`, `SpeakSync`, `SpeakiOSLib`, `SpeakHotKeys`, `SpeakAutomationKit`) via `scripts/check-api-compatibility.sh`:
- symbol/member removal, signature changes and visibility reductions fail with an actionable message;
- the **intentional update workflow** is the conventional-commit breaking marker: a PR titled `type!: …` declares the major release, and the gate reports the diff but passes, so approved breaks stay reviewable rather than bypassing the check (this also matches how auto-release versions them);
- tooling failures are distinguished from genuine findings.
- Validated against the pre-#628 tree: the gate reports the exact historical removals it was designed to catch.

**Decision on the removed symbols** (the issue offers shim-or-document per symbol):
- `SpeakErrorMessage` — restored verbatim as a **deprecated shim** (`Sources/SpeakCore/DeprecatedCompatibility.swift`), removable only in a declared major version. An external-consumer compile fixture (`PublicAPICompatibilityFixtureTests`, plain `import SpeakCore`, public surface only) pins the pre-#628 call shape. Its `SecureStorageError` switch gains a `default` so parallel additions to that enum (e.g. PR #763) cannot break the frozen shim.
- `PermissionStatus` — **documented break, not restored**: its name collides with the app's live `PermissionStatus` (the very collision #628 fixed), and the `SpeakApp` module also exports a `SpeakApp` type, so `SpeakApp.PermissionStatus` qualification is impossible. The shipped break and migration path (platform permission APIs) are documented in the shim file; the new gate prevents this class of undeclared removal from recurring.

- Note: iOS-only public symbols inside `#if os(iOS)` compile out on the macOS runner, so the gate covers the macOS-visible surface of `SpeakiOSLib`; broader coverage would need an xcodebuild-based digester and is out of scope here.

## Verification

Gate run against `origin/main` (no findings) and against `758c0fc^` (reports the #628-era breakage and fails without the `!` marker; the marker path allows it). Fixture test passes; full suite 1717 tests, 0 failures; `make lint` clean; workflow YAML parses.

Fixes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW