### PR TITLE
fix(watch): make capture imports durable and recoverable

### DIFF
--- a/JustSpeakWatch/WatchAudioRecorder.swift
+++ b/JustSpeakWatch/WatchAudioRecorder.swift
@@ -45,6 +45,8 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
     private let activeCaptureRegistry: WatchActiveCaptureRegistry
     private var recorder: AVAudioRecorder?
     private var currentID = UUID()
+    /// Serialises `start()` across its suspension points (issue #674).
+    private var isStarting = false
     private var isFinalising = false
     private var finalisationTask: Task<Void, Never>?
     private var didRecoverInterruptedCapture = false
@@ -92,7 +94,13 @@ final class WatchAudioRecorder: NSObject, ObservableObject {
     }
 
     func start() async {
-        guard !isRecording else { return }
+        // Owned-operation guard (issue #674): `isRecording` stays false across
+        // the awaits below (finalisation wait, recovery, permission prompt),
+        // so two rapid taps could interleave and replace `recorder` /
+        // `currentID`, orphaning one capture. Serialise the whole start.
+        guard !isRecording, !isStarting else { return }
+        isStarting = true
+        defer { isStarting = false }
         lastError = nil
 
         // A stop keeps the marker on disk while it inspects the finished asset.

--- a/Sources/SpeakCore/WatchCaptureImportJournal.swift
+++ b/Sources/SpeakCore/WatchCaptureImportJournal.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+/// Durable record of one delivered-but-not-yet-imported Watch capture
+/// (issue #674). The job is parked the moment the audio file is, so a
+/// suspended or killed import is rediscovered on the next activation or
+/// foreground entry instead of stranding the audio (and the Watch at
+/// "Delivered") forever.
+public struct WatchCaptureImportJob: Codable, Equatable, Sendable {
+    public let captureID: UUID
+    public let fileExtension: String
+    public let createdAt: Date
+    public let duration: TimeInterval
+    public var attempts: Int
+    public var lastErrorMessage: String?
+    public var updatedAt: Date
+
+    public init(
+        captureID: UUID,
+        fileExtension: String,
+        createdAt: Date,
+        duration: TimeInterval,
+        attempts: Int = 0,
+        lastErrorMessage: String? = nil,
+        updatedAt: Date = Date()
+    ) {
+        self.captureID = captureID
+        self.fileExtension = fileExtension
+        self.createdAt = createdAt
+        self.duration = duration
+        self.attempts = attempts
+        self.lastErrorMessage = lastErrorMessage
+        self.updatedAt = updatedAt
+    }
+}
+
+/// An acknowledgement owed to the Watch, retained until its delivery is
+/// confirmed so a failed `transferUserInfo` cannot leave the Watch at
+/// "Delivered" while the phone already holds the history entry (issue #674).
+public struct WatchCaptureAckRecord: Codable, Equatable, Sendable {
+    public let captureID: UUID
+    public let outcome: WatchCaptureAck.Outcome
+    public let message: String?
+    public let recordedAt: Date
+
+    public init(
+        captureID: UUID,
+        outcome: WatchCaptureAck.Outcome,
+        message: String? = nil,
+        recordedAt: Date = Date()
+    ) {
+        self.captureID = captureID
+        self.outcome = outcome
+        self.message = message
+        self.recordedAt = recordedAt
+    }
+
+    public var ack: WatchCaptureAck {
+        WatchCaptureAck(id: captureID, outcome: outcome, message: message)
+    }
+}
+
+/// File-backed journal for Watch capture imports and their acknowledgements
+/// (issue #674).
+///
+/// One JSON document beside the parked audio holds every pending import job
+/// and undelivered acknowledgement. All operations are idempotent by capture
+/// UUID: re-delivery of a capture, a crashed import retried after relaunch,
+/// or a replayed acknowledgement can never duplicate work that already
+/// completed. Retention is bounded: jobs that exhausted their attempts or
+/// outlived the retention window are purged (with their audio) rather than
+/// accumulating as unrecoverable failures.
+public final class WatchCaptureImportJournal: @unchecked Sendable {
+    /// One import may run at a time; retries use bounded attempts.
+    public static let defaultMaximumAttempts = 5
+    /// Failed captures are kept for a fortnight before being reclaimed.
+    public static let defaultRetentionInterval: TimeInterval = 14 * 24 * 60 * 60
+
+    private struct State: Codable {
+        var jobs: [WatchCaptureImportJob] = []
+        var pendingAcks: [WatchCaptureAckRecord] = []
+    }
+
+    private let lock = NSLock()
+    private let journalURL: URL
+    private var state: State
+
+    /// - Parameter directoryURL: the parked-captures directory; the journal
+    ///   document lives beside the audio it describes.
+    public init(directoryURL: URL) {
+        self.journalURL = directoryURL.appendingPathComponent(
+            "import-journal.json",
+            isDirectory: false
+        )
+        if let data = try? Data(contentsOf: journalURL),
+           let decoded = try? JSONDecoder.watchJournal.decode(State.self, from: data) {
+            self.state = decoded
+        } else {
+            self.state = State()
+        }
+    }
+
+    // MARK: - Jobs
+
+    /// Parks an import job for a delivered capture. Idempotent: re-delivery
+    /// of a capture already journalled (or already completed and removed)
+    /// leaves the existing record untouched.
+    public func parkJob(
+        captureID: UUID,
+        fileExtension: String,
+        createdAt: Date,
+        duration: TimeInterval
+    ) {
+        withState { state in
+            guard !state.jobs.contains(where: { $0.captureID == captureID }) else { return }
+            state.jobs.append(WatchCaptureImportJob(
+                captureID: captureID,
+                fileExtension: fileExtension,
+                createdAt: createdAt,
+                duration: duration
+            ))
+        }
+    }
+
+    /// Pending imports, oldest first.
+    public func pendingJobs() -> [WatchCaptureImportJob] {
+        lock.lock()
+        defer { lock.unlock() }
+        return state.jobs.sorted { $0.createdAt < $1.createdAt }
+    }
+
+    /// Records one failed import attempt and keeps the job retryable.
+    public func recordAttemptFailure(captureID: UUID, message: String) {
+        withState { state in
+            guard let index = state.jobs.firstIndex(where: { $0.captureID == captureID }) else {
+                return
+            }
+            state.jobs[index].attempts += 1
+            state.jobs[index].lastErrorMessage = message
+            state.jobs[index].updatedAt = Date()
+        }
+    }
+
+    /// Whether the job may still be retried under the bounded attempt policy.
+    public func isRetryable(
+        captureID: UUID,
+        maximumAttempts: Int = WatchCaptureImportJournal.defaultMaximumAttempts
+    ) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let job = state.jobs.first(where: { $0.captureID == captureID }) else { return false }
+        return job.attempts < maximumAttempts
+    }
+
+    /// Removes a completed job. The acknowledgement lifecycle is separate.
+    public func completeJob(captureID: UUID) {
+        withState { state in
+            state.jobs.removeAll { $0.captureID == captureID }
+        }
+    }
+
+    /// Purges jobs that exhausted their attempts or outlived retention.
+    /// Returns the purged jobs so the caller can delete their audio files and
+    /// send terminal failure acknowledgements.
+    public func purgeExpired(
+        now: Date = Date(),
+        retentionInterval: TimeInterval = WatchCaptureImportJournal.defaultRetentionInterval,
+        maximumAttempts: Int = WatchCaptureImportJournal.defaultMaximumAttempts
+    ) -> [WatchCaptureImportJob] {
+        var purged: [WatchCaptureImportJob] = []
+        withState { state in
+            let (expired, kept) = state.jobs.reduce(
+                into: ([WatchCaptureImportJob](), [WatchCaptureImportJob]())
+            ) { partition, job in
+                let outOfAttempts = job.attempts >= maximumAttempts
+                let outOfTime = now.timeIntervalSince(job.createdAt) > retentionInterval
+                if outOfAttempts || outOfTime {
+                    partition.0.append(job)
+                } else {
+                    partition.1.append(job)
+                }
+            }
+            purged = expired
+            state.jobs = kept
+        }
+        return purged
+    }
+
+    // MARK: - Acknowledgements
+
+    /// Retains an acknowledgement until delivery is confirmed. Idempotent by
+    /// capture UUID; a newer outcome for the same capture replaces the old.
+    public func recordPendingAck(_ record: WatchCaptureAckRecord) {
+        withState { state in
+            state.pendingAcks.removeAll { $0.captureID == record.captureID }
+            state.pendingAcks.append(record)
+        }
+    }
+
+    /// Acknowledgements not yet confirmed delivered, oldest first.
+    public func pendingAcks() -> [WatchCaptureAckRecord] {
+        lock.lock()
+        defer { lock.unlock() }
+        return state.pendingAcks.sorted { $0.recordedAt < $1.recordedAt }
+    }
+
+    /// Clears an acknowledgement whose delivery the transport confirmed.
+    public func confirmAckDelivered(captureID: UUID) {
+        withState { state in
+            state.pendingAcks.removeAll { $0.captureID == captureID }
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func withState(_ mutate: (inout State) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        mutate(&state)
+        persistLocked()
+    }
+
+    private func persistLocked() {
+        do {
+            let data = try JSONEncoder.watchJournal.encode(state)
+            try data.write(to: journalURL, options: [.atomic])
+        } catch {
+            // The journal is the recovery record; a failed write must not
+            // crash the import path, but it must be visible in diagnostics.
+            SpeakLogger.logError(error, context: "WatchCaptureImportJournal.persist")
+        }
+    }
+}
+
+private extension JSONEncoder {
+    static var watchJournal: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}
+
+private extension JSONDecoder {
+    static var watchJournal: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/SpeakiOS/Services/WatchCaptureImportPipeline.swift
+++ b/Sources/SpeakiOS/Services/WatchCaptureImportPipeline.swift
@@ -1,0 +1,263 @@
+#if os(iOS)
+import Foundation
+import SpeakCore
+import UIKit
+
+/// Durable, recoverable import pipeline for Apple Watch captures
+/// (issue #674).
+///
+/// The WatchConnectivity receiver stays a thin shim: it parks the delivered
+/// file (synchronously, before the system reclaims its inbox), forwards
+/// acknowledgement transport, and triggers processing. Everything else —
+/// journalled jobs, bounded retries with an expiration-safe background task,
+/// history persistence that must succeed before anything is acknowledged or
+/// deleted, terminal retention, and acknowledgement replay — lives here,
+/// where it is compiled by CI and reachable from tests.
+@MainActor
+public final class WatchCaptureImportPipeline: ObservableObject {
+    public static let shared = WatchCaptureImportPipeline()
+
+    /// Directory where delivered captures are parked until their import has
+    /// fully completed (history write durable, acknowledgement recorded).
+    nonisolated public static var inboxDirectory: URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        return base.appendingPathComponent("WatchCaptures", isDirectory: true)
+    }
+
+    /// Sends one acknowledgement to the Watch. Set by the receiver, which
+    /// owns the WCSession; delivery confirmation comes back through
+    /// `handleAckTransferFinished`.
+    nonisolated(unsafe) public var sendAck: (@Sendable (WatchCaptureAck) -> Void)?
+
+    private let journal: WatchCaptureImportJournal
+    private let inboxDirectory: URL
+    private var isProcessing = false
+    private var activeImportTask: Task<Void, Error>?
+
+    public convenience init() {
+        self.init(inboxDirectory: Self.inboxDirectory)
+    }
+
+    /// Test seam: an isolated inbox directory.
+    public init(inboxDirectory: URL) {
+        self.inboxDirectory = inboxDirectory
+        self.journal = WatchCaptureImportJournal(directoryURL: inboxDirectory)
+    }
+
+    // MARK: - Delivery
+
+    /// Moves a delivered capture into the durable inbox and journals its
+    /// import job. Must complete synchronously on the caller's thread — the
+    /// system reclaims a WatchConnectivity inbox file when the delegate
+    /// callback returns. Idempotent per capture id.
+    ///
+    /// - Returns: `false` when the file could not be parked (the delivery
+    ///   should be treated as not received so the Watch retries).
+    nonisolated public func parkDeliveredFile(
+        at temporaryURL: URL,
+        envelope: WatchCaptureEnvelope
+    ) -> Bool {
+        let destination = inboxDirectory
+            .appendingPathComponent(envelope.id.uuidString)
+            .appendingPathExtension(envelope.fileExtension)
+        do {
+            try FileManager.default.createDirectory(
+                at: inboxDirectory,
+                withIntermediateDirectories: true
+            )
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.moveItem(at: temporaryURL, to: destination)
+        } catch {
+            SpeakLogger.logError(error, context: "WatchCaptureImportPipeline.park")
+            return false
+        }
+        // The job is parked the moment the audio is: a process death after
+        // this point is recovered by the next reconcile pass.
+        journal.parkJob(
+            captureID: envelope.id,
+            fileExtension: envelope.fileExtension,
+            createdAt: envelope.createdAt,
+            duration: envelope.duration
+        )
+        return true
+    }
+
+    // MARK: - Processing
+
+    /// Reconciles the inbox: purges expired jobs (deleting their audio and
+    /// sending terminal failure acknowledgements), replays undelivered
+    /// acknowledgements, and runs every retryable pending import serially.
+    /// Call on activation and on foreground entry; safe to call repeatedly.
+    public func processPendingImports() async {
+        guard !isProcessing else { return }
+        isProcessing = true
+        defer { isProcessing = false }
+
+        purgeExpiredJobs()
+        replayPendingAcks()
+
+        for job in journal.pendingJobs() {
+            guard journal.isRetryable(captureID: job.captureID) else { continue }
+            await runImport(for: job)
+        }
+    }
+
+    /// Runs one import under a background task whose expiration handler
+    /// cancels the work cleanly, leaving the job journalled and retryable
+    /// rather than assuming a network transcription fits the allowance.
+    private func runImport(for job: WatchCaptureImportJob) async {
+        let backgroundTask = UIApplication.shared.beginBackgroundTask(
+            withName: "WatchCaptureImport"
+        ) { [weak self] in
+            self?.activeImportTask?.cancel()
+        }
+        defer {
+            if backgroundTask != .invalid {
+                UIApplication.shared.endBackgroundTask(backgroundTask)
+            }
+        }
+
+        let importTask = Task { try await importOne(job) }
+        activeImportTask = importTask
+        defer { activeImportTask = nil }
+        do {
+            try await importTask.value
+        } catch is CancellationError {
+            journal.recordAttemptFailure(
+                captureID: job.captureID,
+                message: "Import interrupted by background expiration"
+            )
+        } catch {
+            SpeakLogger.logError(error, context: "WatchCaptureImportPipeline.import")
+            journal.recordAttemptFailure(
+                captureID: job.captureID,
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    private func importOne(_ job: WatchCaptureImportJob) async throws {
+        let audioURL = inboxDirectory
+            .appendingPathComponent(job.captureID.uuidString)
+            .appendingPathExtension(job.fileExtension)
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            completeUnrecoverable(job)
+            return
+        }
+
+        let settings = AppSettings.shared
+        // API keys load from the keychain asynchronously after init; a cold
+        // background launch must wait for them before resolving the model.
+        await settings.ensureKeysLoaded()
+        try Task.checkCancellation()
+        let model = settings.batchTranscriptionModel
+
+        let result = try await IOSBatchTranscriber.transcribeFile(
+            at: audioURL,
+            model: model,
+            apiKey: settings.batchAPIKey,
+            language: settings.preferredModelLanguage
+        )
+        try Task.checkCancellation()
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            throw IOSBatchTranscriptionError.emptyTranscript
+        }
+
+        // The history id is the capture id, so a re-delivered or re-imported
+        // capture upserts the same row instead of duplicating it.
+        let item = iOSHistoryItem(
+            id: job.captureID,
+            createdAt: job.createdAt,
+            transcription: result.text,
+            model: model,
+            duration: result.duration > 0 ? result.duration : job.duration,
+            wordCount: result.text.split(separator: " ").count,
+            originPlatform: "watchos"
+        )
+        // Acknowledge and delete only after the history write is durable:
+        // a full or unwritable store keeps the audio parked and the job
+        // retryable instead of acknowledging data loss (issue #674).
+        guard iOSHistoryManager.shared.upsertReportingDurability(item) else {
+            journal.recordAttemptFailure(
+                captureID: job.captureID,
+                message: "History could not be written to disk."
+            )
+            return
+        }
+        SpeakLogger.logTranscription(
+            event: "Watch capture transcribed",
+            model: model,
+            wordCount: item.wordCount
+        )
+
+        commitSuccessfulImport(of: job, audioURL: audioURL)
+
+        if settings.autoPostProcess && settings.hasOpenRouterKey {
+            await iOSHistoryManager.shared.reprocess(item)
+        }
+    }
+
+    /// The audio is gone (e.g. reclaimed storage): the capture is
+    /// unrecoverable, which is exactly what the Watch must learn.
+    private func completeUnrecoverable(_ job: WatchCaptureImportJob) {
+        journal.recordPendingAck(WatchCaptureAckRecord(
+            captureID: job.captureID,
+            outcome: .failed,
+            message: "The capture's audio was no longer available on the phone."
+        ))
+        journal.completeJob(captureID: job.captureID)
+        replayPendingAcks()
+    }
+
+    /// Records the durable success: acknowledgement retained until confirmed,
+    /// job removed, parked audio released.
+    private func commitSuccessfulImport(of job: WatchCaptureImportJob, audioURL: URL) {
+        journal.recordPendingAck(WatchCaptureAckRecord(
+            captureID: job.captureID,
+            outcome: .transcribed
+        ))
+        journal.completeJob(captureID: job.captureID)
+        try? FileManager.default.removeItem(at: audioURL)
+        replayPendingAcks()
+    }
+
+    // MARK: - Acknowledgements
+
+    /// Re-sends every acknowledgement whose delivery is unconfirmed.
+    public func replayPendingAcks() {
+        guard let sendAck else { return }
+        for record in journal.pendingAcks() {
+            sendAck(record.ack)
+        }
+    }
+
+    /// Transport confirmation from the receiver's `didFinish` delegate: a
+    /// confirmed delivery clears the retained acknowledgement; a failed one
+    /// keeps it for the next replay, without retranscribing anything.
+    nonisolated public func handleAckTransferFinished(captureID: UUID, delivered: Bool) {
+        guard delivered else { return }
+        journal.confirmAckDelivered(captureID: captureID)
+    }
+
+    // MARK: - Retention
+
+    private func purgeExpiredJobs() {
+        let purged = journal.purgeExpired()
+        for job in purged {
+            let audioURL = inboxDirectory
+                .appendingPathComponent(job.captureID.uuidString)
+                .appendingPathExtension(job.fileExtension)
+            try? FileManager.default.removeItem(at: audioURL)
+            journal.recordPendingAck(WatchCaptureAckRecord(
+                captureID: job.captureID,
+                outcome: .failed,
+                message: job.lastErrorMessage
+                    ?? "The capture could not be imported and was removed after retries."
+            ))
+        }
+    }
+}
+#endif

--- a/Sources/SpeakiOS/Views/iOSHistoryManager.swift
+++ b/Sources/SpeakiOS/Views/iOSHistoryManager.swift
@@ -162,11 +162,25 @@ public final class iOSHistoryManager: ObservableObject {
 
     /// Adds a new transcription to history.
     public func add(_ item: iOSHistoryItem) {
-        loadHistoryFromDiskIfNeeded()
-        items.insert(item, at: 0)
-        saveHistory()
+        _ = upsertReportingDurability(item)
+    }
 
-        guard syncEnabled else { return }
+    /// Inserts (or replaces, by id) a history item and reports whether the
+    /// write actually reached disk (issue #674): callers that must not
+    /// acknowledge or delete source material until the entry is durable —
+    /// the Watch import pipeline — branch on this. Replacing by id keeps
+    /// duplicate imports of the same capture from creating duplicate rows.
+    @discardableResult
+    public func upsertReportingDurability(_ item: iOSHistoryItem) -> Bool {
+        loadHistoryFromDiskIfNeeded()
+        if let existing = items.firstIndex(where: { $0.id == item.id }) {
+            items[existing] = item
+        } else {
+            items.insert(item, at: 0)
+        }
+        guard saveHistoryReportingDurability() else { return false }
+
+        guard syncEnabled else { return true }
         Task {
             do {
                 try await HistorySyncEngine.shared.upload(entry: item.toSyncable())
@@ -178,6 +192,7 @@ public final class iOSHistoryManager: ObservableObject {
                 logger.error("Failed to upload item: \(error.localizedDescription, privacy: .public)")
             }
         }
+        return true
     }
 
     /// Creates and adds a history item from transcription result.
@@ -345,6 +360,13 @@ public final class iOSHistoryManager: ObservableObject {
     }
 
     private func saveHistory() {
+        _ = saveHistoryReportingDurability()
+    }
+
+    /// Persists history and reports whether the write reached disk, so
+    /// import paths can refuse to acknowledge data that was never saved.
+    @discardableResult
+    private func saveHistoryReportingDurability() -> Bool {
         do {
             let data = try encoder.encode(items)
             // `completeUntilFirstUserAuthentication` keeps the file readable and
@@ -354,8 +376,10 @@ public final class iOSHistoryManager: ObservableObject {
                 to: fileURL,
                 options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
             )
+            return true
         } catch {
             logger.error("Failed to save history: \(error.localizedDescription, privacy: .public)")
+            return false
         }
     }
 

--- a/SpeakiOSApp/SpeakiOSApp.swift
+++ b/SpeakiOSApp/SpeakiOSApp.swift
@@ -96,8 +96,15 @@ struct SpeakiOSApp: App {
                     keyboardInstantDictation.activate()
                 }
                 .onChange(of: scenePhase) { _, newPhase in
-                    guard FeatureFlags.iOSKeyboardEnabled, newPhase == .active else { return }
-                    keyboardInstantDictation.activate()
+                    guard newPhase == .active else { return }
+                    if FeatureFlags.iOSKeyboardEnabled {
+                        keyboardInstantDictation.activate()
+                    }
+                    // Foreground entry reconciles Watch imports interrupted by
+                    // suspension and replays unconfirmed acks (issue #674).
+                    if FeatureFlags.watchCaptureEnabled {
+                        WatchCaptureReceiver.shared.reconcilePendingWork()
+                    }
                 }
         }
     }

--- a/SpeakiOSApp/WatchCaptureReceiver.swift
+++ b/SpeakiOSApp/WatchCaptureReceiver.swift
@@ -4,36 +4,36 @@ import SpeakiOSLib
 import UIKit
 import WatchConnectivity
 
-/// iPhone-side endpoint for Apple Watch audio captures.
+/// iPhone-side WatchConnectivity endpoint for Apple Watch audio captures.
 ///
-/// The watch records audio locally and hands it off via a WatchConnectivity
-/// file transfer (which queues while the phone is out of range and launches
-/// this app in the background on delivery). This receiver:
-///
-/// 1. moves the delivered file out of WatchConnectivity's inbox synchronously
-///    (the system deletes it when the delegate callback returns),
-/// 2. transcribes it with the user's configured batch model,
-/// 3. saves the transcript to history (which syncs to the Mac via the
-///    existing CloudKit machinery), optionally kicking off the user's
-///    auto-polish, and
-/// 4. queues an acknowledgement back to the watch so it can mark the capture
-///    as done (`transferUserInfo` also queues while unreachable).
+/// Deliberately a thin shim (issue #674): it owns the `WCSession` and nothing
+/// else. Delivered files are parked synchronously (the system reclaims the
+/// inbox file when the delegate returns) into the durable
+/// `WatchCaptureImportPipeline`, which journals every import, retries with
+/// bounded attempts under an expiration-safe background task, acknowledges
+/// the Watch only after the history write is durable, and replays
+/// unconfirmed acknowledgements. Activation and foreground entry reconcile
+/// pending work, so a suspended or killed import resumes instead of
+/// stranding audio with the Watch stuck at "Delivered".
 ///
 /// Activation is gated by `FeatureFlags.watchCaptureEnabled`; without the
 /// watch app build flag this class stays dormant.
 final class WatchCaptureReceiver: NSObject {
     static let shared = WatchCaptureReceiver()
 
+    private let pipeline = WatchCaptureImportPipeline.shared
+
     private override init() {
         super.init()
+        pipeline.sendAck = { ack in
+            guard let userInfo = ack.userInfo() else { return }
+            WCSession.default.transferUserInfo(userInfo)
+        }
     }
 
-    /// Directory where delivered captures are parked until transcription
-    /// succeeds. Files for failed transcriptions are retained here so a
-    /// future retry path can pick them up.
+    /// Kept for existing callers; the pipeline owns the directory.
     static var inboxDirectory: URL {
-        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-        return base.appendingPathComponent("WatchCaptures", isDirectory: true)
+        WatchCaptureImportPipeline.inboxDirectory
     }
 
     func activate() {
@@ -43,75 +43,12 @@ final class WatchCaptureReceiver: NSObject {
         session.activate()
     }
 
-    // MARK: - Import pipeline
-
-    /// Transcribes a delivered capture, saves it to history, and queues an
-    /// acknowledgement back to the watch.
-    @MainActor
-    private func importCapture(at url: URL, envelope: WatchCaptureEnvelope) async {
-        // Keep the (likely background-launched) process alive long enough for
-        // the upload + history write to commit.
-        let backgroundTask = UIApplication.shared.beginBackgroundTask(withName: "WatchCaptureImport")
-        defer {
-            if backgroundTask != .invalid {
-                UIApplication.shared.endBackgroundTask(backgroundTask)
-            }
+    /// Reconciles parked imports and unconfirmed acknowledgements. Called on
+    /// activation and whenever the app returns to the foreground.
+    func reconcilePendingWork() {
+        Task { @MainActor in
+            await self.pipeline.processPendingImports()
         }
-
-        let settings = AppSettings.shared
-        // API keys load from the keychain asynchronously after init; a cold
-        // background launch must wait for them before resolving the model.
-        await settings.ensureKeysLoaded()
-        let model = settings.batchTranscriptionModel
-
-        do {
-            let result = try await IOSBatchTranscriber.transcribeFile(
-                at: url,
-                model: model,
-                apiKey: settings.batchAPIKey,
-                language: settings.preferredModelLanguage
-            )
-            let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !text.isEmpty else {
-                throw IOSBatchTranscriptionError.emptyTranscript
-            }
-
-            let item = iOSHistoryItem(
-                createdAt: envelope.createdAt,
-                transcription: result.text,
-                model: model,
-                duration: result.duration > 0 ? result.duration : envelope.duration,
-                wordCount: result.text.split(separator: " ").count,
-                originPlatform: "watchos"
-            )
-            iOSHistoryManager.shared.add(item)
-            SpeakLogger.logTranscription(
-                event: "Watch capture transcribed",
-                model: model,
-                wordCount: item.wordCount
-            )
-
-            sendAck(WatchCaptureAck(id: envelope.id, outcome: .transcribed))
-            try? FileManager.default.removeItem(at: url)
-
-            if settings.autoPostProcess && settings.hasOpenRouterKey {
-                await iOSHistoryManager.shared.reprocess(item)
-            }
-        } catch {
-            SpeakLogger.logError(error, context: "WatchCaptureReceiver.importCapture")
-            // Retain the audio file for a future retry; tell the watch so the
-            // capture surfaces as failed instead of silently pending forever.
-            sendAck(WatchCaptureAck(
-                id: envelope.id,
-                outcome: .failed,
-                message: error.localizedDescription
-            ))
-        }
-    }
-
-    private func sendAck(_ ack: WatchCaptureAck) {
-        guard let userInfo = ack.userInfo() else { return }
-        WCSession.default.transferUserInfo(userInfo)
     }
 }
 
@@ -137,6 +74,11 @@ extension WatchCaptureReceiver: WCSessionDelegate {
         if let error {
             SpeakLogger.logError(error, context: "WatchCaptureReceiver.activation")
         }
+        // A fresh activation is the recovery point for imports interrupted by
+        // suspension or death, and for acknowledgements the Watch never got.
+        if activationState == .activated {
+            reconcilePendingWork()
+        }
     }
 
     func sessionDidBecomeInactive(_ session: WCSession) {}
@@ -148,7 +90,7 @@ extension WatchCaptureReceiver: WCSessionDelegate {
 
     func session(_ session: WCSession, didReceive file: WCSessionFile) {
         // The system deletes `file.fileURL` when this method returns, so the
-        // move must happen synchronously — everything after is async.
+        // park must happen synchronously — everything after is async.
         guard let envelope = WatchCaptureEnvelope.from(metadata: file.metadata) else {
             // Without a decodable envelope there is no capture identity to
             // acknowledge, so importing would ack an id the watch never sent.
@@ -161,25 +103,24 @@ extension WatchCaptureReceiver: WCSessionDelegate {
             return
         }
 
-        let destination = Self.inboxDirectory
-            .appendingPathComponent(envelope.id.uuidString)
-            .appendingPathExtension(envelope.fileExtension)
-        do {
-            try FileManager.default.createDirectory(
-                at: Self.inboxDirectory,
-                withIntermediateDirectories: true
-            )
-            if FileManager.default.fileExists(atPath: destination.path) {
-                try FileManager.default.removeItem(at: destination)
-            }
-            try FileManager.default.moveItem(at: file.fileURL, to: destination)
-        } catch {
-            SpeakLogger.logError(error, context: "WatchCaptureReceiver.didReceiveFile")
+        guard pipeline.parkDeliveredFile(at: file.fileURL, envelope: envelope) else {
             return
         }
+        reconcilePendingWork()
+    }
 
-        Task { @MainActor in
-            await self.importCapture(at: destination, envelope: envelope)
+    func session(
+        _ session: WCSession,
+        didFinish userInfoTransfer: WCSessionUserInfoTransfer,
+        error: Error?
+    ) {
+        // Delivery confirmation for a queued acknowledgement: only a
+        // confirmed transfer clears the retained record; failures stay for
+        // the next replay, without retranscribing anything.
+        guard let ack = WatchCaptureAck.from(userInfo: userInfoTransfer.userInfo) else { return }
+        if let error {
+            SpeakLogger.logError(error, context: "WatchCaptureReceiver.ackTransfer")
         }
+        pipeline.handleAckTransferFinished(captureID: ack.id, delivered: error == nil)
     }
 }

--- a/Tests/SpeakCoreTests/WatchCaptureImportJournalTests.swift
+++ b/Tests/SpeakCoreTests/WatchCaptureImportJournalTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+@testable import SpeakCore
+
+/// Durable Watch-import journalling (issue #674): jobs are parked
+/// idempotently, survive relaunch, retry with bounded attempts, purge under
+/// retention, and acknowledgements persist until the transport confirms
+/// delivery.
+final class WatchCaptureImportJournalTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("watch-journal-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+        directory = nil
+        try super.tearDownWithError()
+    }
+
+    private func makeJournal() -> WatchCaptureImportJournal {
+        WatchCaptureImportJournal(directoryURL: directory)
+    }
+
+    func testParkJob_isIdempotentPerCaptureAndSurvivesRelaunch() {
+        let journal = makeJournal()
+        let captureID = UUID()
+        journal.parkJob(captureID: captureID, fileExtension: "m4a", createdAt: Date(), duration: 12)
+        // Re-delivery of the same capture must not duplicate the job.
+        journal.parkJob(captureID: captureID, fileExtension: "m4a", createdAt: Date(), duration: 12)
+        XCTAssertEqual(journal.pendingJobs().count, 1)
+
+        // A process death is survived: a fresh journal instance re-reads the
+        // same pending job from disk.
+        let relaunched = makeJournal()
+        XCTAssertEqual(relaunched.pendingJobs().map(\.captureID), [captureID])
+    }
+
+    func testAttemptFailures_areBoundedAndPurgedWithTerminalOutcome() {
+        let journal = makeJournal()
+        let captureID = UUID()
+        journal.parkJob(captureID: captureID, fileExtension: "m4a", createdAt: Date(), duration: 5)
+
+        for attempt in 1...WatchCaptureImportJournal.defaultMaximumAttempts {
+            XCTAssertEqual(
+                journal.isRetryable(captureID: captureID),
+                attempt <= WatchCaptureImportJournal.defaultMaximumAttempts,
+                "attempt \(attempt)"
+            )
+            journal.recordAttemptFailure(captureID: captureID, message: "network down")
+        }
+        XCTAssertFalse(journal.isRetryable(captureID: captureID))
+
+        let purged = journal.purgeExpired()
+        XCTAssertEqual(purged.map(\.captureID), [captureID])
+        XCTAssertEqual(purged.first?.lastErrorMessage, "network down")
+        XCTAssertTrue(journal.pendingJobs().isEmpty)
+    }
+
+    func testRetention_purgesJobsOlderThanTheWindowEvenWithAttemptsLeft() {
+        let journal = makeJournal()
+        let stale = UUID()
+        let fresh = UUID()
+        journal.parkJob(
+            captureID: stale,
+            fileExtension: "m4a",
+            createdAt: Date().addingTimeInterval(-15 * 24 * 60 * 60),
+            duration: 5
+        )
+        journal.parkJob(captureID: fresh, fileExtension: "m4a", createdAt: Date(), duration: 5)
+
+        let purged = journal.purgeExpired()
+        XCTAssertEqual(purged.map(\.captureID), [stale])
+        XCTAssertEqual(journal.pendingJobs().map(\.captureID), [fresh])
+    }
+
+    func testCompleteJob_removesOnlyThatCapture() {
+        let journal = makeJournal()
+        let first = UUID()
+        let second = UUID()
+        journal.parkJob(captureID: first, fileExtension: "m4a", createdAt: Date(), duration: 1)
+        journal.parkJob(captureID: second, fileExtension: "m4a", createdAt: Date(), duration: 1)
+
+        journal.completeJob(captureID: first)
+        XCTAssertEqual(journal.pendingJobs().map(\.captureID), [second])
+
+        // Completion is idempotent, and a completed capture re-parked later
+        // (a true re-delivery after completion) journals cleanly again.
+        journal.completeJob(captureID: first)
+        journal.parkJob(captureID: first, fileExtension: "m4a", createdAt: Date(), duration: 1)
+        XCTAssertEqual(journal.pendingJobs().count, 2)
+    }
+
+    func testAcks_persistUntilDeliveryConfirmedAndSurviveRelaunch() {
+        let journal = makeJournal()
+        let captureID = UUID()
+        journal.recordPendingAck(WatchCaptureAckRecord(captureID: captureID, outcome: .transcribed))
+
+        // Failed transport delivery keeps the record for the next replay…
+        XCTAssertEqual(makeJournal().pendingAcks().map(\.captureID), [captureID])
+
+        // …a newer outcome replaces rather than duplicates…
+        journal.recordPendingAck(WatchCaptureAckRecord(
+            captureID: captureID,
+            outcome: .failed,
+            message: "gone"
+        ))
+        XCTAssertEqual(journal.pendingAcks().count, 1)
+        XCTAssertEqual(journal.pendingAcks().first?.outcome, .failed)
+
+        // …and confirmation clears it durably.
+        journal.confirmAckDelivered(captureID: captureID)
+        XCTAssertTrue(journal.pendingAcks().isEmpty)
+        XCTAssertTrue(makeJournal().pendingAcks().isEmpty)
+    }
+
+    func testAckRecord_bridgesToTheWireAck() {
+        let captureID = UUID()
+        let record = WatchCaptureAckRecord(captureID: captureID, outcome: .failed, message: "why")
+        XCTAssertEqual(record.ack, WatchCaptureAck(id: captureID, outcome: .failed, message: "why"))
+    }
+}


### PR DESCRIPTION
## Defects (#674)

1. `WatchCaptureReceiver` ran an unbounded network transcription under a finite background task with no expiration handler and no durable job record — a suspended/killed process stranded the parked audio forever with the Watch stuck at *Delivered*.
2. `iOSHistoryManager.add` could not report a disk-write failure, so the receiver acknowledged `.transcribed` and deleted the only retained audio even when nothing was saved — acknowledged data loss.
3. The first transcription error sent a terminal `.failed` ack although the Watch had already deleted its local copy, leaving an unrecoverable failed state with no file to retry.
4. `transferUserInfo` acknowledgements had no failure recovery: phone history existed while the Watch stayed *Delivered*.
5. `WatchAudioRecorder.start()` kept `isRecording == false` across its awaits; two rapid taps could interleave and orphan a capture.

## Fix

The receiver is now a thin `WCSession` shim over a durable pipeline:

- **`WatchCaptureImportJournal` (SpeakCore, CI-tested)** — file-backed jobs + pending acks, all idempotent by capture UUID, surviving relaunch.
- **`WatchCaptureImportPipeline` (SpeakiOSLib, CI-compiled)** — parks the delivered file synchronously together with its journalled job; reconciles on activation **and** foreground entry; runs each import under a background task whose **expiration handler cancels it cleanly**, leaving the job retryable with bounded attempts (5) rather than assuming the transcription fits the allowance; acknowledges the Watch and deletes audio **only after the history write is durable**; keeps transient failures retrying phone-side (no premature terminal ack — fixing defect 3); purges exhausted/fortnight-old jobs with their audio plus a terminal failure ack; retains acks until `didFinish` confirms delivery and replays them on every reconcile — without retranscribing.
- **`iOSHistoryManager.upsertReportingDurability`** — reports whether the write reached disk and upserts by id; the history id **is the capture id**, so re-delivery/re-import can never duplicate rows.
- **`WatchAudioRecorder.start()`** — serialised across its suspension points with an owned-operation guard (same pattern as #767).

## Verification

- `WatchCaptureImportJournalTests` (SpeakCore, CI-run): idempotent parking + relaunch survival, bounded attempts with terminal purge carrying the last error, retention-window purge, per-capture completion, ack retention until confirmed delivery + newer-outcome replacement.
- Full suite 1722 tests, 0 failures; `make lint` clean; SpeakiOSLib builds.
- **App target compiled via `tuist generate` + `xcodebuild` (iOS Simulator)** — this caught a real MainActor isolation error SwiftPM builds cannot see; now BUILD SUCCEEDED.
- Watch target: no watchOS simulator runtime on this machine, so the 4-line recorder guard is syntax-parse-verified; it references only existing members. The next TestFlight build (which compiles the watch app) is the type-check gate — flagging explicitly rather than claiming verification I don't have.

Physical-device acceptance (suspend/terminate during each import stage, storage-full simulation, offline retry, rapid Watch taps) maps onto the journalled stages and belongs to the device verification matrix (#659/#657).

Fixes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW