### PR TITLE
fix(mac): make WhisperKit streaming lifecycle and finalisation lossless

### DIFF
--- a/Sources/SpeakApp/BoundedOperation.swift
+++ b/Sources/SpeakApp/BoundedOperation.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Runs an operation with a deadline the caller can rely on.
+///
+/// A late completion is discarded rather than awaited, so an operation that
+/// wedges (a Core ML decode, a socket send) cannot hold a stop path open
+/// indefinitely. The operation itself keeps running to completion in its own
+/// task; only the wait is bounded.
+enum BoundedOperation {
+    /// Returns the operation's outcome, or nil if `timeout` elapsed first.
+    static func run<Value: Sendable>(
+        timeout: Duration,
+        operation: @escaping @MainActor () async throws -> Value
+    ) async -> Result<Value, any Error>? {
+        let resumption = OnceResumption<Result<Value, any Error>?>()
+        var timeoutTask: Task<Void, Never>?
+        let outcome = await withCheckedContinuation { continuation in
+            resumption.arm(continuation)
+            Task { @MainActor in
+                do {
+                    resumption.resume(.success(try await operation()))
+                } catch {
+                    resumption.resume(.failure(error))
+                }
+            }
+            timeoutTask = Task {
+                guard (try? await Task.sleep(for: timeout)) != nil else { return }
+                resumption.resume(nil)
+            }
+        }
+        timeoutTask?.cancel()
+        return outcome
+    }
+
+    /// Resumes a continuation exactly once from whichever racing task
+    /// finishes first.
+    private final class OnceResumption<Value: Sendable>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Value, Never>?
+
+        func arm(_ continuation: CheckedContinuation<Value, Never>) {
+            lock.withLock { self.continuation = continuation }
+        }
+
+        func resume(_ value: Value) {
+            let continuation = lock.withLock { () -> CheckedContinuation<Value, Never>? in
+                defer { self.continuation = nil }
+                return self.continuation
+            }
+            continuation?.resume(returning: value)
+        }
+    }
+}

--- a/Sources/SpeakApp/WhisperKitLiveController.swift
+++ b/Sources/SpeakApp/WhisperKitLiveController.swift
@@ -1,39 +1,76 @@
 import Foundation
 import SpeakCore
-import WhisperKit
 
+/// Live local streaming via WhisperKit's `AudioStreamTranscriber`.
+///
+/// Lifecycle is the run-identity state machine shared with
+/// `FluidAudioParakeetLiveController`: every start mints a run ID before any
+/// awaited work, every later step and callback requires that ID to still be
+/// current, and stop retires the ID only after owned cleanup. A stop during
+/// cold model preparation therefore never lets the microphone start, late
+/// events from a retired run cannot touch a replacement, and each run produces
+/// exactly one terminal delegate outcome (issue #713).
+///
+/// Stop also owns finalisation: WhisperKit's streaming loop only decodes once
+/// more than a second of new audio exists, so the controller decodes the
+/// remaining tail itself before reporting the recording finished.
 @MainActor
 final class WhisperKitLiveController: LiveTranscriptionController {
+    typealias StreamProvider = @MainActor (
+        _ request: WhisperKitStreamRequest,
+        _ onEvent: @escaping WhisperKitStreamEventHandler
+    ) async throws -> any WhisperKitLiveStreaming
+
     weak var delegate: LiveTranscriptionSessionDelegate?
-    private(set) var isRunning = false
+
+    private enum Phase: Equatable {
+        case idle
+        case starting
+        case running
+        case stopping
+    }
+
+    var isRunning: Bool { phase == .running }
 
     private let permissionsManager: PermissionsManager
     private let audioDeviceManager: AudioInputDeviceManager
     private let modelManager: LocalModelManager
-    private var transcriber: AudioStreamTranscriber?
-    /// Identity of the stream run currently allowed to publish transcript text
-    /// and to resume `startupContinuation`. See `LiveTranscriptionRun.Token`:
-    /// the state-change callback is an argument to the transcriber's
-    /// initialiser, so it cannot capture the transcriber it belongs to.
-    private var activeRun: LiveTranscriptionRun.Token?
+    private let streamProvider: StreamProvider?
+    private let startupTimeout: Duration
+    private let finalisationTimeout: Duration
+    private let logger = SpeakLogger.logger(category: "WhisperKitLive")
+
+    private var phase: Phase = .idle
+    private var runID: UUID?
+    private var startTask: Task<Void, any Error>?
+    private var finishTask: Task<Void, Never>?
+    private var stream: (any WhisperKitLiveStreaming)?
     private var streamTask: Task<Void, Never>?
-    private var startupTask: Task<Void, Never>?
-    private var startupContinuation: CheckedContinuation<Void, Error>?
+    private var startupContinuation: CheckedContinuation<Void, any Error>?
+    private var startupTimeoutTask: Task<Void, Never>?
     private var activeInputSession: AudioInputDeviceManager.SessionContext?
     private var currentLanguage: String?
     private var currentModel = WhisperKitStreamingModel.prefix + "tiny"
+    private var latestState = WhisperKitTranscriptState()
     private var latestText = ""
     private var startedAt: Date?
-    private var isStopping = false
+    private var streamFailure: (any Error)?
+    private var didDeliverFailure = false
 
     init(
         permissionsManager: PermissionsManager,
         audioDeviceManager: AudioInputDeviceManager,
-        modelManager: LocalModelManager
+        modelManager: LocalModelManager,
+        streamProvider: StreamProvider? = nil,
+        startupTimeout: Duration = .seconds(10),
+        finalisationTimeout: Duration = .seconds(15)
     ) {
         self.permissionsManager = permissionsManager
         self.audioDeviceManager = audioDeviceManager
         self.modelManager = modelManager
+        self.streamProvider = streamProvider
+        self.startupTimeout = startupTimeout
+        self.finalisationTimeout = finalisationTimeout
     }
 
     func configure(language: String?, model: String) {
@@ -41,129 +78,201 @@ final class WhisperKitLiveController: LiveTranscriptionController {
         currentModel = model
     }
 
-    // swiftlint:disable:next function_body_length
     func start() async throws {
-        guard !isRunning, streamTask == nil, !isStopping else {
+        guard phase == .idle else {
             throw TranscriptionManagerError.liveSessionAlreadyRunning
         }
-        guard await permissionsManager.ensureGranted(.microphone).isGranted else {
-            throw TranscriptionManagerError.microphonePermissionMissing
-        }
-        guard let batchModelID = WhisperKitStreamingModel.batchModelID(from: currentModel) else {
-            throw TranscriptionManagerError.invalidLocalStreamingSource(currentModel)
-        }
-
-        let pipeline = try await modelManager.makeReadyPipeline(modelID: batchModelID)
-        guard let tokenizer = pipeline.tokenizer else {
-            throw TranscriptionManagerError.localLiveStreamingUnsupported
-        }
-
-        activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+        let run = UUID()
+        runID = run
+        phase = .starting
+        latestState = WhisperKitTranscriptState()
         latestText = ""
-        startedAt = Date()
+        streamFailure = nil
+        didDeliverFailure = false
 
-        let language = currentLanguage?
-            .split(whereSeparator: { $0 == "_" || $0 == "-" })
-            .first
-            .map(String.init)
-            .map { $0.lowercased() }
-        let options = DecodingOptions(
-            task: .transcribe,
-            language: language,
-            usePrefillPrompt: language != nil,
-            skipSpecialTokens: true,
-            wordTimestamps: true
-        )
-        // Published before the transcriber exists so the callback can never
-        // observe a window in which this run is not yet the active one. The
-        // callback hops to the main actor through an unstructured Task, so a
-        // state change from the previous recording can land after `stop()`
-        // returned; this controller instance is reused across recordings, so it
-        // would repaint the next recording's transcript — and worse, resume the
-        // next run's `startupContinuation` early (issue #668).
-        let run = LiveTranscriptionRun.Token()
-        activeRun = run
-
-        let transcriber = AudioStreamTranscriber(
-            audioEncoder: pipeline.audioEncoder,
-            featureExtractor: pipeline.featureExtractor,
-            segmentSeeker: pipeline.segmentSeeker,
-            textDecoder: pipeline.textDecoder,
-            tokenizer: tokenizer,
-            audioProcessor: pipeline.audioProcessor,
-            decodingOptions: options,
-            stateChangeCallback: { [weak self, weak run] oldState, newState in
-                Task { @MainActor [weak self, weak run] in
-                    guard let self,
-                        LiveTranscriptionRun.isCurrent(run, activeStream: self.activeRun)
-                    else { return }
-                    self.handleStateChange(from: oldState, to: newState)
-                }
+        // Startup runs in an owned task so a concurrent stop can cancel it and
+        // await its unwinding before tearing down whatever it already acquired.
+        let task = Task { @MainActor [weak self] in
+            guard let self else { throw CancellationError() }
+            try await self.performStart(run: run)
+        }
+        startTask = task
+        do {
+            try await task.value
+            if startTask == task { startTask = nil }
+        } catch {
+            if startTask == task { startTask = nil }
+            // When phase is `.stopping` a concurrent stop owns the teardown; it
+            // is already awaiting this task and cleans up once we unwind.
+            if runID == run, phase == .starting {
+                await teardownRunResources()
+                retire(run)
             }
-        )
-        self.transcriber = transcriber
-
-        try await withCheckedThrowingContinuation { continuation in
-            startupContinuation = continuation
-            streamTask = Task { [weak self, transcriber] in
-                do {
-                    try await transcriber.startStreamTranscription()
-                    await self?.streamEnded(error: nil)
-                } catch {
-                    await self?.streamEnded(error: error)
-                }
-            }
-            startupTask = Task { @MainActor [weak self] in
-                do {
-                    try await Task.sleep(for: .seconds(10))
-                } catch {
-                    return
-                }
-                guard let self, let continuation = self.startupContinuation else { return }
-                let activeStreamTask = self.streamTask
-                self.startupContinuation = nil
-                self.isStopping = true
-                continuation.resume(throwing: TranscriptionManagerError.localLiveStreamingStartupTimedOut)
-                await self.cleanupAfterFailedStart()
-                await activeStreamTask?.value
-                self.isStopping = false
-            }
+            throw error
         }
     }
 
     func stop() async {
-        guard isRunning || streamTask != nil else { return }
-        isStopping = true
-        startupTask?.cancel()
-        startupTask = nil
-        if let continuation = startupContinuation {
-            startupContinuation = nil
-            continuation.resume(throwing: TranscriptionManagerError.liveSessionNotRunning)
+        switch phase {
+        case .idle:
+            return
+        case .stopping:
+            await finishTask?.value
+        case .starting:
+            guard let run = runID else { return }
+            await finish { await self.abortStart(run) }
+        case .running:
+            guard let run = runID else { return }
+            await finish { await self.stopRunning(run, failure: nil) }
+        }
+    }
+
+    // MARK: - Startup
+
+    private func performStart(run: UUID) async throws {
+        guard await permissionsManager.ensureGranted(.microphone).isGranted else {
+            throw TranscriptionManagerError.microphonePermissionMissing
+        }
+        try ensureActive(run)
+        guard let batchModelID = WhisperKitStreamingModel.batchModelID(from: currentModel) else {
+            throw TranscriptionManagerError.invalidLocalStreamingSource(currentModel)
         }
 
-        if let transcriber {
-            await transcriber.stopStreamTranscription()
+        // Each resource is published to `self` immediately upon acquisition so
+        // a stop that cancelled this task can tear everything down after
+        // awaiting our unwinding.
+        let request = WhisperKitStreamRequest(
+            batchModelID: batchModelID,
+            language: Self.languageCode(currentLanguage)
+        )
+        let stream = try await makeStream(request: request, run: run)
+        self.stream = stream
+        try ensureActive(run)
+
+        activeInputSession = await audioDeviceManager.beginUsingPreferredInput()
+        try ensureActive(run)
+        startedAt = Date()
+
+        try await awaitFirstAudio(from: stream, run: run)
+        try ensureActive(run)
+        // The stream can end between its first audio and this resumption;
+        // that is a failed start, not a running session with a dead stream.
+        if let streamFailure {
+            throw streamFailure
         }
-        await streamTask?.value
+        phase = .running
+    }
+
+    private func makeStream(request: WhisperKitStreamRequest, run: UUID) async throws -> any WhisperKitLiveStreaming {
+        let onEvent: WhisperKitStreamEventHandler = { [weak self] event in
+            Task { @MainActor [weak self] in
+                self?.handle(event, run: run)
+            }
+        }
+        if let streamProvider {
+            return try await streamProvider(request, onEvent)
+        }
+        let pipeline = try await modelManager.makeReadyPipeline(modelID: request.batchModelID)
+        return try WhisperKitLiveStream(pipeline: pipeline, request: request, onEvent: onEvent)
+    }
+
+    /// Runs the stream and suspends until its first audio arrives, a timeout
+    /// elapses, the stream ends, or a stop resolves the wait.
+    private func awaitFirstAudio(from stream: any WhisperKitLiveStreaming, run: UUID) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            startupContinuation = continuation
+            streamTask = Task { @MainActor [weak self] in
+                do {
+                    try await stream.startStream()
+                    await self?.streamEnded(error: nil, run: run)
+                } catch {
+                    await self?.streamEnded(error: error, run: run)
+                }
+            }
+            startupTimeoutTask = Task { @MainActor [weak self, startupTimeout] in
+                guard (try? await Task.sleep(for: startupTimeout)) != nil else { return }
+                self?.resolveStartup(
+                    .failure(TranscriptionManagerError.localLiveStreamingStartupTimedOut),
+                    run: run
+                )
+            }
+        }
+    }
+
+    private func resolveStartup(_ result: Result<Void, any Error>, run: UUID) {
+        guard runID == run, let continuation = startupContinuation else { return }
+        startupContinuation = nil
+        startupTimeoutTask?.cancel()
+        startupTimeoutTask = nil
+        continuation.resume(with: result)
+    }
+
+    /// Startup barrier: throws unless `run` is still the live starting run.
+    private func ensureActive(_ run: UUID) throws {
+        try Task.checkCancellation()
+        guard runID == run, phase == .starting else {
+            throw CancellationError()
+        }
+    }
+
+    private static func languageCode(_ language: String?) -> String? {
+        language?
+            .split(whereSeparator: { $0 == "_" || $0 == "-" })
+            .first
+            .map { $0.lowercased() }
+    }
+}
+
+// MARK: - Stop
+
+extension WhisperKitLiveController {
+    private func finish(_ body: @escaping @MainActor () async -> Void) async {
+        phase = .stopping
+        let task = Task { @MainActor in await body() }
+        finishTask = task
+        await task.value
+        if finishTask == task { finishTask = nil }
+    }
+
+    private func abortStart(_ run: UUID) async {
+        let task = startTask
+        startTask = nil
+        task?.cancel()
+        resolveStartup(.failure(TranscriptionManagerError.liveSessionNotRunning), run: run)
+        _ = try? await task?.value
+        await teardownRunResources()
+        retire(run)
+    }
+
+    private func stopRunning(_ run: UUID, failure: (any Error)?) async {
+        let stream = self.stream
+        await stream?.stopStream()
+        // The streaming loop exits after its in-flight decode; the state
+        // changes it publishes on the way out still belong to this run.
+        let drain = streamTask
         streamTask = nil
-        // Retired only here, after the stream has drained, so the run's final
-        // state changes still count towards this recording's `latestText`.
-        activeRun = nil
-        transcriber = nil
-        isRunning = false
+        await drain?.value
 
-        if let activeInputSession {
-            await audioDeviceManager.endUsingPreferredInput(session: activeInputSession)
-            self.activeInputSession = nil
+        let failure = failure ?? streamFailure
+        var finalText = latestText
+        if failure == nil, let stream {
+            finalText = await finalise(with: stream)
         }
+        self.stream = nil
+        await endActiveInputSession()
 
         let duration = startedAt.map { Date().timeIntervalSince($0) } ?? 0
         startedAt = nil
-        isStopping = false
+        retire(run)
+
+        if let failure {
+            deliverFailureIfNeeded(failure)
+            return
+        }
         delegate?.liveTranscriber(
             self,
             didFinishWith: TranscriptionResult(
-                text: latestText,
+                text: finalText,
                 segments: [],
                 confidence: nil,
                 duration: duration,
@@ -175,88 +284,106 @@ final class WhisperKitLiveController: LiveTranscriptionController {
         )
     }
 
-    private func handleStateChange(
-        from oldState: AudioStreamTranscriber.State,
-        to newState: AudioStreamTranscriber.State
-    ) {
-        let beganProcessingAudio = newState.isRecording
-            && (oldState.currentText != newState.currentText
-                || oldState.bufferEnergy != newState.bufferEnergy
-                || oldState.lastBufferSize != newState.lastBufferSize)
-        if beganProcessingAudio, let continuation = startupContinuation {
-            startupTask?.cancel()
-            startupTask = nil
-            startupContinuation = nil
-            isRunning = true
-            continuation.resume()
+    /// Decodes the audio after the last confirmed segment so trailing speech
+    /// the streaming loop never reached (including recordings shorter than
+    /// its one-second minimum) makes it into the result.
+    private func finalise(with stream: any WhisperKitLiveStreaming) async -> String {
+        let state = latestState
+        let tailStart = WhisperKitTranscriptProjection.tailStart(for: state)
+        let outcome = await BoundedOperation.run(timeout: finalisationTimeout) {
+            try await stream.decodeTail(after: tailStart)
         }
-
-        guard oldState.currentText != newState.currentText
-            || oldState.confirmedSegments != newState.confirmedSegments
-            || oldState.unconfirmedSegments != newState.unconfirmedSegments
-        else { return }
-        handleState(newState)
+        switch outcome {
+        case .success(let tailText):
+            return WhisperKitTranscriptProjection.finalText(
+                for: state,
+                tailText: tailText,
+                displayedText: latestText
+            )
+        case .failure(let error):
+            logger.warning(
+                "WhisperKit tail decode failed; keeping streamed text: \(error.localizedDescription, privacy: .public)")
+            return latestText
+        case nil:
+            logger.warning("WhisperKit tail decode timed out; keeping streamed text")
+            return latestText
+        }
     }
 
-    private func handleState(_ state: AudioStreamTranscriber.State) {
-        let segmentText = (state.confirmedSegments + state.unconfirmedSegments)
-            .map(\.text)
-            .joined(separator: " ")
-        let currentText = state.currentText == "Waiting for speech..." ? "" : state.currentText
-        let text = clean([segmentText, currentText].joined(separator: " "))
-        guard text != latestText else { return }
-        latestText = text
-        delegate?.liveTranscriber(self, didUpdatePartial: text)
+    /// Cleanup for runs that never reached `.running`. Publishes no delegate
+    /// outcome: the start path throws to its caller instead.
+    private func teardownRunResources() async {
+        startupTimeoutTask?.cancel()
+        startupTimeoutTask = nil
+        if let stream {
+            self.stream = nil
+            await stream.stopStream()
+        }
+        let drain = streamTask
+        streamTask = nil
+        await drain?.value
+        await endActiveInputSession()
+        startedAt = nil
     }
 
-    private func streamEnded(error: Error?) async {
-        startupTask?.cancel()
-        startupTask = nil
-        if let continuation = startupContinuation {
-            startupContinuation = nil
-            continuation.resume(throwing: error ?? TranscriptionManagerError.liveSessionNotRunning)
-            await cleanupAfterFailedStart()
+    private func retire(_ run: UUID) {
+        guard runID == run else { return }
+        runID = nil
+        phase = .idle
+    }
+
+    private func endActiveInputSession() async {
+        guard let session = activeInputSession else { return }
+        activeInputSession = nil
+        await audioDeviceManager.endUsingPreferredInput(session: session)
+    }
+
+    private func deliverFailureIfNeeded(_ error: any Error) {
+        guard !didDeliverFailure else { return }
+        didDeliverFailure = true
+        delegate?.liveTranscriber(self, didFail: error)
+    }
+}
+
+// MARK: - Stream callbacks
+
+extension WhisperKitLiveController {
+    private func handle(_ event: WhisperKitStreamEvent, run: UUID) {
+        guard runID == run else { return }
+        switch event {
+        case .audioArrived:
+            resolveStartup(.success(()), run: run)
+        case .transcript(let state):
+            latestState = state
+            let text = WhisperKitTranscriptProjection.displayText(for: state)
+            guard text != latestText else { return }
+            latestText = text
+            delegate?.liveTranscriber(self, didUpdatePartial: text)
+        }
+    }
+
+    /// Called from the stream task when `startStream()` returns, so it must
+    /// never await that task.
+    private func streamEnded(error: (any Error)?, run: UUID) async {
+        guard runID == run else { return }
+        streamTask = nil
+        if startupContinuation != nil {
+            resolveStartup(.failure(error ?? TranscriptionManagerError.liveSessionNotRunning), run: run)
             return
         }
-        guard !isStopping else { return }
-        isRunning = false
-        streamTask = nil
-        activeRun = nil
-        if let transcriber {
-            await transcriber.stopStreamTranscription()
+        switch phase {
+        case .running:
+            // WhisperKit's loop also returns normally after an internal decode
+            // error, so any end while running is a failure of the run.
+            let failure = error ?? TranscriptionManagerError.liveSessionNotRunning
+            streamFailure = failure
+            await finish { await self.stopRunning(run, failure: failure) }
+        case .starting:
+            streamFailure = error ?? TranscriptionManagerError.liveSessionNotRunning
+        case .stopping:
+            if let error { streamFailure = error }
+        case .idle:
+            break
         }
-        transcriber = nil
-        startedAt = nil
-        await cleanupInputSession()
-        delegate?.liveTranscriber(
-            self,
-            didFail: error ?? TranscriptionManagerError.liveSessionNotRunning
-        )
-    }
-
-    private func cleanupAfterFailedStart() async {
-        streamTask = nil
-        activeRun = nil
-        if let transcriber {
-            await transcriber.stopStreamTranscription()
-        }
-        transcriber = nil
-        startedAt = nil
-        isRunning = false
-        await cleanupInputSession()
-    }
-
-    private func cleanupInputSession() async {
-        if let activeInputSession {
-            await audioDeviceManager.endUsingPreferredInput(session: activeInputSession)
-            self.activeInputSession = nil
-        }
-    }
-
-    private func clean(_ text: String) -> String {
-        text
-            .replacingOccurrences(of: "[BLANK_AUDIO]", with: "", options: .caseInsensitive)
-            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/SpeakApp/WhisperKitLiveStream.swift
+++ b/Sources/SpeakApp/WhisperKitLiveStream.swift
@@ -1,0 +1,238 @@
+import Foundation
+import SpeakCore
+import WhisperKit
+
+/// One spoken segment as WhisperKit reports it, timed from the start of the
+/// recording.
+struct WhisperKitSegment: Equatable, Sendable {
+    let start: Float
+    let end: Float
+    let text: String
+}
+
+/// The transcript-bearing part of WhisperKit's streaming state.
+struct WhisperKitTranscriptState: Equatable, Sendable {
+    /// Segments WhisperKit will not revise again.
+    var confirmedSegments: [WhisperKitSegment] = []
+    /// The latest complete decode of the audio after the confirmed segments;
+    /// replaced wholesale by the next decode.
+    var unconfirmedSegments: [WhisperKitSegment] = []
+    /// The hypothesis of the decode in progress. It covers the same audio as
+    /// `unconfirmedSegments` because every decode restarts at the end of the
+    /// last confirmed segment. WhisperKit parks a placeholder here while it
+    /// waits for speech.
+    var currentText: String = ""
+}
+
+/// What the streaming transcriber reports to the controller.
+enum WhisperKitStreamEvent: Equatable, Sendable {
+    /// Microphone audio reached the transcriber, so capture is live.
+    case audioArrived
+    case transcript(WhisperKitTranscriptState)
+}
+
+typealias WhisperKitStreamEventHandler = @Sendable (WhisperKitStreamEvent) -> Void
+
+struct WhisperKitStreamRequest: Equatable, Sendable {
+    let batchModelID: String
+    /// Two-letter language code, or nil to let the model detect it.
+    let language: String?
+}
+
+/// Boundary between `WhisperKitLiveController` and WhisperKit's streaming
+/// machinery. The controller's lifecycle, transcript projection and
+/// finalisation policy are written against this protocol so they can be
+/// exercised with deterministic events; `WhisperKitLiveStream` is the only
+/// production conformance.
+@MainActor
+protocol WhisperKitLiveStreaming: AnyObject {
+    /// Starts microphone capture and runs the realtime decode loop. Returns
+    /// only once `stopStream()` or a failure ends the loop.
+    func startStream() async throws
+    /// Stops capture. The decode loop notices after its in-flight iteration,
+    /// so callers drain `startStream()` before reading final state.
+    func stopStream() async
+    /// Decodes every captured sample after `confirmedEndSeconds` in one batch
+    /// pass, unconstrained by the streaming loop's one-second minimum.
+    func decodeTail(after confirmedEndSeconds: Float) async throws -> String
+}
+
+/// Replacement-semantic projection of WhisperKit streaming state into
+/// transcript text (issue #713).
+///
+/// Every streaming decode restarts at the end of the last confirmed segment,
+/// so the in-progress hypothesis re-covers the audio behind the unconfirmed
+/// segments: the two are alternatives, never neighbours. Unconfirmed segments
+/// are additionally checked against confirmed timing because WhisperKit
+/// publishes the confirmed and unconfirmed arrays in separate state changes,
+/// and one observation can hold the same segment in both.
+enum WhisperKitTranscriptProjection {
+    static let waitingPlaceholder = "Waiting for speech..."
+    /// Tails shorter than this cannot hold a word; decoding them only delays
+    /// the stop.
+    static let minimumTailSeconds: Float = 0.1
+
+    static func displayText(for state: WhisperKitTranscriptState) -> String {
+        let confirmed = state.confirmedSegments.map(\.text)
+        let hypothesis = state.currentText == waitingPlaceholder ? "" : clean(state.currentText)
+        let window: [String]
+        if hypothesis.isEmpty {
+            let confirmedEnd = state.confirmedSegments.last?.end
+            window = state.unconfirmedSegments
+                .filter { segment in confirmedEnd.map { segment.start >= $0 } ?? true }
+                .map(\.text)
+        } else {
+            window = [hypothesis]
+        }
+        return clean((confirmed + window).joined(separator: " "))
+    }
+
+    /// Where the stop-time tail decode starts: the confirmed text is kept
+    /// verbatim and everything after it is decoded again in full.
+    static func tailStart(for state: WhisperKitTranscriptState) -> Float {
+        state.confirmedSegments.last?.end ?? 0
+    }
+
+    /// The final transcript once capture has stopped. A non-empty tail decode
+    /// is authoritative for the audio after the confirmed segments; an empty
+    /// one keeps whatever the stream already displayed, so words the user saw
+    /// are never dropped by a silent final pass.
+    static func finalText(
+        for state: WhisperKitTranscriptState,
+        tailText: String,
+        displayedText: String
+    ) -> String {
+        let tail = clean(tailText)
+        guard !tail.isEmpty else { return displayedText }
+        return clean((state.confirmedSegments.map(\.text) + [tail]).joined(separator: " "))
+    }
+
+    static func tailSampleRange(
+        sampleCount: Int,
+        confirmedEndSeconds: Float,
+        sampleRate: Int
+    ) -> Range<Int>? {
+        let start = max(0, Int((max(0, confirmedEndSeconds) * Float(sampleRate)).rounded(.down)))
+        let minimumSamples = Int(minimumTailSeconds * Float(sampleRate))
+        guard start < sampleCount, sampleCount - start >= minimumSamples else { return nil }
+        return start..<sampleCount
+    }
+
+    static func clean(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "[BLANK_AUDIO]", with: "", options: .caseInsensitive)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+/// Production stream: WhisperKit's `AudioStreamTranscriber` for capture and
+/// streaming decodes, and the owning pipeline for the stop-time tail decode.
+@MainActor
+final class WhisperKitLiveStream: WhisperKitLiveStreaming {
+    private let pipeline: WhisperKit
+    private let transcriber: AudioStreamTranscriber
+    private let options: DecodingOptions
+
+    init(
+        pipeline: WhisperKit,
+        request: WhisperKitStreamRequest,
+        onEvent: @escaping WhisperKitStreamEventHandler
+    ) throws {
+        guard let tokenizer = pipeline.tokenizer else {
+            throw TranscriptionManagerError.localLiveStreamingUnsupported
+        }
+        let options = Self.decodingOptions(language: request.language)
+        self.pipeline = pipeline
+        self.options = options
+        self.transcriber = AudioStreamTranscriber(
+            audioEncoder: pipeline.audioEncoder,
+            featureExtractor: pipeline.featureExtractor,
+            segmentSeeker: pipeline.segmentSeeker,
+            textDecoder: pipeline.textDecoder,
+            tokenizer: tokenizer,
+            audioProcessor: pipeline.audioProcessor,
+            decodingOptions: options,
+            stateChangeCallback: { oldState, newState in
+                for event in Self.events(from: oldState, to: newState) {
+                    onEvent(event)
+                }
+            }
+        )
+    }
+
+    func startStream() async throws {
+        try await transcriber.startStreamTranscription()
+    }
+
+    func stopStream() async {
+        await transcriber.stopStreamTranscription()
+    }
+
+    func decodeTail(after confirmedEndSeconds: Float) async throws -> String {
+        // The processor keeps the whole recording until the next capture
+        // starts, so the tail is still addressable after `stopStream()`.
+        let samples = pipeline.audioProcessor.audioSamples
+        guard let range = WhisperKitTranscriptProjection.tailSampleRange(
+            sampleCount: samples.count,
+            confirmedEndSeconds: confirmedEndSeconds,
+            sampleRate: WhisperKit.sampleRate
+        ) else { return "" }
+        var tailOptions = options
+        tailOptions.clipTimestamps = []
+        let results = try await pipeline.transcribe(
+            audioArray: Array(samples[range]),
+            decodeOptions: tailOptions
+        )
+        return results.map { $0.text }.joined(separator: " ")
+    }
+
+    nonisolated static func decodingOptions(language: String?) -> DecodingOptions {
+        DecodingOptions(
+            task: .transcribe,
+            language: language,
+            usePrefillPrompt: language != nil,
+            skipSpecialTokens: true,
+            wordTimestamps: true
+        )
+    }
+
+    /// Audio arrival is inferred from any buffer energy, buffer size or
+    /// hypothesis change while recording: each of those needs microphone
+    /// samples to have reached the transcriber.
+    nonisolated static func events(
+        from oldState: AudioStreamTranscriber.State,
+        to newState: AudioStreamTranscriber.State
+    ) -> [WhisperKitStreamEvent] {
+        var events: [WhisperKitStreamEvent] = []
+        let hypothesisChanged = oldState.currentText != newState.currentText
+        if newState.isRecording,
+            hypothesisChanged
+                || oldState.bufferEnergy != newState.bufferEnergy
+                || oldState.lastBufferSize != newState.lastBufferSize {
+            events.append(.audioArrived)
+        }
+        if hypothesisChanged
+            || oldState.confirmedSegments != newState.confirmedSegments
+            || oldState.unconfirmedSegments != newState.unconfirmedSegments {
+            // The segment type is named through inference: SpeakCore declares
+            // its own `TranscriptionSegment`, and WhisperKit's cannot be
+            // module-qualified because the module also exports a class of
+            // the same name.
+            events.append(
+                .transcript(
+                    WhisperKitTranscriptState(
+                        confirmedSegments: newState.confirmedSegments.map {
+                            WhisperKitSegment(start: $0.start, end: $0.end, text: $0.text)
+                        },
+                        unconfirmedSegments: newState.unconfirmedSegments.map {
+                            WhisperKitSegment(start: $0.start, end: $0.end, text: $0.text)
+                        },
+                        currentText: newState.currentText
+                    )
+                )
+            )
+        }
+        return events
+    }
+}

--- a/Tests/SpeakAppTests/WhisperKitLiveControllerLifecycleTests.swift
+++ b/Tests/SpeakAppTests/WhisperKitLiveControllerLifecycleTests.swift
@@ -1,0 +1,267 @@
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// Lifecycle tests for issue #713: a WhisperKit start must be cancellable at
+/// every suspension before the microphone runs, a retired run must never
+/// touch its replacement, and each run gets exactly one terminal outcome.
+@MainActor
+final class WhisperKitLiveControllerLifecycleTests: XCTestCase {
+    private enum TestError: Error, Equatable {
+        case stream
+    }
+
+    // MARK: - Stop during startup
+
+    func testStopDuringPipelinePreparation_preventsStreamStart() async throws {
+        let gate = TestGate()
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make { _, onEvent in
+            await gate.wait()
+            stream.onEvent = onEvent
+            return stream
+        }
+
+        let startTask = Task { try await harness.controller.start() }
+        await gate.waitUntilEntered()
+        await harness.controller.stop()
+
+        let result = await startTask.result
+        guard case .failure = result else {
+            XCTFail("A start interrupted by stop must throw, not report success")
+            return
+        }
+        XCTAssertEqual(stream.startCount, 0, "Stop during model preparation must prevent capture from starting")
+        XCTAssertFalse(harness.controller.isRunning)
+        XCTAssertTrue(harness.delegate.finished.isEmpty)
+        XCTAssertTrue(
+            harness.delegate.failures.isEmpty,
+            "A cancelled start throws to its caller; the delegate gets no terminal outcome"
+        )
+
+        // The controller must be reusable for a clean replacement run.
+        await gate.open()
+        try await harness.startRunning(with: stream)
+        XCTAssertTrue(harness.controller.isRunning)
+        XCTAssertEqual(stream.startCount, 1)
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.finished.count, 1)
+        XCTAssertTrue(harness.delegate.failures.isEmpty)
+    }
+
+    func testStopWhileWaitingForFirstAudio_throwsAndStopsStream() async throws {
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+
+        let startTask = Task { try await harness.controller.start() }
+        await stream.waitUntilStarted(after: 0)
+        await harness.controller.stop()
+
+        let result = await startTask.result
+        guard case .failure(let error) = result else {
+            XCTFail("A start interrupted by stop must throw")
+            return
+        }
+        XCTAssertEqual(error as? TranscriptionManagerError, .liveSessionNotRunning)
+        XCTAssertGreaterThanOrEqual(stream.stopCount, 1, "The started stream must be stopped on abort")
+        XCTAssertFalse(harness.controller.isRunning)
+        XCTAssertTrue(harness.delegate.finished.isEmpty)
+        XCTAssertTrue(harness.delegate.failures.isEmpty)
+        XCTAssertTrue(stream.tailRequests.isEmpty, "An aborted start has nothing to finalise")
+
+        try await harness.startRunning(with: stream)
+        XCTAssertTrue(harness.controller.isRunning)
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.finished.count, 1)
+    }
+
+    func testStartupTimeout_throwsAndReleasesStream() async throws {
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make(stream: stream, startupTimeout: .milliseconds(50))
+
+        let result = await Task { try await harness.controller.start() }.result
+        guard case .failure(let error) = result else {
+            XCTFail("A stream that never delivers audio must time out")
+            return
+        }
+        XCTAssertEqual(error as? TranscriptionManagerError, .localLiveStreamingStartupTimedOut)
+        XCTAssertEqual(stream.stopCount, 1)
+        XCTAssertFalse(harness.controller.isRunning)
+        XCTAssertTrue(harness.delegate.finished.isEmpty)
+        XCTAssertTrue(harness.delegate.failures.isEmpty)
+
+        try await harness.startRunning(with: stream)
+        XCTAssertTrue(harness.controller.isRunning)
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.finished.count, 1)
+    }
+
+    func testStreamFailureBeforeFirstAudio_throwsWithoutDelegateOutcome() async throws {
+        let stream = MockWhisperKitStream()
+        stream.startError = TestError.stream
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+
+        let result = await Task { try await harness.controller.start() }.result
+        guard case .failure(let error) = result else {
+            XCTFail("A stream that fails to start must fail the start")
+            return
+        }
+        XCTAssertEqual(error as? TestError, .stream)
+        XCTAssertFalse(harness.controller.isRunning)
+        XCTAssertTrue(harness.delegate.finished.isEmpty)
+        XCTAssertTrue(harness.delegate.failures.isEmpty)
+
+        stream.startError = nil
+        try await harness.startRunning(with: stream)
+        XCTAssertTrue(harness.controller.isRunning)
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.finished.count, 1)
+    }
+
+    func testStreamEndingRightAfterFirstAudio_failsStartInsteadOfRunning() async throws {
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+
+        let startTask = Task { try await harness.controller.start() }
+        await stream.waitUntilStarted(after: 0)
+        // Both land on the main actor before the start path can resume: the
+        // audio event resolves the startup wait, then the stream ends.
+        stream.emit(.audioArrived)
+        stream.endStream()
+
+        let result = await startTask.result
+        guard case .failure = result else {
+            XCTFail("A stream that ends before the session is running must fail the start")
+            return
+        }
+        XCTAssertFalse(harness.controller.isRunning)
+        XCTAssertTrue(harness.delegate.finished.isEmpty)
+        XCTAssertTrue(harness.delegate.failures.isEmpty)
+
+        try await harness.startRunning(with: stream)
+        XCTAssertTrue(harness.controller.isRunning)
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.finished.count, 1)
+    }
+
+    // MARK: - Run isolation
+
+    func testLateEventsFromRetiredRun_doNotAffectReplacement() async throws {
+        let first = MockWhisperKitStream()
+        first.tailText = " first run"
+        let second = MockWhisperKitStream()
+        second.tailText = " second run"
+        let box = WhisperKitStreamBox(first)
+        let harness = WhisperKitLiveHarness.make { _, onEvent in
+            let stream = box.take()
+            stream.onEvent = onEvent
+            return stream
+        }
+
+        try await harness.startRunning(with: first)
+        let staleHandler = try XCTUnwrap(first.onEvent)
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.finished.map(\.text), ["first run"])
+
+        box.set(second)
+        try await harness.startRunning(with: second)
+        staleHandler(.transcript(WhisperKitTranscriptState(currentText: " stale text from the retired run")))
+        staleHandler(.audioArrived)
+        await drainWhisperKitAsyncWork()
+        XCTAssertTrue(
+            harness.delegate.partials.isEmpty,
+            "A late event from a retired run must not reach the delegate"
+        )
+        XCTAssertTrue(harness.controller.isRunning)
+
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.finished.map(\.text), ["first run", "second run"])
+        XCTAssertEqual(second.tailRequests, [0])
+        XCTAssertTrue(harness.delegate.failures.isEmpty)
+    }
+
+    func testStartWhileRunning_throwsWithoutDisturbingRun() async throws {
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+        try await harness.startRunning(with: stream)
+
+        do {
+            try await harness.controller.start()
+            XCTFail("A second start while running must throw")
+        } catch {
+            XCTAssertEqual(error as? TranscriptionManagerError, .liveSessionAlreadyRunning)
+        }
+        XCTAssertTrue(harness.controller.isRunning)
+        XCTAssertEqual(stream.startCount, 1)
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.finished.count, 1)
+    }
+
+    // MARK: - Exactly-once terminal outcome
+
+    func testStreamFailureMidRun_deliversExactlyOneFailure() async throws {
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+        try await harness.startRunning(with: stream)
+
+        stream.fail(TestError.stream)
+        await waitUntilWhisperKit { harness.delegate.failures.count == 1 }
+
+        XCTAssertEqual(harness.delegate.failures.count, 1)
+        XCTAssertEqual(harness.delegate.failures.first as? TestError, .stream)
+        XCTAssertTrue(harness.delegate.finished.isEmpty, "No success may follow a stream failure")
+        XCTAssertFalse(harness.controller.isRunning)
+        XCTAssertTrue(stream.tailRequests.isEmpty, "A failed run is not finalised")
+
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.failures.count, 1, "A stop after the failure adds no second outcome")
+        XCTAssertTrue(harness.delegate.finished.isEmpty)
+    }
+
+    func testStreamEndingWithoutErrorMidRun_isReportedAsFailure() async throws {
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+        try await harness.startRunning(with: stream)
+
+        stream.endStream()
+        await waitUntilWhisperKit { harness.delegate.failures.count == 1 }
+
+        XCTAssertEqual(harness.delegate.failures.first as? TranscriptionManagerError, .liveSessionNotRunning)
+        XCTAssertTrue(harness.delegate.finished.isEmpty)
+        XCTAssertFalse(harness.controller.isRunning)
+    }
+
+    // MARK: - Request mapping
+
+    func testStreamRequest_mapsStreamingModelAndLanguage() async throws {
+        let stream = MockWhisperKitStream()
+        var requests: [WhisperKitStreamRequest] = []
+        let harness = WhisperKitLiveHarness.make { request, onEvent in
+            requests.append(request)
+            stream.onEvent = onEvent
+            return stream
+        }
+        harness.controller.configure(language: "en-GB", model: WhisperKitStreamingModel.prefix + "base")
+
+        try await harness.startRunning(with: stream)
+        await harness.controller.stop()
+
+        XCTAssertEqual(requests, [WhisperKitStreamRequest(batchModelID: "local/whisperkit/base", language: "en")])
+    }
+
+    func testStart_rejectsNonWhisperKitModel() async throws {
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+        harness.controller.configure(language: nil, model: "local/streaming/other")
+
+        do {
+            try await harness.controller.start()
+            XCTFail("A model outside the WhisperKit streaming namespace must be rejected")
+        } catch {
+            XCTAssertEqual(error as? TranscriptionManagerError, .invalidLocalStreamingSource("local/streaming/other"))
+        }
+        XCTAssertEqual(stream.startCount, 0)
+        XCTAssertFalse(harness.controller.isRunning)
+    }
+}

--- a/Tests/SpeakAppTests/WhisperKitLiveFinalisationTests.swift
+++ b/Tests/SpeakAppTests/WhisperKitLiveFinalisationTests.swift
@@ -1,0 +1,195 @@
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// Finalisation and projection tests for issue #713: stop must decode the
+/// audio WhisperKit's streaming loop never reached, and partial output must
+/// never duplicate the window a decode hypothesis re-covers.
+@MainActor
+final class WhisperKitLiveFinalisationTests: XCTestCase {
+    private enum TestError: Error, Equatable {
+        case tail
+    }
+
+    // MARK: - Tail decode
+
+    func testSubSecondRecording_returnsTailDecode() async throws {
+        let stream = MockWhisperKitStream()
+        stream.tailText = " Yes."
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+
+        try await harness.startRunning(with: stream)
+        XCTAssertTrue(harness.delegate.partials.isEmpty, "Nothing was decoded while streaming")
+        await harness.controller.stop()
+
+        XCTAssertEqual(stream.tailRequests, [0], "With nothing confirmed the whole recording is decoded")
+        XCTAssertEqual(harness.delegate.finished.map(\.text), ["Yes."])
+        XCTAssertTrue(harness.delegate.failures.isEmpty)
+        XCTAssertFalse(harness.controller.isRunning)
+    }
+
+    func testLongerRecording_keepsPhraseFromFinalBuffer() async throws {
+        let stream = MockWhisperKitStream()
+        stream.tailText = " how are you"
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+
+        try await harness.startRunning(with: stream)
+        stream.emit(
+            .transcript(
+                WhisperKitTranscriptState(
+                    confirmedSegments: [whisperKitSegment(0, 2.5, " Hello there")],
+                    unconfirmedSegments: [whisperKitSegment(2.5, 3.2, " how")],
+                    currentText: ""
+                )
+            )
+        )
+        await drainWhisperKitAsyncWork()
+        XCTAssertEqual(harness.delegate.partials, ["Hello there how"])
+
+        await harness.controller.stop()
+
+        XCTAssertEqual(stream.tailRequests, [2.5], "The tail starts where the confirmed text ends")
+        XCTAssertEqual(harness.delegate.finished.map(\.text), ["Hello there how are you"])
+    }
+
+    func testEmptyTailDecode_keepsDisplayedText() async throws {
+        let stream = MockWhisperKitStream()
+        stream.tailText = " [BLANK_AUDIO] "
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+
+        try await harness.startRunning(with: stream)
+        stream.emit(
+            .transcript(
+                WhisperKitTranscriptState(
+                    confirmedSegments: [whisperKitSegment(0, 2, " Hello")],
+                    unconfirmedSegments: [],
+                    currentText: " world"
+                )
+            )
+        )
+        await drainWhisperKitAsyncWork()
+        await harness.controller.stop()
+
+        XCTAssertEqual(harness.delegate.finished.map(\.text), ["Hello world"])
+    }
+
+    func testTailDecodeFailure_keepsDisplayedText() async throws {
+        let stream = MockWhisperKitStream()
+        stream.tailError = TestError.tail
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+
+        try await harness.startRunning(with: stream)
+        stream.emit(.transcript(WhisperKitTranscriptState(currentText: " streamed words")))
+        await drainWhisperKitAsyncWork()
+        await harness.controller.stop()
+
+        XCTAssertEqual(harness.delegate.finished.map(\.text), ["streamed words"])
+        XCTAssertTrue(harness.delegate.failures.isEmpty, "A failed tail decode degrades, it does not fail the run")
+        XCTAssertFalse(harness.controller.isRunning)
+    }
+
+    func testTailDecodeTimeout_keepsDisplayedTextAndCompletesStop() async throws {
+        let stream = MockWhisperKitStream()
+        let tailGate = TestGate()
+        stream.tailGate = tailGate
+        stream.tailText = " late words"
+        let harness = WhisperKitLiveHarness.make(stream: stream, finalisationTimeout: .milliseconds(50))
+
+        try await harness.startRunning(with: stream)
+        stream.emit(.transcript(WhisperKitTranscriptState(currentText: " streamed words")))
+        await drainWhisperKitAsyncWork()
+        await harness.controller.stop()
+
+        XCTAssertEqual(harness.delegate.finished.map(\.text), ["streamed words"])
+        XCTAssertFalse(harness.controller.isRunning)
+
+        // A decode that completes after the deadline must not produce a second
+        // outcome or disturb a replacement run.
+        try await harness.startRunning(with: stream)
+        await tailGate.open()
+        await drainWhisperKitAsyncWork()
+        XCTAssertEqual(harness.delegate.finished.count, 1)
+        XCTAssertTrue(harness.controller.isRunning)
+        stream.tailGate = nil
+        await harness.controller.stop()
+        XCTAssertEqual(harness.delegate.finished.map(\.text), ["streamed words", "late words"])
+    }
+
+    // MARK: - Projection
+
+    func testHypothesisRevisingUnconfirmedWindow_neverDuplicatesWords() async throws {
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+        try await harness.startRunning(with: stream)
+
+        let confirmed = [whisperKitSegment(0, 2, " The cat")]
+        let unconfirmed = [whisperKitSegment(2, 3, " sat on")]
+        for currentText in ["", " sat", " sat on the", " sat on the mat"] {
+            stream.emit(
+                .transcript(
+                    WhisperKitTranscriptState(
+                        confirmedSegments: confirmed,
+                        unconfirmedSegments: unconfirmed,
+                        currentText: currentText
+                    )
+                )
+            )
+        }
+        await drainWhisperKitAsyncWork()
+
+        XCTAssertEqual(
+            harness.delegate.partials,
+            ["The cat sat on", "The cat sat", "The cat sat on the", "The cat sat on the mat"]
+        )
+        for partial in harness.delegate.partials {
+            XCTAssertFalse(partial.contains("sat on sat"), "Hypothesis must replace the unconfirmed window: \(partial)")
+        }
+        await harness.controller.stop()
+    }
+
+    func testConfirmationPublishedBeforeUnconfirmedReset_doesNotDuplicate() async throws {
+        let stream = MockWhisperKitStream()
+        let harness = WhisperKitLiveHarness.make(stream: stream)
+        try await harness.startRunning(with: stream)
+
+        // WhisperKit publishes a decode result as three state changes: the
+        // hypothesis clears, the confirmed array grows, then the unconfirmed
+        // array is replaced. The middle observation holds " sat on" in both.
+        let oldConfirmed = [whisperKitSegment(0, 2, " The cat")]
+        let oldUnconfirmed = [whisperKitSegment(2, 3, " sat on"), whisperKitSegment(3, 4, " the")]
+        let newConfirmed = oldConfirmed + [whisperKitSegment(2, 3, " sat on")]
+        let states = [
+            WhisperKitTranscriptState(
+                confirmedSegments: oldConfirmed,
+                unconfirmedSegments: oldUnconfirmed,
+                currentText: " sat on the mat"
+            ),
+            WhisperKitTranscriptState(
+                confirmedSegments: oldConfirmed,
+                unconfirmedSegments: oldUnconfirmed,
+                currentText: ""
+            ),
+            WhisperKitTranscriptState(
+                confirmedSegments: newConfirmed,
+                unconfirmedSegments: oldUnconfirmed,
+                currentText: ""
+            ),
+            WhisperKitTranscriptState(
+                confirmedSegments: newConfirmed,
+                unconfirmedSegments: [whisperKitSegment(3, 4, " the"), whisperKitSegment(4, 5, " mat")],
+                currentText: ""
+            )
+        ]
+        for state in states {
+            stream.emit(.transcript(state))
+        }
+        await drainWhisperKitAsyncWork()
+
+        XCTAssertEqual(
+            harness.delegate.partials,
+            ["The cat sat on the mat", "The cat sat on the", "The cat sat on the mat"]
+        )
+        await harness.controller.stop()
+    }
+}

--- a/Tests/SpeakAppTests/WhisperKitLiveTestDoubles.swift
+++ b/Tests/SpeakAppTests/WhisperKitLiveTestDoubles.swift
@@ -1,0 +1,171 @@
+import Foundation
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+// MARK: - Test doubles
+
+/// Stands in for WhisperKit behind `WhisperKitLiveStreaming`: the test drives
+/// stream events, stream termination and the stop-time tail decode directly.
+@MainActor
+final class MockWhisperKitStream: WhisperKitLiveStreaming {
+    var onEvent: WhisperKitStreamEventHandler?
+    /// Thrown from `startStream()` before any audio, like a capture failure.
+    var startError: (any Error)?
+    var tailText = ""
+    var tailError: (any Error)?
+    var tailGate: TestGate?
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    private(set) var tailRequests: [Float] = []
+    private var streamContinuation: CheckedContinuation<Void, any Error>?
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func startStream() async throws {
+        startCount += 1
+        let waiters = startedWaiters
+        startedWaiters = []
+        for waiter in waiters {
+            waiter.resume()
+        }
+        if let startError {
+            throw startError
+        }
+        try await withCheckedThrowingContinuation { continuation in
+            streamContinuation = continuation
+        }
+    }
+
+    func stopStream() async {
+        stopCount += 1
+        endStream()
+    }
+
+    func decodeTail(after confirmedEndSeconds: Float) async throws -> String {
+        tailRequests.append(confirmedEndSeconds)
+        if let tailGate {
+            await tailGate.wait()
+        }
+        if let tailError {
+            throw tailError
+        }
+        return tailText
+    }
+
+    /// Suspends until `startStream()` has been entered more than
+    /// `previousCount` times, so a reused stream waits for its *new* run.
+    func waitUntilStarted(after previousCount: Int) async {
+        guard startCount <= previousCount else { return }
+        await withCheckedContinuation { startedWaiters.append($0) }
+    }
+
+    func emit(_ event: WhisperKitStreamEvent) {
+        onEvent?(event)
+    }
+
+    /// Ends `startStream()` the way WhisperKit's loop does after an internal
+    /// decode error: by returning normally while still "recording".
+    func endStream() {
+        streamContinuation?.resume()
+        streamContinuation = nil
+    }
+
+    func fail(_ error: any Error) {
+        streamContinuation?.resume(throwing: error)
+        streamContinuation = nil
+    }
+}
+
+@MainActor
+final class WhisperKitStreamBox {
+    private var stream: MockWhisperKitStream
+
+    init(_ stream: MockWhisperKitStream) {
+        self.stream = stream
+    }
+
+    func set(_ stream: MockWhisperKitStream) {
+        self.stream = stream
+    }
+
+    func take() -> MockWhisperKitStream {
+        stream
+    }
+}
+
+// MARK: - Harness
+
+struct WhisperKitLiveHarness {
+    let controller: WhisperKitLiveController
+    let delegate: RecordingDelegate
+
+    @MainActor
+    static func make(
+        stream: MockWhisperKitStream,
+        startupTimeout: Duration = .seconds(5),
+        finalisationTimeout: Duration = .seconds(5)
+    ) -> WhisperKitLiveHarness {
+        make(startupTimeout: startupTimeout, finalisationTimeout: finalisationTimeout) { _, onEvent in
+            stream.onEvent = onEvent
+            return stream
+        }
+    }
+
+    @MainActor
+    static func make(
+        startupTimeout: Duration = .seconds(5),
+        finalisationTimeout: Duration = .seconds(5),
+        provider: @escaping WhisperKitLiveController.StreamProvider
+    ) -> WhisperKitLiveHarness {
+        let defaults = UserDefaults(suiteName: "whisperkit-live-tests-\(UUID().uuidString)") ?? .standard
+        let settings = AppSettings(defaults: defaults)
+        let permissions = PermissionsManager(statusProvider: { _ in .granted })
+        let audioDevices = AudioInputDeviceManager(appSettings: settings)
+        let delegate = RecordingDelegate()
+        let controller = WhisperKitLiveController(
+            permissionsManager: permissions,
+            audioDeviceManager: audioDevices,
+            modelManager: LocalModelManager.shared,
+            streamProvider: provider,
+            startupTimeout: startupTimeout,
+            finalisationTimeout: finalisationTimeout
+        )
+        controller.delegate = delegate
+        return WhisperKitLiveHarness(controller: controller, delegate: delegate)
+    }
+
+    /// Starts the controller and delivers the first audio so it reaches
+    /// `.running`.
+    @MainActor
+    func startRunning(with stream: MockWhisperKitStream) async throws {
+        let previousStarts = stream.startCount
+        let task = Task { try await controller.start() }
+        await stream.waitUntilStarted(after: previousStarts)
+        stream.emit(.audioArrived)
+        try await task.value
+    }
+}
+
+func whisperKitSegment(_ start: Float, _ end: Float, _ text: String) -> WhisperKitSegment {
+    WhisperKitSegment(start: start, end: end, text: text)
+}
+
+func drainWhisperKitAsyncWork() async {
+    for _ in 0..<20 {
+        await Task.yield()
+    }
+}
+
+@MainActor
+func waitUntilWhisperKit(
+    _ condition: @MainActor () -> Bool,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    for _ in 0..<200 {
+        if condition() { return }
+        try? await Task.sleep(for: .milliseconds(5))
+    }
+    XCTFail("Condition not met in time", file: file, line: line)
+}

--- a/Tests/SpeakAppTests/WhisperKitTranscriptProjectionTests.swift
+++ b/Tests/SpeakAppTests/WhisperKitTranscriptProjectionTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+
+@testable import SpeakApp
+
+/// The replacement-semantic projection behind `WhisperKitLiveController`
+/// (issue #713): confirmed text plus exactly one rendering of the audio after
+/// it, never the unconfirmed window and the hypothesis that re-decodes it.
+final class WhisperKitTranscriptProjectionTests: XCTestCase {
+    // MARK: - Display text
+
+    func testDisplayText_hypothesisReplacesUnconfirmedWindow() {
+        let state = WhisperKitTranscriptState(
+            confirmedSegments: [segment(0, 2, " The cat")],
+            unconfirmedSegments: [segment(2, 3, " sat on")],
+            currentText: " sat on the"
+        )
+        XCTAssertEqual(WhisperKitTranscriptProjection.displayText(for: state), "The cat sat on the")
+    }
+
+    func testDisplayText_fallsBackToUnconfirmedSegmentsWithoutHypothesis() {
+        let state = WhisperKitTranscriptState(
+            confirmedSegments: [segment(0, 2, " The cat")],
+            unconfirmedSegments: [segment(2, 3, " sat on"), segment(3, 4, " the mat")],
+            currentText: ""
+        )
+        XCTAssertEqual(WhisperKitTranscriptProjection.displayText(for: state), "The cat sat on the mat")
+    }
+
+    func testDisplayText_treatsWaitingPlaceholderAsNoHypothesis() {
+        let state = WhisperKitTranscriptState(
+            confirmedSegments: [],
+            unconfirmedSegments: [segment(0, 1, " Hello")],
+            currentText: WhisperKitTranscriptProjection.waitingPlaceholder
+        )
+        XCTAssertEqual(WhisperKitTranscriptProjection.displayText(for: state), "Hello")
+
+        let empty = WhisperKitTranscriptState(currentText: WhisperKitTranscriptProjection.waitingPlaceholder)
+        XCTAssertEqual(WhisperKitTranscriptProjection.displayText(for: empty), "")
+    }
+
+    func testDisplayText_dropsUnconfirmedSegmentsAlreadyCoveredByConfirmedTiming() {
+        // Mid-publication state: the segment was appended to the confirmed
+        // array but the unconfirmed array has not been replaced yet.
+        let state = WhisperKitTranscriptState(
+            confirmedSegments: [segment(0, 2, " The cat"), segment(2, 3, " sat on")],
+            unconfirmedSegments: [segment(2, 3, " sat on"), segment(3, 4, " the")],
+            currentText: ""
+        )
+        XCTAssertEqual(WhisperKitTranscriptProjection.displayText(for: state), "The cat sat on the")
+    }
+
+    func testDisplayText_cleansBlankAudioMarkersAndWhitespace() {
+        let state = WhisperKitTranscriptState(
+            confirmedSegments: [segment(0, 1, " [BLANK_AUDIO] "), segment(1, 2, "  Hello\n")],
+            unconfirmedSegments: [],
+            currentText: "  there   [blank_audio]"
+        )
+        XCTAssertEqual(WhisperKitTranscriptProjection.displayText(for: state), "Hello there")
+    }
+
+    // MARK: - Final text
+
+    func testFinalText_appendsTailDecodeToConfirmedText() {
+        let state = WhisperKitTranscriptState(
+            confirmedSegments: [segment(0, 2, " Hello there")],
+            unconfirmedSegments: [segment(2, 2.8, " how")],
+            currentText: " how are"
+        )
+        XCTAssertEqual(
+            WhisperKitTranscriptProjection.finalText(
+                for: state,
+                tailText: " how are you",
+                displayedText: "Hello there how are"
+            ),
+            "Hello there how are you"
+        )
+        XCTAssertEqual(WhisperKitTranscriptProjection.tailStart(for: state), 2)
+    }
+
+    func testFinalText_keepsDisplayedTextWhenTailDecodeIsEmpty() {
+        let state = WhisperKitTranscriptState(
+            confirmedSegments: [segment(0, 2, " Hello")],
+            unconfirmedSegments: [],
+            currentText: " world"
+        )
+        for tail in ["", "   ", " [BLANK_AUDIO] "] {
+            XCTAssertEqual(
+                WhisperKitTranscriptProjection.finalText(
+                    for: state,
+                    tailText: tail,
+                    displayedText: "Hello world"
+                ),
+                "Hello world"
+            )
+        }
+    }
+
+    func testTailStart_isZeroWithoutConfirmedSegments() {
+        XCTAssertEqual(WhisperKitTranscriptProjection.tailStart(for: WhisperKitTranscriptState()), 0)
+    }
+
+    // MARK: - Tail sample range
+
+    func testTailSampleRange_coversWholeBufferWhenNothingIsConfirmed() {
+        XCTAssertEqual(tailSampleRange(sampleCount: 8000, confirmedEndSeconds: 0), 0..<8000)
+    }
+
+    func testTailSampleRange_startsAtConfirmedEnd() {
+        XCTAssertEqual(tailSampleRange(sampleCount: 48_000, confirmedEndSeconds: 2.5), 40_000..<48_000)
+    }
+
+    func testTailSampleRange_isNilForTailsTooShortToHoldSpeech() {
+        XCTAssertNil(tailSampleRange(sampleCount: 1000, confirmedEndSeconds: 0))
+        XCTAssertNil(tailSampleRange(sampleCount: 16_000, confirmedEndSeconds: 1))
+        XCTAssertNil(tailSampleRange(sampleCount: 16_000, confirmedEndSeconds: 2))
+        XCTAssertNil(tailSampleRange(sampleCount: 0, confirmedEndSeconds: 0))
+    }
+
+    func testTailSampleRange_clampsNegativeConfirmedEnd() {
+        XCTAssertEqual(tailSampleRange(sampleCount: 4000, confirmedEndSeconds: -1), 0..<4000)
+    }
+
+    private func tailSampleRange(sampleCount: Int, confirmedEndSeconds: Float) -> Range<Int>? {
+        WhisperKitTranscriptProjection.tailSampleRange(
+            sampleCount: sampleCount,
+            confirmedEndSeconds: confirmedEndSeconds,
+            sampleRate: 16_000
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func segment(_ start: Float, _ end: Float, _ text: String) -> WhisperKitSegment {
+        WhisperKitSegment(start: start, end: end, text: text)
+    }
+}


### PR DESCRIPTION
Closes #713.

## Problem

The App Store WhisperKit streaming controller had three related correctness gaps:

1. `start()` awaited cold `makeReadyPipeline` work before publishing any cancellable state. A `stop()` during model loading saw neither `isRunning` nor `streamTask`, returned, and the resumed start activated the microphone against the user's explicit stop.
2. WhisperKit's streaming loop only decodes once more than one second of new audio exists, and `stopStreamTranscription()` stops capture without decoding the remaining buffer. Recordings under a second returned empty; longer ones lost their trailing phrase.
3. `handleState` concatenated confirmed + unconfirmed segments + `currentText`. The hypothesis re-decodes the audio behind the unconfirmed window (every decode restarts at `lastConfirmedSegmentEndSeconds`), so words were transiently duplicated in the HUD and in live insertion.

## Fix

**Lifecycle** — the run-identity state machine already used by `FluidAudioParakeetLiveController` (#715): a run ID and owned startup task exist before the first suspension, every later step (`ensureActive`) and every callback checks it, and stop retires the run only after owned cleanup. Stop while waiting for first audio resolves the startup wait; stop during pipeline preparation awaits the start task's unwinding before tearing down what it acquired. A stream that ends between first audio and `.running` now fails the start instead of leaving a "running" session with a dead stream. Each run produces exactly one terminal delegate outcome.

**Finalisation** — stop drains the stream, then decodes every sample after the last confirmed segment in one batch pass (`pipeline.transcribe(audioArray:)` over the retained processor buffer), so sub-second recordings and trailing phrases are included. The decode is bounded (`BoundedOperation`, 15s) so a wedged Core ML decode cannot hold the stop open; an empty, failed or timed-out tail keeps the already-displayed text, so words the user saw are never dropped by a silent final pass.

**Projection** — `WhisperKitTranscriptProjection.displayText` is replacement-semantic: confirmed text plus *either* the current hypothesis *or* the unconfirmed window. Unconfirmed segments whose start lies before the confirmed end are dropped, because WhisperKit publishes the confirmed and unconfirmed arrays in separate state changes and one observation can hold a segment in both.

**Boundary** — WhisperKit sits behind `WhisperKitLiveStreaming` (`startStream`/`stopStream`/`decodeTail`) with the controller's own `WhisperKitStreamEvent` / `WhisperKitTranscriptState` value types. WhisperKit's `AudioStreamTranscriber.State` has no public initialiser and `TranscriptionSegment` collides with SpeakCore's type, so the production adapter (`WhisperKitLiveStream`) is the only place those appear.

## Tests

30 new tests, all deterministic through the injected stream (`swift test --filter 'WhisperKitLive|WhisperKitTranscriptProjection'`):

- stop during pipeline preparation → start throws, capture never starts, controller reusable
- stop while waiting for first audio → `liveSessionNotRunning`, stream stopped, nothing finalised
- startup timeout, stream failure before first audio, stream ending right after first audio → start fails with no delegate outcome
- sub-second recording → tail decode of the whole buffer returned; longer recording → tail appended after the confirmed text from `confirmedEnd`
- empty / failing / timed-out tail decode → displayed text kept, stop completes, a late decode cannot produce a second outcome or disturb the next run
- hypothesis revising the unconfirmed window and WhisperKit's three-step confirmation publish → no duplicated words in any partial
- late events from a retired run ignored by the replacement; mid-run stream failure (thrown or normal return) → exactly one failure, no success
- pure projection / tail-range unit tests

Full `swift test` and `make lint` (strict) pass locally.

## Notes for review

- `stop()` during cold model preparation awaits the load before returning (same as the FluidAudio controller): `LocalModelManager.makeReadyPipeline` is not cancellation-aware, and the load is cached for the next start. The microphone never starts in that case.
- `LiveTranscriptionRun.Token` is no longer used by this controller; left in place as it documents #668 and carries no cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b
