### PR TITLE
feat(mac): show insertion latency percentiles with sample counts

### DIFF
--- a/Sources/SpeakApp/LatencyInsights.swift
+++ b/Sources/SpeakApp/LatencyInsights.swift
@@ -3,6 +3,22 @@ import SwiftUI
 
 // MARK: - Data Models
 
+/// Percentiles of one latency interval together with how many sessions
+/// measured it. Not every session measures every interval (batch sessions
+/// have no partials, failed sessions stop part-way), so the count travels
+/// with the percentiles rather than being inferred from the session count.
+struct LatencyDistribution: Equatable {
+  let sampleCount: Int
+  let p50: Int?
+  let p95: Int?
+
+  init(samples: [Int]) {
+    self.sampleCount = samples.count
+    self.p50 = LatencyPercentiles.p50(of: samples)
+    self.p95 = LatencyPercentiles.p95(of: samples)
+  }
+}
+
 /// Latency percentiles for one transcription provider, aggregated over history.
 struct ProviderLatencyInsight: Identifiable {
   /// Provider identifier, e.g. "deepgram", "openai", "apple".
@@ -10,11 +26,13 @@ struct ProviderLatencyInsight: Identifiable {
   let providerName: String
   let sessionCount: Int
   /// Capture start → first live partial (streaming providers only).
-  let firstPartialP50: Int?
-  let firstPartialP95: Int?
+  let firstPartial: LatencyDistribution
+  /// Capture start → first character visible in the target app. Streaming
+  /// sessions measure their first live insert; one-shot sessions measure the
+  /// final paste, so both kinds contribute a sample (issue #611).
+  let firstInsert: LatencyDistribution
   /// Stop pressed → final insert complete.
-  let stopToFinalP50: Int?
-  let stopToFinalP95: Int?
+  let stopToFinal: LatencyDistribution
 }
 
 /// Provider-independent start latency (hotkey → audio capture running).
@@ -28,13 +46,15 @@ struct LatencyOverview {
 
 private struct ProviderLatencyAccumulator {
   var firstPartial: [Int] = []
+  var firstInsert: [Int] = []
   var stopToFinal: [Int] = []
   var sessions = 0
 }
 
 extension Array where Element == HistoryItem {
   /// Groups measured sessions by transcription provider and computes
-  /// p50/p95 for first-partial and stop→final latency.
+  /// p50/p95 (with sample counts) for first-partial, first-insert and
+  /// stop→final latency.
   func latencyInsightsByProvider() -> [ProviderLatencyInsight] {
     var byProvider: [String: ProviderLatencyAccumulator] = [:]
 
@@ -44,6 +64,7 @@ extension Array where Element == HistoryItem {
       var accumulator = byProvider[provider] ?? ProviderLatencyAccumulator()
       accumulator.sessions += 1
       if let value = latency.firstPartialMs { accumulator.firstPartial.append(value) }
+      if let value = latency.firstInsertMs { accumulator.firstInsert.append(value) }
       if let value = latency.stopToFinalMs { accumulator.stopToFinal.append(value) }
       byProvider[provider] = accumulator
     }
@@ -54,10 +75,9 @@ extension Array where Element == HistoryItem {
           id: provider,
           providerName: Self.providerDisplayName(provider),
           sessionCount: accumulator.sessions,
-          firstPartialP50: LatencyPercentiles.p50(of: accumulator.firstPartial),
-          firstPartialP95: LatencyPercentiles.p95(of: accumulator.firstPartial),
-          stopToFinalP50: LatencyPercentiles.p50(of: accumulator.stopToFinal),
-          stopToFinalP95: LatencyPercentiles.p95(of: accumulator.stopToFinal)
+          firstPartial: LatencyDistribution(samples: accumulator.firstPartial),
+          firstInsert: LatencyDistribution(samples: accumulator.firstInsert),
+          stopToFinal: LatencyDistribution(samples: accumulator.stopToFinal)
         )
       }
       .sorted { $0.sessionCount > $1.sessionCount }
@@ -128,9 +148,13 @@ struct LatencyInsightsView: View {
           providerTable
         }
         if !density.isCompact {
-          Text("p50 / p95 across measured sessions. First words: capture to first partial. Finish: stop to inserted.")
-            .font(.caption)
-            .foregroundStyle(.secondary)
+          Text(
+            "p50 / p95 across measured sessions (sample count beside each row). "
+              + "First words: capture to first partial. First insert: capture to first visible character. "
+              + "Finish: stop to inserted."
+          )
+          .font(.caption)
+          .foregroundStyle(.secondary)
         }
       }
     }
@@ -150,12 +174,23 @@ struct LatencyInsightsView: View {
   }
 
   private var overviewRow: some View {
-    HStack {
+    HStack(spacing: density.inlineSpacing) {
       Label("Start (hotkey → audio)", systemImage: "power")
         .font(density.isCompact ? .caption : .subheadline)
+      if overview.sessionCount > 0 {
+        Text("×\(overview.sessionCount)")
+          .font((density.isCompact ? Font.caption2 : Font.caption).monospacedDigit())
+          .foregroundStyle(.tertiary)
+      }
       Spacer()
       percentilePair(p50: overview.captureStartP50, p95: overview.captureStartP95)
     }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(
+      "Start, hotkey to audio: p50 \(formatted(overview.captureStartP50)), "
+        + "p95 \(formatted(overview.captureStartP95)), "
+        + "\(overview.sessionCount) sample\(overview.sessionCount == 1 ? "" : "s")"
+    )
   }
 
   private var providerTable: some View {
@@ -170,16 +205,9 @@ struct LatencyInsightsView: View {
               .font(density.isCompact ? .caption2 : .caption)
               .foregroundStyle(.secondary)
           }
-          metricRow(
-            label: "First words",
-            p50: provider.firstPartialP50,
-            p95: provider.firstPartialP95
-          )
-          metricRow(
-            label: "Finish",
-            p50: provider.stopToFinalP50,
-            p95: provider.stopToFinalP95
-          )
+          metricRow(label: "First words", distribution: provider.firstPartial)
+          metricRow(label: "First insert", distribution: provider.firstInsert)
+          metricRow(label: "Finish", distribution: provider.stopToFinal)
         }
         .padding(density.isCompact ? 5 : 10)
         .background(
@@ -191,15 +219,23 @@ struct LatencyInsightsView: View {
   }
 
   @ViewBuilder
-  private func metricRow(label: String, p50: Int?, p95: Int?) -> some View {
-    if p50 != nil || p95 != nil {
-      HStack {
+  private func metricRow(label: String, distribution: LatencyDistribution) -> some View {
+    if distribution.sampleCount > 0 {
+      HStack(spacing: density.inlineSpacing) {
         Text(label)
           .font(density.isCompact ? .caption2 : .caption)
           .foregroundStyle(.secondary)
+        Text("×\(distribution.sampleCount)")
+          .font((density.isCompact ? Font.caption2 : Font.caption).monospacedDigit())
+          .foregroundStyle(.tertiary)
         Spacer()
-        percentilePair(p50: p50, p95: p95)
+        percentilePair(p50: distribution.p50, p95: distribution.p95)
       }
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(
+        "\(label): p50 \(formatted(distribution.p50)), p95 \(formatted(distribution.p95)), "
+          + "\(distribution.sampleCount) sample\(distribution.sampleCount == 1 ? "" : "s")"
+      )
     }
   }
 

--- a/Tests/SpeakAppTests/HistoryItemLatencyTests.swift
+++ b/Tests/SpeakAppTests/HistoryItemLatencyTests.swift
@@ -44,6 +44,7 @@ final class HistoryItemLatencyTests: XCTestCase {
 
     private func makeLatency(
         firstPartialMs: Int? = nil,
+        firstInsertMs: Int? = nil,
         stopToFinalMs: Int? = nil,
         captureStartMs: Int? = nil
     ) -> SessionLatencyMetrics {
@@ -55,9 +56,38 @@ final class HistoryItemLatencyTests: XCTestCase {
             hotKeyPressedAt: captureStartMs != nil ? hotKey : nil,
             captureStartedAt: capture,
             firstPartialAt: firstPartialMs.map { capture.addingTimeInterval(Double($0) / 1000) },
-            firstInsertAt: nil,
+            firstInsertAt: firstInsertMs.map { capture.addingTimeInterval(Double($0) / 1000) },
             stopPressedAt: stop,
             finalInsertAt: stopToFinalMs.map { stop.addingTimeInterval(Double($0) / 1000) }
+        )
+    }
+
+    private func streamingItem(
+        provider: String = "deepgram/nova-3",
+        firstPartialMs: Int,
+        firstInsertMs: Int,
+        stopToFinalMs: Int? = nil
+    ) -> HistoryItem {
+        self.makeItem(
+            modelUsages: [ModelUsage(modelIdentifier: provider, phase: .transcriptionLive)],
+            latency: self.makeLatency(
+                firstPartialMs: firstPartialMs,
+                firstInsertMs: firstInsertMs,
+                stopToFinalMs: stopToFinalMs
+            )
+        )
+    }
+
+    /// A one-shot (transcribe-then-paste) session: no partials, and the first
+    /// visible character is the final paste.
+    private func oneShotItem(
+        provider: String = "openai/whisper-1",
+        firstInsertMs: Int,
+        stopToFinalMs: Int? = nil
+    ) -> HistoryItem {
+        self.makeItem(
+            modelUsages: [ModelUsage(modelIdentifier: provider, phase: .transcriptionBatch)],
+            latency: self.makeLatency(firstInsertMs: firstInsertMs, stopToFinalMs: stopToFinalMs)
         )
     }
 
@@ -131,15 +161,88 @@ final class HistoryItemLatencyTests: XCTestCase {
 
         let deepgram = insights.first { $0.id == "deepgram" }
         XCTAssertEqual(deepgram?.sessionCount, 5)
-        XCTAssertEqual(deepgram?.firstPartialP50, 500)
-        XCTAssertEqual(deepgram?.firstPartialP95, 700)
-        XCTAssertEqual(deepgram?.stopToFinalP50, 600)
-        XCTAssertEqual(deepgram?.stopToFinalP95, 800)
+        XCTAssertEqual(deepgram?.firstPartial.p50, 500)
+        XCTAssertEqual(deepgram?.firstPartial.p95, 700)
+        XCTAssertEqual(deepgram?.stopToFinal.p50, 600)
+        XCTAssertEqual(deepgram?.stopToFinal.p95, 800)
 
         let apple = insights.first { $0.id == "apple" }
         XCTAssertEqual(apple?.sessionCount, 1)
-        XCTAssertEqual(apple?.firstPartialP50, 200)
-        XCTAssertNil(apple?.stopToFinalP50)
+        XCTAssertEqual(apple?.firstPartial.p50, 200)
+        XCTAssertNil(apple?.stopToFinal.p50)
+    }
+
+    // MARK: - Insertion latency (issue #611)
+
+    func testLatencyInsightsByProvider_AggregatesFirstInsertForStreamingSessions() {
+        let items = [350, 450, 550, 650, 750].map { insert in
+            self.streamingItem(firstPartialMs: insert - 50, firstInsertMs: insert, stopToFinalMs: 900)
+        }
+
+        let deepgram = items.latencyInsightsByProvider().first { $0.id == "deepgram" }
+        XCTAssertEqual(deepgram?.sessionCount, 5)
+        XCTAssertEqual(deepgram?.firstInsert, LatencyDistribution(samples: [350, 450, 550, 650, 750]))
+        XCTAssertEqual(deepgram?.firstInsert.sampleCount, 5)
+        XCTAssertEqual(deepgram?.firstInsert.p50, 550)
+        XCTAssertEqual(deepgram?.firstInsert.p95, 750)
+        XCTAssertEqual(deepgram?.firstPartial.sampleCount, 5)
+        XCTAssertEqual(deepgram?.stopToFinal.sampleCount, 5)
+    }
+
+    func testLatencyInsightsByProvider_AggregatesFirstInsertForOneShotFallbackSessions() {
+        let items = [
+            self.oneShotItem(firstInsertMs: 900, stopToFinalMs: 850),
+            self.oneShotItem(firstInsertMs: 1100, stopToFinalMs: 1050)
+        ]
+
+        let openai = items.latencyInsightsByProvider().first { $0.id == "openai" }
+        XCTAssertEqual(openai?.sessionCount, 2)
+        XCTAssertEqual(openai?.firstPartial.sampleCount, 0, "One-shot sessions have no partials")
+        XCTAssertNil(openai?.firstPartial.p50)
+        XCTAssertEqual(openai?.firstInsert.sampleCount, 2)
+        XCTAssertEqual(openai?.firstInsert.p50, 900)
+        XCTAssertEqual(openai?.firstInsert.p95, 1100)
+        XCTAssertEqual(openai?.stopToFinal.p50, 850)
+    }
+
+    func testLatencyInsightsByProvider_SampleCountsExcludeSessionsMissingThatInterval() {
+        let items = [
+            self.streamingItem(firstPartialMs: 300, firstInsertMs: 400),
+            // Streamed partials but never inserted (clipboard-only session).
+            self.makeItem(
+                modelUsages: [ModelUsage(modelIdentifier: "deepgram/nova-3", phase: .transcriptionLive)],
+                latency: self.makeLatency(firstPartialMs: 320)
+            ),
+            // Inserted at the end but stop-to-final unknown.
+            self.streamingItem(firstPartialMs: 280, firstInsertMs: 2000)
+        ]
+
+        let deepgram = items.latencyInsightsByProvider().first { $0.id == "deepgram" }
+        XCTAssertEqual(deepgram?.sessionCount, 3)
+        XCTAssertEqual(deepgram?.firstPartial.sampleCount, 3)
+        XCTAssertEqual(deepgram?.firstInsert.sampleCount, 2)
+        XCTAssertEqual(deepgram?.firstInsert.p50, 400)
+        XCTAssertEqual(deepgram?.firstInsert.p95, 2000)
+        XCTAssertEqual(deepgram?.stopToFinal.sampleCount, 0)
+    }
+
+    func testLatencyInsightsByProvider_KeepsStreamingAndOneShotProvidersSeparate() {
+        let items = [
+            self.streamingItem(firstPartialMs: 300, firstInsertMs: 400),
+            self.oneShotItem(firstInsertMs: 1200)
+        ]
+
+        let insights = items.latencyInsightsByProvider()
+        XCTAssertEqual(Set(insights.map(\.id)), ["deepgram", "openai"])
+        XCTAssertEqual(insights.first { $0.id == "deepgram" }?.firstInsert.p50, 400)
+        XCTAssertEqual(insights.first { $0.id == "openai" }?.firstInsert.p50, 1200)
+    }
+
+    func testLatencyDistribution_EmptySamplesHaveNoPercentiles() {
+        let distribution = LatencyDistribution(samples: [])
+        XCTAssertEqual(distribution.sampleCount, 0)
+        XCTAssertNil(distribution.p50)
+        XCTAssertNil(distribution.p95)
     }
 
     func testLatencyOverview_UsesCaptureStartSamplesOnly() {


### PR DESCRIPTION
Part of #611 — closes the post-merge audit gap noted on that issue: `firstInsertMs` was recorded and persisted by #644 but `latencyInsightsByProvider()` never consumed it, so the dashboard could not show insertion latency per provider.

## What changes

- `LatencyDistribution` (sample count + p50 + p95) replaces the loose `…P50/…P95` pairs on `ProviderLatencyInsight`, and a third distribution, **first insert** (capture start → first character visible in the target app), is aggregated alongside first-partial and stop→final. Sample counts travel with the percentiles because not every session measures every interval (one-shot sessions have no partials; clipboard-only sessions never insert; failed sessions stop part-way).
- The Latency dashboard card renders a **First insert** row per provider and shows the sample count (`×n`) beside every metric row, with an accessibility label that reads the percentiles and count. Footer copy explains the three intervals.
- `MainManagerSession` already derives `firstInsertMs` from the first live insertion, falling back to the final paste for one-shot sessions, so both session kinds contribute samples without producer changes.

## Tests

`HistoryItemLatencyTests` gains coverage for: streaming sessions (first insert aggregated with counts), one-shot fallback sessions (no partials, first insert = final paste), sample counts excluding sessions that lack the interval (clipboard-only, unknown stop-to-final), separate providers staying separate, and the empty distribution. Existing aggregation tests updated to the new accessors.

No snapshot test covers the dashboard latency card (only `LatencyBadge`), so no snapshots change.

Remaining #611 acceptance items (5-target streaming verification, cold-start budget, published benchmarks) are unchanged and stay with the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b
