### PR TITLE
fix(ios): surface recording-persistence backpressure and gaps

### DIFF
--- a/Sources/SpeakCore/RecordingPersistenceAdmission.swift
+++ b/Sources/SpeakCore/RecordingPersistenceAdmission.swift
@@ -16,7 +16,7 @@ public enum RecordingPersistenceAdmission: Equatable, Sendable {
 /// What a completed recording's persistence actually did — the truth the
 /// session and UI must report instead of presenting every saved file as a
 /// healthy complete recording (issue #705).
-public struct RecordingPersistenceDiagnostics: Equatable, Sendable {
+public struct RecordingPersistenceDiagnostics: Equatable, Hashable, Sendable {
     /// Frames admitted (pool or overflow) and handed to the writer.
     public var admittedFrames: Int = 0
     /// Audio duration admitted, in seconds of source PCM.

--- a/Sources/SpeakCore/RecordingPersistenceAdmission.swift
+++ b/Sources/SpeakCore/RecordingPersistenceAdmission.swift
@@ -68,6 +68,14 @@ public final class RecordingPersistenceAdmissionController: @unchecked Sendable 
         return storedDiagnostics
     }
 
+    /// Audio currently admitted but not yet written; exposed for tests that
+    /// assert the budget is released correctly.
+    var inFlightSecondsForTesting: Double {
+        lock.lock()
+        defer { lock.unlock() }
+        return inFlightSeconds
+    }
+
     /// Decides admission for one frame.
     ///
     /// - Parameters:
@@ -106,5 +114,21 @@ public final class RecordingPersistenceAdmissionController: @unchecked Sendable 
         if failed {
             storedDiagnostics.writeFailures += 1
         }
+    }
+
+    /// Records that an admitted frame never reached the writer — the fallback
+    /// allocation failed after `admit` granted `.acceptedViaOverflow`. The
+    /// admission is reversed and the frame is accounted as dropped audio, not
+    /// as a write failure, so `droppedSeconds` stays the exact gap and the
+    /// diagnostics agree with the `.backpressured` result the caller returns.
+    public func abandonAdmittedFrame(frameSeconds: Double) {
+        lock.lock()
+        defer { lock.unlock() }
+        inFlightSeconds = max(0, inFlightSeconds - frameSeconds)
+        storedDiagnostics.admittedFrames = max(0, storedDiagnostics.admittedFrames - 1)
+        storedDiagnostics.admittedSeconds = max(0, storedDiagnostics.admittedSeconds - frameSeconds)
+        storedDiagnostics.overflowAllocations = max(0, storedDiagnostics.overflowAllocations - 1)
+        storedDiagnostics.droppedFrames += 1
+        storedDiagnostics.droppedSeconds += frameSeconds
     }
 }

--- a/Sources/SpeakCore/RecordingPersistenceAdmission.swift
+++ b/Sources/SpeakCore/RecordingPersistenceAdmission.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// How one PCM frame was admitted to (or refused by) recording persistence
+/// (issue #705).
+public enum RecordingPersistenceAdmission: Equatable, Sendable {
+    /// Copied through the reusable pool and queued for writing.
+    case accepted
+    /// The pool was exhausted, but the in-flight budget allowed a controlled
+    /// fallback allocation to absorb the stall.
+    case acceptedViaOverflow
+    /// The bounded in-flight budget is exhausted: the frame was dropped and
+    /// recorded as a gap. The saved recording is no longer complete.
+    case backpressured
+}
+
+/// What a completed recording's persistence actually did — the truth the
+/// session and UI must report instead of presenting every saved file as a
+/// healthy complete recording (issue #705).
+public struct RecordingPersistenceDiagnostics: Equatable, Sendable {
+    /// Frames admitted (pool or overflow) and handed to the writer.
+    public var admittedFrames: Int = 0
+    /// Audio duration admitted, in seconds of source PCM.
+    public var admittedSeconds: Double = 0
+    /// Frames dropped because the bounded in-flight budget was exhausted.
+    public var droppedFrames: Int = 0
+    /// Exactly how much audio the drops removed, in seconds.
+    public var droppedSeconds: Double = 0
+    /// File writes that failed after admission.
+    public var writeFailures: Int = 0
+    /// Fallback allocations used while the pool was exhausted.
+    public var overflowAllocations: Int = 0
+    /// Most audio seconds simultaneously in flight (admitted, not yet
+    /// written) — evidence for sizing the pool and budget.
+    public var inFlightHighWaterSeconds: Double = 0
+
+    public init() {}
+
+    /// A recording is complete only when nothing was dropped and every
+    /// admitted write landed.
+    public var isComplete: Bool { droppedFrames == 0 && writeFailures == 0 }
+}
+
+/// Bounded admission for the persistence write queue (issue #705).
+///
+/// The real-time audio callback must never block, so admission is a
+/// constant-time decision: use the reusable pool while it has capacity, absorb
+/// short I/O stalls with fallback allocations up to a duration budget sized
+/// from the actual sample format, and beyond that drop the frame while
+/// accounting for exactly how much audio was lost. Sustained overflow can
+/// therefore never masquerade as a healthy complete recording.
+public final class RecordingPersistenceAdmissionController: @unchecked Sendable {
+    private let lock = NSLock()
+    private let overflowBudgetSeconds: Double
+    private var inFlightSeconds: Double = 0
+    private var storedDiagnostics = RecordingPersistenceDiagnostics()
+
+    /// - Parameter overflowBudgetSeconds: how much audio may sit admitted but
+    ///   unwritten before further frames are dropped. Two seconds absorbs a
+    ///   short filesystem stall without letting a wedged writer grow memory
+    ///   unboundedly.
+    public init(overflowBudgetSeconds: Double = 2.0) {
+        self.overflowBudgetSeconds = overflowBudgetSeconds
+    }
+
+    public var diagnostics: RecordingPersistenceDiagnostics {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedDiagnostics
+    }
+
+    /// Decides admission for one frame.
+    ///
+    /// - Parameters:
+    ///   - frameSeconds: the frame's duration derived from the actual sample
+    ///     format (`frameLength / sampleRate`).
+    ///   - poolHasCapacity: whether the reusable pool produced a copy.
+    public func admit(frameSeconds: Double, poolHasCapacity: Bool) -> RecordingPersistenceAdmission {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if !poolHasCapacity && inFlightSeconds + frameSeconds > overflowBudgetSeconds {
+            storedDiagnostics.droppedFrames += 1
+            storedDiagnostics.droppedSeconds += frameSeconds
+            return .backpressured
+        }
+
+        inFlightSeconds += frameSeconds
+        storedDiagnostics.admittedFrames += 1
+        storedDiagnostics.admittedSeconds += frameSeconds
+        storedDiagnostics.inFlightHighWaterSeconds = max(
+            storedDiagnostics.inFlightHighWaterSeconds,
+            inFlightSeconds
+        )
+        if poolHasCapacity {
+            return .accepted
+        }
+        storedDiagnostics.overflowAllocations += 1
+        return .acceptedViaOverflow
+    }
+
+    /// Records the completion of one admitted write.
+    public func completeWrite(frameSeconds: Double, failed: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        inFlightSeconds = max(0, inFlightSeconds - frameSeconds)
+        if failed {
+            storedDiagnostics.writeFailures += 1
+        }
+    }
+}

