### PR TITLE
fix(mac): make Voice Edit selection and audio ownership safe

### DIFF
--- a/Sources/SpeakApp/AudioFileManager.swift
+++ b/Sources/SpeakApp/AudioFileManager.swift
@@ -16,6 +16,10 @@ struct RecordingSummary: Identifiable, Hashable {
 enum AudioRecordingOwner: Sendable {
   case dictation
   case auxiliary
+  /// A Voice Edit instruction recording. Reported to the warm coordinator like
+  /// any auxiliary capture, but identified so dictation's failure cleanup can
+  /// never cancel it (issue #673).
+  case voiceEdit
 }
 
 enum AudioRecordingLifecycleEvent: Sendable {
@@ -429,7 +433,7 @@ actor AudioFileManager { // swiftlint:disable:this type_body_length
         try? FileManager.default.setAttributes(
           [.creationDate: startDate], ofItemAtPath: started.url.path)
       }
-      if owner == .auxiliary {
+      if owner != .dictation {
         self.lifecycleHandler?(.auxiliaryStarted)
       }
       return RecordingStart(url: started.url, usedWarmRecorder: started.isWarm)
@@ -567,14 +571,23 @@ actor AudioFileManager { // swiftlint:disable:this type_body_length
       activeInputSession = nil
     }
 
-    if owner == .auxiliary {
+    if owner != .dictation {
       self.lifecycleHandler?(.auxiliaryEnded)
     }
 
     return summary
   }
 
-  func cancelRecording(deleteFile: Bool = true) async {
+  /// Cancels the active recording. When `expectedOwner` is given, a recording
+  /// owned by another flow is left untouched: each flow may only cancel what
+  /// it started (issue #673).
+  func cancelRecording(
+    deleteFile: Bool = true,
+    ifOwnedBy expectedOwner: AudioRecordingOwner? = nil
+  ) async {
+    if let expectedOwner, let currentOwner = currentRecordingOwner, currentOwner != expectedOwner {
+      return
+    }
     let session = activeInputSession
     let owner = currentRecordingOwner
 
@@ -596,7 +609,7 @@ actor AudioFileManager { // swiftlint:disable:this type_body_length
       activeInputSession = nil
     }
 
-    if owner == .auxiliary {
+    if let owner, owner != .dictation {
       self.lifecycleHandler?(.auxiliaryEnded)
     }
   }

--- a/Sources/SpeakApp/CaptureSessionOwnership.swift
+++ b/Sources/SpeakApp/CaptureSessionOwnership.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// The single owner of the shared microphone recorder and live transcriber.
+///
+/// Normal dictation and Voice Edit both record through `AudioFileManager` and
+/// `TranscriptionManager`. Asking "is the other flow busy?" at start is not
+/// enough: the check and the start are separate suspensions, and each flow's
+/// failure path tears down resources the other may own. Every flow therefore
+/// reserves capture before touching either service and releases it only after
+/// its own teardown has finished, and a flow may only cancel the shared
+/// services while it holds the reservation (issue #673).
+@MainActor
+final class CaptureSessionOwnership {
+  enum Owner: Equatable, Sendable {
+    case dictation
+    case voiceEdit
+  }
+
+  private(set) var owner: Owner?
+
+  /// Claims capture for `owner`. Re-entrant for the current owner; false
+  /// while another flow holds it.
+  @discardableResult
+  func reserve(_ owner: Owner) -> Bool {
+    if let current = self.owner {
+      return current == owner
+    }
+    self.owner = owner
+    return true
+  }
+
+  /// Gives capture back. Ignored unless `owner` holds it, so a late release
+  /// from a finished flow can never free a reservation the other flow took.
+  func release(_ owner: Owner) {
+    guard self.owner == owner else { return }
+    self.owner = nil
+  }
+
+  func isHeld(by owner: Owner) -> Bool {
+    self.owner == owner
+  }
+
+  /// Whether `owner` may cancel the shared recorder and live stream: only
+  /// while it holds the reservation, or while nobody does.
+  func mayTearDownCapture(_ owner: Owner) -> Bool {
+    self.owner == nil || self.owner == owner
+  }
+}

--- a/Sources/SpeakApp/LiveTextInserter.swift
+++ b/Sources/SpeakApp/LiveTextInserter.swift
@@ -60,6 +60,12 @@ final class LiveTextInserter: ObservableObject { // swiftlint:disable:this type_
   /// (latency checkpoint: first character visible in the target app).
   private(set) var firstInsertionAt: Date?
 
+  /// UTF-16 range the finalised text occupies in the target field after the
+  /// last successful write, or nil when the session cannot vouch for where its
+  /// text landed. Voice Edit's "last dictation" fallback edits exactly this
+  /// range (issue #673).
+  private(set) var lastInsertedRange: VoiceEditTextRange?
+
   /// Strategy chosen for the current session.
   private(set) var strategy: InsertionStrategy = .fullValue
 
@@ -112,6 +118,7 @@ final class LiveTextInserter: ObservableObject { // swiftlint:disable:this type_
     firstInsertionVerified = false
     hasPerformedAccessibilityWrite = false
     self.firstInsertionAt = nil
+    self.lastInsertedRange = nil
     self.strategy = strategy
     self.streamingAnchorUTF16 = nil
     self.streamingPendingSelectionUTF16 = 0
@@ -143,6 +150,7 @@ final class LiveTextInserter: ObservableObject { // swiftlint:disable:this type_
     firstInsertionVerified = false
     hasPerformedAccessibilityWrite = false
     self.firstInsertionAt = nil
+    self.lastInsertedRange = nil
     self.strategy = .fullValue
     self.streamingAnchorUTF16 = nil
     self.streamingPendingSelectionUTF16 = 0
@@ -322,17 +330,22 @@ final class LiveTextInserter: ObservableObject { // swiftlint:disable:this type_
     )
 
     var finalValue: String
+    // UTF-16 offset where `newText` starts in `finalValue`, when known.
+    var insertedLocation: Int?
     if getStatus == .success, let current = currentValue as? String {
       // Remove what we previously inserted, add the new text
       if current.hasSuffix(insertedText) && !insertedText.isEmpty {
         let prefix = String(current.dropLast(insertedText.count))
         finalValue = prefix + newText
+        insertedLocation = prefix.utf16.count
       } else {
         // Can't find our inserted text - just append
         finalValue = current.isEmpty ? newText : current
+        insertedLocation = current.isEmpty ? 0 : nil
       }
     } else {
       finalValue = newText
+      insertedLocation = 0
     }
 
     let setResult = AXUIElementSetAttributeValue(
@@ -343,6 +356,9 @@ final class LiveTextInserter: ObservableObject { // swiftlint:disable:this type_
       recordAccessibilityWrite()
       insertedText = newText
       confirmedCharCount = insertedText.count
+      lastInsertedRange = insertedLocation.map {
+        VoiceEditTextRange(location: $0, length: newText.utf16.count)
+      }
       return .applied
     } else {
       deferToStandardDelivery(
@@ -383,6 +399,10 @@ final class LiveTextInserter: ObservableObject { // swiftlint:disable:this type_
       recordAccessibilityWrite()
       insertedText = text
       confirmedCharCount = text.count
+      lastInsertedRange = VoiceEditTextRange(
+        location: newValue.utf16.count - text.utf16.count,
+        length: text.utf16.count
+      )
       return .applied
     } else {
       deferToStandardDelivery(
@@ -506,6 +526,7 @@ extension LiveTextInserter {
       // the first partial.
       logger.warning("Streaming finalize: focused element lost, keeping streamed text")
       lastError = TextOutputError.unableToFindFocusedElement
+      recordStreamedRegion(length: insertedText.utf16.count)
       return .applied
     }
 
@@ -539,12 +560,14 @@ extension LiveTextInserter {
 
     let diff = StreamingTextReconciler.diff(from: insertedText, to: finalText)
     if diff.isNoOp {
+      recordStreamedRegion(length: finalText.utf16.count)
       return .applied
     }
 
     if applyStreamingDiff(diff, on: field) {
       insertedText = finalText
       confirmedCharCount = finalText.count
+      recordStreamedRegion(length: finalText.utf16.count)
       return .applied
     }
     if usingClipboardFallback {
@@ -561,7 +584,15 @@ extension LiveTextInserter {
     // delivery the user can see, which is a worse report than the mild
     // inaccuracy of treating a near-final transcript as delivered.
     logger.warning("Streaming finalize failed after writes; keeping streamed text")
+    recordStreamedRegion(length: insertedText.utf16.count)
     return .applied
+  }
+
+  /// Publishes the streamed region as this session's final insertion range.
+  private func recordStreamedRegion(length: Int) {
+    lastInsertedRange = self.streamingAnchorUTF16.map {
+      VoiceEditTextRange(location: $0, length: length)
+    }
   }
 
   /// Selects `diff`'s range (offset by the region anchor) and replaces it.

--- a/Sources/SpeakApp/MainManager+InsertionRecord.swift
+++ b/Sources/SpeakApp/MainManager+InsertionRecord.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+// MARK: - Insertion record for Voice Edit's "last dictation" fallback (issue #673)
+
+extension MainManager {
+  /// Remembers where this dictation landed. An unknown range clears the
+  /// previous record rather than leaving it in place, so Voice Edit can never
+  /// rewrite the range of an older dictation after a newer one was delivered
+  /// somewhere it could not track.
+  func recordInsertion(of text: String, range: VoiceEditTextRange?, target: TextOutputTarget?) {
+    guard let target, let range, !text.isEmpty else {
+      insertionRecords.clear()
+      return
+    }
+    insertionRecords.record(
+      InsertionRecord(target: target, range: range, text: text, recordedAt: Date())
+    )
+  }
+}

--- a/Sources/SpeakApp/MainManager+SessionDiagnostics.swift
+++ b/Sources/SpeakApp/MainManager+SessionDiagnostics.swift
@@ -49,10 +49,18 @@ extension MainManager {
         stopAudioLevelMonitoring()
         livePolishManager.reset()
         liveTextInserter.reset()
-        if isStreamingTranscriptionMode { transcriptionManager.cancelLiveTranscription() }
+        // The recorder and live stream are shared with Voice Edit: only cancel
+        // them while dictation owns capture, and never a recording another
+        // flow started (issue #673).
+        let mayTearDownCapture = captureOwnership.mayTearDownCapture(.dictation)
+        if isStreamingTranscriptionMode, mayTearDownCapture {
+            transcriptionManager.cancelLiveTranscription()
+        }
         if let session = activeSession { attachFailureDiagnostics(to: session) }
         Task { [failedSession = activeSession] in
-            await audioFileManager.cancelRecording(deleteFile: !preserveFile)
+            if mayTearDownCapture {
+                await audioFileManager.cancelRecording(deleteFile: !preserveFile, ifOwnedBy: .dictation)
+            }
             if let session = failedSession {
                 let historyItem = session.buildHistoryItem(finalText: session.transcriptionResult?.text)
                 await historyManager.append(historyItem)

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -77,6 +77,15 @@ final class MainManager: ObservableObject {
   /// Applies/reverts per-app dictation profile overrides for a session.
   private let profileApplier = SessionProfileApplier()
 
+  /// Reservation shared with Voice Edit for the recorder and live transcriber
+  /// (issue #673). Dictation claims it in `startSession` and gives it back
+  /// whenever `activeSession` clears.
+  let captureOwnership = CaptureSessionOwnership()
+
+  /// Where the last dictation landed, for Voice Edit's "last dictation"
+  /// fallback (issue #673).
+  let insertionRecords = InsertionRecordStore()
+
   var activeSession: ActiveSession? {
     didSet {
       // Every session-teardown path clears `activeSession`, so this is the one
@@ -85,6 +94,7 @@ final class MainManager: ObservableObject {
       if activeSession == nil {
         profileApplier.end(settings: appSettings, postProcessing: postProcessingManager)
         captureWarmer?.sessionDidEnd()
+        captureOwnership.release(.dictation)
       }
     }
   }
@@ -591,6 +601,23 @@ final class MainManager: ObservableObject {
         message: "Plug in a USB or Bluetooth microphone and try again."
       )
       return .rejected(.audioUnavailable)
+    }
+
+    // Voice Edit may own the shared recorder and live stream right now. Starting
+    // on top of it would hit `alreadyRecording` and the failure path would then
+    // cancel Voice Edit's capture, so refuse before touching either (issue #673).
+    guard captureOwnership.reserve(.dictation) else {
+      profileApplier.end(settings: appSettings, postProcessing: postProcessingManager)
+      captureWarmer?.sessionDidEnd()
+      let message = "Voice edit is in progress. Finish or cancel it first."
+      state = .failed(message)
+      lastErrorMessage = message
+      hudManager.finishFailure(
+        headline: "Voice edit in progress",
+        message: "Finish or cancel the voice edit, then start dictation.",
+        displayDuration: 3
+      )
+      return .rejected(.captureFailed)
     }
 
     // Failsafe: if live transcription is still running but we have no activeSession,
@@ -1109,10 +1136,18 @@ final class MainManager: ObservableObject {
       switch liveFinalizationResult {
       case .applied:
         session.outputMethod = .accessibility
+        recordInsertion(
+          of: liveTextInserter.insertedText,
+          range: liveTextInserter.lastInsertedRange,
+          target: session.outputTarget
+        )
       case .deferred:
         let output = SmartTextOutput(permissionsManager: permissionsManager, appSettings: appSettings)
         let outputResult = output.output(text: finalText, target: session.outputTarget)
         session.outputMethod = outputResult.method
+        if outputResult.error == nil {
+          recordInsertion(of: finalText, range: outputResult.insertedRange, target: session.outputTarget)
+        }
 
         if let error = outputResult.error {
           session.errors.append(
@@ -1292,6 +1327,9 @@ final class MainManager: ObservableObject {
       let outputResult = output.output(text: finalText, target: session.outputTarget)
       session.outputMethod = outputResult.method
       session.outputDelivered = Date()
+      if outputResult.error == nil {
+        recordInsertion(of: finalText, range: outputResult.insertedRange, target: session.outputTarget)
+      }
 
       if let error = outputResult.error {
         session.errors.append(

--- a/Sources/SpeakApp/PasteboardSnapshot.swift
+++ b/Sources/SpeakApp/PasteboardSnapshot.swift
@@ -1,0 +1,45 @@
+import AppKit
+
+/// Byte-for-byte copy of everything on a pasteboard — every item and every
+/// type — so a temporary paste can put the user's clipboard back exactly as it
+/// was, whether it held plain text, rich text, an image, files or several
+/// items at once (issue #673).
+struct PasteboardSnapshot: Equatable {
+  let items: [[NSPasteboard.PasteboardType: Data]]
+
+  init(items: [[NSPasteboard.PasteboardType: Data]]) {
+    self.items = items
+  }
+
+  /// Reads every item and type currently on `pasteboard`. Promised data is
+  /// resolved now, because the source app may be gone by the time we restore.
+  init(reading pasteboard: NSPasteboard) {
+    let pasteboardItems = pasteboard.pasteboardItems ?? []
+    self.items = pasteboardItems.compactMap { item in
+      var contents: [NSPasteboard.PasteboardType: Data] = [:]
+      for type in item.types {
+        if let data = item.data(forType: type) {
+          contents[type] = data
+        }
+      }
+      return contents.isEmpty ? nil : contents
+    }
+  }
+
+  var isEmpty: Bool { items.isEmpty }
+
+  /// Replaces the pasteboard's contents with the snapshot. An empty snapshot
+  /// leaves the pasteboard cleared, which is what the user had.
+  func restore(to pasteboard: NSPasteboard) {
+    pasteboard.clearContents()
+    guard !items.isEmpty else { return }
+    let objects = items.map { contents -> NSPasteboardItem in
+      let item = NSPasteboardItem()
+      for (type, data) in contents {
+        item.setData(data, forType: type)
+      }
+      return item
+    }
+    pasteboard.writeObjects(objects)
+  }
+}

--- a/Sources/SpeakApp/Services/ShortcutManager.swift
+++ b/Sources/SpeakApp/Services/ShortcutManager.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Carbon
 import Foundation
+import SpeakCore
 import SpeakHotKeys
 
 // swiftlint:disable file_length
@@ -169,6 +170,28 @@ enum ShortcutAction: String, CaseIterable, Identifiable, Codable {
             return false
         }
     }
+
+    /// The build capability this action needs, or nil when every channel has it.
+    var requiredChannelFeature: ChannelFeature? {
+        switch self {
+        case .editSelectionByVoice:
+            return .voiceEdit
+        default:
+            return nil
+        }
+    }
+
+    /// Whether this action can work in `channel`. Unavailable actions are never
+    /// registered, dispatched or listed, so a build does not offer a flow that
+    /// can only end in "Nothing to edit" (issue #673).
+    func isAvailable(in channel: DistributionChannel) -> Bool {
+        guard let feature = requiredChannelFeature else { return true }
+        return channel.supports(feature)
+    }
+
+    static func availableCases(in channel: DistributionChannel = .current) -> [ShortcutAction] {
+        allCases.filter { $0.isAvailable(in: channel) }
+    }
 }
 
 /// Represents a keyboard shortcut binding.
@@ -285,8 +308,10 @@ final class ShortcutManager: ObservableObject {
         unregisterCarbonHotkeys()
     }
 
-    /// Registers a handler for a specific shortcut action.
+    /// Registers a handler for a specific shortcut action. Actions the current
+    /// distribution channel cannot support are ignored, so they can never fire.
     func register(action: ShortcutAction, handler: @escaping () -> Void) {
+        guard action.isAvailable(in: .current) else { return }
         handlers[action] = handler
     }
 
@@ -426,7 +451,7 @@ final class ShortcutManager: ObservableObject {
         }
 
         for (action, binding) in bindings {
-            guard binding.isEnabled else { continue }
+            guard binding.isEnabled, action.isAvailable(in: .current) else { continue }
             guard binding.isGlobal == isGlobal || !isGlobal else { continue }
 
             if event.keyCode == binding.keyCode && modifiers == binding.modifiers {
@@ -449,7 +474,7 @@ final class ShortcutManager: ObservableObject {
     private func registerCarbonHotkeys() {
         installCarbonEventHandler()
         for (action, binding) in bindings {
-            guard binding.isEnabled && binding.isGlobal else { continue }
+            guard binding.isEnabled && binding.isGlobal, action.isAvailable(in: .current) else { continue }
 
             var hotKeyRef: EventHotKeyRef?
             let carbonModifiers = carbonModifierFlags(from: binding.modifiers)
@@ -531,7 +556,9 @@ final class ShortcutManager: ObservableObject {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             guard !self.isRecordingShortcut else { return }
-            guard let action = self.carbonHotKeyActions[hotKeyID.id] else { return }
+            guard let action = self.carbonHotKeyActions[hotKeyID.id], action.isAvailable(in: .current) else {
+                return
+            }
             guard let binding = self.bindings[action], binding.isEnabled && binding.isGlobal else { return }
             self.handlers[action]?()
         }

--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -37,6 +37,20 @@ private let logger = SpeakLogger.logger(category: "TextOutput")
 struct TextOutputResult {
   let method: HistoryTrigger.OutputMethod
   let error: Error?
+  /// Where the text landed in the focused field, when the delivery path can
+  /// tell. Voice Edit's "last dictation" fallback edits this exact range
+  /// (issue #673).
+  let insertedRange: VoiceEditTextRange?
+
+  init(
+    method: HistoryTrigger.OutputMethod,
+    error: Error?,
+    insertedRange: VoiceEditTextRange? = nil
+  ) {
+    self.method = method
+    self.error = error
+    self.insertedRange = insertedRange
+  }
 }
 
 private func currentSystemFocusedElement() -> AXUIElement? {
@@ -171,22 +185,7 @@ struct AccessibilityTextOutput: TextOutputting {
 
     switch appSettings.accessibilityInsertionMode {
     case .insertAtCursor:
-      // Insert at cursor by replacing the current selection (or inserting if selection is empty)
-      let setResult = AXUIElementSetAttributeValue(
-        focusedElement, kAXSelectedTextAttribute as CFString, text as CFTypeRef)
-      guard setResult == .success else {
-        // Fall back to replacing the whole field if selected text insertion isn't supported
-        let fallbackResult = AXUIElementSetAttributeValue(
-          focusedElement, kAXValueAttribute as CFString, text as CFTypeRef)
-        guard fallbackResult == .success else {
-          return TextOutputResult(
-            method: .none,
-            error: TextOutputError.unableToSetValue(fallbackResult)
-          )
-        }
-        return TextOutputResult(method: .accessibility, error: nil)
-      }
-      return TextOutputResult(method: .accessibility, error: nil)
+      return insertAtCursor(text, into: focusedElement)
 
     case .replaceAll:
       let setResult = AXUIElementSetAttributeValue(
@@ -197,10 +196,45 @@ struct AccessibilityTextOutput: TextOutputting {
           error: TextOutputError.unableToSetValue(setResult)
         )
       }
-      return TextOutputResult(method: .accessibility, error: nil)
+      return TextOutputResult(
+        method: .accessibility,
+        error: nil,
+        insertedRange: VoiceEditTextRange(location: 0, length: text.utf16.count)
+      )
     }
   }
 
+  /// Replaces the current selection (or inserts at the caret), falling back to
+  /// replacing the whole field when the app rejects selected-text insertion.
+  private func insertAtCursor(_ text: String, into focusedElement: AXUIElement) -> TextOutputResult {
+    // The selection about to be replaced tells us where the text will land.
+    let selectionBeforeInsert = AccessibilityStreamingTextField(element: focusedElement)
+      .readSelectedRange()
+    let setResult = AXUIElementSetAttributeValue(
+      focusedElement, kAXSelectedTextAttribute as CFString, text as CFTypeRef)
+    guard setResult == .success else {
+      let fallbackResult = AXUIElementSetAttributeValue(
+        focusedElement, kAXValueAttribute as CFString, text as CFTypeRef)
+      guard fallbackResult == .success else {
+        return TextOutputResult(
+          method: .none,
+          error: TextOutputError.unableToSetValue(fallbackResult)
+        )
+      }
+      return TextOutputResult(
+        method: .accessibility,
+        error: nil,
+        insertedRange: VoiceEditTextRange(location: 0, length: text.utf16.count)
+      )
+    }
+    return TextOutputResult(
+      method: .accessibility,
+      error: nil,
+      insertedRange: selectionBeforeInsert.map {
+        VoiceEditTextRange(location: $0.location, length: text.utf16.count)
+      }
+    )
+  }
 }
 
 // @Implement: This implementation should use the clipboard to paste text into the focused app. It should restore the previous pasteboard value (if the app setting output to clipboard is false) It should respect any relevant settings from app settings
@@ -233,13 +267,16 @@ struct PasteTextOutput: TextOutputting {
 
     let canPasteIntoOtherApps = DistributionChannel.current.supportsAccessibilityTextInsertion
     let restoreClipboard = canPasteIntoOtherApps && appSettings.restoreClipboardAfterPaste
-    let previousString = restoreClipboard ? pasteboard.string(forType: .string) : nil
+    // Every item and type, not just the string: an image, file or rich-only
+    // clipboard must survive the temporary paste intact (issue #673).
+    let previousContents = restoreClipboard ? PasteboardSnapshot(reading: pasteboard) : nil
 
     pasteboard.clearContents()
     guard pasteboard.setString(text, forType: .string) else {
       return TextOutputResult(method: .none, error: TextOutputError.clipboardWriteFailed)
     }
 
+    var insertedRange: VoiceEditTextRange?
     if canPasteIntoOtherApps {
       let destination = Self.eventDestination(for: target)
       guard destination != .none else {
@@ -248,16 +285,30 @@ struct PasteTextOutput: TextOutputting {
           error: TextOutputError.targetApplicationUnavailable
         )
       }
+      // Read before the paste replaces the selection; the pasted text starts
+      // where the selection started.
+      insertedRange = pasteLandingRange(in: target, for: text)
       guard simulatePasteShortcut(destination: destination) else {
         return TextOutputResult(method: .clipboard, error: TextOutputError.pasteShortcutUnavailable)
       }
     }
 
-    if restoreClipboard {
-      scheduleClipboardRestore(previousString, on: pasteboard)
+    if let previousContents {
+      scheduleClipboardRestore(previousContents, on: pasteboard)
     }
 
-    return TextOutputResult(method: .clipboard, error: nil)
+    return TextOutputResult(method: .clipboard, error: nil, insertedRange: insertedRange)
+  }
+
+  /// Where `text` will land in the captured field, when Accessibility lets us
+  /// read the current selection. Nil when unknown; consumers verify the text
+  /// at the range before trusting it.
+  private func pasteLandingRange(in target: TextOutputTarget?, for text: String) -> VoiceEditTextRange? {
+    guard let element = target?.focusedElement,
+      permissionsManager.status(for: .accessibility).isGranted,
+      let selection = AccessibilityStreamingTextField(element: element).readSelectedRange()
+    else { return nil }
+    return VoiceEditTextRange(location: selection.location, length: text.utf16.count)
   }
 
   static func hasDeliverableText(_ text: String) -> Bool {
@@ -299,13 +350,10 @@ struct PasteTextOutput: TextOutputting {
     return .process(processIdentifier)
   }
 
-  private func scheduleClipboardRestore(_ previousString: String?, on pasteboard: NSPasteboard) {
+  private func scheduleClipboardRestore(_ previousContents: PasteboardSnapshot, on pasteboard: NSPasteboard) {
     let delay = DispatchTime.now() + .milliseconds(300)
     DispatchQueue.main.asyncAfter(deadline: delay) {
-      pasteboard.clearContents()
-      if let previousString {
-        pasteboard.setString(previousString, forType: .string)
-      }
+      previousContents.restore(to: pasteboard)
     }
   }
 }

--- a/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
+++ b/Sources/SpeakApp/Views/Settings/ShortcutsSettingsView.swift
@@ -19,7 +19,7 @@ struct ShortcutsSettingsView: View {
                         .foregroundStyle(.secondary)
 
                     LazyVGrid(columns: shortcutColumns, alignment: .leading, spacing: density.inlineSpacing) {
-                        ForEach(ShortcutAction.allCases.filter { $0.isGlobalByDefault }) { action in
+                        ForEach(ShortcutAction.availableCases().filter { $0.isGlobalByDefault }) { action in
                             shortcutRow(for: action)
                         }
                     }
@@ -34,7 +34,7 @@ struct ShortcutsSettingsView: View {
                         .foregroundStyle(.secondary)
 
                     LazyVGrid(columns: shortcutColumns, alignment: .leading, spacing: density.inlineSpacing) {
-                        ForEach(ShortcutAction.allCases.filter { !$0.isGlobalByDefault }) { action in
+                        ForEach(ShortcutAction.availableCases().filter { !$0.isGlobalByDefault }) { action in
                             shortcutRow(for: action)
                         }
                     }

--- a/Sources/SpeakApp/VoiceEdit/AppEnvironment+VoiceEdit.swift
+++ b/Sources/SpeakApp/VoiceEdit/AppEnvironment+VoiceEdit.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SpeakCore
 
 extension AppEnvironment {
   /// Creates the voice-edit controller ("select text → hotkey → speak an instruction →
@@ -14,14 +15,17 @@ extension AppEnvironment {
       hotKeyManager: hotKeys,
       selectionService: VoiceEditSelectionService(
         permissionsManager: permissions,
-        appSettings: settings,
-        historyManager: history
-      )
+        insertionRecords: main.insertionRecords
+      ),
+      replacementService: VoiceEditReplacementService(permissionsManager: permissions)
     )
   }
 
-  /// Global-shortcut entry point for voice edit mode.
+  /// Global-shortcut entry point for voice edit mode. Inert on channels that
+  /// cannot read or replace another app's selection; the shortcut is not
+  /// registered there either, so this is the last line of defence.
   func toggleVoiceEdit() {
+    guard DistributionChannel.current.supportsVoiceEdit else { return }
     installVoiceEdit()
     voiceEdit?.toggle()
   }

--- a/Sources/SpeakApp/VoiceEdit/InsertionRecordStore.swift
+++ b/Sources/SpeakApp/VoiceEdit/InsertionRecordStore.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// A UTF-16 range inside a text field, as accessibility reports it.
+struct VoiceEditTextRange: Equatable, Sendable {
+  let location: Int
+  let length: Int
+
+  init(location: Int, length: Int) {
+    self.location = location
+    self.length = length
+  }
+
+  init(_ range: CFRange) {
+    self.init(location: range.location, length: range.length)
+  }
+
+  var cfRange: CFRange {
+    CFRange(location: location, length: length)
+  }
+
+  var end: Int { location + length }
+
+  /// The substring of `value` this range covers, or nil when the range no
+  /// longer fits the value.
+  func substring(of value: String) -> String? {
+    let utf16 = value.utf16
+    guard location >= 0, length >= 0, end <= utf16.count,
+      let start = utf16.index(utf16.startIndex, offsetBy: location, limitedBy: utf16.endIndex),
+      let finish = utf16.index(start, offsetBy: length, limitedBy: utf16.endIndex)
+    else { return nil }
+    return String(utf16[start..<finish])
+  }
+}
+
+/// Where normal dictation last put text: the field, the exact UTF-16 range
+/// and the text written there. Voice Edit's "last dictation" fallback edits
+/// this range, never a text search that could pick a different occurrence
+/// (issue #673).
+struct InsertionRecord {
+  let target: TextOutputTarget
+  let range: VoiceEditTextRange
+  let text: String
+  let recordedAt: Date
+}
+
+@MainActor
+final class InsertionRecordStore {
+  private(set) var latest: InsertionRecord?
+
+  func record(_ record: InsertionRecord) {
+    latest = record
+  }
+
+  func clear() {
+    latest = nil
+  }
+}

--- a/Sources/SpeakApp/VoiceEdit/VoiceEditAnchor.swift
+++ b/Sources/SpeakApp/VoiceEdit/VoiceEditAnchor.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Immutable description of what a voice-edit session will replace: the
+/// captured text and, when the field reported one, its UTF-16 range. The
+/// anchor is re-verified against the field before anything is written, so a
+/// caret or selection that moved while the user spoke can never cause a
+/// different range to be rewritten (issue #673).
+struct VoiceEditAnchor: Equatable {
+  let text: String
+  let range: VoiceEditTextRange?
+}
+
+/// Why automatic replacement was not performed and the rewrite was parked on
+/// the clipboard for a manual ⌘V instead.
+enum VoiceEditClipboardReason: Equatable {
+  /// The captured text is no longer where it was: edited, moved, or focus is
+  /// in another field.
+  case selectionChanged
+  /// The field reports neither its text nor its selection, so the anchor
+  /// cannot be confirmed.
+  case selectionUnverifiable
+  /// The captured app or field is gone.
+  case targetUnavailable
+  /// Accessibility replacement was accepted but the field does not show the
+  /// rewrite, so pasting on top could only duplicate it.
+  case replacementUnverified
+  /// ⌘V was posted but the field still does not show the rewrite (read-only
+  /// or ignoring target).
+  case pasteUnverified
+  /// Accessibility and paste delivery both failed before any write.
+  case replacementFailed
+  /// Nothing was captured to replace.
+  case noCapture
+}
+
+/// How a verified anchor relates to the field right now.
+enum VoiceEditAnchorState: Equatable {
+  /// The captured text is still where it was; `range` is where to write when known.
+  case intact(VoiceEditTextRange?)
+  /// The captured text is no longer at the anchor.
+  case moved
+  /// The field cannot report enough to decide.
+  case unverifiable
+
+  /// Checks `anchor` against the field, preferring the strongest evidence
+  /// available: the text at the recorded range, then the current selection.
+  static func evaluate(_ anchor: VoiceEditAnchor, in field: any VoiceEditField) -> VoiceEditAnchorState {
+    if let range = anchor.range {
+      if let value = field.readValue() {
+        return range.substring(of: value) == anchor.text ? .intact(range) : .moved
+      }
+      if let selection = field.readSelectedRange() {
+        guard VoiceEditTextRange(selection) == range, field.readSelectedText() == anchor.text else {
+          return .moved
+        }
+        return .intact(range)
+      }
+      if let selectedText = field.readSelectedText() {
+        return selectedText == anchor.text ? .intact(nil) : .moved
+      }
+      return .unverifiable
+    }
+    guard let selectedText = field.readSelectedText() else { return .unverifiable }
+    return selectedText == anchor.text ? .intact(nil) : .moved
+  }
+
+  /// Stricter check for paste delivery, which replaces whatever is selected
+  /// *now*: the current selection itself must still be the captured text.
+  static func evaluateSelection(
+    _ anchor: VoiceEditAnchor,
+    in field: any VoiceEditField
+  ) -> VoiceEditAnchorState {
+    if let range = anchor.range, let selection = field.readSelectedRange() {
+      guard VoiceEditTextRange(selection) == range else { return .moved }
+      if let value = field.readValue() {
+        return range.substring(of: value) == anchor.text ? .intact(range) : .moved
+      }
+      return .intact(range)
+    }
+    guard let selectedText = field.readSelectedText() else { return .unverifiable }
+    return selectedText == anchor.text ? .intact(anchor.range) : .moved
+  }
+}

--- a/Sources/SpeakApp/VoiceEdit/VoiceEditController+HUD.swift
+++ b/Sources/SpeakApp/VoiceEdit/VoiceEditController+HUD.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+// MARK: - HUD feedback
+
+extension VoiceEditController {
+  func handle(_ event: VoiceEditOrchestrator.Event) {
+    switch event {
+    case .listeningStarted(let source):
+      hudManager.beginEditing(subheadline: Self.listeningSubheadline(for: source))
+    case .transcribingInstruction:
+      hudManager.beginEditing(subheadline: "Understanding your instruction")
+    case .rewriting:
+      hudManager.beginEditing(subheadline: "Rewriting with your model")
+    case .applying:
+      hudManager.beginEditing(subheadline: "Applying the edit")
+    case .finished(let outcome):
+      pendingCapture = nil
+      finish(outcome)
+    case .failed(let reason):
+      pendingCapture = nil
+      fail(reason)
+    case .cancelled:
+      pendingCapture = nil
+      hudManager.hide()
+    }
+  }
+
+  private func finish(_ outcome: VoiceEditOrchestrator.ReplacementOutcome) {
+    switch outcome {
+    case .replaced, .pasted:
+      hudManager.finishSuccess(message: "Edited")
+    case .leftOnClipboard(let reason):
+      let (headline, message) = Self.clipboardGuidance(for: reason)
+      hudManager.finishFailure(headline: headline, message: message)
+    }
+  }
+
+  /// Every parked rewrite ends with the same instruction — press ⌘V — but says
+  /// why the edit was not applied automatically, so "Edited" is never shown
+  /// for a change that did not happen.
+  static func clipboardGuidance(for reason: VoiceEditClipboardReason) -> (headline: String, message: String) {
+    switch reason {
+    case .selectionChanged:
+      return (
+        "Selection changed",
+        "The text moved or changed while you spoke, so nothing was replaced. "
+          + "The rewrite is on your clipboard — select the text and press ⌘V."
+      )
+    case .selectionUnverifiable:
+      return (
+        "Couldn't confirm the selection",
+        "This app doesn't report its selection, so nothing was replaced. "
+          + "The rewrite is on your clipboard — press ⌘V where you want it."
+      )
+    case .targetUnavailable:
+      return (
+        "App no longer available",
+        "The app you were editing in has gone away. The rewrite is on your clipboard — press ⌘V."
+      )
+    case .replacementUnverified:
+      return (
+        "Couldn't confirm the edit",
+        "The app accepted the change but doesn't show it. The rewrite is on your clipboard — "
+          + "check the text and press ⌘V if needed."
+      )
+    case .pasteUnverified:
+      return (
+        "Nothing changed",
+        "The app didn't accept the paste (it may be read-only). "
+          + "The rewrite is on your clipboard — press ⌘V where you want it."
+      )
+    case .replacementFailed, .noCapture:
+      return (
+        "Press ⌘V to paste",
+        "Couldn't replace the selection automatically. The rewrite is on your clipboard."
+      )
+    }
+  }
+
+  private func fail(_ reason: VoiceEditOrchestrator.FailureReason) {
+    switch reason {
+    case .dictationBusy:
+      hudManager.finishFailure(
+        headline: "Voice edit unavailable",
+        message: "Finish the current dictation first.",
+        displayDuration: 3
+      )
+    case .noSelection:
+      hudManager.finishFailure(
+        headline: "Nothing to edit",
+        message: "Select some text, or dictate something first, then try again.",
+        displayDuration: 4
+      )
+    case .noConfiguredLLM:
+      hudManager.finishFailure(
+        headline: "No language model configured",
+        message: "Voice edit uses your post-processing model. Add an OpenRouter API key in Settings › API Keys."
+      )
+    case .emptyInstruction:
+      hudManager.finishFailure(
+        headline: "No instruction heard",
+        message: "Press the hotkey again and speak an instruction like \"make this shorter\".",
+        displayDuration: 4
+      )
+    case .recordingFailed(let message):
+      hudManager.finishFailure(headline: "Couldn't record instruction", message: message)
+    case .transcriptionFailed(let message):
+      hudManager.finishFailure(headline: "Couldn't transcribe instruction", message: message)
+    case .rewriteFailed(let message):
+      hudManager.finishFailure(headline: "Rewrite failed", message: message)
+    }
+  }
+
+  private static func listeningSubheadline(
+    for source: VoiceEditOrchestrator.SelectionSource
+  ) -> String {
+    switch source {
+    case .accessibility, .clipboard:
+      return "Speak an instruction for the selection"
+    case .lastInsertion:
+      return "Speak an instruction for your last dictation"
+    }
+  }
+}

--- a/Sources/SpeakApp/VoiceEdit/VoiceEditController.swift
+++ b/Sources/SpeakApp/VoiceEdit/VoiceEditController.swift
@@ -7,15 +7,16 @@ import SpeakCore
 /// LLM rewrite via the post-processing client, and HUD feedback.
 @MainActor
 final class VoiceEditController {
-  private let mainManager: MainManager
+  let mainManager: MainManager
   private let audioFileManager: AudioFileManager
   private let transcriptionManager: TranscriptionManager
   private let rewriter: VoiceEditRewriter
-  private let hudManager: HUDManager
+  let hudManager: HUDManager
   private let selectionService: VoiceEditSelectionService
+  private let replacementService: VoiceEditReplacementService
 
   private var orchestrator: VoiceEditOrchestrator?
-  private var pendingCapture: VoiceEditSelectionService.Capture?
+  var pendingCapture: VoiceEditSelectionService.Capture?
   private var escapeToken: ShortcutListenerToken?
 
   init(
@@ -25,7 +26,8 @@ final class VoiceEditController {
     rewriter: VoiceEditRewriter,
     hudManager: HUDManager,
     hotKeyManager: HotKeyManager,
-    selectionService: VoiceEditSelectionService
+    selectionService: VoiceEditSelectionService,
+    replacementService: VoiceEditReplacementService
   ) {
     self.mainManager = mainManager
     self.audioFileManager = audioFileManager
@@ -33,9 +35,12 @@ final class VoiceEditController {
     self.rewriter = rewriter
     self.hudManager = hudManager
     self.selectionService = selectionService
+    self.replacementService = replacementService
     self.orchestrator = VoiceEditOrchestrator(dependencies: makeDependencies())
     self.escapeToken = hotKeyManager.register(shortcut: .escape) { [weak self] in
-      self?.orchestrator?.cancel()
+      Task { @MainActor [weak self] in
+        await self?.orchestrator?.cancel()
+      }
     }
   }
 
@@ -55,6 +60,12 @@ final class VoiceEditController {
         guard let self else { return true }
         return self.mainManager.activeSession != nil || self.mainManager.isBusy
       },
+      reserveCapture: { [weak self] in
+        self?.mainManager.captureOwnership.reserve(.voiceEdit) ?? false
+      },
+      releaseCapture: { [weak self] in
+        self?.mainManager.captureOwnership.release(.voiceEdit)
+      },
       hasConfiguredLLM: { [weak self] in
         guard let self else { return false }
         return await self.rewriter.isConfigured()
@@ -73,7 +84,7 @@ final class VoiceEditController {
         return try await self.finishListening()
       },
       cancelListening: { [weak self] in
-        self?.cancelListening()
+        await self?.cancelListening()
       },
       rewrite: { [weak self] selection, instruction in
         guard let self else { throw VoiceEditControllerError.unavailable }
@@ -83,11 +94,11 @@ final class VoiceEditController {
         )
       },
       applyReplacement: { [weak self] _, rewrittenText in
-        guard let self else { return .leftOnClipboard }
+        guard let self else { return .leftOnClipboard(.noCapture) }
         guard let capture = self.pendingCapture else {
-          return self.selectionService.leaveOnClipboard(rewrittenText)
+          return self.replacementService.leaveOnClipboard(rewrittenText)
         }
-        return await self.selectionService.replace(capture, with: rewrittenText)
+        return await self.replacementService.replace(capture, with: rewrittenText)
       },
       onEvent: { [weak self] event in
         self?.handle(event)
@@ -98,12 +109,12 @@ final class VoiceEditController {
   // MARK: - Instruction capture
 
   private func startListening() async throws {
-    _ = try await audioFileManager.startRecording()
+    _ = try await audioFileManager.startRecording(owner: .voiceEdit)
     guard mainManager.isStreamingTranscriptionMode else { return }
     do {
       try await transcriptionManager.startLiveTranscription()
     } catch {
-      await audioFileManager.cancelRecording()
+      await audioFileManager.cancelRecording(ifOwnedBy: .voiceEdit)
       throw error
     }
   }
@@ -117,103 +128,22 @@ final class VoiceEditController {
     return try await transcriptionManager.transcribeFile(at: summary.url).text
   }
 
-  private func cancelListening() {
+  /// Awaited by the orchestrator, so Escape returns to idle only after the recorder has
+  /// actually been released and a rapid restart cannot hit `alreadyRecording`.
+  private func cancelListening() async {
     if mainManager.isStreamingTranscriptionMode {
       transcriptionManager.cancelLiveTranscription()
     }
-    Task { [audioFileManager] in
-      await audioFileManager.cancelRecording()
-    }
+    await audioFileManager.cancelRecording(ifOwnedBy: .voiceEdit)
   }
 
   private func cleanUpInstructionAudio(at url: URL) {
     // Instruction clips never appear in history, so drop the backing file straight away.
     try? FileManager.default.removeItem(at: url)
   }
-
-  // MARK: - HUD feedback
-
-  private func handle(_ event: VoiceEditOrchestrator.Event) {
-    switch event {
-    case .listeningStarted(let source):
-      hudManager.beginEditing(subheadline: Self.listeningSubheadline(for: source))
-    case .transcribingInstruction:
-      hudManager.beginEditing(subheadline: "Understanding your instruction")
-    case .rewriting:
-      hudManager.beginEditing(subheadline: "Rewriting with your model")
-    case .applying:
-      hudManager.beginEditing(subheadline: "Applying the edit")
-    case .finished(let outcome):
-      pendingCapture = nil
-      finish(outcome)
-    case .failed(let reason):
-      pendingCapture = nil
-      fail(reason)
-    case .cancelled:
-      pendingCapture = nil
-      hudManager.hide()
-    }
-  }
-
-  private func finish(_ outcome: VoiceEditOrchestrator.ReplacementOutcome) {
-    switch outcome {
-    case .replaced, .pasted:
-      hudManager.finishSuccess(message: "Edited")
-    case .leftOnClipboard:
-      hudManager.finishFailure(
-        headline: "Press ⌘V to paste",
-        message: "Couldn't replace the selection automatically. The rewrite is on your clipboard."
-      )
-    }
-  }
-
-  private func fail(_ reason: VoiceEditOrchestrator.FailureReason) {
-    switch reason {
-    case .dictationBusy:
-      hudManager.finishFailure(
-        headline: "Voice edit unavailable",
-        message: "Finish the current dictation first.",
-        displayDuration: 3
-      )
-    case .noSelection:
-      hudManager.finishFailure(
-        headline: "Nothing to edit",
-        message: "Select some text, or dictate something first, then try again.",
-        displayDuration: 4
-      )
-    case .noConfiguredLLM:
-      hudManager.finishFailure(
-        headline: "No language model configured",
-        message: "Voice edit uses your post-processing model. Add an OpenRouter API key in Settings › API Keys."
-      )
-    case .emptyInstruction:
-      hudManager.finishFailure(
-        headline: "No instruction heard",
-        message: "Press the hotkey again and speak an instruction like \"make this shorter\".",
-        displayDuration: 4
-      )
-    case .recordingFailed(let message):
-      hudManager.finishFailure(headline: "Couldn't record instruction", message: message)
-    case .transcriptionFailed(let message):
-      hudManager.finishFailure(headline: "Couldn't transcribe instruction", message: message)
-    case .rewriteFailed(let message):
-      hudManager.finishFailure(headline: "Rewrite failed", message: message)
-    }
-  }
-
-  private static func listeningSubheadline(
-    for source: VoiceEditOrchestrator.SelectionSource
-  ) -> String {
-    switch source {
-    case .accessibility, .clipboard:
-      return "Speak an instruction for the selection"
-    case .lastInsertion:
-      return "Speak an instruction for your last dictation"
-    }
-  }
 }
 
-private enum VoiceEditControllerError: LocalizedError {
+enum VoiceEditControllerError: LocalizedError {
   case unavailable
 
   var errorDescription: String? { "Voice edit is unavailable." }

--- a/Sources/SpeakApp/VoiceEdit/VoiceEditFieldAccess.swift
+++ b/Sources/SpeakApp/VoiceEdit/VoiceEditFieldAccess.swift
@@ -1,0 +1,98 @@
+import ApplicationServices
+import Foundation
+
+/// The accessibility surface Voice Edit needs from a text field: everything
+/// the ranged streaming path uses, plus the selected text itself and an
+/// identity so apply-time focus can be compared with capture-time focus.
+///
+/// Kept behind a protocol so capture, anchor verification and replacement are
+/// testable against an in-memory field, without a live `AXUIElement`.
+protocol VoiceEditField: StreamingTextField {
+  /// The selected text as the app reports it, or nil when unreadable.
+  func readSelectedText() -> String?
+  /// The process that owns the field, or nil when unknown.
+  var processIdentifier: pid_t? { get }
+  /// Whether `other` is the very same control, not merely an equal snapshot.
+  func isSameField(as other: any VoiceEditField) -> Bool
+}
+
+/// Resolves the field captured with a target and whichever field has focus now.
+@MainActor
+protocol VoiceEditFieldResolving {
+  func field(for target: TextOutputTarget) -> (any VoiceEditField)?
+  func focusedField() -> (any VoiceEditField)?
+}
+
+/// The live implementation, backed by an accessibility element.
+struct AccessibilityVoiceEditField: VoiceEditField {
+  let element: AXUIElement
+  private let streaming: AccessibilityStreamingTextField
+
+  init(element: AXUIElement) {
+    self.element = element
+    self.streaming = AccessibilityStreamingTextField(element: element)
+  }
+
+  func readValue() -> String? {
+    streaming.readValue()
+  }
+
+  func readSelectedRange() -> CFRange? {
+    streaming.readSelectedRange()
+  }
+
+  func setSelectedRange(_ range: CFRange) -> AXError {
+    streaming.setSelectedRange(range)
+  }
+
+  func setSelectedText(_ text: String) -> AXError {
+    streaming.setSelectedText(text)
+  }
+
+  func readSelectedText() -> String? {
+    var value: CFTypeRef?
+    let status = AXUIElementCopyAttributeValue(element, kAXSelectedTextAttribute as CFString, &value)
+    guard status == .success else { return nil }
+    return value as? String
+  }
+
+  var processIdentifier: pid_t? {
+    var pid: pid_t = 0
+    guard AXUIElementGetPid(element, &pid) == .success else { return nil }
+    return pid
+  }
+
+  func isSameField(as other: any VoiceEditField) -> Bool {
+    guard let other = other as? AccessibilityVoiceEditField else { return false }
+    return CFEqual(element, other.element)
+  }
+}
+
+@MainActor
+struct AccessibilityVoiceEditFieldResolver: VoiceEditFieldResolving {
+  /// Nonisolated so the resolver can be a default argument of main-actor
+  /// initialisers, which evaluate their defaults outside the actor; the
+  /// synthesised initialiser would be actor-isolated.
+  nonisolated init() {}
+  // swiftlint:disable:previous unneeded_synthesized_initializer
+
+  func field(for target: TextOutputTarget) -> (any VoiceEditField)? {
+    guard let element = target.focusedElement ?? Self.systemFocusedElement() else { return nil }
+    return AccessibilityVoiceEditField(element: element)
+  }
+
+  func focusedField() -> (any VoiceEditField)? {
+    guard let element = Self.systemFocusedElement() else { return nil }
+    return AccessibilityVoiceEditField(element: element)
+  }
+
+  private static func systemFocusedElement() -> AXUIElement? {
+    let systemWide = AXUIElementCreateSystemWide()
+    var rawFocused: CFTypeRef?
+    let status = AXUIElementCopyAttributeValue(
+      systemWide, kAXFocusedUIElementAttribute as CFString, &rawFocused
+    )
+    guard status == .success, let rawFocused else { return nil }
+    return unsafeBitCast(rawFocused, to: AXUIElement.self)
+  }
+}

--- a/Sources/SpeakApp/VoiceEdit/VoiceEditOrchestrator.swift
+++ b/Sources/SpeakApp/VoiceEdit/VoiceEditOrchestrator.swift
@@ -7,6 +7,10 @@ import SpeakCore
 /// All side effects (Accessibility reads, audio recording, transcription, LLM calls, HUD
 /// updates) go through `Dependencies` closures so the state machine is unit-testable without
 /// Accessibility, audio, or network access.
+///
+/// Shared capture (the recorder and live transcriber) is reserved before the first
+/// suspension and released only after this flow's own teardown has finished, so normal
+/// dictation can neither start on top of a listening session nor cancel it (issue #673).
 @MainActor
 final class VoiceEditOrchestrator {
   enum Phase: Equatable {
@@ -15,6 +19,8 @@ final class VoiceEditOrchestrator {
     case listening
     /// Transcribing the instruction, rewriting, or applying the replacement.
     case processing
+    /// Escape was pressed; recorder/stream teardown is still in flight.
+    case cancelling
   }
 
   enum SelectionSource: Equatable {
@@ -22,7 +28,7 @@ final class VoiceEditOrchestrator {
     case accessibility
     /// Captured by simulating ⌘C into a saved-and-restored pasteboard.
     case clipboard
-    /// No live selection; falling back to the last inserted transcription.
+    /// No live selection; falling back to the range the last dictation was inserted into.
     case lastInsertion
   }
 
@@ -34,10 +40,11 @@ final class VoiceEditOrchestrator {
   enum ReplacementOutcome: Equatable {
     /// The selection was replaced via Accessibility and verified.
     case replaced
-    /// The rewrite was pasted over the selection via a simulated ⌘V.
+    /// The rewrite was pasted over the selection via a simulated ⌘V and verified.
     case pasted
-    /// Automatic replacement failed; the rewrite was left on the clipboard for manual ⌘V.
-    case leftOnClipboard
+    /// Automatic replacement was not performed; the rewrite was left on the clipboard
+    /// for manual ⌘V.
+    case leftOnClipboard(VoiceEditClipboardReason)
   }
 
   enum FailureReason: Equatable {
@@ -62,11 +69,15 @@ final class VoiceEditOrchestrator {
 
   struct Dependencies {
     var isDictationBusy: () -> Bool
+    /// Claims the shared recorder/transcriber; false when dictation holds them.
+    var reserveCapture: () -> Bool
+    var releaseCapture: () -> Void
     var hasConfiguredLLM: () async -> Bool
     var captureSelection: () async -> Selection?
     var startListening: () async throws -> Void
     var finishListening: () async throws -> String
-    var cancelListening: () -> Void
+    /// Tears down the recorder and live stream; returns once they are released.
+    var cancelListening: () async -> Void
     var rewrite: (_ selection: Selection, _ instruction: String) async throws -> String
     var applyReplacement: (_ selection: Selection, _ rewrite: String) async -> ReplacementOutcome
     var onEvent: (Event) -> Void
@@ -74,6 +85,7 @@ final class VoiceEditOrchestrator {
 
   private(set) var phase: Phase = .idle
   private var selection: Selection?
+  private var cancelTask: Task<Void, Never>?
   private let dependencies: Dependencies
 
   init(dependencies: Dependencies) {
@@ -81,7 +93,9 @@ final class VoiceEditOrchestrator {
   }
 
   /// Hotkey entry point: starts an edit session, or finishes the listening stage.
-  /// Ignored while a previous session is still processing.
+  /// Ignored while a previous session is still processing. A press while Escape's
+  /// teardown is still running waits for it and then starts cleanly, so a rapid
+  /// restart never meets the previous session's recorder.
   func toggle() async {
     switch phase {
     case .idle:
@@ -90,22 +104,36 @@ final class VoiceEditOrchestrator {
       await finish()
     case .processing:
       break
+    case .cancelling:
+      await cancelTask?.value
+      guard phase == .idle else { return }
+      await begin()
     }
   }
 
-  /// Cancels an in-flight listening session (Escape). No-op in other phases.
-  func cancel() {
+  /// Cancels an in-flight listening session (Escape) and returns once the recorder and
+  /// live stream have been released. No-op in other phases.
+  func cancel() async {
     guard phase == .listening else { return }
-    dependencies.cancelListening()
-    selection = nil
-    phase = .idle
-    dependencies.onEvent(.cancelled)
+    phase = .cancelling
+    // State moves back to idle inside the task, so every waiter — this call and a
+    // toggle that arrived meanwhile — observes the same settled state.
+    let task = Task { @MainActor [self] in
+      await dependencies.cancelListening()
+      selection = nil
+      dependencies.releaseCapture()
+      cancelTask = nil
+      phase = .idle
+      dependencies.onEvent(.cancelled)
+    }
+    cancelTask = task
+    await task.value
   }
 
   // MARK: - Private
 
   private func begin() async {
-    guard !dependencies.isDictationBusy() else {
+    guard !dependencies.isDictationBusy(), dependencies.reserveCapture() else {
       dependencies.onEvent(.failed(.dictationBusy))
       return
     }
@@ -133,7 +161,7 @@ final class VoiceEditOrchestrator {
 
   private func finish() async {
     guard let captured = selection else {
-      phase = .idle
+      complete(with: .cancelled)
       return
     }
     phase = .processing
@@ -171,6 +199,7 @@ final class VoiceEditOrchestrator {
 
   private func complete(with event: Event) {
     selection = nil
+    dependencies.releaseCapture()
     phase = .idle
     dependencies.onEvent(event)
   }

--- a/Sources/SpeakApp/VoiceEdit/VoiceEditReplacementService.swift
+++ b/Sources/SpeakApp/VoiceEdit/VoiceEditReplacementService.swift
@@ -1,0 +1,219 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import SpeakCore
+
+/// Replaces a captured selection with the LLM rewrite, and only that
+/// selection: the anchor is re-verified against the field before any write,
+/// every delivery path reads the field back where it can, and a rewrite that
+/// could not be applied verifiably is parked on the clipboard instead of being
+/// reported as "Edited" (issue #673).
+@MainActor
+final class VoiceEditReplacementService {
+  typealias Capture = VoiceEditSelectionService.Capture
+  typealias Outcome = VoiceEditOrchestrator.ReplacementOutcome
+  typealias PasteShortcut = @MainActor (PasteTextOutput.EventDestination) -> Bool
+
+  private let permissionsManager: PermissionsManager
+  private let fieldResolver: any VoiceEditFieldResolving
+  private let pasteboard: NSPasteboard
+  private let pasteShortcut: PasteShortcut
+  /// How long to wait for the app to apply an accessibility write before
+  /// reading it back.
+  private let accessibilityVerificationDelay: Duration
+  /// How long to wait between read-backs after posting ⌘V, and how many times.
+  /// Slow (Electron) targets need several hundred milliseconds.
+  private let pasteVerificationInterval: Duration
+  private let pasteVerificationAttempts: Int
+
+  init(
+    permissionsManager: PermissionsManager,
+    fieldResolver: any VoiceEditFieldResolving = AccessibilityVoiceEditFieldResolver(),
+    pasteboard: NSPasteboard = .general,
+    pasteShortcut: @escaping PasteShortcut = VoiceEditKeyboardShortcuts.postPaste,
+    accessibilityVerificationDelay: Duration = .milliseconds(50),
+    pasteVerificationInterval: Duration = .milliseconds(100),
+    pasteVerificationAttempts: Int = 10
+  ) {
+    self.permissionsManager = permissionsManager
+    self.fieldResolver = fieldResolver
+    self.pasteboard = pasteboard
+    self.pasteShortcut = pasteShortcut
+    self.accessibilityVerificationDelay = accessibilityVerificationDelay
+    self.pasteVerificationInterval = pasteVerificationInterval
+    self.pasteVerificationAttempts = max(1, pasteVerificationAttempts)
+  }
+
+  func replace(_ capture: Capture, with rewrite: String) async -> Outcome {
+    guard capture.target.isApplicationRunning else {
+      return park(rewrite, reason: .targetUnavailable)
+    }
+    switch await replaceViaAccessibility(capture, rewrite: rewrite) {
+    case .replaced:
+      return .replaced
+    case .parked(let reason):
+      return park(rewrite, reason: reason)
+    case .notAttempted:
+      return await pasteReplacement(capture, rewrite: rewrite)
+    }
+  }
+
+  /// Terminal fallback when no capture is available to replace: park the
+  /// rewrite on the clipboard so the HUD's "Press ⌘V" guidance is accurate.
+  func leaveOnClipboard(_ rewrite: String) -> Outcome {
+    park(rewrite, reason: .noCapture)
+  }
+
+  // MARK: - Accessibility path
+
+  private enum AccessibilityAttempt {
+    case replaced
+    case parked(VoiceEditClipboardReason)
+    /// Nothing was written; paste delivery may still be tried.
+    case notAttempted
+  }
+
+  private func replaceViaAccessibility(_ capture: Capture, rewrite: String) async -> AccessibilityAttempt {
+    guard permissionsManager.status(for: .accessibility).isGranted, let field = capture.field else {
+      return .notAttempted
+    }
+    switch anchorPreflight(capture, field: field, forPaste: false) {
+    case .park(let reason):
+      return .parked(reason)
+    case .ready(let range):
+      return await writeViaAccessibility(rewrite, at: range, in: field)
+    }
+  }
+
+  private func writeViaAccessibility(
+    _ rewrite: String,
+    at range: VoiceEditTextRange?,
+    in field: any VoiceEditField
+  ) async -> AccessibilityAttempt {
+    let valueBeforeWrite = field.readValue()
+    if let range, field.setSelectedRange(range.cfRange) != .success {
+      return .notAttempted
+    }
+    // A rejected write leaves the anchored range selected on purpose: that is
+    // exactly the selection the paste fallback must replace.
+    guard field.setSelectedText(rewrite) == .success else { return .notAttempted }
+
+    // A write was accepted: from here on, pasting could only duplicate it.
+    try? await Task.sleep(for: accessibilityVerificationDelay)
+    guard let after = field.readValue() else { return .replaced }
+    let landed = Self.rewriteShows(rewrite, at: range, before: valueBeforeWrite, after: after)
+    return landed ? .replaced : .parked(.replacementUnverified)
+  }
+
+  // MARK: - Anchor preflight
+
+  private enum Preflight {
+    case ready(VoiceEditTextRange?)
+    case park(VoiceEditClipboardReason)
+  }
+
+  /// Confirms focus is still the captured field in the captured process and
+  /// that the anchor still holds the captured text. Paste delivery uses the
+  /// stricter selection check because ⌘V replaces whatever is selected *now*.
+  private func anchorPreflight(_ capture: Capture, field: any VoiceEditField, forPaste: Bool) -> Preflight {
+    guard let focused = fieldResolver.focusedField(), focused.isSameField(as: field) else {
+      return .park(.selectionChanged)
+    }
+    if let expected = capture.target.processIdentifier, let actual = field.processIdentifier, expected != actual {
+      return .park(.selectionChanged)
+    }
+    let state = forPaste
+      ? VoiceEditAnchorState.evaluateSelection(capture.anchor, in: field)
+      : VoiceEditAnchorState.evaluate(capture.anchor, in: field)
+    switch state {
+    case .intact(let range):
+      return .ready(range)
+    case .moved:
+      return .park(.selectionChanged)
+    case .unverifiable:
+      return .park(.selectionUnverifiable)
+    }
+  }
+
+  // MARK: - Paste path
+
+  private func pasteReplacement(_ capture: Capture, rewrite: String) async -> Outcome {
+    guard DistributionChannel.current.supportsAccessibilityTextInsertion else {
+      return park(rewrite, reason: .replacementFailed)
+    }
+    let destination = PasteTextOutput.eventDestination(for: capture.target)
+    guard destination != .none else {
+      return park(rewrite, reason: .targetUnavailable)
+    }
+    guard let field = capture.field else {
+      return park(rewrite, reason: .selectionUnverifiable)
+    }
+    if case .park(let reason) = anchorPreflight(capture, field: field, forPaste: true) {
+      return park(rewrite, reason: reason)
+    }
+
+    let saved = PasteboardSnapshot(reading: pasteboard)
+    let valueBeforePaste = field.readValue()
+    pasteboard.clearContents()
+    guard pasteboard.setString(rewrite, forType: .string), pasteShortcut(destination) else {
+      saved.restore(to: pasteboard)
+      return park(rewrite, reason: .replacementFailed)
+    }
+
+    if await pasteLanded(rewrite, anchor: capture.anchor, before: valueBeforePaste, in: field) {
+      saved.restore(to: pasteboard)
+      return .pasted
+    }
+    // The target ignored the paste (read-only, or not accepting input). The
+    // rewrite stays on the clipboard so a manual ⌘V can still complete the edit.
+    return .leftOnClipboard(.pasteUnverified)
+  }
+
+  /// Polls the field for the pasted rewrite. A field that cannot be read back
+  /// is trusted, as an accepted accessibility write is.
+  private func pasteLanded(
+    _ rewrite: String,
+    anchor: VoiceEditAnchor,
+    before: String?,
+    in field: any VoiceEditField
+  ) async -> Bool {
+    for _ in 0..<pasteVerificationAttempts {
+      try? await Task.sleep(for: pasteVerificationInterval)
+      guard let value = field.readValue() else { return true }
+      if value != before, Self.rewriteShows(rewrite, at: anchor.range, before: before, after: value) {
+        return true
+      }
+    }
+    return false
+  }
+
+  private static func rewriteShows(
+    _ rewrite: String,
+    at range: VoiceEditTextRange?,
+    before: String?,
+    after: String
+  ) -> Bool {
+    if let range, let before, let expected = replacing(range, in: before, with: rewrite) {
+      return after == expected
+    }
+    return after.contains(rewrite)
+  }
+
+  /// `value` with `range` replaced by `replacement`, or nil when the range no
+  /// longer fits the value.
+  private static func replacing(_ range: VoiceEditTextRange, in value: String, with replacement: String) -> String? {
+    guard range.substring(of: value) != nil else { return nil }
+    let utf16 = Array(value.utf16)
+    let prefix = String(utf16CodeUnits: Array(utf16[0..<range.location]), count: range.location)
+    let suffix = String(utf16CodeUnits: Array(utf16[range.end...]), count: utf16.count - range.end)
+    return prefix + replacement + suffix
+  }
+
+  // MARK: - Clipboard parking
+
+  private func park(_ rewrite: String, reason: VoiceEditClipboardReason) -> Outcome {
+    pasteboard.clearContents()
+    pasteboard.setString(rewrite, forType: .string)
+    return .leftOnClipboard(reason)
+  }
+}

--- a/Sources/SpeakApp/VoiceEdit/VoiceEditRewriter.swift
+++ b/Sources/SpeakApp/VoiceEdit/VoiceEditRewriter.swift
@@ -46,6 +46,6 @@ final class VoiceEditRewriter {
     )
     let reply = response.messages.last(where: { $0.role == .assistant })?.content ?? ""
     log.info("Voice edit rewrite completed (\(reply.count, privacy: .public) characters)")
-    return VoiceEditPolicy.normalizedRewrite(reply, original: selection)
+    return VoiceEditPolicy.normalizedRewrite(reply, original: selection, instruction: instruction)
   }
 }

--- a/Sources/SpeakApp/VoiceEdit/VoiceEditSelectionService.swift
+++ b/Sources/SpeakApp/VoiceEdit/VoiceEditSelectionService.swift
@@ -3,208 +3,169 @@ import ApplicationServices
 import Foundation
 import SpeakCore
 
-/// Captures the text selection in the frontmost app for voice-edit sessions and later replaces
-/// it with the LLM rewrite.
+/// Captures the text selection in the frontmost app for voice-edit sessions,
+/// together with an anchor the replacement step re-verifies before writing.
 ///
-/// Capture prefers a direct Accessibility read, then a simulated ⌘C into a
-/// saved-and-always-restored pasteboard, then the last inserted transcription when it is still
-/// present in the focused field. These paths need a real window server, so they are covered by
-/// manual testing rather than unit tests.
+/// Capture prefers a direct Accessibility read (which also yields the selected
+/// range), then a simulated ⌘C into a saved-and-always-restored pasteboard,
+/// then the exact range where the last dictation was inserted. Field access,
+/// the frontmost target, and the copy shortcut are injectable so every path is
+/// unit-testable without a window server (issue #673).
 @MainActor
 final class VoiceEditSelectionService {
   struct Capture {
     let selection: VoiceEditOrchestrator.Selection
     let target: TextOutputTarget
+    /// The field that held the selection, when Accessibility could resolve it.
+    let field: (any VoiceEditField)?
+    let anchor: VoiceEditAnchor
   }
 
+  typealias CopyShortcut = @MainActor (PasteTextOutput.EventDestination) -> Bool
+
   private let permissionsManager: PermissionsManager
-  private let appSettings: AppSettings
-  private let historyManager: HistoryManager
+  private let insertionRecords: InsertionRecordStore
+  private let fieldResolver: any VoiceEditFieldResolving
   private let pasteboard: NSPasteboard
+  private let targetProvider: @MainActor () -> TextOutputTarget
+  private let copyShortcut: CopyShortcut
+  private let copySettleDelay: Duration
 
   init(
     permissionsManager: PermissionsManager,
-    appSettings: AppSettings,
-    historyManager: HistoryManager,
-    pasteboard: NSPasteboard = .general
+    insertionRecords: InsertionRecordStore,
+    fieldResolver: any VoiceEditFieldResolving = AccessibilityVoiceEditFieldResolver(),
+    pasteboard: NSPasteboard = .general,
+    targetProvider: @escaping @MainActor () -> TextOutputTarget = { TextOutputTarget.capture() },
+    copyShortcut: @escaping CopyShortcut = VoiceEditKeyboardShortcuts.postCopy,
+    copySettleDelay: Duration = .milliseconds(40)
   ) {
     self.permissionsManager = permissionsManager
-    self.appSettings = appSettings
-    self.historyManager = historyManager
+    self.insertionRecords = insertionRecords
+    self.fieldResolver = fieldResolver
     self.pasteboard = pasteboard
+    self.targetProvider = targetProvider
+    self.copyShortcut = copyShortcut
+    self.copySettleDelay = copySettleDelay
   }
 
-  // MARK: - Capture
-
   func capture() async -> Capture? {
-    let target = TextOutputTarget.capture()
+    let target = targetProvider()
     permissionsManager.refresh(.accessibility)
+    let field = permissionsManager.status(for: .accessibility).isGranted
+      ? fieldResolver.field(for: target)
+      : nil
 
-    if let selected = accessibilitySelectedText(target: target), !selected.isEmpty {
+    if let field, let selected = field.readSelectedText(), !selected.isEmpty {
       return Capture(
         selection: .init(text: selected, source: .accessibility),
-        target: target
+        target: target,
+        field: field,
+        anchor: VoiceEditAnchor(text: selected, range: Self.verifiedSelectionRange(for: selected, in: field))
       )
     }
     if let copied = await copySelectionViaClipboard(target: target), !copied.isEmpty {
       return Capture(
         selection: .init(text: copied, source: .clipboard),
-        target: target
+        target: target,
+        field: field,
+        anchor: VoiceEditAnchor(
+          text: copied,
+          range: field.flatMap { Self.verifiedSelectionRange(for: copied, in: $0) }
+        )
       )
     }
-    if let lastInserted = lastInsertedTranscription(),
-       let element = focusedElement(for: target),
-       let value = Self.stringAttribute(kAXValueAttribute, of: element),
-       (value as NSString).range(of: lastInserted, options: .backwards).location != NSNotFound {
-      return Capture(
-        selection: .init(text: lastInserted, source: .lastInsertion),
-        target: target
-      )
+    if let record = insertionRecords.latest, let capture = lastInsertionCapture(record, target: target) {
+      return capture
     }
     return nil
   }
 
-  private func accessibilitySelectedText(target: TextOutputTarget) -> String? {
-    guard permissionsManager.status(for: .accessibility).isGranted,
-          let element = focusedElement(for: target)
-    else { return nil }
-    return Self.stringAttribute(kAXSelectedTextAttribute, of: element)
+  /// The current selected range, but only when it provably covers `text`.
+  /// A range that disagrees with the field's value is not an anchor.
+  private static func verifiedSelectionRange(
+    for text: String,
+    in field: any VoiceEditField
+  ) -> VoiceEditTextRange? {
+    guard let selection = field.readSelectedRange() else { return nil }
+    let range = VoiceEditTextRange(selection)
+    guard let value = field.readValue() else { return range }
+    return range.substring(of: value) == text ? range : nil
   }
 
-  /// Copies the current selection by simulating ⌘C. The user's pasteboard contents are saved
-  /// first and restored on every exit path, including empty selections and errors.
+  /// The last dictation is editable only where it actually landed: the same
+  /// app, the same field, and the recorded range still holding the recorded
+  /// text. No text search, so identical text elsewhere is never picked.
+  private func lastInsertionCapture(_ record: InsertionRecord, target: TextOutputTarget) -> Capture? {
+    guard record.target.isApplicationRunning,
+      record.target.processIdentifier == target.processIdentifier,
+      permissionsManager.status(for: .accessibility).isGranted,
+      let recordedField = fieldResolver.field(for: record.target),
+      let focused = fieldResolver.focusedField(),
+      focused.isSameField(as: recordedField),
+      let value = recordedField.readValue(),
+      record.range.substring(of: value) == record.text
+    else { return nil }
+    return Capture(
+      selection: .init(text: record.text, source: .lastInsertion),
+      target: target,
+      field: recordedField,
+      anchor: VoiceEditAnchor(text: record.text, range: record.range)
+    )
+  }
+
+  /// Copies the current selection by simulating ⌘C. The user's pasteboard
+  /// contents — every item and type — are saved first and restored on every
+  /// exit path, including empty selections and errors.
   private func copySelectionViaClipboard(target: TextOutputTarget) async -> String? {
     guard DistributionChannel.current.supportsAccessibilityTextInsertion else { return nil }
-    let saved = savedPasteboardItems()
-    defer { restorePasteboard(with: saved) }
+    let saved = PasteboardSnapshot(reading: pasteboard)
+    defer { saved.restore(to: pasteboard) }
 
     pasteboard.clearContents()
     let baseline = pasteboard.changeCount
     let destination = PasteTextOutput.eventDestination(for: target)
-    guard Self.postCopyShortcut(destination: destination) else { return nil }
+    guard copyShortcut(destination) else { return nil }
 
     // Give the target app a moment to service the copy; bail out early once it lands.
     for _ in 0..<10 {
       guard pasteboard.changeCount == baseline else { break }
-      try? await Task.sleep(nanoseconds: 40_000_000)
+      try? await Task.sleep(for: copySettleDelay)
     }
     guard pasteboard.changeCount != baseline else { return nil }
     return pasteboard.string(forType: .string)
   }
+}
 
-  private func lastInsertedTranscription() -> String? {
-    let text = historyManager.items.first
-      .flatMap { $0.postProcessedTranscription ?? $0.rawTranscription }?
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    guard let text, !text.isEmpty else { return nil }
-    return text
+/// Simulated ⌘C / ⌘V delivery to a target process.
+enum VoiceEditKeyboardShortcuts {
+  private static let copyKeyCode: CGKeyCode = 8
+  private static let pasteKeyCode: CGKeyCode = 9
+
+  @MainActor
+  static func postCopy(to destination: PasteTextOutput.EventDestination) -> Bool {
+    post(keyCode: copyKeyCode, destination: destination)
   }
 
-  // MARK: - Replacement
-
-  func replace(
-    _ capture: Capture,
-    with rewrite: String
-  ) async -> VoiceEditOrchestrator.ReplacementOutcome {
-    if await replaceViaAccessibility(capture, rewrite: rewrite) {
-      return .replaced
-    }
-    return pasteReplacement(rewrite, target: capture.target)
+  @MainActor
+  static func postPaste(to destination: PasteTextOutput.EventDestination) -> Bool {
+    post(keyCode: pasteKeyCode, destination: destination)
   }
 
-  /// Terminal fallback when no capture is available to replace: park the rewrite on the
-  /// clipboard so the HUD's "Press ⌘V to paste" guidance is accurate.
-  func leaveOnClipboard(_ rewrite: String) -> VoiceEditOrchestrator.ReplacementOutcome {
-    pasteboard.clearContents()
-    pasteboard.setString(rewrite, forType: .string)
-    return .leftOnClipboard
-  }
-
-  private func replaceViaAccessibility(_ capture: Capture, rewrite: String) async -> Bool {
-    guard permissionsManager.status(for: .accessibility).isGranted,
-          let element = focusedElement(for: capture.target)
-    else { return false }
-
-    if capture.selection.source == .lastInsertion {
-      guard Self.selectLastOccurrence(of: capture.selection.text, in: element) else {
-        return false
-      }
-    }
-
-    let status = AXUIElementSetAttributeValue(
-      element, kAXSelectedTextAttribute as CFString, rewrite as CFTypeRef
-    )
-    guard status == .success else { return false }
-    return await Self.verifyRewriteApplied(rewrite, in: element)
-  }
-
-  private func pasteReplacement(
-    _ rewrite: String,
-    target: TextOutputTarget
-  ) -> VoiceEditOrchestrator.ReplacementOutcome {
-    if DistributionChannel.current.supportsAccessibilityTextInsertion {
-      let output = PasteTextOutput(
-        permissionsManager: permissionsManager,
-        appSettings: appSettings,
-        pasteboard: pasteboard
-      )
-      let result = output.output(text: rewrite, target: target)
-      if result.error == nil, result.method == .clipboard {
-        return .pasted
-      }
-    }
-    // Mirror the existing delivery fallback: leave the rewrite on the clipboard so a manual
-    // ⌘V still completes the edit.
-    pasteboard.clearContents()
-    pasteboard.setString(rewrite, forType: .string)
-    return .leftOnClipboard
-  }
-
-  // MARK: - Pasteboard save/restore
-
-  private func savedPasteboardItems() -> [[NSPasteboard.PasteboardType: Data]] {
-    let items = pasteboard.pasteboardItems ?? []
-    return items.compactMap { item in
-      var contents: [NSPasteboard.PasteboardType: Data] = [:]
-      for type in item.types {
-        if let data = item.data(forType: type) {
-          contents[type] = data
-        }
-      }
-      return contents.isEmpty ? nil : contents
-    }
-  }
-
-  private func restorePasteboard(with saved: [[NSPasteboard.PasteboardType: Data]]) {
-    pasteboard.clearContents()
-    let items = saved.map { contents -> NSPasteboardItem in
-      let item = NSPasteboardItem()
-      for (type, data) in contents {
-        item.setData(data, forType: type)
-      }
-      return item
-    }
-    if !items.isEmpty {
-      pasteboard.writeObjects(items)
-    }
-  }
-
-  // MARK: - Copy shortcut simulation
-
-  private static func postCopyShortcut(destination: PasteTextOutput.EventDestination) -> Bool {
+  private static func post(keyCode: CGKeyCode, destination: PasteTextOutput.EventDestination) -> Bool {
     guard destination != .none,
-          let source = CGEventSource(stateID: .combinedSessionState),
-          let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 8, keyDown: true),
-          let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 8, keyDown: false)
+      let source = CGEventSource(stateID: .combinedSessionState),
+      let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+      let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
     else { return false }
     keyDown.flags = .maskCommand
     keyUp.flags = .maskCommand
-    post(keyDown, destination: destination)
-    post(keyUp, destination: destination)
+    deliver(keyDown, to: destination)
+    deliver(keyUp, to: destination)
     return true
   }
 
-  private static func post(_ event: CGEvent, destination: PasteTextOutput.EventDestination) {
+  private static func deliver(_ event: CGEvent, to destination: PasteTextOutput.EventDestination) {
     switch destination {
     case .process(let processIdentifier):
       event.postToPid(processIdentifier)
@@ -213,49 +174,5 @@ final class VoiceEditSelectionService {
     case .none:
       break
     }
-  }
-
-  // MARK: - Accessibility helpers
-
-  private func focusedElement(for target: TextOutputTarget) -> AXUIElement? {
-    target.focusedElement ?? Self.systemFocusedElement()
-  }
-
-  private static func systemFocusedElement() -> AXUIElement? {
-    let systemWide = AXUIElementCreateSystemWide()
-    var rawFocused: CFTypeRef?
-    let status = AXUIElementCopyAttributeValue(
-      systemWide, kAXFocusedUIElementAttribute as CFString, &rawFocused
-    )
-    guard status == .success, let rawFocused else { return nil }
-    return unsafeBitCast(rawFocused, to: AXUIElement.self)
-  }
-
-  private static func stringAttribute(_ attribute: String, of element: AXUIElement) -> String? {
-    var value: CFTypeRef?
-    let status = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
-    guard status == .success else { return nil }
-    return value as? String
-  }
-
-  private static func selectLastOccurrence(of text: String, in element: AXUIElement) -> Bool {
-    guard let current = stringAttribute(kAXValueAttribute, of: element) else { return false }
-    let nsRange = (current as NSString).range(of: text, options: .backwards)
-    guard nsRange.location != NSNotFound else { return false }
-    var cfRange = CFRange(location: nsRange.location, length: nsRange.length)
-    guard let axRange = AXValueCreate(.cfRange, &cfRange) else { return false }
-    let status = AXUIElementSetAttributeValue(
-      element, kAXSelectedTextRangeAttribute as CFString, axRange
-    )
-    return status == .success
-  }
-
-  /// Re-reads the field after a short delay to confirm the rewrite landed. Fields whose value
-  /// cannot be read back (web areas, custom views) are trusted after a successful set call,
-  /// because pasting on top of an already-applied rewrite would duplicate it.
-  private static func verifyRewriteApplied(_ rewrite: String, in element: AXUIElement) async -> Bool {
-    try? await Task.sleep(for: .milliseconds(50))
-    guard let current = stringAttribute(kAXValueAttribute, of: element) else { return true }
-    return current.contains(rewrite)
   }
 }

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -90,6 +90,11 @@ public enum ChannelFeature: String, Sendable, CaseIterable {
     /// Cross-app text insertion via AXUIElement. The App Store sandbox blocks
     /// reading and mutating another app's accessibility hierarchy.
     case accessibilityTextInsertion
+    /// Voice Edit: reading another app's selection and replacing it through its
+    /// accessibility hierarchy or a simulated ⌘C/⌘V. Needs the same cross-app
+    /// access as `accessibilityTextInsertion`, so the App Store build must not
+    /// offer the shortcut at all rather than fail at apply time (issue #673).
+    case voiceEdit
     /// Freedom to reference other distribution channels or external purchases in UI copy.
     /// App Store review guidelines discourage this, so App Store builds must not.
     case crossChannelMessaging
@@ -111,7 +116,7 @@ public extension DistributionChannel {
     func supports(_ feature: ChannelFeature) -> Bool {
         switch feature {
         case .selfUpdate, .externalLocalModelRuntime, .automaticAccessibilityPrompt,
-             .accessibilityTextInsertion, .crossChannelMessaging:
+             .accessibilityTextInsertion, .voiceEdit, .crossChannelMessaging:
             return self == .direct
         case .iCloudSync, .encryptedCloudKitKeySync:
             // iOS and Mac App Store builds carry the managed iCloud entitlements.
@@ -140,6 +145,9 @@ public extension DistributionChannel {
 
     /// Whether this build may insert text directly into another app via AXUIElement.
     var supportsAccessibilityTextInsertion: Bool { supports(.accessibilityTextInsertion) }
+
+    /// Whether this build can offer Voice Edit (select text → speak → replaced in place).
+    var supportsVoiceEdit: Bool { supports(.voiceEdit) }
 
     /// Whether UI copy may reference other distribution channels (e.g. the direct
     /// download). `false` for App Store builds to stay within review guidelines.

--- a/Sources/SpeakCore/VoiceEditPolicy.swift
+++ b/Sources/SpeakCore/VoiceEditPolicy.swift
@@ -37,12 +37,24 @@ public enum VoiceEditPolicy {
         raw.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Cleans a model response into replacement text: trims outer whitespace, strips a wrapping
-    /// code fence, and strips symmetric wrapping quotes that the original selection did not have.
-    public static func normalizedRewrite(_ raw: String, original: String) -> String {
-        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        text = strippingCodeFence(from: text, original: original)
-        text = strippingWrappingQuotes(from: text, original: original)
+    /// Cleans a model response into replacement text by removing only provably accidental
+    /// wrappers: outer whitespace the original selection did not have, a wrapping code fence,
+    /// and symmetric wrapping quotes the original did not have. Formatting the spoken
+    /// instruction asked for — quotes, a code block, indentation, line breaks — is never
+    /// removed, because the response is then the requested output (issue #673).
+    public static func normalizedRewrite(
+        _ raw: String,
+        original: String,
+        instruction: String = ""
+    ) -> String {
+        let intent = VoiceEditFormattingIntent(instruction: instruction)
+        var text = trimmingAccidentalWhitespace(from: raw, original: original, intent: intent)
+        if !intent.requestsCodeFence {
+            text = strippingCodeFence(from: text, original: original)
+        }
+        if !intent.requestsQuotes {
+            text = strippingWrappingQuotes(from: text, original: original)
+        }
         return text
     }
 
@@ -53,6 +65,28 @@ public enum VoiceEditPolicy {
         let instruction: String
     }
 
+    /// Trims leading/trailing whitespace only where the original selection had none, so an
+    /// indented selection keeps its indentation and a selection ending in a newline keeps it.
+    private static func trimmingAccidentalWhitespace(
+        from text: String,
+        original: String,
+        intent: VoiceEditFormattingIntent
+    ) -> String {
+        guard !intent.requestsWhitespace else { return text }
+        var result = Substring(text)
+        let originalStartsWithWhitespace = original.first?.isWhitespace ?? false
+        let originalEndsWithWhitespace = original.last?.isWhitespace ?? false
+        if !originalStartsWithWhitespace {
+            result = result.drop(while: \.isWhitespace)
+        }
+        if !originalEndsWithWhitespace {
+            while let last = result.last, last.isWhitespace {
+                result.removeLast()
+            }
+        }
+        return String(result)
+    }
+
     private static func strippingCodeFence(from text: String, original: String) -> String {
         guard text.hasPrefix("```"), text.hasSuffix("```"), !original.hasPrefix("```") else {
             return text
@@ -61,7 +95,8 @@ public enum VoiceEditPolicy {
         guard lines.count >= 2 else { return text }
         lines.removeFirst()
         lines.removeLast()
-        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        // Only the fence's own line breaks are accidental; indentation inside it is content.
+        return lines.joined(separator: "\n").trimmingCharacters(in: .newlines)
     }
 
     private static func strippingWrappingQuotes(from text: String, original: String) -> String {
@@ -87,5 +122,36 @@ public enum VoiceEditPolicy {
             preconditionFailure("Voice edit payload must be JSON encodable")
         }
         return string
+    }
+}
+
+/// Output formatting the spoken instruction explicitly asked for. Response cleanup consults
+/// this so it only removes wrappers the model added on its own.
+public struct VoiceEditFormattingIntent: Equatable, Sendable {
+    public let requestsQuotes: Bool
+    public let requestsCodeFence: Bool
+    public let requestsWhitespace: Bool
+
+    public init(requestsQuotes: Bool, requestsCodeFence: Bool, requestsWhitespace: Bool) {
+        self.requestsQuotes = requestsQuotes
+        self.requestsCodeFence = requestsCodeFence
+        self.requestsWhitespace = requestsWhitespace
+    }
+
+    public init(instruction: String) {
+        let lowered = instruction.lowercased()
+        func mentions(_ terms: [String]) -> Bool {
+            terms.contains { lowered.contains($0) }
+        }
+        self.init(
+            requestsQuotes: mentions(["quote", "quotation", "inverted comma", "speech mark"]),
+            requestsCodeFence: mentions([
+                "code block", "code fence", "fenced", "backtick", "```", "code snippet", "as code"
+            ]),
+            requestsWhitespace: mentions([
+                "indent", "whitespace", "white space", "newline", "new line", "line break",
+                "blank line", "trailing", "leading", "tab", "padding"
+            ])
+        )
     }
 }

--- a/Tests/SpeakAppTests/CaptureSessionOwnershipTests.swift
+++ b/Tests/SpeakAppTests/CaptureSessionOwnershipTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+
+@testable import SpeakApp
+
+/// The shared-capture reservation between normal dictation and Voice Edit
+/// (issue #673).
+@MainActor
+final class CaptureSessionOwnershipTests: XCTestCase {
+  func testReserve_isExclusiveBetweenFlows() {
+    let ownership = CaptureSessionOwnership()
+
+    XCTAssertTrue(ownership.reserve(.voiceEdit))
+    XCTAssertFalse(ownership.reserve(.dictation), "Dictation must not start on top of Voice Edit")
+    XCTAssertTrue(ownership.isHeld(by: .voiceEdit))
+    XCTAssertFalse(ownership.isHeld(by: .dictation))
+
+    ownership.release(.voiceEdit)
+    XCTAssertNil(ownership.owner)
+    XCTAssertTrue(ownership.reserve(.dictation))
+    XCTAssertFalse(ownership.reserve(.voiceEdit), "Voice Edit must not start on top of dictation")
+  }
+
+  func testReserve_isReentrantForTheHolder() {
+    let ownership = CaptureSessionOwnership()
+    XCTAssertTrue(ownership.reserve(.dictation))
+    XCTAssertTrue(ownership.reserve(.dictation))
+    XCTAssertEqual(ownership.owner, .dictation)
+  }
+
+  func testRelease_ignoresFlowsThatDoNotHoldTheReservation() {
+    let ownership = CaptureSessionOwnership()
+    ownership.reserve(.voiceEdit)
+
+    ownership.release(.dictation)
+
+    XCTAssertEqual(ownership.owner, .voiceEdit, "A late release from the other flow must not free it")
+    ownership.release(.voiceEdit)
+    XCTAssertNil(ownership.owner)
+  }
+
+  func testMayTearDownCapture_onlyForTheHolderOrWhenFree() {
+    let ownership = CaptureSessionOwnership()
+    XCTAssertTrue(ownership.mayTearDownCapture(.dictation))
+    XCTAssertTrue(ownership.mayTearDownCapture(.voiceEdit))
+
+    ownership.reserve(.voiceEdit)
+    XCTAssertFalse(
+      ownership.mayTearDownCapture(.dictation),
+      "Dictation's failure cleanup must not cancel Voice Edit's recorder or live stream"
+    )
+    XCTAssertTrue(ownership.mayTearDownCapture(.voiceEdit))
+  }
+}

--- a/Tests/SpeakAppTests/LiveTextInserterStreamingTests.swift
+++ b/Tests/SpeakAppTests/LiveTextInserterStreamingTests.swift
@@ -84,6 +84,41 @@ final class LiveTextInserterStreamingTests: XCTestCase {
         return inserter
     }
 
+    // MARK: - Insertion range for Voice Edit (issue #673)
+
+    @MainActor
+    func testFinalizeRecordsTheStreamedRegionAsTheInsertionRange() {
+        let field = FakeStreamingTextField(
+            value: "Note: ", selection: CFRange(location: 6, length: 0)
+        )
+        let inserter = self.makeInserter(field: field)
+        XCTAssertNil(inserter.lastInsertedRange, "Nothing has been written yet")
+
+        inserter.update(with: "hello")
+        inserter.update(with: "hello there")
+        let result = inserter.applyPolishedFinal("Hello there.")
+
+        guard case .applied = result else {
+            return XCTFail("Expected the final text to be applied, got \(result)")
+        }
+        XCTAssertEqual(field.value, "Note: Hello there.")
+        XCTAssertEqual(inserter.lastInsertedRange, VoiceEditTextRange(location: 6, length: 12))
+        XCTAssertEqual(inserter.lastInsertedRange?.substring(of: field.value), "Hello there.")
+    }
+
+    @MainActor
+    func testInsertionRangeIsClearedWhenANewSessionBegins() {
+        let field = FakeStreamingTextField(value: "", selection: CFRange(location: 0, length: 0))
+        let inserter = self.makeInserter(field: field)
+        inserter.update(with: "hello")
+        _ = inserter.applyPolishedFinal("hello")
+        XCTAssertNotNil(inserter.lastInsertedRange)
+
+        inserter.reset()
+
+        XCTAssertNil(inserter.lastInsertedRange)
+    }
+
     // MARK: - Happy path
 
     @MainActor

--- a/Tests/SpeakAppTests/PasteboardSnapshotTests.swift
+++ b/Tests/SpeakAppTests/PasteboardSnapshotTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import XCTest
+
+@testable import SpeakApp
+
+/// Pasteboard save/restore must be byte-for-byte across every item and type,
+/// not just the plain string (issue #673).
+final class PasteboardSnapshotTests: XCTestCase {
+  private let customType = NSPasteboard.PasteboardType("com.speakapp.tests.blob")
+
+  private func makePasteboard() -> NSPasteboard {
+    NSPasteboard(name: NSPasteboard.Name("com.speakapp.pasteboard-snapshot-tests.\(UUID().uuidString)"))
+  }
+
+  func testRestore_bringsBackEveryItemAndTypeByteForByte() throws {
+    let pasteboard = makePasteboard()
+    defer { pasteboard.clearContents() }
+
+    let rich = NSPasteboardItem()
+    rich.setString("plain form", forType: .string)
+    rich.setData(Data("{\\rtf1 rich form}".utf8), forType: .rtf)
+    rich.setData(Data([0x00, 0xFF, 0x10, 0x20]), forType: customType)
+    let second = NSPasteboardItem()
+    second.setData(Data(repeating: 0xAB, count: 64), forType: .tiff)
+    pasteboard.clearContents()
+    XCTAssertTrue(pasteboard.writeObjects([rich, second]))
+
+    let snapshot = PasteboardSnapshot(reading: pasteboard)
+    XCTAssertEqual(snapshot.items.count, 2)
+
+    pasteboard.clearContents()
+    pasteboard.setString("transient paste", forType: .string)
+    snapshot.restore(to: pasteboard)
+
+    let items = try XCTUnwrap(pasteboard.pasteboardItems)
+    XCTAssertEqual(items.count, 2)
+    XCTAssertEqual(items[0].string(forType: .string), "plain form")
+    XCTAssertEqual(items[0].data(forType: .rtf), Data("{\\rtf1 rich form}".utf8))
+    XCTAssertEqual(items[0].data(forType: customType), Data([0x00, 0xFF, 0x10, 0x20]))
+    XCTAssertEqual(items[1].data(forType: .tiff), Data(repeating: 0xAB, count: 64))
+    XCTAssertNil(items[1].string(forType: .string), "An item must not gain types it never had")
+  }
+
+  func testSnapshotOfEmptyPasteboard_restoresToEmpty() {
+    let pasteboard = makePasteboard()
+    defer { pasteboard.clearContents() }
+    pasteboard.clearContents()
+
+    let snapshot = PasteboardSnapshot(reading: pasteboard)
+    XCTAssertTrue(snapshot.isEmpty)
+
+    pasteboard.setString("transient paste", forType: .string)
+    snapshot.restore(to: pasteboard)
+
+    XCTAssertNil(pasteboard.string(forType: .string))
+    XCTAssertEqual(pasteboard.pasteboardItems?.count ?? 0, 0)
+  }
+
+  func testSnapshot_isValueComparable() {
+    let contents: [[NSPasteboard.PasteboardType: Data]] = [[.string: Data("x".utf8)]]
+    XCTAssertEqual(PasteboardSnapshot(items: contents), PasteboardSnapshot(items: contents))
+    XCTAssertNotEqual(PasteboardSnapshot(items: contents), PasteboardSnapshot(items: []))
+  }
+}

--- a/Tests/SpeakAppTests/ShortcutAvailabilityTests.swift
+++ b/Tests/SpeakAppTests/ShortcutAvailabilityTests.swift
@@ -1,0 +1,42 @@
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// Voice Edit needs cross-app accessibility access the App Store sandbox
+/// blocks, so its shortcut must not exist on that channel (issue #673).
+final class ShortcutAvailabilityTests: XCTestCase {
+  func testVoiceEditFeature_isDirectChannelOnly() {
+    XCTAssertTrue(DistributionChannel.direct.supportsVoiceEdit)
+    XCTAssertFalse(DistributionChannel.appStore.supportsVoiceEdit)
+    XCTAssertEqual(
+      DistributionChannel.appStore.supports(.voiceEdit),
+      DistributionChannel.appStore.supports(.accessibilityTextInsertion),
+      "Voice Edit is gated by the same cross-app access as accessibility insertion"
+    )
+  }
+
+  func testEditSelectionByVoice_isUnavailableOnTheAppStoreChannel() {
+    XCTAssertEqual(ShortcutAction.editSelectionByVoice.requiredChannelFeature, .voiceEdit)
+    XCTAssertTrue(ShortcutAction.editSelectionByVoice.isAvailable(in: .direct))
+    XCTAssertFalse(ShortcutAction.editSelectionByVoice.isAvailable(in: .appStore))
+  }
+
+  func testEveryOtherAction_isAvailableOnEveryChannel() {
+    for channel in DistributionChannel.allCases {
+      for action in ShortcutAction.allCases where action != .editSelectionByVoice {
+        XCTAssertNil(action.requiredChannelFeature, "\(action.displayName) needs no channel gate")
+        XCTAssertTrue(action.isAvailable(in: channel), "\(action.displayName) on \(channel)")
+      }
+    }
+  }
+
+  func testAvailableCases_excludeVoiceEditOnlyWhereUnsupported() {
+    let appStore = ShortcutAction.availableCases(in: .appStore)
+    XCTAssertFalse(appStore.contains(.editSelectionByVoice))
+    XCTAssertEqual(appStore.count, ShortcutAction.allCases.count - 1)
+
+    let direct = ShortcutAction.availableCases(in: .direct)
+    XCTAssertEqual(direct, ShortcutAction.allCases)
+  }
+}

--- a/Tests/SpeakAppTests/VoiceEditOrchestratorLifecycleTests.swift
+++ b/Tests/SpeakAppTests/VoiceEditOrchestratorLifecycleTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+
+@testable import SpeakApp
+
+/// Shared-capture reservation and awaited cancellation (issue #673): Voice Edit
+/// must never start on top of dictation, must hold capture until its own
+/// teardown is done, and a restart right after Escape must not meet the
+/// previous session's recorder.
+@MainActor
+final class VoiceEditOrchestratorLifecycleTests: XCTestCase {
+    private typealias Harness = VoiceEditOrchestratorHarness
+
+    // MARK: - Reservation
+
+    func testReservationHeldByDictation_failsBeforeTouchingCapture() async {
+        let harness = Harness()
+        harness.reservationAvailable = false
+
+        await harness.orchestrator.toggle()
+
+        XCTAssertEqual(harness.events, [.failed(.dictationBusy)])
+        XCTAssertEqual(harness.reserveCount, 1)
+        XCTAssertEqual(harness.captureCount, 0)
+        XCTAssertEqual(harness.startCount, 0)
+        XCTAssertEqual(harness.releaseCount, 0, "Nothing was reserved, so nothing is released")
+    }
+
+    func testReservation_isHeldForTheWholeSessionAndReleasedOnSuccess() async {
+        let harness = Harness()
+        await harness.orchestrator.toggle()
+        XCTAssertEqual(harness.reserveCount, 1)
+        XCTAssertEqual(harness.releaseCount, 0, "Held while listening")
+
+        await harness.orchestrator.toggle()
+
+        XCTAssertEqual(harness.releaseCount, 1)
+    }
+
+    func testReservation_isReleasedAfterAFailedStart() async {
+        let harness = Harness()
+        harness.selection = nil
+
+        await harness.orchestrator.toggle()
+
+        XCTAssertEqual(harness.reserveCount, 1)
+        XCTAssertEqual(harness.releaseCount, 1)
+    }
+
+    func testReservation_isReleasedAfterCancel() async {
+        let harness = Harness()
+        await harness.orchestrator.toggle()
+
+        await harness.orchestrator.cancel()
+
+        XCTAssertEqual(harness.releaseCount, 1)
+    }
+
+    // MARK: - Cancellation
+
+    func testCancelDuringListening_stopsRecordingAndEmitsCancelled() async {
+        let harness = Harness()
+        await harness.orchestrator.toggle()
+
+        await harness.orchestrator.cancel()
+
+        XCTAssertEqual(harness.cancelCount, 1)
+        XCTAssertEqual(harness.events.last, .cancelled)
+        XCTAssertEqual(harness.orchestrator.phase, .idle)
+        XCTAssertEqual(harness.finishCount, 0)
+    }
+
+    func testCancelWhenIdle_isANoOp() async {
+        let harness = Harness()
+
+        await harness.orchestrator.cancel()
+
+        XCTAssertTrue(harness.events.isEmpty)
+        XCTAssertEqual(harness.cancelCount, 0)
+    }
+
+    func testCancel_returnsToIdleOnlyAfterTeardownCompletes() async {
+        let harness = Harness()
+        await harness.orchestrator.toggle()
+        let teardownEntered = expectation(description: "teardown entered")
+        let gate = VoiceEditTestGate()
+        harness.cancelGate = {
+            teardownEntered.fulfill()
+            await gate.wait()
+        }
+
+        let cancel = Task { await harness.orchestrator.cancel() }
+        await fulfillment(of: [teardownEntered], timeout: 2)
+
+        XCTAssertEqual(harness.orchestrator.phase, .cancelling)
+        XCTAssertFalse(harness.events.contains(.cancelled), "Cancelled is reported only once teardown is done")
+        XCTAssertEqual(harness.releaseCount, 0, "Capture stays reserved until the recorder is released")
+
+        gate.open()
+        await cancel.value
+
+        XCTAssertEqual(harness.orchestrator.phase, .idle)
+        XCTAssertEqual(harness.events.last, .cancelled)
+        XCTAssertEqual(harness.releaseCount, 1)
+    }
+
+    func testRestartDuringCancel_waitsForTeardownThenStartsFresh() async {
+        let harness = Harness()
+        await harness.orchestrator.toggle()
+        let teardownEntered = expectation(description: "teardown entered")
+        let gate = VoiceEditTestGate()
+        harness.cancelGate = {
+            teardownEntered.fulfill()
+            await gate.wait()
+        }
+
+        let cancel = Task { await harness.orchestrator.cancel() }
+        await fulfillment(of: [teardownEntered], timeout: 2)
+        let restart = Task { await harness.orchestrator.toggle() }
+        await Task.yield()
+
+        XCTAssertEqual(harness.startCount, 1, "The restart must not start recording over the old recorder")
+        XCTAssertEqual(harness.captureCount, 1)
+
+        gate.open()
+        await cancel.value
+        await restart.value
+
+        XCTAssertEqual(harness.orchestrator.phase, .listening)
+        XCTAssertEqual(harness.cancelCount, 1)
+        XCTAssertEqual(harness.startCount, 2)
+        XCTAssertEqual(
+            harness.events,
+            [.listeningStarted(.accessibility), .cancelled, .listeningStarted(.accessibility)]
+        )
+    }
+}

--- a/Tests/SpeakAppTests/VoiceEditOrchestratorTestHarness.swift
+++ b/Tests/SpeakAppTests/VoiceEditOrchestratorTestHarness.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+@testable import SpeakApp
+
+struct VoiceEditStubError: LocalizedError {
+    let message: String
+
+    var errorDescription: String? { message }
+}
+
+/// Test double owning every orchestrator seam, so each test tweaks only what it needs.
+@MainActor
+final class VoiceEditOrchestratorHarness {
+    var busy = false
+    var reservationAvailable = true
+    var llmConfigured = true
+    var selection: VoiceEditOrchestrator.Selection? = .init(
+        text: "The quick brown fox jumps over the lazy dog",
+        source: .accessibility
+    )
+    var startError: Error?
+    var instructionResult: Result<String, Error> = .success("make this shorter")
+    var rewriteResult: Result<String, Error> = .success("Quick fox, lazy dog.")
+    var replacementOutcome: VoiceEditOrchestrator.ReplacementOutcome = .replaced
+    /// Suspends selection capture so tests can press the hotkey again mid-startup.
+    var captureGate: (() async -> Void)?
+    /// Suspends cancellation teardown so tests can observe the cancelling phase.
+    var cancelGate: (() async -> Void)?
+
+    private(set) var events: [VoiceEditOrchestrator.Event] = []
+    private(set) var captureCount = 0
+    private(set) var startCount = 0
+    private(set) var finishCount = 0
+    private(set) var cancelCount = 0
+    private(set) var reserveCount = 0
+    private(set) var releaseCount = 0
+    private(set) var rewriteRequests: [(selection: String, instruction: String)] = []
+    private(set) var appliedRewrites: [String] = []
+
+    lazy var orchestrator = VoiceEditOrchestrator(
+        dependencies: .init(
+            isDictationBusy: { self.busy },
+            reserveCapture: {
+                self.reserveCount += 1
+                return self.reservationAvailable
+            },
+            releaseCapture: { self.releaseCount += 1 },
+            hasConfiguredLLM: { self.llmConfigured },
+            captureSelection: {
+                self.captureCount += 1
+                await self.captureGate?()
+                return self.selection
+            },
+            startListening: {
+                self.startCount += 1
+                if let error = self.startError { throw error }
+            },
+            finishListening: {
+                self.finishCount += 1
+                return try self.instructionResult.get()
+            },
+            cancelListening: {
+                self.cancelCount += 1
+                await self.cancelGate?()
+            },
+            rewrite: { selection, instruction in
+                self.rewriteRequests.append((selection.text, instruction))
+                return try self.rewriteResult.get()
+            },
+            applyReplacement: { _, rewrite in
+                self.appliedRewrites.append(rewrite)
+                return self.replacementOutcome
+            },
+            onEvent: { self.events.append($0) }
+        )
+    )
+}
+
+/// One-shot gate used to hold an orchestrator dependency at a suspension point.
+@MainActor
+final class VoiceEditTestGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        guard !self.isOpen else { return }
+        await withCheckedContinuation { self.continuation = $0 }
+    }
+
+    func open() {
+        self.isOpen = true
+        self.continuation?.resume()
+        self.continuation = nil
+    }
+}

--- a/Tests/SpeakAppTests/VoiceEditOrchestratorTests.swift
+++ b/Tests/SpeakAppTests/VoiceEditOrchestratorTests.swift
@@ -4,66 +4,7 @@ import XCTest
 
 @MainActor
 final class VoiceEditOrchestratorTests: XCTestCase {
-    private struct StubError: LocalizedError {
-        let message: String
-
-        var errorDescription: String? { message }
-    }
-
-    /// Test double owning every orchestrator seam, so each test tweaks only what it needs.
-    @MainActor
-    private final class Harness {
-        var busy = false
-        var llmConfigured = true
-        var selection: VoiceEditOrchestrator.Selection? = .init(
-            text: "The quick brown fox jumps over the lazy dog",
-            source: .accessibility
-        )
-        var startError: Error?
-        var instructionResult: Result<String, Error> = .success("make this shorter")
-        var rewriteResult: Result<String, Error> = .success("Quick fox, lazy dog.")
-        var replacementOutcome: VoiceEditOrchestrator.ReplacementOutcome = .replaced
-        /// Suspends selection capture so tests can press the hotkey again mid-startup.
-        var captureGate: (() async -> Void)?
-
-        private(set) var events: [VoiceEditOrchestrator.Event] = []
-        private(set) var captureCount = 0
-        private(set) var startCount = 0
-        private(set) var finishCount = 0
-        private(set) var cancelCount = 0
-        private(set) var rewriteRequests: [(selection: String, instruction: String)] = []
-        private(set) var appliedRewrites: [String] = []
-
-        lazy var orchestrator = VoiceEditOrchestrator(
-            dependencies: .init(
-                isDictationBusy: { self.busy },
-                hasConfiguredLLM: { self.llmConfigured },
-                captureSelection: {
-                    self.captureCount += 1
-                    await self.captureGate?()
-                    return self.selection
-                },
-                startListening: {
-                    self.startCount += 1
-                    if let error = self.startError { throw error }
-                },
-                finishListening: {
-                    self.finishCount += 1
-                    return try self.instructionResult.get()
-                },
-                cancelListening: { self.cancelCount += 1 },
-                rewrite: { selection, instruction in
-                    self.rewriteRequests.append((selection.text, instruction))
-                    return try self.rewriteResult.get()
-                },
-                applyReplacement: { _, rewrite in
-                    self.appliedRewrites.append(rewrite)
-                    return self.replacementOutcome
-                },
-                onEvent: { self.events.append($0) }
-            )
-        )
-    }
+    private typealias Harness = VoiceEditOrchestratorHarness
 
     // MARK: - Happy path
 
@@ -119,12 +60,12 @@ final class VoiceEditOrchestratorTests: XCTestCase {
 
     func testClipboardReplacementOutcome_isPropagated() async {
         let harness = Harness()
-        harness.replacementOutcome = .leftOnClipboard
+        harness.replacementOutcome = .leftOnClipboard(.selectionChanged)
 
         await harness.orchestrator.toggle()
         await harness.orchestrator.toggle()
 
-        XCTAssertEqual(harness.events.last, .finished(.leftOnClipboard))
+        XCTAssertEqual(harness.events.last, .finished(.leftOnClipboard(.selectionChanged)))
         XCTAssertEqual(harness.orchestrator.phase, .idle)
     }
 
@@ -174,7 +115,7 @@ final class VoiceEditOrchestratorTests: XCTestCase {
 
     func testRecordingStartFailure_reportsAndStaysIdle() async {
         let harness = Harness()
-        harness.startError = StubError(message: "mic unavailable")
+        harness.startError = VoiceEditStubError(message: "mic unavailable")
 
         await harness.orchestrator.toggle()
 
@@ -199,7 +140,7 @@ final class VoiceEditOrchestratorTests: XCTestCase {
 
     func testTranscriptionFailure_isReported() async {
         let harness = Harness()
-        harness.instructionResult = .failure(StubError(message: "provider offline"))
+        harness.instructionResult = .failure(VoiceEditStubError(message: "provider offline"))
 
         await harness.orchestrator.toggle()
         await harness.orchestrator.toggle()
@@ -210,7 +151,7 @@ final class VoiceEditOrchestratorTests: XCTestCase {
 
     func testRewriteFailure_isReportedWithoutApplying() async {
         let harness = Harness()
-        harness.rewriteResult = .failure(StubError(message: "429 rate limited"))
+        harness.rewriteResult = .failure(VoiceEditStubError(message: "429 rate limited"))
 
         await harness.orchestrator.toggle()
         await harness.orchestrator.toggle()
@@ -234,29 +175,6 @@ final class VoiceEditOrchestratorTests: XCTestCase {
         XCTAssertTrue(harness.appliedRewrites.isEmpty)
     }
 
-    // MARK: - Cancellation
-
-    func testCancelDuringListening_stopsRecordingAndEmitsCancelled() async {
-        let harness = Harness()
-        await harness.orchestrator.toggle()
-
-        harness.orchestrator.cancel()
-
-        XCTAssertEqual(harness.cancelCount, 1)
-        XCTAssertEqual(harness.events.last, .cancelled)
-        XCTAssertEqual(harness.orchestrator.phase, .idle)
-        XCTAssertEqual(harness.finishCount, 0)
-    }
-
-    func testCancelWhenIdle_isANoOp() {
-        let harness = Harness()
-
-        harness.orchestrator.cancel()
-
-        XCTAssertTrue(harness.events.isEmpty)
-        XCTAssertEqual(harness.cancelCount, 0)
-    }
-
     func testSessionAfterFailure_startsCleanly() async {
         let harness = Harness()
         harness.selection = nil
@@ -273,7 +191,7 @@ final class VoiceEditOrchestratorTests: XCTestCase {
     func testSecondPressDuringStartup_doesNotStartAParallelSession() async {
         let harness = Harness()
         let captureEntered = expectation(description: "selection capture entered")
-        let gate = Gate()
+        let gate = VoiceEditTestGate()
         harness.captureGate = {
             captureEntered.fulfill()
             await gate.wait()
@@ -293,23 +211,5 @@ final class VoiceEditOrchestratorTests: XCTestCase {
         XCTAssertEqual(harness.startCount, 1)
         XCTAssertEqual(harness.events, [.listeningStarted(.accessibility)])
         XCTAssertEqual(harness.orchestrator.phase, .listening)
-    }
-}
-
-/// One-shot gate used to hold an orchestrator dependency at a suspension point.
-@MainActor
-private final class Gate {
-    private var continuation: CheckedContinuation<Void, Never>?
-    private var isOpen = false
-
-    func wait() async {
-        guard !self.isOpen else { return }
-        await withCheckedContinuation { self.continuation = $0 }
-    }
-
-    func open() {
-        self.isOpen = true
-        self.continuation?.resume()
-        self.continuation = nil
     }
 }

--- a/Tests/SpeakAppTests/VoiceEditReplacementServiceTests.swift
+++ b/Tests/SpeakAppTests/VoiceEditReplacementServiceTests.swift
@@ -1,0 +1,302 @@
+import AppKit
+import XCTest
+
+@testable import SpeakApp
+
+/// Replacement must touch only the captured range, verify what it wrote, and
+/// park the rewrite on the clipboard — never report "Edited" — whenever it
+/// cannot (issue #673).
+@MainActor
+final class VoiceEditReplacementServiceTests: XCTestCase {
+  private typealias Support = VoiceEditTestSupport
+
+  // MARK: - Accessibility replacement
+
+  func testReplace_intactAnchor_replacesTheCapturedRangeEvenAfterTheCaretMoved() async {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    let harness = makeHarness(field: field)
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5))
+    // The user clicked to the end of the field while speaking.
+    field.selection = CFRange(location: 19, length: 0)
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .replaced)
+    XCTAssertEqual(field.value, "The slow brown fox")
+    XCTAssertEqual(field.selectedTextWrites.count, 1)
+    XCTAssertEqual(field.selectedTextWrites.first?.range.map(VoiceEditTextRange.init), Support.range(4, 5))
+    XCTAssertEqual(harness.pasteRequests, 0)
+  }
+
+  func testReplace_editedAnchor_parksRewriteWithoutWriting() async {
+    let field = FakeVoiceEditField(value: "The QUICK brown fox", selection: CFRange(location: 4, length: 5))
+    let harness = makeHarness(field: field)
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5))
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .leftOnClipboard(.selectionChanged))
+    XCTAssertEqual(field.value, "The QUICK brown fox")
+    XCTAssertTrue(field.selectedTextWrites.isEmpty)
+    XCTAssertEqual(harness.pasteboard.string(forType: .string), "slow")
+    XCTAssertEqual(harness.pasteRequests, 0)
+  }
+
+  func testReplace_focusInAnotherField_parksRewriteWithoutWriting() async {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    let harness = makeHarness(field: field)
+    harness.resolver.focused = FakeVoiceEditField(
+      value: "The quick brown fox", selection: CFRange(location: 4, length: 5)
+    )
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5))
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .leftOnClipboard(.selectionChanged))
+    XCTAssertTrue(field.selectedTextWrites.isEmpty)
+    XCTAssertEqual(harness.pasteRequests, 0)
+  }
+
+  func testReplace_targetGone_parksRewrite() async {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    let harness = makeHarness(field: field)
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5), target: Support.goneTarget())
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .leftOnClipboard(.targetUnavailable))
+    XCTAssertTrue(field.selectedTextWrites.isEmpty)
+    XCTAssertEqual(harness.pasteRequests, 0)
+  }
+
+  func testReplace_unverifiableField_parksRewrite() async {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    field.valueReadable = false
+    field.selectionRangeReadable = false
+    field.selectedTextReadable = false
+    let harness = makeHarness(field: field)
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5))
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .leftOnClipboard(.selectionUnverifiable))
+    XCTAssertTrue(field.selectedTextWrites.isEmpty)
+    XCTAssertEqual(harness.pasteRequests, 0)
+  }
+
+  func testReplace_acceptedWriteThatDoesNotShow_parksWithoutPastingOnTop() async {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    field.transformOnWrite = { _ in "garbled" }
+    let harness = makeHarness(field: field)
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5))
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .leftOnClipboard(.replacementUnverified))
+    XCTAssertEqual(harness.pasteRequests, 0, "Pasting after an accepted write could only duplicate it")
+    XCTAssertEqual(harness.pasteboard.string(forType: .string), "slow")
+  }
+
+  func testReplace_unreadableValueAfterAcceptedWrite_isTrusted() async {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    field.valueReadable = false
+    let harness = makeHarness(field: field)
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5))
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .replaced)
+    XCTAssertEqual(field.value, "The slow brown fox")
+  }
+
+  func testReplace_textOnlyAnchor_requiresTheSelectionToStillMatch() async {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    let harness = makeHarness(field: field)
+    let capture = harness.capture(text: "quick", range: nil)
+
+    let intact = await harness.service.replace(capture, with: "slow")
+    XCTAssertEqual(intact, .replaced)
+    XCTAssertEqual(field.value, "The slow brown fox")
+
+    field.selection = CFRange(location: 0, length: 3)
+    let moved = await harness.service.replace(harness.capture(text: "slow", range: nil), with: "fast")
+    XCTAssertEqual(moved, .leftOnClipboard(.selectionChanged))
+    XCTAssertEqual(field.value, "The slow brown fox")
+  }
+
+  // MARK: - Paste fallback
+
+  #if !APP_STORE
+  func testReplace_whenAccessibilityWriteIsRejected_pastesAndRestoresClipboard() async throws {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    field.setSelectedTextResult = .failure
+    let harness = makeHarness(field: field)
+    harness.pasteboard.clearContents()
+    harness.pasteboard.setString("user clipboard", forType: .string)
+    harness.onPaste = { [weak harness] in
+      guard let pasted = harness?.pasteboard.string(forType: .string) else { return }
+      field.setSelectedTextResult = .success
+      field.simulatePaste(pasted)
+    }
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5))
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .pasted)
+    XCTAssertEqual(field.value, "The slow brown fox")
+    XCTAssertEqual(harness.pasteRequests, 1)
+    XCTAssertEqual(
+      harness.pasteboard.string(forType: .string), "user clipboard",
+      "A verified paste restores the clipboard"
+    )
+  }
+
+  func testReplace_ignoredPaste_parksRewriteAndKeepsItOnClipboard() async {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    field.setSelectedTextResult = .failure
+    let harness = makeHarness(field: field)
+    harness.pasteboard.clearContents()
+    harness.pasteboard.setString("user clipboard", forType: .string)
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5))
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .leftOnClipboard(.pasteUnverified))
+    XCTAssertEqual(field.value, "The quick brown fox")
+    XCTAssertEqual(harness.pasteRequests, 1)
+    XCTAssertEqual(harness.pasteboard.string(forType: .string), "slow", "The rewrite stays available for a manual ⌘V")
+  }
+
+  func testReplace_pastePath_refusesWhenTheSelectionMoved() async {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    field.setSelectedRangeResult = .failure
+    field.setSelectedTextResult = .failure
+    field.selection = CFRange(location: 19, length: 0)
+    let harness = makeHarness(field: field)
+    let capture = harness.capture(text: "quick", range: Support.range(4, 5))
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .leftOnClipboard(.selectionChanged))
+    XCTAssertEqual(harness.pasteRequests, 0, "⌘V would replace whatever is selected now, so it must not be posted")
+  }
+
+  func testReplace_withoutFieldAccess_parksInsteadOfPastingBlind() async {
+    let harness = makeHarness(field: nil)
+    let capture = VoiceEditSelectionService.Capture(
+      selection: .init(text: "quick", source: .clipboard),
+      target: Support.runningTarget(),
+      field: nil,
+      anchor: VoiceEditAnchor(text: "quick", range: nil)
+    )
+
+    let outcome = await harness.service.replace(capture, with: "slow")
+
+    XCTAssertEqual(outcome, .leftOnClipboard(.selectionUnverifiable))
+    XCTAssertEqual(harness.pasteRequests, 0)
+    XCTAssertEqual(harness.pasteboard.string(forType: .string), "slow")
+  }
+  #endif
+
+  func testLeaveOnClipboard_parksWithNoCaptureReason() {
+    let harness = makeHarness(field: nil)
+
+    XCTAssertEqual(harness.service.leaveOnClipboard("slow"), .leftOnClipboard(.noCapture))
+    XCTAssertEqual(harness.pasteboard.string(forType: .string), "slow")
+  }
+
+  // MARK: - Helpers
+
+  @MainActor
+  private final class Harness {
+    let service: VoiceEditReplacementService
+    let resolver: FakeVoiceEditFieldResolver
+    let pasteboard: NSPasteboard
+    let field: FakeVoiceEditField?
+    var onPaste: (() -> Void)?
+    private(set) var pasteRequests = 0
+
+    init(field: FakeVoiceEditField?) {
+      let resolver = FakeVoiceEditFieldResolver(captured: field)
+      let pasteboard = Support.makePasteboard()
+      self.resolver = resolver
+      self.pasteboard = pasteboard
+      self.field = field
+      var recordPaste: (() -> Void)?
+      self.service = VoiceEditReplacementService(
+        permissionsManager: PermissionsManager(statusProvider: { _ in .granted }),
+        fieldResolver: resolver,
+        pasteboard: pasteboard,
+        pasteShortcut: { _ in
+          recordPaste?()
+          return true
+        },
+        accessibilityVerificationDelay: .milliseconds(1),
+        pasteVerificationInterval: .milliseconds(1),
+        pasteVerificationAttempts: 3
+      )
+      recordPaste = { [weak self] in
+        self?.pasteRequests += 1
+        self?.onPaste?()
+      }
+    }
+
+    deinit {
+      pasteboard.clearContents()
+    }
+
+    func capture(
+      text: String,
+      range: VoiceEditTextRange?,
+      target: TextOutputTarget? = nil
+    ) -> VoiceEditSelectionService.Capture {
+      VoiceEditSelectionService.Capture(
+        selection: .init(text: text, source: .accessibility),
+        target: target ?? Support.runningTarget(),
+        field: field,
+        anchor: VoiceEditAnchor(text: text, range: range)
+      )
+    }
+  }
+
+  private func makeHarness(field: FakeVoiceEditField?) -> Harness {
+    Harness(field: field)
+  }
+}
+
+/// The pure anchor checks behind the replacement paths.
+final class VoiceEditAnchorStateTests: XCTestCase {
+  private typealias Support = VoiceEditTestSupport
+
+  func testEvaluate_prefersTheValueAtTheRecordedRange() {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 19, length: 0))
+    let anchor = VoiceEditAnchor(text: "quick", range: Support.range(4, 5))
+
+    XCTAssertEqual(VoiceEditAnchorState.evaluate(anchor, in: field), .intact(Support.range(4, 5)))
+    field.value = "The slow brown fox"
+    XCTAssertEqual(VoiceEditAnchorState.evaluate(anchor, in: field), .moved)
+  }
+
+  func testEvaluate_fallsBackToTheSelectionWhenTheValueIsUnreadable() {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    field.valueReadable = false
+    let anchor = VoiceEditAnchor(text: "quick", range: Support.range(4, 5))
+
+    XCTAssertEqual(VoiceEditAnchorState.evaluate(anchor, in: field), .intact(Support.range(4, 5)))
+    field.selection = CFRange(location: 0, length: 3)
+    XCTAssertEqual(VoiceEditAnchorState.evaluate(anchor, in: field), .moved)
+    field.selectionRangeReadable = false
+    field.selectedTextReadable = false
+    XCTAssertEqual(VoiceEditAnchorState.evaluate(anchor, in: field), .unverifiable)
+  }
+
+  func testEvaluateSelection_requiresTheCurrentSelectionToBeTheAnchor() {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    let anchor = VoiceEditAnchor(text: "quick", range: Support.range(4, 5))
+
+    XCTAssertEqual(VoiceEditAnchorState.evaluateSelection(anchor, in: field), .intact(Support.range(4, 5)))
+    // Same text still there, but the caret moved: a paste would land in the wrong place.
+    field.selection = CFRange(location: 19, length: 0)
+    XCTAssertEqual(VoiceEditAnchorState.evaluateSelection(anchor, in: field), .moved)
+  }
+}

--- a/Tests/SpeakAppTests/VoiceEditSelectionServiceTests.swift
+++ b/Tests/SpeakAppTests/VoiceEditSelectionServiceTests.swift
@@ -1,0 +1,196 @@
+import AppKit
+import XCTest
+
+@testable import SpeakApp
+
+/// Selection capture must produce an anchor the replacement step can verify,
+/// restore the user's clipboard exactly, and edit the last dictation only at
+/// the range it was inserted into (issue #673).
+@MainActor
+final class VoiceEditSelectionServiceTests: XCTestCase {
+  private typealias Support = VoiceEditTestSupport
+
+  // MARK: - Accessibility selection
+
+  func testCapture_accessibilitySelection_anchorsToVerifiedRange() async throws {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 4, length: 5))
+    let harness = makeHarness(field: field)
+
+    let captured = await harness.service.capture()
+    let capture = try XCTUnwrap(captured)
+
+    XCTAssertEqual(capture.selection, .init(text: "quick", source: .accessibility))
+    XCTAssertEqual(capture.anchor, VoiceEditAnchor(text: "quick", range: Support.range(4, 5)))
+    XCTAssertTrue(capture.field?.isSameField(as: field) ?? false)
+    XCTAssertEqual(harness.copyRequests, 0, "A direct selection read needs no ⌘C")
+  }
+
+  func testCapture_dropsRangeThatDisagreesWithTheFieldValue() async throws {
+    let field = FakeVoiceEditField(value: "The quick brown fox", selection: CFRange(location: 0, length: 3))
+    field.selectedTextOverride = "quick"
+    let harness = makeHarness(field: field)
+
+    let captured = await harness.service.capture()
+    let capture = try XCTUnwrap(captured)
+
+    XCTAssertEqual(capture.selection.text, "quick")
+    XCTAssertNil(capture.anchor.range, "A range that does not cover the selected text is not an anchor")
+  }
+
+  func testCapture_withoutAccessibilityPermission_doesNotReadTheField() async throws {
+    let field = FakeVoiceEditField(value: "secret text", selection: CFRange(location: 0, length: 6))
+    let harness = makeHarness(field: field, accessibilityGranted: false, copiedText: "copied text")
+
+    let captured = await harness.service.capture()
+    let capture = try XCTUnwrap(captured)
+
+    XCTAssertEqual(capture.selection, .init(text: "copied text", source: .clipboard))
+    XCTAssertNil(capture.field)
+    XCTAssertNil(capture.anchor.range)
+  }
+
+  // MARK: - Clipboard capture
+
+  func testCapture_clipboardFallback_restoresEveryPasteboardTypeAfterwards() async throws {
+    let field = FakeVoiceEditField(value: "no selection here", selection: nil)
+    let harness = makeHarness(field: field, copiedText: "copied words")
+    let userItem = NSPasteboardItem()
+    userItem.setString("user text", forType: .string)
+    userItem.setData(Data("{\\rtf1 user}".utf8), forType: .rtf)
+    harness.pasteboard.clearContents()
+    harness.pasteboard.writeObjects([userItem])
+
+    let captured = await harness.service.capture()
+    let capture = try XCTUnwrap(captured)
+
+    XCTAssertEqual(capture.selection, .init(text: "copied words", source: .clipboard))
+    XCTAssertEqual(harness.copyRequests, 1)
+    let restored = try XCTUnwrap(harness.pasteboard.pasteboardItems?.first)
+    XCTAssertEqual(restored.string(forType: .string), "user text")
+    XCTAssertEqual(restored.data(forType: .rtf), Data("{\\rtf1 user}".utf8))
+  }
+
+  func testCapture_clipboardFallbackThatCopiesNothing_restoresPasteboardAndFallsThrough() async {
+    let field = FakeVoiceEditField(value: "nothing selected", selection: nil)
+    let harness = makeHarness(field: field, copiedText: nil)
+    harness.pasteboard.clearContents()
+    harness.pasteboard.setString("user text", forType: .string)
+
+    let capture = await harness.service.capture()
+
+    XCTAssertNil(capture)
+    XCTAssertEqual(harness.pasteboard.string(forType: .string), "user text")
+  }
+
+  // MARK: - Last dictation
+
+  func testCapture_lastInsertion_usesRecordedRangeNotTextSearch() async throws {
+    // The same words occur twice; only the second occurrence was dictated.
+    let field = FakeVoiceEditField(value: "hello world hello", selection: nil)
+    let harness = makeHarness(field: field, copiedText: nil)
+    harness.records.record(
+      InsertionRecord(target: Support.runningTarget(), range: Support.range(12, 5), text: "hello", recordedAt: Date())
+    )
+
+    let captured = await harness.service.capture()
+    let capture = try XCTUnwrap(captured)
+
+    XCTAssertEqual(capture.selection, .init(text: "hello", source: .lastInsertion))
+    XCTAssertEqual(capture.anchor.range, Support.range(12, 5))
+  }
+
+  func testCapture_lastInsertion_rejectsRangeWhoseTextChanged() async {
+    let field = FakeVoiceEditField(value: "hello world HELLO", selection: nil)
+    let harness = makeHarness(field: field, copiedText: nil)
+    harness.records.record(
+      InsertionRecord(target: Support.runningTarget(), range: Support.range(12, 5), text: "hello", recordedAt: Date())
+    )
+
+    let capture = await harness.service.capture()
+
+    XCTAssertNil(capture, "Edited text at the recorded range must not be treated as the last dictation")
+  }
+
+  func testCapture_lastInsertion_rejectsWhenAnotherFieldHasFocus() async {
+    let field = FakeVoiceEditField(value: "hello world hello", selection: nil)
+    let harness = makeHarness(field: field, copiedText: nil)
+    harness.resolver.focused = FakeVoiceEditField(value: "hello world hello", selection: nil)
+    harness.records.record(
+      InsertionRecord(target: Support.runningTarget(), range: Support.range(12, 5), text: "hello", recordedAt: Date())
+    )
+
+    let capture = await harness.service.capture()
+
+    XCTAssertNil(capture)
+  }
+
+  func testCapture_lastInsertion_rejectsRecordFromAnotherApp() async {
+    let field = FakeVoiceEditField(value: "hello world hello", selection: nil)
+    let harness = makeHarness(field: field, copiedText: nil)
+    harness.records.record(
+      InsertionRecord(target: Support.goneTarget(), range: Support.range(12, 5), text: "hello", recordedAt: Date())
+    )
+
+    let capture = await harness.service.capture()
+
+    XCTAssertNil(capture)
+  }
+
+  func testCapture_withoutRecordOrSelection_returnsNil() async {
+    let field = FakeVoiceEditField(value: "hello", selection: nil)
+    let harness = makeHarness(field: field, copiedText: nil)
+
+    let capture = await harness.service.capture()
+
+    XCTAssertNil(capture)
+  }
+
+  // MARK: - Helpers
+
+  @MainActor
+  private final class Harness {
+    let service: VoiceEditSelectionService
+    let resolver: FakeVoiceEditFieldResolver
+    let records: InsertionRecordStore
+    let pasteboard: NSPasteboard
+    private(set) var copyRequests = 0
+
+    init(field: FakeVoiceEditField, accessibilityGranted: Bool, copiedText: String?) {
+      let resolver = FakeVoiceEditFieldResolver(captured: field)
+      let records = InsertionRecordStore()
+      let pasteboard = Support.makePasteboard()
+      self.resolver = resolver
+      self.records = records
+      self.pasteboard = pasteboard
+      var countCopies: (() -> Void)?
+      self.service = VoiceEditSelectionService(
+        permissionsManager: PermissionsManager(statusProvider: { _ in accessibilityGranted ? .granted : .denied }),
+        insertionRecords: records,
+        fieldResolver: resolver,
+        pasteboard: pasteboard,
+        targetProvider: { Support.runningTarget() },
+        copyShortcut: { _ in
+          countCopies?()
+          guard let copiedText else { return true }
+          pasteboard.clearContents()
+          pasteboard.setString(copiedText, forType: .string)
+          return true
+        },
+        copySettleDelay: .milliseconds(1)
+      )
+      countCopies = { [weak self] in self?.copyRequests += 1 }
+    }
+
+    deinit {
+      pasteboard.clearContents()
+    }
+  }
+
+  private func makeHarness(
+    field: FakeVoiceEditField,
+    accessibilityGranted: Bool = true,
+    copiedText: String? = nil
+  ) -> Harness {
+    Harness(field: field, accessibilityGranted: accessibilityGranted, copiedText: copiedText)
+  }
+}

--- a/Tests/SpeakAppTests/VoiceEditTestDoubles.swift
+++ b/Tests/SpeakAppTests/VoiceEditTestDoubles.swift
@@ -1,0 +1,142 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+@testable import SpeakApp
+
+// MARK: - Fields
+
+/// In-memory text field with identity, modelling the accessibility contract
+/// Voice Edit relies on: a value, a selection, selected text derived from
+/// both, and writes that replace the selection and leave a caret after the
+/// inserted text.
+final class FakeVoiceEditField: VoiceEditField {
+  private let id = UUID()
+  var value: String
+  var selection: CFRange?
+  var valueReadable = true
+  var selectionRangeReadable = true
+  var selectedTextReadable = true
+  /// Reported instead of the selection's substring, to model an app whose
+  /// selected-text and selected-range attributes disagree.
+  var selectedTextOverride: String?
+  var setSelectedRangeResult: AXError = .success
+  var setSelectedTextResult: AXError = .success
+  /// Applied to every accepted write, to model an app that reformats what it receives.
+  var transformOnWrite: ((String) -> String)?
+  var processIdentifier: pid_t? = ProcessInfo.processInfo.processIdentifier
+  private(set) var selectedTextWrites: [(range: CFRange?, text: String)] = []
+
+  init(value: String = "", selection: CFRange? = CFRange(location: 0, length: 0)) {
+    self.value = value
+    self.selection = selection
+  }
+
+  func readValue() -> String? {
+    valueReadable ? value : nil
+  }
+
+  func readSelectedRange() -> CFRange? {
+    selectionRangeReadable ? selection : nil
+  }
+
+  func readSelectedText() -> String? {
+    guard selectedTextReadable else { return nil }
+    if let selectedTextOverride { return selectedTextOverride }
+    guard let selection else { return nil }
+    return VoiceEditTextRange(selection).substring(of: value)
+  }
+
+  func setSelectedRange(_ range: CFRange) -> AXError {
+    guard setSelectedRangeResult == .success else { return setSelectedRangeResult }
+    selection = range
+    return .success
+  }
+
+  func setSelectedText(_ text: String) -> AXError {
+    selectedTextWrites.append((selection, text))
+    guard setSelectedTextResult == .success else { return setSelectedTextResult }
+    return apply(text)
+  }
+
+  /// What the app does with a ⌘V: replaces the current selection with the pasted text.
+  @discardableResult
+  func simulatePaste(_ text: String) -> AXError {
+    apply(text)
+  }
+
+  func isSameField(as other: any VoiceEditField) -> Bool {
+    (other as? FakeVoiceEditField)?.id == id
+  }
+
+  private func apply(_ text: String) -> AXError {
+    guard let selection else { return .failure }
+    let range = VoiceEditTextRange(selection)
+    guard range.substring(of: value) != nil else { return .failure }
+    let written = transformOnWrite?(text) ?? text
+    let utf16 = Array(value.utf16)
+    let prefix = String(utf16CodeUnits: Array(utf16[0..<range.location]), count: range.location)
+    let suffix = String(utf16CodeUnits: Array(utf16[range.end...]), count: utf16.count - range.end)
+    value = prefix + written + suffix
+    self.selection = CFRange(location: range.location + written.utf16.count, length: 0)
+    return .success
+  }
+}
+
+@MainActor
+final class FakeVoiceEditFieldResolver: VoiceEditFieldResolving {
+  var captured: FakeVoiceEditField?
+  var focused: FakeVoiceEditField?
+
+  init(captured: FakeVoiceEditField? = nil, focused: FakeVoiceEditField? = nil) {
+    self.captured = captured
+    self.focused = focused ?? captured
+  }
+
+  func field(for target: TextOutputTarget) -> (any VoiceEditField)? {
+    captured
+  }
+
+  func focusedField() -> (any VoiceEditField)? {
+    focused
+  }
+}
+
+// MARK: - Targets and pasteboards
+
+enum VoiceEditTestSupport {
+  /// A target describing this test process, which `isApplicationRunning` accepts.
+  /// `NSRunningApplication` only knows processes registered with Launch
+  /// Services, so AppKit is initialised first; otherwise the answer depends on
+  /// which other suites happened to run earlier.
+  @MainActor
+  static func runningTarget() -> TextOutputTarget {
+    _ = NSApplication.shared
+    return TextOutputTarget(
+      processIdentifier: ProcessInfo.processInfo.processIdentifier,
+      applicationName: "Tests",
+      bundleIdentifier: nil,
+      applicationLaunchDate: nil,
+      focusedElement: nil
+    )
+  }
+
+  /// A target whose process no longer exists.
+  static func goneTarget() -> TextOutputTarget {
+    TextOutputTarget(
+      processIdentifier: pid_t.max,
+      applicationName: "Gone",
+      bundleIdentifier: nil,
+      applicationLaunchDate: nil,
+      focusedElement: nil
+    )
+  }
+
+  static func makePasteboard() -> NSPasteboard {
+    NSPasteboard(name: NSPasteboard.Name("com.speakapp.voice-edit-tests.\(UUID().uuidString)"))
+  }
+
+  static func range(_ location: Int, _ length: Int) -> VoiceEditTextRange {
+    VoiceEditTextRange(location: location, length: length)
+  }
+}

--- a/Tests/SpeakCoreTests/VoiceEditPolicyTests.swift
+++ b/Tests/SpeakCoreTests/VoiceEditPolicyTests.swift
@@ -107,4 +107,91 @@ final class VoiceEditPolicyTests: XCTestCase {
             "\"alpha\" and \"beta\""
         )
     }
+
+    // MARK: - Instruction-aware cleanup (issue #673)
+
+    func testNormalizedRewrite_keepsQuotesTheInstructionAskedFor() {
+        for instruction in ["put this in quotes", "wrap it in quotation marks", "add speech marks"] {
+            XCTAssertEqual(
+                VoiceEditPolicy.normalizedRewrite("\"Hello there.\"", original: "Hi.", instruction: instruction),
+                "\"Hello there.\"",
+                instruction
+            )
+        }
+    }
+
+    func testNormalizedRewrite_keepsCodeFenceTheInstructionAskedFor() {
+        let response = "```swift\nlet x = 1\n```"
+        XCTAssertEqual(
+            VoiceEditPolicy.normalizedRewrite(response, original: "let x = 1", instruction: "put this in a code block"),
+            response
+        )
+        XCTAssertEqual(
+            VoiceEditPolicy.normalizedRewrite(response, original: "let x = 1", instruction: "make it shorter"),
+            "let x = 1",
+            "Without a formatting request the accidental fence is still removed"
+        )
+    }
+
+    func testNormalizedRewrite_keepsWhitespaceTheInstructionAskedFor() {
+        XCTAssertEqual(
+            VoiceEditPolicy.normalizedRewrite(
+                "    indented\n",
+                original: "indented",
+                instruction: "indent this by four spaces"
+            ),
+            "    indented\n"
+        )
+        XCTAssertEqual(
+            VoiceEditPolicy.normalizedRewrite("text\n", original: "text", instruction: "add a trailing newline"),
+            "text\n"
+        )
+    }
+
+    func testNormalizedRewrite_preservesIndentationTheOriginalHad() {
+        XCTAssertEqual(
+            VoiceEditPolicy.normalizedRewrite("    let value = 1\n", original: "    let x = 1"),
+            "    let value = 1",
+            "Leading whitespace the original had is content; the trailing newline it lacked is accidental"
+        )
+    }
+
+    func testNormalizedRewrite_preservesTrailingNewlineTheOriginalHad() {
+        XCTAssertEqual(
+            VoiceEditPolicy.normalizedRewrite("Rewritten line.\n", original: "Original line.\n"),
+            "Rewritten line.\n"
+        )
+        XCTAssertEqual(
+            VoiceEditPolicy.normalizedRewrite("  Rewritten line.\n", original: "Original line.\n"),
+            "Rewritten line.\n",
+            "Leading whitespace the original lacked is still trimmed"
+        )
+    }
+
+    func testNormalizedRewrite_keepsIndentationInsideAStrippedFence() {
+        let response = "```\n    if ok {\n        go()\n    }\n```"
+        XCTAssertEqual(
+            VoiceEditPolicy.normalizedRewrite(response, original: "if ok { go() }"),
+            "    if ok {\n        go()\n    }"
+        )
+    }
+
+    func testFormattingIntent_detectsRequestedFormatting() {
+        let quotes = VoiceEditFormattingIntent(instruction: "Put this in quotes")
+        XCTAssertTrue(quotes.requestsQuotes)
+        XCTAssertFalse(quotes.requestsCodeFence)
+        XCTAssertFalse(quotes.requestsWhitespace)
+
+        let fence = VoiceEditFormattingIntent(instruction: "format as a fenced code block")
+        XCTAssertTrue(fence.requestsCodeFence)
+
+        let whitespace = VoiceEditFormattingIntent(instruction: "keep the indentation and add a line break")
+        XCTAssertTrue(whitespace.requestsWhitespace)
+
+        let plain = VoiceEditFormattingIntent(instruction: "make this shorter")
+        XCTAssertEqual(
+            plain,
+            VoiceEditFormattingIntent(requestsQuotes: false, requestsCodeFence: false, requestsWhitespace: false)
+        )
+    }
 }


### PR DESCRIPTION
Closes #673.

Voice Edit could replace the wrong text, interrupt the other capture flow, or report an edit that never happened. This PR addresses all eight problems in the issue with one replacement anchor, one capture reservation, awaited teardown, an exact insertion record, byte-exact clipboard restoration, instruction-aware cleanup, and channel gating.

## What changes

**1. Immutable replacement anchor** — `VoiceEditSelectionService` now captures a `VoiceEditAnchor` (text + UTF-16 range, verified against the field's value at capture) together with the field's identity. `VoiceEditReplacementService` re-verifies it before any write (`VoiceEditAnchorState`): same focused field (`CFEqual`), same process, and the captured text still at the recorded range — else the rewrite is parked on the clipboard with a specific reason. The write re-selects the anchored range, so a caret the user moved while speaking does not change where the rewrite lands.

**2. Shared capture reservation** — `CaptureSessionOwnership` (on `MainManager`) is claimed by dictation in `startSession` (before the live-transcription failsafe) and by Voice Edit in `begin()`, and released only after each flow's own teardown. `cleanupAfterFailure` cancels the live stream and recorder only while dictation may tear down capture, and `AudioFileManager.cancelRecording(ifOwnedBy:)` refuses to cancel a recording another owner started (`AudioRecordingOwner.voiceEdit`). Starting dictation during Voice Edit is rejected with a HUD message instead of hitting `alreadyRecording` and cancelling Voice Edit's capture.

**3. Escape awaits teardown** — `cancelListening` is `async`; the orchestrator enters a `.cancelling` phase, returns to idle only once the recorder is released, and a hotkey press during that window waits for the teardown and then starts fresh.

**4. "Last dictation" edits the actual inserted range** — `TextOutputResult.insertedRange` (accessibility and paste delivery) and `LiveTextInserter.lastInsertedRange` (full-value and ranged streaming) feed `MainManager.recordInsertion` → `InsertionRecordStore`. Voice Edit's fallback requires the same app, the same focused field, and the recorded text still at the recorded range; it never searches for text, so identical text elsewhere cannot be picked. An unknown range clears the record rather than leaving a stale one.

**5. Paste fallback verifies** — the paste path requires the current selection to *be* the anchor (⌘V replaces whatever is selected now), then polls the field (up to ~1 s) for the rewrite. Unverified pastes report `Nothing changed` and keep the rewrite on the clipboard; only verified pastes (or fields that cannot be read back, mirroring the accessibility path's documented trust) report "Edited". An accepted accessibility write that the field does not show is parked as `replacementUnverified` and never followed by a paste, so nothing can be duplicated.

**6. Byte-exact clipboard restoration** — `PasteboardSnapshot` copies every item and type and is used by `PasteTextOutput` and both Voice Edit paste paths, replacing the string-only save/restore.

**7. Instruction-aware cleanup** — `VoiceEditPolicy.normalizedRewrite(_:original:instruction:)` keeps quotes, code fences and whitespace the spoken instruction asked for (`VoiceEditFormattingIntent`), trims leading/trailing whitespace only where the original selection had none (indentation and trailing newlines survive), and no longer strips indentation inside a removed fence.

**8. Channel gating** — `ChannelFeature.voiceEdit` (direct only). `ShortcutAction.isAvailable(in:)` gates registration, Carbon hotkeys, local dispatch and the Shortcuts settings list; `toggleVoiceEdit()` is inert on unsupported channels.

HUD copy distinguishes every parked outcome (selection changed, couldn't confirm selection, app gone, couldn't confirm edit, nothing changed) and always says the rewrite is on the clipboard.

## Tests

- `VoiceEditSelectionServiceTests` — anchor from a verified range; range dropped when it disagrees with the value; no field reads without Accessibility; clipboard capture restores every pasteboard type; last-dictation fallback uses the recorded range (two identical occurrences), rejects changed text, another focused field, another app.
- `VoiceEditReplacementServiceTests` + `VoiceEditAnchorStateTests` — replaces the anchored range after the caret moved; edited anchor / other field / gone app / unverifiable field park without writing; accepted-but-unshown write parks without pasting; unreadable value after accepted write is trusted; text-only anchor requires the selection to match; paste verified → restores clipboard; ignored paste → `pasteUnverified` with rewrite kept; paste refused when the selection moved; no field access parks instead of pasting blind.
- `VoiceEditOrchestratorLifecycleTests` — reservation refused/held/released on success, failure and cancel; cancel returns to idle only after teardown; restart during cancel waits then starts fresh.
- `CaptureSessionOwnershipTests`, `PasteboardSnapshotTests`, `ShortcutAvailabilityTests`, `VoiceEditPolicyTests` (instruction-aware cases), `LiveTextInserterStreamingTests` (`lastInsertedRange`).

Test doubles: `FakeVoiceEditField` / `FakeVoiceEditFieldResolver` model the accessibility contract in memory (`VoiceEditTestDoubles.swift`).

## Notes for review

- Without Accessibility permission the paste fallback no longer pastes blind; it parks the rewrite with "Couldn't confirm the selection". That is the issue's "fail safely or leave the rewrite on the clipboard" contract applied to the one path that could not verify anything.
- The Escape handlers of dictation and Voice Edit both remain registered; each is guarded by its own phase, so they cannot act on the other flow's session.
- `LiveTranscriptionRun`/`MainManager` initialisers are unchanged: the reservation and the record store are owned by `MainManager` and reached through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b
