### PR TITLE
fix(mac): bound Parakeet streaming decode and finalisation latency

### DIFF
--- a/Sources/SpeakApp/SherpaOnnxLiveController.swift
+++ b/Sources/SpeakApp/SherpaOnnxLiveController.swift
@@ -32,6 +32,9 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
   private var streamingStartTime: Date?
   private var latestText: String = ""
   private var hasFinished: Bool = false
+  /// Whether this run's sidecar delivered its `session_final` event — the
+  /// proof that finalisation covered every accepted PCM frame (issue #679).
+  private var receivedSessionFinal = false
   private var isStopping: Bool = false
   private var sidecarOutputBuffer = ""
   /// Sink for the current process's stderr. Replaced on every start so stderr
@@ -82,6 +85,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
 
     latestText = ""
     hasFinished = false
+    receivedSessionFinal = false
     sidecarOutputBuffer = ""
     processDidLaunch = false
     let errorSink = SidecarErrorSink(maxByteCount: Self.maxSidecarErrorByteCount)
@@ -183,20 +187,34 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
     isRunning = false
 
     let duration = streamingStartTime.map { Date().timeIntervalSince($0) } ?? 0
-    let result = TranscriptionResult(
-      text: latestText,
-      segments: latestText.isEmpty ? [] : [
-        TranscriptionSegment(startTime: 0, endTime: duration, text: latestText)
-      ],
-      confidence: nil,
-      duration: duration,
-      modelIdentifier: currentModel ?? appSettings.localStreamingModelSource,
-      cost: nil,
-      rawPayload: nil,
-      debugInfo: nil
-    )
     hasFinished = true
-    delegate?.liveTranscriber(self, didFinishWith: result)
+    if receivedSessionFinal {
+      let result = TranscriptionResult(
+        text: latestText,
+        segments: latestText.isEmpty ? [] : [
+          TranscriptionSegment(startTime: 0, endTime: duration, text: latestText)
+        ],
+        confidence: nil,
+        duration: duration,
+        modelIdentifier: currentModel ?? appSettings.localStreamingModelSource,
+        cost: nil,
+        rawPayload: nil,
+        debugInfo: nil
+      )
+      delegate?.liveTranscriber(self, didFinishWith: result)
+    } else {
+      // The sidecar never delivered its whole-session final: forced
+      // termination or a crash must surface as an explicit failure, never as
+      // a success carrying a stale partial that silently drops trailing
+      // speech (issue #679).
+      delegate?.liveTranscriber(
+        self,
+        didFail: SherpaOnnxRuntimeError.processFailed(
+          "Local finalisation did not complete; the transcript may be missing "
+            + "trailing speech. The live text shown so far was kept."
+        )
+      )
+    }
     await endActiveInputSession()
     resetProcessState()
     isStopping = false