--- a/Sources/SpeakiOS/Services/AudioRecordingLibrary.swift
+++ b/Sources/SpeakiOS/Services/AudioRecordingLibrary.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import AVFoundation
+import CryptoKit
 import Foundation
 import SpeakCore
 
@@ -33,13 +34,8 @@ extension AudioRecordingPersistence {
                 let created = res?.creationDate ?? Date()
                 let size = Int64(res?.fileSize ?? 0)
 
-                let stem = url.deletingPathExtension().lastPathComponent
-                let cleanStem = stem
-                    .replacingOccurrences(of: "Recording-", with: "")
-                let rid = UUID(uuidString: String(cleanStem.suffix(8))) ?? UUID()
-
                 return RecordingInfo(
-                    id: rid,
+                    id: stableRecordingID(for: url),
                     url: url,
                     startedAt: created,
                     duration: 0,
@@ -47,6 +43,23 @@ extension AudioRecordingPersistence {
                 )
             }
             .sorted { $0.startedAt > $1.startedAt }
+    }
+
+    /// Stable identity for a recording on disk, derived from its file name, so
+    /// the same file yields the same `id` on every listing. `RecordingInfo` is
+    /// `Identifiable`/`Hashable`: SwiftUI diffing and any selection or
+    /// pending-delete state keyed on `id` break if it changes between
+    /// refreshes. (The file name's 8-character suffix is not a UUID, so it
+    /// cannot simply be parsed back.)
+    public static func stableRecordingID(for url: URL) -> UUID {
+        let digest = SHA256.hash(data: Data(url.lastPathComponent.utf8))
+        let bytes = Array(digest.prefix(16))
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 
     /// Load a recording's duration without blocking the calling thread.

--- a/Sources/SpeakiOS/Services/AudioRecordingLibrary.swift
+++ b/Sources/SpeakiOS/Services/AudioRecordingLibrary.swift
@@ -50,8 +50,8 @@ extension AudioRecordingPersistence {
     /// `Identifiable`/`Hashable`: SwiftUI diffing and any selection or
     /// pending-delete state keyed on `id` break if it changes between
     /// refreshes. (The file name's 8-character suffix is not a UUID, so it
-    /// cannot simply be parsed back.)
-    public static func stableRecordingID(for url: URL) -> UUID {
+    /// cannot simply be parsed back.) Pure, so callable from any isolation.
+    nonisolated public static func stableRecordingID(for url: URL) -> UUID {
         let digest = SHA256.hash(data: Data(url.lastPathComponent.utf8))
         let bytes = Array(digest.prefix(16))
         return UUID(uuid: (

--- a/Sources/SpeakiOS/Services/AudioRecordingLibrary.swift
+++ b/Sources/SpeakiOS/Services/AudioRecordingLibrary.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 import AVFoundation
 import Foundation
+import SpeakCore
 
 // MARK: - Saved-recording library
 

--- a/Sources/SpeakiOS/Services/AudioRecordingLibrary.swift
+++ b/Sources/SpeakiOS/Services/AudioRecordingLibrary.swift
@@ -1,0 +1,105 @@
+#if os(iOS)
+import AVFoundation
+import Foundation
+
+// MARK: - Saved-recording library
+
+extension AudioRecordingPersistence {
+    // MARK: - Listing & Management
+
+    /// List all saved recordings, newest first.
+    ///
+    /// Durations are not read here: opening each file just to ask for its
+    /// length stalls the main thread on large libraries. Entries are returned
+    /// with `duration == 0`; load real values asynchronously per file with
+    /// `loadDuration(for:)`.
+    public static func listRecordings() -> [RecordingInfo] {
+        let dir = recordingsDirectory
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.creationDateKey, .fileSizeKey],
+            options: .skipsHiddenFiles
+        ) else { return [] }
+
+        let validExt: Set<String> = ["m4a", "wav", "aac", "caf"]
+
+        return files
+            .filter { validExt.contains($0.pathExtension.lowercased()) }
+            .compactMap { url -> RecordingInfo? in
+                let res = try? url.resourceValues(
+                    forKeys: [.creationDateKey, .fileSizeKey]
+                )
+                let created = res?.creationDate ?? Date()
+                let size = Int64(res?.fileSize ?? 0)
+
+                let stem = url.deletingPathExtension().lastPathComponent
+                let cleanStem = stem
+                    .replacingOccurrences(of: "Recording-", with: "")
+                let rid = UUID(uuidString: String(cleanStem.suffix(8))) ?? UUID()
+
+                return RecordingInfo(
+                    id: rid,
+                    url: url,
+                    startedAt: created,
+                    duration: 0,
+                    fileSize: size
+                )
+            }
+            .sorted { $0.startedAt > $1.startedAt }
+    }
+
+    /// Load a recording's duration without blocking the calling thread.
+    /// `AVURLAsset` reads just the metadata it needs, off the main thread.
+    public static func loadDuration(for url: URL) async -> TimeInterval {
+        let asset = AVURLAsset(url: url)
+        guard let duration = try? await asset.load(.duration) else { return 0 }
+        let seconds = duration.seconds
+        return seconds.isFinite ? max(0, seconds) : 0
+    }
+
+    /// Delete a specific recording file.
+    public static func deleteRecording(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+// MARK: - Supporting Types
+
+public struct RecordingInfo: Identifiable, Hashable {
+    public let id: UUID
+    public let url: URL
+    public let startedAt: Date
+    public let duration: TimeInterval
+    public let fileSize: Int64
+    /// Persistence truth for a recording captured this session; `nil` for
+    /// entries listed from disk, whose session diagnostics are gone.
+    public var diagnostics: RecordingPersistenceDiagnostics?
+
+    init(
+        id: UUID,
+        url: URL,
+        startedAt: Date,
+        duration: TimeInterval,
+        fileSize: Int64,
+        diagnostics: RecordingPersistenceDiagnostics? = nil
+    ) {
+        self.id = id
+        self.url = url
+        self.startedAt = startedAt
+        self.duration = duration
+        self.fileSize = fileSize
+        self.diagnostics = diagnostics
+    }
+}
+
+public enum AudioPersistenceError: LocalizedError {
+    case alreadyRecording
+
+    public var errorDescription: String? {
+        switch self {
+        case .alreadyRecording:
+            return "A persistent recording session is already active."
+        }
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Services/AudioRecordingPersistence.swift
+++ b/Sources/SpeakiOS/Services/AudioRecordingPersistence.swift
@@ -14,6 +14,15 @@ public final class AudioRecordingPersistence: ObservableObject {
 
     @Published private(set) public var isRecording = false
     @Published private(set) public var currentFileURL: URL?
+    /// Persistence truth for the most recently stopped recording (issue #705):
+    /// dropped audio and write failures make `isComplete` false, so the saved
+    /// file is never presented as healthy when it has gaps.
+    @Published private(set) public var lastDiagnostics: RecordingPersistenceDiagnostics?
+
+    /// Invoked (off the audio thread) the first time a session drops audio or
+    /// fails a write, so the owning session can surface the problem while the
+    /// recording is still running rather than discovering it at stop.
+    nonisolated(unsafe) public var onPersistenceIssue: (@Sendable (RecordingPersistenceDiagnostics) -> Void)?
 
     // MARK: - Private
 
@@ -29,6 +38,14 @@ public final class AudioRecordingPersistence: ObservableObject {
     /// Pool for buffer copies handed to `ioQueue` so writes never touch the
     /// caller's (reused) buffer.
     private let writeBufferPool = PCMBufferPool(maximumBuffers: 8)
+    /// Bounded admission (issue #705): short I/O stalls are absorbed by
+    /// fallback allocations up to a duration budget sized from the sample
+    /// format; sustained overflow drops frames and records the gap instead of
+    /// silently presenting a complete recording. Replaced per session.
+    nonisolated(unsafe) private var admission = RecordingPersistenceAdmissionController()
+    /// Set once per session after the first drop/write failure so the
+    /// owning-session callback fires exactly once, off the audio thread.
+    nonisolated(unsafe) private var didReportIssue = false
     private var recordingID: UUID?
     private var startTime: Date?
 
@@ -118,12 +135,15 @@ public final class AudioRecordingPersistence: ObservableObject {
         stateLock.lock()
         ioQueue.async { [weak self] in self?.ioFile = file }
         isWriterOpen = true
+        admission = RecordingPersistenceAdmissionController()
+        didReportIssue = false
         stateLock.unlock()
 
         recordingID = rid
         startTime = Date()
         currentFileURL = url
         isRecording = true
+        lastDiagnostics = nil
 
         logger.info("Started persistent recording: \(filename)")
         return url
@@ -133,7 +153,8 @@ public final class AudioRecordingPersistence: ObservableObject {
     /// This method is nonisolated so it can be called from any thread: the
     /// buffer is copied immediately and the AAC encode + file write happen
     /// asynchronously on the persistence I/O queue.
-    nonisolated public func writeBuffer(_ buffer: AVAudioPCMBuffer) {
+    @discardableResult
+    nonisolated public func writeBuffer(_ buffer: AVAudioPCMBuffer) -> RecordingPersistenceAdmission? {
         // Admission and enqueue are one atomic step against `closeWriter`'s
         // barrier. Releasing the lock before `ioQueue.async` would let a stalled
         // caller enqueue *after* the session closed; that block would then
@@ -144,25 +165,117 @@ public final class AudioRecordingPersistence: ObservableObject {
         // `ioQueue` blocks never take `stateLock`, so the async submit can't deadlock.
         stateLock.lock()
         defer { stateLock.unlock() }
-        if isWriterOpen, let copy = writeBufferPool.copy(buffer) {
-            #if DEBUG
-            writeAdmissionStallHook?()
-            #endif
-            ioQueue.async { [weak self] in
-                guard let self else { return }
-                defer { self.writeBufferPool.recycle(copy) }
-                guard let file = self.ioFile else { return }
-                do {
-                    try file.write(from: copy)
-                    #if DEBUG
-                    self.didWriteBufferHook?(file.url)
-                    #endif
-                } catch {
-                    // Log but don't throw — we don't want to interrupt the
-                    // transcription pipeline for a write failure.
-                    self.logger.error("Write error: \(error.localizedDescription, privacy: .public)")
-                }
+        guard isWriterOpen else { return nil }
+
+        // Bounded admission (issue #705): the pool absorbs the steady state, a
+        // duration budget derived from the actual format absorbs short stalls
+        // via fallback allocations, and sustained overflow drops the frame
+        // while recording exactly how much audio was lost.
+        let sampleRate = buffer.format.sampleRate
+        let frameSeconds = sampleRate > 0 ? Double(buffer.frameLength) / sampleRate : 0
+        let admissionController = admission
+        let pooledCopy = writeBufferPool.copy(buffer)
+        let verdict = admissionController.admit(
+            frameSeconds: frameSeconds,
+            poolHasCapacity: pooledCopy != nil
+        )
+
+        let copy: AVAudioPCMBuffer?
+        switch verdict {
+        case .accepted:
+            copy = pooledCopy
+        case .acceptedViaOverflow:
+            copy = Self.fallbackCopy(of: buffer)
+        case .backpressured:
+            copy = nil
+        }
+
+        guard let copy else {
+            // Admission granted but the fallback allocation itself failed, or
+            // the frame was backpressured: either way it is a recorded gap.
+            if verdict != .backpressured {
+                admissionController.completeWrite(frameSeconds: frameSeconds, failed: true)
             }
+            reportIssueIfNeeded(admissionController)
+            return .backpressured
+        }
+
+        #if DEBUG
+        writeAdmissionStallHook?()
+        #endif
+        enqueueAdmittedWrite(
+            copy: copy,
+            isPooled: verdict == .accepted,
+            frameSeconds: frameSeconds,
+            controller: admissionController
+        )
+        return verdict
+    }
+
+    /// Submits one admitted copy to the I/O queue. Must be called while
+    /// `stateLock` is held so the submit is ordered ahead of `closeWriter`'s
+    /// barrier (see `writeBuffer`).
+    private nonisolated func enqueueAdmittedWrite(
+        copy: AVAudioPCMBuffer,
+        isPooled: Bool,
+        frameSeconds: Double,
+        controller: RecordingPersistenceAdmissionController
+    ) {
+        ioQueue.async { [weak self] in
+            guard let self else { return }
+            defer {
+                if isPooled { self.writeBufferPool.recycle(copy) }
+            }
+            guard let file = self.ioFile else {
+                controller.completeWrite(frameSeconds: frameSeconds, failed: false)
+                return
+            }
+            do {
+                try file.write(from: copy)
+                controller.completeWrite(frameSeconds: frameSeconds, failed: false)
+                #if DEBUG
+                self.didWriteBufferHook?(file.url)
+                #endif
+            } catch {
+                // Never interrupt the transcription pipeline for a write
+                // failure — but never pretend it didn't happen either.
+                controller.completeWrite(frameSeconds: frameSeconds, failed: true)
+                self.reportIssueIfNeeded(controller)
+                self.logger.error("Write error: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// Controlled fallback allocation for a pool-exhausted frame within the
+    /// admission budget.
+    private nonisolated static func fallbackCopy(of buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard let copy = AVAudioPCMBuffer(
+            pcmFormat: buffer.format,
+            frameCapacity: buffer.frameLength
+        ) else { return nil }
+        copy.frameLength = buffer.frameLength
+        let source = UnsafeMutableAudioBufferListPointer(
+            UnsafeMutablePointer(mutating: buffer.audioBufferList)
+        )
+        let destination = UnsafeMutableAudioBufferListPointer(copy.mutableAudioBufferList)
+        for index in 0..<min(source.count, destination.count) {
+            guard let sourceData = source[index].mData,
+                  let destinationData = destination[index].mData else { continue }
+            memcpy(destinationData, sourceData, Int(source[index].mDataByteSize))
+            destination[index].mDataByteSize = source[index].mDataByteSize
+        }
+        return copy
+    }
+
+    /// Surfaces the first drop/failure of the session to the owning session,
+    /// exactly once, without blocking the audio thread.
+    private nonisolated func reportIssueIfNeeded(_ controller: RecordingPersistenceAdmissionController) {
+        guard !didReportIssue else { return }
+        didReportIssue = true
+        guard let onPersistenceIssue else { return }
+        let diagnostics = controller.diagnostics
+        DispatchQueue.global(qos: .utility).async {
+            onPersistenceIssue(diagnostics)
         }
     }
 
@@ -206,12 +319,29 @@ public final class AudioRecordingPersistence: ObservableObject {
         let fileSize = (try? FileManager.default
             .attributesOfItem(atPath: url.path)[.size] as? Int64) ?? 0
 
+        // closeWriter drained the I/O queue, so the diagnostics are final:
+        // drops or write failures mark this saved file incomplete instead of
+        // presenting it as a healthy recording (issue #705).
+        let diagnostics = admission.diagnostics
+        lastDiagnostics = diagnostics
+        if !diagnostics.isComplete {
+            logger.error(
+                """
+                Recording persisted incomplete: dropped \
+                \(String(format: "%.2f", diagnostics.droppedSeconds), privacy: .public)s \
+                across \(diagnostics.droppedFrames) frames, \
+                \(diagnostics.writeFailures) write failures
+                """
+            )
+        }
+
         let info = RecordingInfo(
             id: recordingID ?? UUID(),
             url: url,
             startedAt: startTime ?? Date(),
             duration: duration,
-            fileSize: fileSize
+            fileSize: fileSize,
+            diagnostics: diagnostics
         )
 
         recordingID = nil
@@ -234,84 +364,6 @@ public final class AudioRecordingPersistence: ObservableObject {
         if let url {
             try? FileManager.default.removeItem(at: url)
             logger.info("Cancelled and deleted: \(url.lastPathComponent)")
-        }
-    }
-
-    // MARK: - Listing & Management
-
-    /// List all saved recordings, newest first.
-    ///
-    /// Durations are not read here: opening each file just to ask for its
-    /// length stalls the main thread on large libraries. Entries are returned
-    /// with `duration == 0`; load real values asynchronously per file with
-    /// `loadDuration(for:)`.
-    public static func listRecordings() -> [RecordingInfo] {
-        let dir = recordingsDirectory
-        guard let files = try? FileManager.default.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.creationDateKey, .fileSizeKey],
-            options: .skipsHiddenFiles
-        ) else { return [] }
-
-        let validExt: Set<String> = ["m4a", "wav", "aac", "caf"]
-
-        return files
-            .filter { validExt.contains($0.pathExtension.lowercased()) }
-            .compactMap { url -> RecordingInfo? in
-                let res = try? url.resourceValues(
-                    forKeys: [.creationDateKey, .fileSizeKey]
-                )
-                let created = res?.creationDate ?? Date()
-                let size = Int64(res?.fileSize ?? 0)
-
-                let stem = url.deletingPathExtension().lastPathComponent
-                let cleanStem = stem
-                    .replacingOccurrences(of: "Recording-", with: "")
-                let rid = UUID(uuidString: String(cleanStem.suffix(8))) ?? UUID()
-
-                return RecordingInfo(
-                    id: rid,
-                    url: url,
-                    startedAt: created,
-                    duration: 0,
-                    fileSize: size
-                )
-            }
-            .sorted { $0.startedAt > $1.startedAt }
-    }
-
-    /// Load a recording's duration without blocking the calling thread.
-    /// `AVURLAsset` reads just the metadata it needs, off the main thread.
-    public static func loadDuration(for url: URL) async -> TimeInterval {
-        let asset = AVURLAsset(url: url)
-        guard let duration = try? await asset.load(.duration) else { return 0 }
-        let seconds = duration.seconds
-        return seconds.isFinite ? max(0, seconds) : 0
-    }
-
-    /// Delete a specific recording file.
-    public static func deleteRecording(at url: URL) {
-        try? FileManager.default.removeItem(at: url)
-    }
-}
-
-// MARK: - Supporting Types
-
-public struct RecordingInfo: Identifiable, Hashable {
-    public let id: UUID
-    public let url: URL
-    public let startedAt: Date
-    public let duration: TimeInterval
-    public let fileSize: Int64
-}
-
-public enum AudioPersistenceError: LocalizedError {
-    case alreadyRecording
-
-    public var errorDescription: String? {
-        switch self {
-        case .alreadyRecording:
-            return "A persistent recording session is already active."
         }
     }
 }

--- a/Sources/SpeakiOS/Services/AudioRecordingPersistence.swift
+++ b/Sources/SpeakiOS/Services/AudioRecordingPersistence.swift
@@ -22,7 +22,10 @@ public final class AudioRecordingPersistence: ObservableObject {
     /// Invoked (off the audio thread) the first time a session drops audio or
     /// fails a write, so the owning session can surface the problem while the
     /// recording is still running rather than discovering it at stop.
-    nonisolated(unsafe) public var onPersistenceIssue: (@Sendable (RecordingPersistenceDiagnostics) -> Void)?
+    nonisolated public var onPersistenceIssue: (@Sendable (RecordingPersistenceDiagnostics) -> Void)? {
+        get { issueLock.withLock { storedIssueHandler } }
+        set { issueLock.withLock { storedIssueHandler = newValue } }
+    }
 
     // MARK: - Private
 
@@ -43,10 +46,19 @@ public final class AudioRecordingPersistence: ObservableObject {
     /// format; sustained overflow drops frames and records the gap instead of
     /// silently presenting a complete recording. Replaced per session.
     nonisolated(unsafe) private var admission = RecordingPersistenceAdmissionController()
+    /// Leaf lock for the once-per-session issue latch and its handler. The
+    /// latch is tested from `writeBuffer` (which holds `stateLock`) and from
+    /// `ioQueue` blocks (which never take `stateLock`), so it needs its own
+    /// lock: a check-then-set on a bare flag would let both paths fire the
+    /// callback, and `stateLock` cannot be taken on `ioQueue` without
+    /// inverting the order against `closeWriter`'s barrier.
+    private let issueLock = NSLock()
+    /// Guarded by `issueLock`.
+    nonisolated(unsafe) private var storedIssueHandler: (@Sendable (RecordingPersistenceDiagnostics) -> Void)?
     /// Set once per session after the first drop/write failure so the
     /// owning-session callback fires exactly once, off the audio thread.
+    /// Guarded by `issueLock`.
     nonisolated(unsafe) private var didReportIssue = false
-    private var recordingID: UUID?
     private var startTime: Date?
 
     private let logger = SpeakLogger.logger(category: "AudioPersistence")
@@ -136,10 +148,9 @@ public final class AudioRecordingPersistence: ObservableObject {
         ioQueue.async { [weak self] in self?.ioFile = file }
         isWriterOpen = true
         admission = RecordingPersistenceAdmissionController()
-        didReportIssue = false
+        issueLock.withLock { didReportIssue = false }
         stateLock.unlock()
 
-        recordingID = rid
         startTime = Date()
         currentFileURL = url
         isRecording = true
@@ -193,8 +204,11 @@ public final class AudioRecordingPersistence: ObservableObject {
         guard let copy else {
             // Admission granted but the fallback allocation itself failed, or
             // the frame was backpressured: either way it is a recorded gap.
+            // An abandoned admission is reversed and counted as dropped audio
+            // so `droppedSeconds` stays exact and the diagnostics agree with
+            // the `.backpressured` result returned here.
             if verdict != .backpressured {
-                admissionController.completeWrite(frameSeconds: frameSeconds, failed: true)
+                admissionController.abandonAdmittedFrame(frameSeconds: frameSeconds)
             }
             reportIssueIfNeeded(admissionController)
             return .backpressured
@@ -270,12 +284,17 @@ public final class AudioRecordingPersistence: ObservableObject {
     /// Surfaces the first drop/failure of the session to the owning session,
     /// exactly once, without blocking the audio thread.
     private nonisolated func reportIssueIfNeeded(_ controller: RecordingPersistenceAdmissionController) {
-        guard !didReportIssue else { return }
-        didReportIssue = true
-        guard let onPersistenceIssue else { return }
+        // Latch and handler are read under one lock hold so two threads can
+        // never both observe an unset latch (see `issueLock`).
+        let handler = issueLock.withLock { () -> (@Sendable (RecordingPersistenceDiagnostics) -> Void)? in
+            guard !didReportIssue else { return nil }
+            didReportIssue = true
+            return storedIssueHandler
+        }
+        guard let handler else { return }
         let diagnostics = controller.diagnostics
         DispatchQueue.global(qos: .utility).async {
-            onPersistenceIssue(diagnostics)
+            handler(diagnostics)
         }
     }
 
@@ -335,8 +354,10 @@ public final class AudioRecordingPersistence: ObservableObject {
             )
         }
 
+        // The same identity a later listing derives for this file, so the
+        // in-session entry and the library entry are one recording to the UI.
         let info = RecordingInfo(
-            id: recordingID ?? UUID(),
+            id: Self.stableRecordingID(for: url),
             url: url,
             startedAt: startTime ?? Date(),
             duration: duration,
@@ -344,7 +365,6 @@ public final class AudioRecordingPersistence: ObservableObject {
             diagnostics: diagnostics
         )
 
-        recordingID = nil
         startTime = nil
 
         let filename = url.lastPathComponent
@@ -358,7 +378,6 @@ public final class AudioRecordingPersistence: ObservableObject {
         closeWriter()
         isRecording = false
         currentFileURL = nil
-        recordingID = nil
         startTime = nil
 
         if let url {

--- a/Tests/SpeakCoreTests/RecordingPersistenceAdmissionTests.swift
+++ b/Tests/SpeakCoreTests/RecordingPersistenceAdmissionTests.swift
@@ -106,6 +106,32 @@ final class RecordingPersistenceAdmissionTests: XCTestCase {
         XCTAssertFalse(diagnostics.isComplete)
     }
 
+    func testFailedFallbackAllocation_isAccountedAsDroppedAudio() {
+        let controller = RecordingPersistenceAdmissionController(overflowBudgetSeconds: 2)
+        XCTAssertEqual(controller.admit(frameSeconds: frame, poolHasCapacity: true), .accepted)
+        controller.completeWrite(frameSeconds: frame, failed: false)
+
+        // Admission granted via overflow, but the allocation itself fails: the
+        // frame is gone, so it is a gap — not a write that failed.
+        XCTAssertEqual(
+            controller.admit(frameSeconds: frame, poolHasCapacity: false),
+            .acceptedViaOverflow
+        )
+        controller.abandonAdmittedFrame(frameSeconds: frame)
+
+        let diagnostics = controller.diagnostics
+        XCTAssertEqual(diagnostics.admittedFrames, 1, "the abandoned admission is reversed")
+        XCTAssertEqual(diagnostics.admittedSeconds, frame, accuracy: 0.0001)
+        XCTAssertEqual(diagnostics.overflowAllocations, 0, "no fallback allocation was actually used")
+        XCTAssertEqual(diagnostics.droppedFrames, 1)
+        XCTAssertEqual(diagnostics.droppedSeconds, frame, accuracy: 0.0001)
+        XCTAssertEqual(diagnostics.writeFailures, 0)
+        XCTAssertFalse(diagnostics.isComplete)
+
+        // The budget was released: the next overflow frame is admitted again.
+        XCTAssertEqual(controller.inFlightSecondsForTesting, 0, accuracy: 0.0001)
+    }
+
     func testPoolCapacity_neverConsultsTheOverflowBudget() {
         // A zero-budget controller still admits every pool-backed frame: the
         // budget only governs fallback allocations.

--- a/Tests/SpeakCoreTests/RecordingPersistenceAdmissionTests.swift
+++ b/Tests/SpeakCoreTests/RecordingPersistenceAdmissionTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+
+@testable import SpeakCore
+
+/// Bounded persistence admission (issue #705): short stalls are absorbed via
+/// fallback allocations, sustained overflow drops frames with exact gap
+/// accounting, write failures are counted, and a recording with any drop or
+/// failure can never report itself complete.
+final class RecordingPersistenceAdmissionTests: XCTestCase {
+    /// 100 ms frames, the app's live-capture cadence.
+    private let frame = 0.1
+
+    func testSteadyState_poolBackedFramesAreAcceptedAndComplete() {
+        let controller = RecordingPersistenceAdmissionController(overflowBudgetSeconds: 2)
+        for _ in 0..<50 {
+            XCTAssertEqual(controller.admit(frameSeconds: frame, poolHasCapacity: true), .accepted)
+            controller.completeWrite(frameSeconds: frame, failed: false)
+        }
+        let diagnostics = controller.diagnostics
+        XCTAssertEqual(diagnostics.admittedFrames, 50)
+        XCTAssertEqual(diagnostics.droppedFrames, 0)
+        XCTAssertEqual(diagnostics.overflowAllocations, 0)
+        XCTAssertTrue(diagnostics.isComplete)
+    }
+
+    func testTemporaryStall_isAbsorbedByOverflowAndRecovers() {
+        let controller = RecordingPersistenceAdmissionController(overflowBudgetSeconds: 2)
+
+        // The writer stalls: the pool is exhausted, but the duration budget
+        // absorbs one second of audio via fallback allocations.
+        for _ in 0..<10 {
+            XCTAssertEqual(
+                controller.admit(frameSeconds: frame, poolHasCapacity: false),
+                .acceptedViaOverflow
+            )
+        }
+        // The writer catches up; everything admitted lands.
+        for _ in 0..<10 {
+            controller.completeWrite(frameSeconds: frame, failed: false)
+        }
+        XCTAssertEqual(controller.admit(frameSeconds: frame, poolHasCapacity: true), .accepted)
+
+        let diagnostics = controller.diagnostics
+        XCTAssertEqual(diagnostics.overflowAllocations, 10)
+        XCTAssertEqual(diagnostics.droppedFrames, 0)
+        XCTAssertTrue(diagnostics.isComplete, "a fully absorbed stall is still a complete recording")
+        XCTAssertEqual(diagnostics.inFlightHighWaterSeconds, 1.0, accuracy: 0.0001)
+    }
+
+    func testSustainedOverflow_dropsFramesWithExactGapAccounting() {
+        let controller = RecordingPersistenceAdmissionController(overflowBudgetSeconds: 1)
+
+        // Nothing ever completes: the budget admits ten frames, then drops.
+        var admitted = 0
+        var dropped = 0
+        for _ in 0..<25 {
+            switch controller.admit(frameSeconds: frame, poolHasCapacity: false) {
+            case .accepted, .acceptedViaOverflow: admitted += 1
+            case .backpressured: dropped += 1
+            }
+        }
+        XCTAssertEqual(admitted, 10)
+        XCTAssertEqual(dropped, 15)
+
+        let diagnostics = controller.diagnostics
+        XCTAssertEqual(diagnostics.droppedFrames, 15)
+        XCTAssertEqual(diagnostics.droppedSeconds, 1.5, accuracy: 0.0001)
+        XCTAssertFalse(
+            diagnostics.isComplete,
+            "sustained overflow must never present a complete recording"
+        )
+    }
+
+    func testWriteFailure_marksTheRecordingIncomplete() {
+        let controller = RecordingPersistenceAdmissionController(overflowBudgetSeconds: 2)
+        XCTAssertEqual(controller.admit(frameSeconds: frame, poolHasCapacity: true), .accepted)
+        controller.completeWrite(frameSeconds: frame, failed: true)
+
+        let diagnostics = controller.diagnostics
+        XCTAssertEqual(diagnostics.writeFailures, 1)
+        XCTAssertFalse(diagnostics.isComplete)
+    }
+
+    func testStopWhileBackpressured_reportsTheGapInFinalDiagnostics() {
+        let controller = RecordingPersistenceAdmissionController(overflowBudgetSeconds: 0.5)
+        for _ in 0..<5 {
+            _ = controller.admit(frameSeconds: frame, poolHasCapacity: false)
+        }
+        // Budget full; these frames are the user's audio that never made it.
+        for _ in 0..<3 {
+            XCTAssertEqual(
+                controller.admit(frameSeconds: frame, poolHasCapacity: false),
+                .backpressured
+            )
+        }
+        // Stop drains the queue: the admitted frames land, the dropped ones
+        // stay recorded as the gap they are.
+        for _ in 0..<5 {
+            controller.completeWrite(frameSeconds: frame, failed: false)
+        }
+
+        let diagnostics = controller.diagnostics
+        XCTAssertEqual(diagnostics.admittedFrames, 5)
+        XCTAssertEqual(diagnostics.droppedFrames, 3)
+        XCTAssertEqual(diagnostics.droppedSeconds, 0.3, accuracy: 0.0001)
+        XCTAssertFalse(diagnostics.isComplete)
+    }
+
+    func testPoolCapacity_neverConsultsTheOverflowBudget() {
+        // A zero-budget controller still admits every pool-backed frame: the
+        // budget only governs fallback allocations.
+        let controller = RecordingPersistenceAdmissionController(overflowBudgetSeconds: 0)
+        XCTAssertEqual(controller.admit(frameSeconds: frame, poolHasCapacity: true), .accepted)
+        XCTAssertEqual(
+            controller.admit(frameSeconds: frame, poolHasCapacity: false),
+            .backpressured
+        )
+    }
+
+    func testHighWaterMark_recordsThePeakNotTheCurrent() {
+        let controller = RecordingPersistenceAdmissionController(overflowBudgetSeconds: 2)
+        for _ in 0..<8 {
+            _ = controller.admit(frameSeconds: frame, poolHasCapacity: true)
+        }
+        for _ in 0..<8 {
+            controller.completeWrite(frameSeconds: frame, failed: false)
+        }
+        _ = controller.admit(frameSeconds: frame, poolHasCapacity: true)
+
+        XCTAssertEqual(controller.diagnostics.inFlightHighWaterSeconds, 0.8, accuracy: 0.0001)
+    }
+}

--- a/Tests/SpeakiOSTests/RecordingInfoIdentityTests.swift
+++ b/Tests/SpeakiOSTests/RecordingInfoIdentityTests.swift
@@ -1,0 +1,32 @@
+#if os(iOS)
+import Foundation
+import XCTest
+
+@testable import SpeakiOSLib
+
+/// Listed recordings must keep a stable identity across refreshes (issue #705
+/// review): `RecordingInfo` is `Identifiable`, and SwiftUI diffing as well as
+/// selection state keyed on `id` break when the same file changes identity.
+final class RecordingInfoIdentityTests: XCTestCase {
+    private let directory = URL(fileURLWithPath: "/var/mobile/Documents/Recordings", isDirectory: true)
+
+    func testStableRecordingID_isDeterministicForTheSameFile() {
+        let url = directory.appendingPathComponent("Recording-2026-08-22T10:00:00Z-1A2B3C4D.m4a")
+        let first = AudioRecordingPersistence.stableRecordingID(for: url)
+        let second = AudioRecordingPersistence.stableRecordingID(for: url)
+        XCTAssertEqual(first, second)
+        // Only the file name matters, not the directory it was listed from.
+        let moved = URL(fileURLWithPath: "/tmp/elsewhere").appendingPathComponent(url.lastPathComponent)
+        XCTAssertEqual(AudioRecordingPersistence.stableRecordingID(for: moved), first)
+    }
+
+    func testStableRecordingID_differsBetweenFiles() {
+        let one = directory.appendingPathComponent("Recording-2026-08-22T10:00:00Z-1A2B3C4D.m4a")
+        let two = directory.appendingPathComponent("Recording-2026-08-22T10:00:00Z-1A2B3C4E.m4a")
+        XCTAssertNotEqual(
+            AudioRecordingPersistence.stableRecordingID(for: one),
+            AudioRecordingPersistence.stableRecordingID(for: two)
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## Defect (#705)

`AudioRecordingPersistence.writeBuffer` silently skipped a PCM frame whenever the eight-buffer pool was exhausted (`PCMBufferPool.copy` returning `nil`), and write failures were only logged — a stalled writer produced an irreversibly gapped recording that was still presented as complete and healthy.

## Fix

- **Explicit bounded admission** (`RecordingPersistenceAdmissionController` in SpeakCore, so the policy is CI-testable — the iOS file is `#if os(iOS)`): `accepted` (pool), `acceptedViaOverflow` (pool exhausted, a controlled fallback allocation absorbs the stall within a duration budget derived from the actual sample format — default 2 s of audio in flight), or `backpressured` (budget exhausted: the frame is dropped and accounted as an exact gap in frames and seconds). The audio callback stays non-blocking and constant-time, and transcription capture is untouched by persistence pressure.
- **Failure truth**: write failures are counted per session; `isComplete` is false whenever anything was dropped or failed.
- **Propagation**: `RecordingInfo` carries the session's diagnostics (nil for entries listed from disk); `stopRecording` publishes `lastDiagnostics` and logs an explicit incomplete summary naming exactly how much audio was dropped; `onPersistenceIssue` fires once per session on the first drop/failure so the owning session can surface it live. The partial file is always preserved.
- **Evidence for sizing**: in-flight high-water marks (seconds) expose what the pool/budget actually absorb.
- `writeBuffer` keeps its lock-ordered submit against `closeWriter` (the #758-era splice guarantee) — admission happens inside the same critical section; the write submit is extracted to a helper called under the lock.

## Tests

`RecordingPersistenceAdmissionTests` (SpeakCore, CI-run): steady state complete; temporary stall absorbed via overflow and recovering to pool admission; sustained overflow admits exactly the budget then drops with exact second accounting and can never report complete; write failure marks incomplete; stop-while-backpressured reports the gap in final diagnostics; pool-backed admission is independent of the overflow budget; high-water marks record the peak. Full suite: 1723 tests, 0 failures; `make lint` clean; SpeakiOSLib builds.

Fixes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recording persistence diagnostics, including accepted, overflow, dropped, failed, and in-flight frame metrics.
  - Added bounded buffering to prevent recording persistence from exceeding its configured capacity.
  - Added recording library support to list, inspect, and delete saved recordings.
  - Recording details now include duration, file size, start time, and persistence status.

- **Bug Fixes**
  - Recording failures and dropped audio are now detected and reported.
  - Prevented overlapping recording attempts with a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->