### PR TITLE
fix(mac): wait for selected microphone to settle

### DIFF
--- a/Sources/SpeakApp/AudioInputDeviceManager.swift
+++ b/Sources/SpeakApp/AudioInputDeviceManager.swift
@@ -3,6 +3,9 @@ import SpeakCore
 import CoreAudio
 import os.log
 
+private let inputDeviceSettleDelay: Duration = .milliseconds(100)
+private let inputDeviceSettleAttempts = 5
+
 @MainActor
 // swiftlint:disable:next type_body_length
 final class AudioInputDeviceManager: ObservableObject {
@@ -144,6 +147,7 @@ final class AudioInputDeviceManager: ObservableObject {
     }
 
     if setDefaultInputDevice(to: targetDeviceID) {
+      await waitForInputDeviceToSettle(targetDeviceID)
       refreshDevices()
       logger.debug("Activated preferred input device with UID \(uid, privacy: .public)")
       return sessionTracker.beginSession(previousDeviceID: currentDefaultID, didChangeDevice: true)
@@ -159,6 +163,7 @@ final class AudioInputDeviceManager: ObservableObject {
     }
 
     if setDefaultInputDevice(to: previous) {
+      await waitForInputDeviceToSettle(previous)
       refreshDevices()
       logger.debug("Restored previous input device after session")
     } else {
@@ -375,6 +380,28 @@ final class AudioInputDeviceManager: ObservableObject {
       return false
     }
     return true
+  }
+
+  /// CoreAudio acknowledges a default-device change before AVAudioEngine's HAL
+  /// graph necessarily exposes the new input format. Creating an engine in that
+  /// window returns a zero-channel format, which every live provider correctly
+  /// rejects as an unavailable microphone. Wait for the selected device to be
+  /// both current and usable before callers bind their fresh audio engine.
+  private func waitForInputDeviceToSettle(_ deviceID: AudioDeviceID) async {
+    for attempt in 0..<inputDeviceSettleAttempts {
+      let sampleRate = doubleProperty(
+        selector: kAudioDevicePropertyNominalSampleRate,
+        deviceID: deviceID
+      ) ?? 0
+      if attempt > 0,
+        currentDefaultInputDeviceID() == deviceID,
+        inputChannelCount(for: deviceID) > 0,
+        sampleRate > 0 {
+        return
+      }
+      try? await Task.sleep(for: inputDeviceSettleDelay)
+    }
+    logger.warning("Timed out waiting for input device \(deviceID) to settle")
   }
 
   private func deviceID(forUID uid: String) -> AudioDeviceID? {


### PR DESCRIPTION
## Summary

- wait for a newly selected CoreAudio input device to become current and report usable channels/sample rate before live providers create AVAudioEngine
- bound the readiness wait to 500 ms so disconnected hardware still fails promptly
- apply the fix in the shared microphone-selection path, covering Deepgram and every other macOS live provider
- leave the system-default/no-switch path unchanged

## Root cause

CoreAudio can acknowledge the default-input property change before AVAudioEngine's HAL graph exposes the selected device. Providers created their engine immediately, observed a transient zero-channel format, and surfaced the selected microphone as unavailable. This is especially visible with USB/webcam microphones on macOS 26.

## Verification

- `swift test --filter 'AudioInput|AudioInputDeviceSessionTracker'` — 10 passed, 0 failed
- `git diff --check` — clean

Closes #772