@@ -283,6 +301,7 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
     else { return }
     switch event.type {
     case "partial", "session_final":
+      if event.type == "session_final" { receivedSessionFinal = true }
       guard let rawText = event.text?.trimmingCharacters(in: .whitespacesAndNewlines), !rawText.isEmpty else {
         return
       }
@@ -304,14 +323,32 @@ final class SherpaOnnxLiveController: NSObject, LiveTranscriptionController {
   private func waitForProcessExit() async {
     guard let process else { return }
     // Offline transducer models (Parakeet TDT) decode the whole session once
-    // stdin closes, so long recordings need more headroom than the online
-    // models, which exit almost immediately.
-    for _ in 0..<100 where process.isRunning {
+    // stdin closes, so the exit allowance must scale with what was recorded —
+    // a fixed window silently truncated long sessions to a stale partial
+    // (issue #679).
+    let sessionSeconds = streamingStartTime.map { Date().timeIntervalSince($0) } ?? 0
+    let deadline = Date().addingTimeInterval(
+      Self.finalisationAllowance(forSessionSeconds: sessionSeconds)
+    )
+    while process.isRunning && Date() < deadline && !receivedSessionFinal {
+      try? await Task.sleep(for: .milliseconds(100))
+    }
+    // Give a process that already produced its final a moment to exit.
+    for _ in 0..<20 where process.isRunning {
       try? await Task.sleep(for: .milliseconds(100))
     }
     if process.isRunning {
       process.terminate()
     }
+  }
+
+  /// How long finalisation may run after stdin closes: at the measured
+  /// real-time factor (~0.04) a quarter of the session duration is six-fold
+  /// headroom, floored at the historical ten seconds for short sessions.
+  nonisolated static func finalisationAllowance(
+    forSessionSeconds seconds: TimeInterval
+  ) -> TimeInterval {
+    max(10, seconds * 0.25)
   }
 
   private func cleanupAfterFailedStart() async {

--- a/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
+++ b/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
@@ -534,9 +534,16 @@ def run_online(args):
 
 def run_offline(args):
     # Offline transducers (e.g. NVIDIA Parakeet TDT) decode a whole utterance
-    # at a time. Re-decode the accumulated audio after every ~2 s of new input
-    # to stream partial results, then decode once more at end of input for the
-    # session final.
+    # at a time. Ingestion and inference are decoupled (issue #679): a reader
+    # thread always drains stdin, so the pipe can never fill and block the
+    # app's real-time audio queue behind model inference. Partials decode a
+    # bounded tail window at an adaptive cadence (never more than ~half the
+    # wall clock), so partial latency and per-decode cost stay constant for
+    # long sessions instead of growing quadratically. The session final still
+    # decodes every retained sample.
+    import threading
+    import time
+
     recognizer = sherpa_onnx.OfflineRecognizer.from_transducer(
         encoder=args.encoder,
         decoder=args.decoder,
@@ -549,34 +556,79 @@ def run_offline(args):
         model_type=args.model_type,
         provider="cpu",
     )
-    buffered = array.array("f")
-    last_text = ""
-    samples_since_decode = 0
-    decode_interval = 16000 * 2
 
-    def decode_buffered():
+    # Bounded retention: one hour of 16 kHz mono float32 (~230 MB). Beyond it
+    # the oldest audio is dropped and the cap is reported once, so memory is
+    # bounded and truncation is explicit rather than silent.
+    max_buffer_samples = 16000 * 60 * 60
+    # Partials decode at most the trailing minute, keeping each partial decode
+    # constant-cost regardless of session length.
+    partial_window_samples = 16000 * 60
+
+    lock = threading.Lock()
+    buffered = array.array("f")
+    eof = threading.Event()
+    capped = threading.Event()
+
+    def reader():
+        while True:
+            samples = read_samples()
+            if samples is None:
+                break
+            if not samples:
+                continue
+            with lock:
+                buffered.extend(samples)
+                if len(buffered) > max_buffer_samples:
+                    del buffered[: len(buffered) - max_buffer_samples]
+                    capped.set()
+        eof.set()
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+
+    def decode(window):
         stream = recognizer.create_stream()
-        stream.accept_waveform(16000, buffered)
+        stream.accept_waveform(16000, window)
         recognizer.decode_stream(stream)
         return stream.result.text
 
-    while True:
-        samples = read_samples()
-        if samples is None:
-            break
-        if not samples:
+    last_text = ""
+    decoded_upto = 0
+    last_decode_seconds = 0.0
+    did_report_cap = False
+
+    while not eof.is_set():
+        time.sleep(0.1)
+        if capped.is_set() and not did_report_cap:
+            did_report_cap = True
+            emit("buffer_capped", "retention window exceeded; oldest audio dropped")
+        with lock:
+            available = len(buffered)
+        # Adaptive cadence: at least two seconds of new audio, and at least
+        # twice the previous decode's duration, so decoding can never occupy
+        # more than about half of real time and ingestion always stays ahead.
+        required = int(16000 * max(2.0, last_decode_seconds * 2.0))
+        if available - decoded_upto < required:
             continue
-        buffered.extend(samples)
-        samples_since_decode += len(samples)
-        if samples_since_decode < decode_interval:
-            continue
-        samples_since_decode = 0
-        text = decode_buffered()
+        with lock:
+            if len(buffered) > partial_window_samples:
+                window = buffered[-partial_window_samples:]
+            else:
+                window = buffered[:]
+        started = time.monotonic()
+        text = decode(window)
+        last_decode_seconds = time.monotonic() - started
+        decoded_upto = available
         if text and text != last_text:
             last_text = text
             emit("partial", text)
 
-    final_text = (decode_buffered() if buffered else "") or last_text
+    thread.join()
+    with lock:
+        final_window = buffered[:]
+    emit("finalizing", "%.1f" % (len(final_window) / 16000.0))
+    final_text = (decode(final_window) if final_window else "") or last_text
     emit("session_final", final_text)
 
 

--- a/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
+++ b/Sources/SpeakApp/SherpaOnnxRuntimeManager.swift
@@ -541,6 +541,7 @@ def run_offline(args):
     # wall clock), so partial latency and per-decode cost stay constant for
     # long sessions instead of growing quadratically. The session final still
     # decodes every retained sample.
+    import collections
     import threading
     import time
 
@@ -566,11 +567,19 @@ def run_offline(args):
     partial_window_samples = 16000 * 60
 
     lock = threading.Lock()
-    buffered = array.array("f")
+    # Retained audio is a deque of PCM chunks rather than one flat array:
+    # evicting old audio drops whole leading chunks (plus a prefix of one
+    # small chunk), so a post-cap read costs the same as any other read
+    # instead of shifting the whole hour of samples while the reader holds
+    # the lock and stdin stops draining.
+    buffered = collections.deque()
+    retained = 0  # samples currently held in `buffered`
+    received = 0  # samples accepted from stdin since start; never decreases
     eof = threading.Event()
     capped = threading.Event()
 
     def reader():
+        nonlocal retained, received
         while True:
             samples = read_samples()
             if samples is None:
@@ -578,11 +587,40 @@ def run_offline(args):
             if not samples:
                 continue
             with lock:
-                buffered.extend(samples)
-                if len(buffered) > max_buffer_samples:
-                    del buffered[: len(buffered) - max_buffer_samples]
+                buffered.append(samples)
+                retained += len(samples)
+                received += len(samples)
+                while retained > max_buffer_samples:
+                    excess = retained - max_buffer_samples
+                    oldest = buffered[0]
+                    if len(oldest) <= excess:
+                        buffered.popleft()
+                        retained -= len(oldest)
+                    else:
+                        del oldest[:excess]
+                        retained -= excess
                     capped.set()
         eof.set()
+
+    def snapshot(limit):
+        # Concatenates the trailing `limit` retained samples (every retained
+        # sample when `limit` is None). Called with the lock held.
+        window = array.array("f")
+        if limit is None or retained <= limit:
+            for chunk in buffered:
+                window.extend(chunk)
+            return window
+        remaining = limit
+        tail = []
+        for chunk in reversed(buffered):
+            if len(chunk) >= remaining:
+                tail.append(chunk[len(chunk) - remaining:])
+                break
+            tail.append(chunk)
+            remaining -= len(chunk)
+        for chunk in reversed(tail):
+            window.extend(chunk)
+        return window
 
     thread = threading.Thread(target=reader, daemon=True)
     thread.start()
@@ -594,17 +632,24 @@ def run_offline(args):
         return stream.result.text
 
     last_text = ""
+    # `received` at the last partial decode. Progress is measured against
+    # samples accepted, not samples retained, so partials continue after the
+    # retention cap holds the buffer at a constant length.
     decoded_upto = 0
     last_decode_seconds = 0.0
     did_report_cap = False
 
-    while not eof.is_set():
-        time.sleep(0.1)
+    def report_cap_once():
+        nonlocal did_report_cap
         if capped.is_set() and not did_report_cap:
             did_report_cap = True
             emit("buffer_capped", "retention window exceeded; oldest audio dropped")
+
+    while not eof.is_set():
+        time.sleep(0.1)
+        report_cap_once()
         with lock:
-            available = len(buffered)
+            available = received
         # Adaptive cadence: at least two seconds of new audio, and at least
         # twice the previous decode's duration, so decoding can never occupy
         # more than about half of real time and ingestion always stays ahead.
@@ -612,10 +657,7 @@ def run_offline(args):
         if available - decoded_upto < required:
             continue
         with lock:
-            if len(buffered) > partial_window_samples:
-                window = buffered[-partial_window_samples:]
-            else:
-                window = buffered[:]
+            window = snapshot(partial_window_samples)
         started = time.monotonic()
         text = decode(window)
         last_decode_seconds = time.monotonic() - started
@@ -625,8 +667,11 @@ def run_offline(args):
             emit("partial", text)
 
     thread.join()
+    # The reader can reach the cap between the last poll and EOF; the
+    # truncation is still reported before the final transcript.
+    report_cap_once()
     with lock:
-        final_window = buffered[:]
+        final_window = snapshot(None)
     emit("finalizing", "%.1f" % (len(final_window) / 16000.0))
     final_text = (decode(final_window) if final_window else "") or last_text
     emit("session_final", final_text)

--- a/Tests/SpeakAppTests/SherpaOnnxRuntimeConfigTests.swift
+++ b/Tests/SpeakAppTests/SherpaOnnxRuntimeConfigTests.swift
@@ -94,9 +94,22 @@ final class SherpaOnnxRuntimeConfigTests: XCTestCase {
         XCTAssertTrue(script.contains("max_buffer_samples = 16000 * 60 * 60"))
         XCTAssertTrue(script.contains("last_decode_seconds * 2.0"))
         XCTAssertTrue(script.contains("emit(\"buffer_capped\""))
+        // Retention is a deque of chunks evicted whole, so a post-cap read
+        // never shifts the entire buffer under the lock.
+        XCTAssertTrue(script.contains("buffered = collections.deque()"))
+        XCTAssertTrue(script.contains("buffered.popleft()"))
+        XCTAssertFalse(script.contains("del buffered[:"))
+        // Partial progress is measured against samples received, not retained,
+        // so partials continue once the cap holds the buffer at a fixed size.
+        XCTAssertTrue(script.contains("received += len(samples)"))
+        XCTAssertTrue(script.contains("available = received"))
+        XCTAssertFalse(script.contains("available = len(buffered)"))
+        // A cap reached just before EOF is still reported, before the final.
+        XCTAssertTrue(script.contains("thread.join()\n    # The reader can reach the cap"))
+        XCTAssertTrue(script.contains("report_cap_once()\n    with lock:\n        final_window = snapshot(None)"))
         // The final decode covers every retained sample and is announced.
         XCTAssertTrue(script.contains("emit(\"finalizing\""))
-        XCTAssertTrue(script.contains("final_window = buffered[:]"))
+        XCTAssertTrue(script.contains("final_window = snapshot(None)"))
         // The old quadratic whole-buffer partial loop must not return.
         XCTAssertFalse(script.contains("samples_since_decode"))
     }

--- a/Tests/SpeakAppTests/SherpaOnnxRuntimeConfigTests.swift
+++ b/Tests/SpeakAppTests/SherpaOnnxRuntimeConfigTests.swift
@@ -77,5 +77,39 @@ final class SherpaOnnxRuntimeConfigTests: XCTestCase {
         XCTAssertTrue(script.contains("model_type=args.model_type"))
         XCTAssertTrue(script.contains("decoding_method=\"greedy_search\""))
     }
+
+    // MARK: - Bounded offline decode contract (issue #679)
+
+    func testSidecarScript_decouplesIngestionFromOfflineDecode() {
+        let script = SherpaOnnxRuntimeManager.sidecarScript
+
+        // A dedicated reader thread must always drain stdin so the pipe can
+        // never fill and block the app's real-time audio queue behind
+        // inference.
+        XCTAssertTrue(script.contains("threading.Thread(target=reader"))
+        XCTAssertTrue(script.contains("eof.set()"))
+        // Partials decode a bounded tail window at an adaptive cadence, and
+        // retention is explicitly capped rather than unbounded.
+        XCTAssertTrue(script.contains("partial_window_samples = 16000 * 60"))
+        XCTAssertTrue(script.contains("max_buffer_samples = 16000 * 60 * 60"))
+        XCTAssertTrue(script.contains("last_decode_seconds * 2.0"))
+        XCTAssertTrue(script.contains("emit(\"buffer_capped\""))
+        // The final decode covers every retained sample and is announced.
+        XCTAssertTrue(script.contains("emit(\"finalizing\""))
+        XCTAssertTrue(script.contains("final_window = buffered[:]"))
+        // The old quadratic whole-buffer partial loop must not return.
+        XCTAssertFalse(script.contains("samples_since_decode"))
+    }
+
+    func testFinalisationAllowance_scalesWithSessionDuration() {
+        // Short sessions keep the historical ten-second floor…
+        XCTAssertEqual(SherpaOnnxLiveController.finalisationAllowance(forSessionSeconds: 0), 10)
+        XCTAssertEqual(SherpaOnnxLiveController.finalisationAllowance(forSessionSeconds: 30), 10)
+        // …and long sessions get time proportional to what was recorded: a
+        // quarter of the duration is six-fold headroom at the measured ~0.04
+        // real-time factor.
+        XCTAssertEqual(SherpaOnnxLiveController.finalisationAllowance(forSessionSeconds: 240), 60)
+        XCTAssertEqual(SherpaOnnxLiveController.finalisationAllowance(forSessionSeconds: 1_200), 300)
+    }
 }
 #endif


### PR DESCRIPTION
## Defects (#679)

- `run_offline` re-decoded the **entire** accumulated recording every ~2 s **in the same loop that reads stdin**: quadratic work, and during each decode the pipe filled (64 KB ≈ 1 s of 16 kHz float32), blocking `SherpaOnnxAudioProcessor` in `FileHandle.write` and — via `stop()`'s `queue.sync` — the main actor.
- The final whole-buffer decode ran under a **fixed ten-second** exit window; at the measured ~0.04 RTF, sessions beyond ~4 minutes were terminated mid-finalisation and a stale partial was reported as the final, silently dropping trailing speech.
- (The casing-rescue exemption for Parakeet's native casing from this issue had already landed separately — `SherpaOnnxTranscriptNormalizer.emitsNativeCasing`.)

## Fix

**Sidecar** (embedded Python, syntax-verified with `py_compile`):
- A dedicated **reader thread always drains stdin** — ingestion is fully independent of inference; the audio queue can no longer block behind a decode.
- **Bounded partials**: decode a 60 s tail window at an **adaptive cadence** (≥ 2 s of new audio *and* ≥ 2× the previous decode's duration → decode duty-cycle ≤ ~50 % of wall clock even on slow machines). Per-partial cost is constant for any session length. For sessions longer than the window the live text shows the trailing window; the final is unaffected.
- **Explicit retention cap**: one hour of PCM (~230 MB); beyond it the oldest audio is dropped and a one-time `buffer_capped` event reports the truncation — bounded memory, never silent.
- The **session final still decodes every retained sample**, announced with a `finalizing` event carrying the buffered seconds.

**Controller**:
- `finalisationAllowance(forSessionSeconds:)` = `max(10 s, 0.25 × duration)` (six-fold headroom at the measured RTF); the wait also ends early once `session_final` arrives.
- A run whose sidecar never delivered `session_final` (forced termination or crash) now surfaces an **explicit failure** ("finalisation did not complete; the transcript may be missing trailing speech") instead of a success carrying a stale partial. Audio-persistence-based retry is out of scope here since this path retains no session PCM on the Swift side; the failure is explicit rather than silent, per the issue's fallback contract.

## Tests

Script-contract pins: reader thread + `eof`, bounded window and retention constants, adaptive-cadence term, `buffer_capped`/`finalizing`/full-final markers, and the **removal of the quadratic loop**. Allowance curve pinned at 0/30/240/1200 s. Existing recognizer-routing pins unchanged. Full suite: 1751 tests, 0 failures; `make lint` clean. Runtime validation against a live sidecar requires the sherpa-onnx Python environment and long synthetic streams — listed for the runtime verification pass rather than claimed here.

Fixes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8XQKx7ZPgnZrTd9R4iUW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session stopping so completion is confirmed before reporting success.
  * Preserved partial transcripts when finalization fails.
  * Added more reliable handling for process shutdown and delayed final results.
  * Improved transcription responsiveness by using bounded, adaptive audio processing.
  * Limited retained audio to prevent excessive memory use while preserving final results.
  * Added duration information and notifications when older audio is discarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->