### PR TITLE
fix(mac): make dictation profile overrides execute as configured

### DIFF
--- a/Sources/SpeakApp/SessionProfileApplier.swift
+++ b/Sources/SpeakApp/SessionProfileApplier.swift
@@ -9,26 +9,24 @@ import os.log
 /// the session-start choke point and `end` whenever the session finishes (any
 /// path). Overrides are applied with persistence suppressed, so a session-only
 /// profile never touches the stored defaults.
+///
+/// Every override remembers the value it replaced and the value it set. `end`
+/// restores a setting only while it still holds the applied value: a change
+/// the user made in Settings during the session is theirs and is kept,
+/// together with the persistence its own setter already performed (issue #690,
+/// coordinating with #642).
 @MainActor
 final class SessionProfileApplier {
-  private struct Snapshot {
-    let transcriptionMode: AppSettings.TranscriptionMode
-    let liveTranscriptionModel: String
-    let batchTranscriptionModel: String
-    let localTranscriptionModel: String
-    let localTranscriptionMode: AppSettings.LocalTranscriptionMode
-    let speedMode: AppSettings.SpeedMode
-    let postProcessingEnabled: Bool
-    let postProcessingModel: String
-    let postProcessingOutputLanguage: String
-    let postProcessingIncludeLexiconDirectives: Bool
-    let postProcessingIncludeContextTags: Bool
-    let preferredLocaleIdentifier: String
+  /// One setting the profile changed, with the knowledge to undo it.
+  private struct Override {
+    let name: String
+    /// Restores the original value; false when the session changed the setting again.
+    let restore: (AppSettings) -> Bool
   }
 
   /// Name of the profile applied to the current session, for HUD display.
   private(set) var activeProfileName: String?
-  private var snapshot: Snapshot?
+  private var overrides: [Override] = []
   private let log = SpeakLogger.logger(category: "SessionProfileApplier")
 
   /// Resolves the profile for the frontmost app and applies its overrides.
@@ -39,25 +37,11 @@ final class SessionProfileApplier {
     profiles: [DictationProfile],
     frontmostBundleID: String?
   ) {
-    // Never stack overrides: restore any leftover snapshot first.
+    // Never stack overrides: restore any leftover overrides first.
     end(settings: settings, postProcessing: postProcessing)
     let resolver = ProfileResolver(profiles: profiles)
     guard let profile = resolver.profile(forBundleID: frontmostBundleID) else { return }
 
-    snapshot = Snapshot(
-      transcriptionMode: settings.transcriptionMode,
-      liveTranscriptionModel: settings.liveTranscriptionModel,
-      batchTranscriptionModel: settings.batchTranscriptionModel,
-      localTranscriptionModel: settings.localTranscriptionModel,
-      localTranscriptionMode: settings.localTranscriptionMode,
-      speedMode: settings.speedMode,
-      postProcessingEnabled: settings.postProcessingEnabled,
-      postProcessingModel: settings.postProcessingModel,
-      postProcessingOutputLanguage: settings.postProcessingOutputLanguage,
-      postProcessingIncludeLexiconDirectives: settings.postProcessingIncludeLexiconDirectives,
-      postProcessingIncludeContextTags: settings.postProcessingIncludeContextTags,
-      preferredLocaleIdentifier: settings.preferredLocaleIdentifier
-    )
     activeProfileName = profile.name
     apply(profile, to: settings, postProcessing: postProcessing)
     let bundleID = frontmostBundleID ?? "unknown"
@@ -69,26 +53,22 @@ final class SessionProfileApplier {
   func end(settings: AppSettings, postProcessing: PostProcessingManager) {
     postProcessing.sessionPromptOverride = nil
     activeProfileName = nil
-    guard let snapshot else { return }
-    self.snapshot = nil
+    guard !overrides.isEmpty else { return }
+    let pending = overrides
+    overrides = []
 
     settings.suppressesPersistence = true
     defer { settings.suppressesPersistence = false }
-    settings.transcriptionMode = snapshot.transcriptionMode
-    settings.liveTranscriptionModel = snapshot.liveTranscriptionModel
-    settings.batchTranscriptionModel = snapshot.batchTranscriptionModel
-    settings.localTranscriptionModel = snapshot.localTranscriptionModel
-    settings.localTranscriptionMode = snapshot.localTranscriptionMode
-    settings.preferredLocaleIdentifier = snapshot.preferredLocaleIdentifier
-    settings.speedMode = snapshot.speedMode
-    settings.postProcessingModel = snapshot.postProcessingModel
-    settings.postProcessingOutputLanguage = snapshot.postProcessingOutputLanguage
-    settings.postProcessingIncludeLexiconDirectives = snapshot.postProcessingIncludeLexiconDirectives
-    settings.postProcessingIncludeContextTags = snapshot.postProcessingIncludeContextTags
-    // Last: the didSet invariant can reject `true` while a speed mode is
-    // active, so restore it after the speed mode is back.
-    settings.postProcessingEnabled = snapshot.postProcessingEnabled
+    // Restore order matters: the transcription selection first so the speed
+    // mode is judged against the user's own model, the speed mode next, and
+    // `postProcessingEnabled` last because its setter rejects `true` while a
+    // speed mode other than instant is active.
+    for override in pending where !override.restore(settings) {
+      log.info("Kept \(override.name, privacy: .public): changed during the session")
+    }
   }
+
+  // MARK: - Applying
 
   private func apply(
     _ profile: DictationProfile,
@@ -98,47 +78,127 @@ final class SessionProfileApplier {
     settings.suppressesPersistence = true
     defer { settings.suppressesPersistence = false }
 
-    if let modelID = normalized(profile.transcriptionModelID) {
-      applyTranscriptionModel(modelID, to: settings)
+    // Speed mode and polish can be disturbed by the setters of every
+    // transcription field, so their originals are captured before anything
+    // is applied and they are restored last.
+    let originalSpeedMode = settings.speedMode
+    let originalPolishEnabled = settings.postProcessingEnabled
+
+    if let override = profile.resolvedTranscriptionOverride {
+      applyTranscriptionModel(override.modelID, routing: override.routing, to: settings)
     }
     if let language = normalized(profile.languageIdentifier) {
-      settings.preferredLocaleIdentifier = language
+      set(\.preferredLocaleIdentifier, to: language, on: settings, name: "preferredLocaleIdentifier")
+    }
+    applyPolish(profile, to: settings, postProcessing: postProcessing)
+
+    if profile.polishEnabled == true {
+      // Profile polish means end-of-session post-processing, which only the
+      // instant speed mode allows; a live-polish session would silently reject
+      // it. Session-only, like every other override.
+      settings.speedMode = .instant
     }
     if let polishEnabled = profile.polishEnabled {
       settings.postProcessingEnabled = polishEnabled
     }
-    if let model = normalized(profile.polishModelID) {
-      settings.postProcessingModel = model
+    track(\.speedMode, original: originalSpeedMode, on: settings, name: "speedMode")
+    track(\.postProcessingEnabled, original: originalPolishEnabled, on: settings, name: "postProcessingEnabled")
+  }
+
+  private func applyPolish(
+    _ profile: DictationProfile,
+    to settings: AppSettings,
+    postProcessing: PostProcessingManager
+  ) {
+    var polishModel: String?
+    if let requested = normalized(profile.polishModelID) {
+      if DictationProfileValidator.isSupportedPolishModel(requested) {
+        polishModel = requested
+        set(\.postProcessingModel, to: requested, on: settings, name: "postProcessingModel")
+      } else {
+        log.error(
+          """
+          Profile "\(profile.name, privacy: .public)" names polish model \(requested, privacy: .public), \
+          which the app cannot run; keeping the user's model
+          """)
+      }
+    }
+
+    // The built-in rules cleaner ignores prompts, output language and lexicon
+    // directives, so none of them is applied for it.
+    let effectiveModel = polishModel ?? settings.postProcessingModel
+    guard effectiveModel != LocalPostProcessingModelManager.builtInRulesModelID else {
+      postProcessing.sessionPromptOverride = nil
+      return
     }
     if let outputLanguage = normalized(profile.polishOutputLanguage) {
-      settings.postProcessingOutputLanguage = outputLanguage
+      set(\.postProcessingOutputLanguage, to: outputLanguage, on: settings, name: "postProcessingOutputLanguage")
     }
     if let includeDirectives = profile.polishIncludeLexiconDirectives {
-      settings.postProcessingIncludeLexiconDirectives = includeDirectives
+      set(
+        \.postProcessingIncludeLexiconDirectives, to: includeDirectives, on: settings,
+        name: "postProcessingIncludeLexiconDirectives"
+      )
     }
     if let includeTags = profile.polishIncludeContextTags {
-      settings.postProcessingIncludeContextTags = includeTags
+      set(\.postProcessingIncludeContextTags, to: includeTags, on: settings, name: "postProcessingIncludeContextTags")
     }
     postProcessing.sessionPromptOverride = normalized(profile.polishPrompt)
   }
 
-  /// Derives the transcription mode from the catalog identifier and applies it
-  /// to the matching model slot.
-  private func applyTranscriptionModel(_ modelID: String, to settings: AppSettings) {
-    let isLiveModel = ModelCatalog.liveTranscription.contains {
-      $0.id.caseInsensitiveCompare(modelID) == .orderedSame
+  /// Applies the model to the slot its routing names. Explicit routing comes
+  /// from the editor; older profiles derive it from the identifier.
+  private func applyTranscriptionModel(
+    _ modelID: String,
+    routing: DictationProfileTranscriptionRouting,
+    to settings: AppSettings
+  ) {
+    switch routing {
+    case .remoteStreaming:
+      set(\.transcriptionMode, to: .liveNative, on: settings, name: "transcriptionMode")
+      set(\.liveTranscriptionModel, to: modelID, on: settings, name: "liveTranscriptionModel")
+    case .remoteBatch:
+      set(\.transcriptionMode, to: .batchRemote, on: settings, name: "transcriptionMode")
+      set(\.batchTranscriptionModel, to: modelID, on: settings, name: "batchTranscriptionModel")
+    case .localBatch:
+      set(\.transcriptionMode, to: .localModel, on: settings, name: "transcriptionMode")
+      set(\.localTranscriptionMode, to: .batch, on: settings, name: "localTranscriptionMode")
+      set(\.localTranscriptionModel, to: modelID, on: settings, name: "localTranscriptionModel")
     }
-    if isLiveModel {
-      settings.transcriptionMode = .liveNative
-      settings.liveTranscriptionModel = modelID
-    } else if modelID.lowercased().hasPrefix("local/") {
-      settings.transcriptionMode = .localModel
-      settings.localTranscriptionMode = .batch
-      settings.localTranscriptionModel = modelID
-    } else {
-      settings.transcriptionMode = .batchRemote
-      settings.batchTranscriptionModel = modelID
-    }
+  }
+
+  // MARK: - Override bookkeeping
+
+  /// Sets a value and records how to undo it. The recorded "applied" value is
+  /// read back after the set, so a setter that normalises its input is still
+  /// matched correctly at restore time.
+  private func set<Value: Equatable>(
+    _ keyPath: ReferenceWritableKeyPath<AppSettings, Value>,
+    to value: Value,
+    on settings: AppSettings,
+    name: String
+  ) {
+    let original = settings[keyPath: keyPath]
+    settings[keyPath: keyPath] = value
+    track(keyPath, original: original, on: settings, name: name)
+  }
+
+  /// Records an undo for a setting whose current value is the session value,
+  /// whether it was set directly or moved by another setter's invariant.
+  private func track<Value: Equatable>(
+    _ keyPath: ReferenceWritableKeyPath<AppSettings, Value>,
+    original: Value,
+    on settings: AppSettings,
+    name: String
+  ) {
+    let applied = settings[keyPath: keyPath]
+    overrides.append(
+      Override(name: name) { settings in
+        guard settings[keyPath: keyPath] == applied else { return false }
+        settings[keyPath: keyPath] = original
+        return true
+      }
+    )
   }
 
   private func normalized(_ value: String?) -> String? {

--- a/Sources/SpeakApp/Views/Settings/ProfileEditorDraft.swift
+++ b/Sources/SpeakApp/Views/Settings/ProfileEditorDraft.swift
@@ -5,6 +5,7 @@ enum ProfileTranscriptionChoice: String, CaseIterable, Identifiable {
   case useDefault
   case streaming
   case batch
+  case local
 
   var id: String { rawValue }
 
@@ -13,6 +14,7 @@ enum ProfileTranscriptionChoice: String, CaseIterable, Identifiable {
     case .useDefault: return "Use Default"
     case .streaming: return "Remote Streaming"
     case .batch: return "Remote Batch"
+    case .local: return "Local Model"
     }
   }
 
@@ -22,14 +24,19 @@ enum ProfileTranscriptionChoice: String, CaseIterable, Identifiable {
     case .useDefault: return nil
     case .streaming: return .remoteStreaming
     case .batch: return .remoteBatch
+    case .local: return .localBatch
     }
   }
 
+  /// Every stored routing has its own choice, so reopening a profile can never
+  /// change how it runs: a local-model profile reopens as Local Model, not as
+  /// Remote Batch.
   init(routing: DictationProfileTranscriptionRouting?) {
     switch routing {
     case .none: self = .useDefault
     case .remoteStreaming: self = .streaming
-    case .remoteBatch, .localBatch: self = .batch
+    case .remoteBatch: self = .batch
+    case .localBatch: self = .local
     }
   }
 }
@@ -59,6 +66,7 @@ struct ProfileEditorDraft: Equatable {
   var transcriptionChoice: ProfileTranscriptionChoice = .useDefault
   var streamingModel = ""
   var batchModel = ""
+  var localModel = ""
   var polishChoice: ProfilePolishChoice = .useDefault
   var polishModel = ""
   var useCustomPrompt = false
@@ -77,11 +85,13 @@ struct ProfileEditorDraft: Equatable {
 
     streamingModel = settings.liveTranscriptionModel
     batchModel = settings.batchTranscriptionModel
+    localModel = settings.localTranscriptionModel
     if let override = profile?.resolvedTranscriptionOverride {
       transcriptionChoice = ProfileTranscriptionChoice(routing: override.routing)
       switch override.routing {
       case .remoteStreaming: streamingModel = override.modelID
-      case .remoteBatch, .localBatch: batchModel = override.modelID
+      case .remoteBatch: batchModel = override.modelID
+      case .localBatch: localModel = override.modelID
       }
     }
 
@@ -131,6 +141,7 @@ struct ProfileEditorDraft: Equatable {
     case .useDefault: transcriptionModelID = nil
     case .streaming: transcriptionModelID = Self.normalized(streamingModel)
     case .batch: transcriptionModelID = Self.normalized(batchModel)
+    case .local: transcriptionModelID = Self.normalized(localModel)
     }
 
     let isPolishOverridden = polishChoice == .enabled

--- a/Sources/SpeakApp/Views/Settings/ProfileEditorDraft.swift
+++ b/Sources/SpeakApp/Views/Settings/ProfileEditorDraft.swift
@@ -1,0 +1,158 @@
+import Foundation
+import SpeakCore
+
+enum ProfileTranscriptionChoice: String, CaseIterable, Identifiable {
+  case useDefault
+  case streaming
+  case batch
+
+  var id: String { rawValue }
+
+  var displayName: String {
+    switch self {
+    case .useDefault: return "Use Default"
+    case .streaming: return "Remote Streaming"
+    case .batch: return "Remote Batch"
+    }
+  }
+
+  /// The routing stored with the profile, so the applier never has to guess.
+  var routing: DictationProfileTranscriptionRouting? {
+    switch self {
+    case .useDefault: return nil
+    case .streaming: return .remoteStreaming
+    case .batch: return .remoteBatch
+    }
+  }
+
+  init(routing: DictationProfileTranscriptionRouting?) {
+    switch routing {
+    case .none: self = .useDefault
+    case .remoteStreaming: self = .streaming
+    case .remoteBatch, .localBatch: self = .batch
+    }
+  }
+}
+
+enum ProfilePolishChoice: String, CaseIterable, Identifiable {
+  case useDefault
+  case enabled
+  case disabled
+
+  var id: String { rawValue }
+
+  var displayName: String {
+    switch self {
+    case .useDefault: return "Use Default"
+    case .enabled: return "Enabled"
+    case .disabled: return "Disabled"
+    }
+  }
+}
+
+/// The editable state behind `ProfileEditorView`, kept as a value so the
+/// save-time rules — what is stored, what is dropped, what blocks saving —
+/// are unit-testable without SwiftUI (issue #690).
+struct ProfileEditorDraft: Equatable {
+  var name = ""
+  var bundleIDs: [String] = []
+  var transcriptionChoice: ProfileTranscriptionChoice = .useDefault
+  var streamingModel = ""
+  var batchModel = ""
+  var polishChoice: ProfilePolishChoice = .useDefault
+  var polishModel = ""
+  var useCustomPrompt = false
+  var customPrompt = ""
+  var outputLanguage = ""
+  var includeLexiconDirectives = false
+  var includeContextTags = false
+  var languageIdentifier = ""
+
+  init() {}
+
+  @MainActor
+  init(profile: DictationProfile?, settings: AppSettings) {
+    name = profile?.name ?? ""
+    bundleIDs = profile?.matchers.filter { $0.kind == .bundleID }.map(\.value) ?? []
+
+    streamingModel = settings.liveTranscriptionModel
+    batchModel = settings.batchTranscriptionModel
+    if let override = profile?.resolvedTranscriptionOverride {
+      transcriptionChoice = ProfileTranscriptionChoice(routing: override.routing)
+      switch override.routing {
+      case .remoteStreaming: streamingModel = override.modelID
+      case .remoteBatch, .localBatch: batchModel = override.modelID
+      }
+    }
+
+    switch profile?.polishEnabled {
+    case .some(true): polishChoice = .enabled
+    case .some(false): polishChoice = .disabled
+    case .none: polishChoice = .useDefault
+    }
+    polishModel = profile?.polishModelID ?? settings.postProcessingModel
+    let prompt = profile?.polishPrompt ?? ""
+    useCustomPrompt = !prompt.isEmpty
+    customPrompt = prompt
+    outputLanguage = profile?.polishOutputLanguage ?? ""
+    includeLexiconDirectives = profile?.polishIncludeLexiconDirectives
+      ?? settings.postProcessingIncludeLexiconDirectives
+    includeContextTags = profile?.polishIncludeContextTags ?? settings.postProcessingIncludeContextTags
+    languageIdentifier = profile?.languageIdentifier ?? ""
+  }
+
+  /// Whether the chosen polish model is the built-in rules cleaner, which
+  /// fixes spacing, punctuation and capitalisation only and ignores prompts,
+  /// output language and lexicon directives.
+  var usesRulesCleanup: Bool {
+    polishChoice == .enabled
+      && polishModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        == LocalPostProcessingModelManager.builtInRulesModelID
+  }
+
+  var issues: [DictationProfileIssue] {
+    DictationProfileValidator.issues(for: profile(id: nil))
+  }
+
+  var canSave: Bool { issues.isEmpty }
+
+  /// The profile exactly as the editor displays it: controls that are hidden
+  /// for the chosen model are not stored, so nothing can apply silently.
+  func profile(id: UUID?) -> DictationProfile {
+    let polishEnabled: Bool?
+    switch polishChoice {
+    case .useDefault: polishEnabled = nil
+    case .enabled: polishEnabled = true
+    case .disabled: polishEnabled = false
+    }
+
+    let transcriptionModelID: String?
+    switch transcriptionChoice {
+    case .useDefault: transcriptionModelID = nil
+    case .streaming: transcriptionModelID = Self.normalized(streamingModel)
+    case .batch: transcriptionModelID = Self.normalized(batchModel)
+    }
+
+    let isPolishOverridden = polishChoice == .enabled
+    let storesPromptControls = isPolishOverridden && !usesRulesCleanup
+    return DictationProfile(
+      id: id ?? UUID(),
+      name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+      matchers: bundleIDs.map(DictationProfileMatcher.bundleID),
+      transcriptionModelID: transcriptionModelID,
+      polishEnabled: polishEnabled,
+      polishModelID: isPolishOverridden ? Self.normalized(polishModel) : nil,
+      polishPrompt: storesPromptControls && useCustomPrompt ? Self.normalized(customPrompt) : nil,
+      polishOutputLanguage: storesPromptControls ? Self.normalized(outputLanguage) : nil,
+      polishIncludeLexiconDirectives: storesPromptControls ? includeLexiconDirectives : nil,
+      polishIncludeContextTags: storesPromptControls ? includeContextTags : nil,
+      languageIdentifier: Self.normalized(languageIdentifier),
+      transcriptionRouting: transcriptionModelID == nil ? nil : transcriptionChoice.routing
+    )
+  }
+
+  private static func normalized(_ value: String) -> String? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}

--- a/Sources/SpeakApp/Views/Settings/ProfileEditorView.swift
+++ b/Sources/SpeakApp/Views/Settings/ProfileEditorView.swift
@@ -2,38 +2,6 @@ import SpeakCore
 import AppKit
 import SwiftUI
 
-private enum ProfileTranscriptionChoice: String, CaseIterable, Identifiable {
-  case useDefault
-  case streaming
-  case batch
-
-  var id: String { rawValue }
-
-  var displayName: String {
-    switch self {
-    case .useDefault: return "Use Default"
-    case .streaming: return "Remote Streaming"
-    case .batch: return "Remote Batch"
-    }
-  }
-}
-
-private enum ProfilePolishChoice: String, CaseIterable, Identifiable {
-  case useDefault
-  case enabled
-  case disabled
-
-  var id: String { rawValue }
-
-  var displayName: String {
-    switch self {
-    case .useDefault: return "Use Default"
-    case .enabled: return "Enabled"
-    case .disabled: return "Disabled"
-    }
-  }
-}
-
 /// Sheet for creating or editing a single dictation profile.
 struct ProfileEditorView: View {
   @Environment(\.dismiss) private var dismiss
@@ -41,67 +9,13 @@ struct ProfileEditorView: View {
   private let originalID: UUID?
   private let onSave: (DictationProfile) -> Void
 
-  @State private var name: String
-  @State private var bundleIDs: [String]
-  @State fileprivate var transcriptionChoice: ProfileTranscriptionChoice
-  @State private var streamingModel: String
-  @State private var batchModel: String
-  @State fileprivate var polishChoice: ProfilePolishChoice
-  @State private var polishModel: String
-  @State private var useCustomPrompt: Bool
-  @State private var customPrompt: String
-  @State private var outputLanguage: String
-  @State private var includeLexiconDirectives: Bool
-  @State private var includeContextTags: Bool
-  @State private var languageIdentifier: String
+  @State private var draft: ProfileEditorDraft
 
   init(profile: DictationProfile?, settings: AppSettings, onSave: @escaping (DictationProfile) -> Void) {
     self.settings = settings
     self.originalID = profile?.id
     self.onSave = onSave
-
-    _name = State(initialValue: profile?.name ?? "")
-    _bundleIDs = State(initialValue: profile?.matchers.filter { $0.kind == .bundleID }.map(\.value) ?? [])
-
-    let transcriptionModelID = profile?.transcriptionModelID?
-      .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    let isLiveModel = ModelCatalog.liveTranscription.contains {
-      $0.id.caseInsensitiveCompare(transcriptionModelID) == .orderedSame
-    }
-    if transcriptionModelID.isEmpty {
-      _transcriptionChoice = State(initialValue: .useDefault)
-      _streamingModel = State(initialValue: settings.liveTranscriptionModel)
-      _batchModel = State(initialValue: settings.batchTranscriptionModel)
-    } else if isLiveModel {
-      _transcriptionChoice = State(initialValue: .streaming)
-      _streamingModel = State(initialValue: transcriptionModelID)
-      _batchModel = State(initialValue: settings.batchTranscriptionModel)
-    } else {
-      _transcriptionChoice = State(initialValue: .batch)
-      _streamingModel = State(initialValue: settings.liveTranscriptionModel)
-      _batchModel = State(initialValue: transcriptionModelID)
-    }
-
-    switch profile?.polishEnabled {
-    case .some(true):
-      _polishChoice = State(initialValue: .enabled)
-    case .some(false):
-      _polishChoice = State(initialValue: .disabled)
-    case .none:
-      _polishChoice = State(initialValue: .useDefault)
-    }
-    _polishModel = State(initialValue: profile?.polishModelID ?? settings.postProcessingModel)
-    let prompt = profile?.polishPrompt ?? ""
-    _useCustomPrompt = State(initialValue: !prompt.isEmpty)
-    _customPrompt = State(initialValue: prompt)
-    _outputLanguage = State(initialValue: profile?.polishOutputLanguage ?? "")
-    _includeLexiconDirectives = State(
-      initialValue: profile?.polishIncludeLexiconDirectives ?? settings.postProcessingIncludeLexiconDirectives
-    )
-    _includeContextTags = State(
-      initialValue: profile?.polishIncludeContextTags ?? settings.postProcessingIncludeContextTags
-    )
-    _languageIdentifier = State(initialValue: profile?.languageIdentifier ?? "")
+    _draft = State(initialValue: ProfileEditorDraft(profile: profile, settings: settings))
   }
 
   var body: some View {
@@ -112,11 +26,11 @@ struct ProfileEditorView: View {
         Spacer()
         Button("Cancel") { dismiss() }
         Button("Save") {
-          onSave(builtProfile)
+          onSave(draft.profile(id: originalID))
           dismiss()
         }
         .buttonStyle(.borderedProminent)
-        .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        .disabled(!draft.canSave)
       }
       .padding(16)
 
@@ -127,59 +41,21 @@ struct ProfileEditorView: View {
           VStack(alignment: .leading, spacing: 6) {
             Text("Name")
               .font(.subheadline.weight(.semibold))
-            TextField("e.g. Slack, Email, Code", text: $name)
+            TextField("e.g. Slack, Email, Code", text: $draft.name)
               .textFieldStyle(.roundedBorder)
           }
 
-          ProfileAppsSection(bundleIDs: $bundleIDs)
+          ProfileAppsSection(bundleIDs: $draft.bundleIDs)
 
           transcriptionSection
           polishSection
           languageSection
+          issuesSection
         }
         .padding(16)
       }
     }
     .frame(minWidth: 560, minHeight: 620)
-  }
-
-  fileprivate var builtProfile: DictationProfile {
-    let polishEnabled: Bool?
-    switch polishChoice {
-    case .useDefault: polishEnabled = nil
-    case .enabled: polishEnabled = true
-    case .disabled: polishEnabled = false
-    }
-
-    let transcriptionModelID: String?
-    switch transcriptionChoice {
-    case .useDefault:
-      transcriptionModelID = nil
-    case .streaming:
-      transcriptionModelID = normalized(streamingModel)
-    case .batch:
-      transcriptionModelID = normalized(batchModel)
-    }
-
-    let isPolishOverridden = polishChoice == .enabled
-    return DictationProfile(
-      id: originalID ?? UUID(),
-      name: name.trimmingCharacters(in: .whitespacesAndNewlines),
-      matchers: bundleIDs.map(DictationProfileMatcher.bundleID),
-      transcriptionModelID: transcriptionModelID,
-      polishEnabled: polishEnabled,
-      polishModelID: isPolishOverridden ? normalized(polishModel) : nil,
-      polishPrompt: isPolishOverridden && useCustomPrompt ? normalized(customPrompt) : nil,
-      polishOutputLanguage: isPolishOverridden ? normalized(outputLanguage) : nil,
-      polishIncludeLexiconDirectives: isPolishOverridden ? includeLexiconDirectives : nil,
-      polishIncludeContextTags: isPolishOverridden ? includeContextTags : nil,
-      languageIdentifier: normalized(languageIdentifier)
-    )
-  }
-
-  private func normalized(_ value: String) -> String? {
-    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmed.isEmpty ? nil : trimmed
   }
 }
 
@@ -190,7 +66,7 @@ extension ProfileEditorView {
     VStack(alignment: .leading, spacing: 8) {
       Text("Transcription")
         .font(.subheadline.weight(.semibold))
-      Picker("Transcription", selection: $transcriptionChoice) {
+      Picker("Transcription", selection: $draft.transcriptionChoice) {
         ForEach(ProfileTranscriptionChoice.allCases) { choice in
           Text(choice.displayName).tag(choice)
         }
@@ -198,21 +74,22 @@ extension ProfileEditorView {
       .pickerStyle(.segmented)
       .labelsHidden()
 
-      if transcriptionChoice == .streaming {
+      if draft.transcriptionChoice == .streaming {
         ModelPicker(
           title: "Streaming Model",
-          help: "Model used while recording when this profile is active.",
+          help: "Model used while recording when this profile is active. "
+            + "Custom identifiers must belong to a supported live provider.",
           options: ModelCatalog.liveTranscription,
-          value: $streamingModel,
+          value: $draft.streamingModel,
           credentialPurpose: .liveTranscription,
           storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers)
         )
-      } else if transcriptionChoice == .batch {
+      } else if draft.transcriptionChoice == .batch {
         ModelPicker(
           title: "Batch Model",
           help: "Model the finished recording is sent to when this profile is active.",
           options: ModelCatalog.batchTranscription,
-          value: $batchModel,
+          value: $draft.batchModel,
           credentialPurpose: .batchTranscription,
           storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers)
         )
@@ -224,7 +101,7 @@ extension ProfileEditorView {
     VStack(alignment: .leading, spacing: 8) {
       Text("Polish (Post-processing)")
         .font(.subheadline.weight(.semibold))
-      Picker("Polish", selection: $polishChoice) {
+      Picker("Polish", selection: $draft.polishChoice) {
         ForEach(ProfilePolishChoice.allCases) { choice in
           Text(choice.displayName).tag(choice)
         }
@@ -232,42 +109,61 @@ extension ProfileEditorView {
       .pickerStyle(.segmented)
       .labelsHidden()
 
-      if polishChoice == .enabled {
+      if draft.polishChoice == .enabled {
+        // Catalogue models only: a custom identifier would be normalised away
+        // at session time, so it cannot be offered here.
         ModelPicker(
           title: "Polish Model",
-          help: "LLM used to clean up the transcript for this profile.",
+          help: "LLM used to clean up the transcript for this profile. "
+            + "Runs after recording even when Live Polish is your usual speed mode.",
           options: ModelCatalog.postProcessing,
-          value: $polishModel,
+          value: $draft.polishModel,
           credentialPurpose: .postProcessing,
           storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
-          usesDetailedChooser: true
+          usesDetailedChooser: true,
+          allowsCustom: false
         )
 
-        Toggle("Custom polish prompt", isOn: $useCustomPrompt)
-        if useCustomPrompt {
-          TextEditor(text: $customPrompt)
-            .font(.body.monospaced())
-            .frame(minHeight: 120)
-            .overlay(
-              RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .strokeBorder(Color.secondary.opacity(0.3))
-            )
-          Text("Replaces the built-in cleanup instructions for this profile.")
-            .font(.caption)
-            .foregroundStyle(.secondary)
+        if draft.usesRulesCleanup {
+          Text(
+            "The built-in rules cleaner fixes spacing, punctuation and capitalisation only. "
+              + "It does not use prompts, an output language or lexicon directives, so those options are hidden."
+          )
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        } else {
+          promptControls
         }
-
-        Picker("Output Language", selection: $outputLanguage) {
-          Text("Use Default").tag("")
-          ForEach(Self.outputLanguages, id: \.self) { language in
-            Text(language).tag(language)
-          }
-        }
-        .pickerStyle(.menu)
-
-        Toggle("Include personal lexicon directives", isOn: $includeLexiconDirectives)
-        Toggle("Include context tags", isOn: $includeContextTags)
       }
+    }
+  }
+
+  fileprivate var promptControls: some View {
+    Group {
+      Toggle("Custom polish prompt", isOn: $draft.useCustomPrompt)
+      if draft.useCustomPrompt {
+        TextEditor(text: $draft.customPrompt)
+          .font(.body.monospaced())
+          .frame(minHeight: 120)
+          .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+              .strokeBorder(Color.secondary.opacity(0.3))
+          )
+        Text("Replaces the built-in cleanup instructions for this profile.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
+      Picker("Output Language", selection: $draft.outputLanguage) {
+        Text("Use Default").tag("")
+        ForEach(Self.outputLanguages, id: \.self) { language in
+          Text(language).tag(language)
+        }
+      }
+      .pickerStyle(.menu)
+
+      Toggle("Include personal lexicon directives", isOn: $draft.includeLexiconDirectives)
+      Toggle("Include context tags", isOn: $draft.includeContextTags)
     }
   }
 
@@ -275,7 +171,7 @@ extension ProfileEditorView {
     VStack(alignment: .leading, spacing: 8) {
       Text("Spoken Language")
         .font(.subheadline.weight(.semibold))
-      Picker("Spoken Language", selection: $languageIdentifier) {
+      Picker("Spoken Language", selection: $draft.languageIdentifier) {
         Text("Use Default").tag("")
         ForEach(TranscriptionLanguageCatalog.options) { option in
           Text(option.displayName).tag(option.id)
@@ -283,6 +179,23 @@ extension ProfileEditorView {
       }
       .pickerStyle(.menu)
       .labelsHidden()
+    }
+  }
+
+  /// Why the profile cannot be saved yet. Shown instead of letting a
+  /// configuration through that would not run as displayed.
+  @ViewBuilder
+  fileprivate var issuesSection: some View {
+    let issues = draft.issues
+    if !issues.isEmpty {
+      VStack(alignment: .leading, spacing: 4) {
+        ForEach(Array(issues.enumerated()), id: \.offset) { _, issue in
+          Label(issue.message, systemImage: "exclamationmark.triangle")
+            .font(.caption)
+            .foregroundStyle(.orange)
+        }
+      }
+      .accessibilityElement(children: .combine)
     }
   }
 

--- a/Sources/SpeakApp/Views/Settings/ProfileEditorView.swift
+++ b/Sources/SpeakApp/Views/Settings/ProfileEditorView.swift
@@ -93,6 +93,17 @@ extension ProfileEditorView {
           credentialPurpose: .batchTranscription,
           storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers)
         )
+      } else if draft.transcriptionChoice == .local {
+        ModelPicker(
+          title: "Local Model",
+          help: "Downloaded model that transcribes the finished recording on this Mac "
+            + "when this profile is active.",
+          options: ModelCatalog.localTranscriptionOptions,
+          value: $draft.localModel,
+          credentialPurpose: .batchTranscription,
+          storedAPIKeyIdentifiers: Set(settings.trackedAPIKeyIdentifiers),
+          allowsCustom: false
+        )
       }
     }
   }

--- a/Sources/SpeakCore/DictationProfile.swift
+++ b/Sources/SpeakCore/DictationProfile.swift
@@ -31,6 +31,18 @@ public struct DictationProfileMatcher: Codable, Equatable, Hashable, Sendable {
 
 // MARK: - Profile
 
+/// How a profile's transcription model override is routed. Stored explicitly
+/// so a custom identifier the catalogue does not list is applied the way the
+/// editor showed it, never re-classified by guesswork (issue #690).
+public enum DictationProfileTranscriptionRouting: String, Codable, Equatable, Sendable, CaseIterable {
+    /// A cloud streaming model used while recording.
+    case remoteStreaming
+    /// A cloud batch model the finished recording is sent to.
+    case remoteBatch
+    /// A downloaded local model run after recording.
+    case localBatch
+}
+
 /// A per-app dictation configuration ("Power Mode" profile).
 ///
 /// Every override is optional; `nil` means "keep the user's normal setting".
@@ -42,8 +54,11 @@ public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
     public var matchers: [DictationProfileMatcher]
 
     /// Transcription model override (catalog identifier, e.g. `deepgram/nova-3-streaming`
-    /// or `openai/whisper-1`). The transcription mode is derived from the identifier.
+    /// or `openai/whisper-1`). Routed by `transcriptionRouting` when set; profiles saved
+    /// before routing metadata existed derive it from the identifier.
     public var transcriptionModelID: String?
+    /// How `transcriptionModelID` is applied. `nil` for profiles saved by older builds.
+    public var transcriptionRouting: DictationProfileTranscriptionRouting?
 
     /// Whether LLM polish (post-processing) runs for this profile.
     public var polishEnabled: Bool?
@@ -72,12 +87,14 @@ public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
         polishOutputLanguage: String? = nil,
         polishIncludeLexiconDirectives: Bool? = nil,
         polishIncludeContextTags: Bool? = nil,
-        languageIdentifier: String? = nil
+        languageIdentifier: String? = nil,
+        transcriptionRouting: DictationProfileTranscriptionRouting? = nil
     ) {
         self.id = id
         self.name = name
         self.matchers = matchers
         self.transcriptionModelID = transcriptionModelID
+        self.transcriptionRouting = transcriptionRouting
         self.polishEnabled = polishEnabled
         self.polishModelID = polishModelID
         self.polishPrompt = polishPrompt
@@ -92,6 +109,7 @@ public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
         case name
         case matchers
         case transcriptionModelID
+        case transcriptionRouting
         case polishEnabled
         case polishModelID
         case polishPrompt
@@ -118,6 +136,11 @@ public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
         let lossyMatchers = try container.decodeIfPresent([LossyMatcher].self, forKey: .matchers) ?? []
         matchers = lossyMatchers.compactMap(\.matcher)
         transcriptionModelID = try container.decodeIfPresent(String.self, forKey: .transcriptionModelID)
+        // A routing written by a newer build is dropped rather than failing the profile;
+        // the legacy derivation then applies.
+        transcriptionRouting = try? container.decodeIfPresent(
+            DictationProfileTranscriptionRouting.self, forKey: .transcriptionRouting
+        )
         polishEnabled = try container.decodeIfPresent(Bool.self, forKey: .polishEnabled)
         polishModelID = try container.decodeIfPresent(String.self, forKey: .polishModelID)
         polishPrompt = try container.decodeIfPresent(String.self, forKey: .polishPrompt)
@@ -127,6 +150,33 @@ public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
         )
         polishIncludeContextTags = try container.decodeIfPresent(Bool.self, forKey: .polishIncludeContextTags)
         languageIdentifier = try container.decodeIfPresent(String.self, forKey: .languageIdentifier)
+    }
+}
+
+// MARK: - Routing
+
+public extension DictationProfile {
+    /// Routing for a profile saved before explicit metadata existed: catalogue live
+    /// models stream, `local/` identifiers run locally, everything else is remote batch.
+    static func derivedTranscriptionRouting(for modelID: String) -> DictationProfileTranscriptionRouting {
+        let trimmed = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if ModelCatalog.liveTranscription.contains(where: { $0.id.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            return .remoteStreaming
+        }
+        if trimmed.lowercased().hasPrefix("local/") {
+            return .localBatch
+        }
+        return .remoteBatch
+    }
+
+    /// The transcription override as a (model, routing) pair, or `nil` when the profile
+    /// keeps the user's own transcription settings.
+    var resolvedTranscriptionOverride: (modelID: String, routing: DictationProfileTranscriptionRouting)? {
+        guard let modelID = transcriptionModelID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !modelID.isEmpty else {
+            return nil
+        }
+        return (modelID, transcriptionRouting ?? Self.derivedTranscriptionRouting(for: modelID))
     }
 }
 

--- a/Sources/SpeakCore/DictationProfileValidation.swift
+++ b/Sources/SpeakCore/DictationProfileValidation.swift
@@ -12,6 +12,11 @@ public enum DictationProfileIssue: Equatable, Sendable {
     /// A polish model the post-processing pipeline would silently replace with the
     /// default model.
     case unsupportedPolishModel(modelID: String)
+    /// A local-model override whose identifier is not a downloaded local model.
+    case unknownLocalModel(modelID: String)
+    /// A local model stored under remote routing: the session would send a local
+    /// identifier to a cloud provider.
+    case localModelUnderRemoteRouting(modelID: String)
 
     public var message: String {
         switch self {
@@ -22,6 +27,10 @@ public enum DictationProfileIssue: Equatable, Sendable {
                 + "Use a provider/model identifier from a supported live provider, or pick a catalogue model."
         case .unsupportedPolishModel(let modelID):
             return "“\(modelID)” is not a polish model the app can run. Pick a catalogue model."
+        case .unknownLocalModel(let modelID):
+            return "“\(modelID)” is not a local model the app can run. Pick a downloaded model."
+        case .localModelUnderRemoteRouting(let modelID):
+            return "“\(modelID)” is a local model. Choose Local Model routing for it."
         }
     }
 }
@@ -32,15 +41,34 @@ public enum DictationProfileValidator {
         if profile.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             issues.append(.emptyName)
         }
-        if let override = profile.resolvedTranscriptionOverride,
-           override.routing == .remoteStreaming,
-           !isRoutableStreamingModel(override.modelID) {
-            issues.append(.unknownStreamingProvider(modelID: override.modelID))
+        if let override = profile.resolvedTranscriptionOverride {
+            issues.append(contentsOf: transcriptionIssues(modelID: override.modelID, routing: override.routing))
         }
         if let polishModel = trimmedNonEmpty(profile.polishModelID), !isSupportedPolishModel(polishModel) {
             issues.append(.unsupportedPolishModel(modelID: polishModel))
         }
         return issues
+    }
+
+    /// Routing and identifier must agree: a local identifier only runs under local
+    /// routing, and local routing only runs a local identifier.
+    private static func transcriptionIssues(
+        modelID: String,
+        routing: DictationProfileTranscriptionRouting
+    ) -> [DictationProfileIssue] {
+        switch routing {
+        case .remoteStreaming:
+            return isRoutableStreamingModel(modelID) ? [] : [.unknownStreamingProvider(modelID: modelID)]
+        case .remoteBatch:
+            return isLocalModel(modelID) ? [.localModelUnderRemoteRouting(modelID: modelID)] : []
+        case .localBatch:
+            return isLocalModel(modelID) ? [] : [.unknownLocalModel(modelID: modelID)]
+        }
+    }
+
+    /// Whether `modelID` is a downloaded-model identifier the local batch pipeline runs.
+    public static func isLocalModel(_ modelID: String) -> Bool {
+        modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("local/")
     }
 
     /// Whether the live-transcription pipeline can start `modelID`: a catalogue entry, or a

--- a/Sources/SpeakCore/DictationProfileValidation.swift
+++ b/Sources/SpeakCore/DictationProfileValidation.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// A reason a dictation profile cannot execute as configured. The editor
+/// refuses to save a profile with issues, and the session applier skips the
+/// parts it cannot honour, so a saved profile always runs the way it was
+/// displayed (issue #690).
+public enum DictationProfileIssue: Equatable, Sendable {
+    case emptyName
+    /// A streaming override whose identifier does not belong to a live-transcription
+    /// provider the app can route to.
+    case unknownStreamingProvider(modelID: String)
+    /// A polish model the post-processing pipeline would silently replace with the
+    /// default model.
+    case unsupportedPolishModel(modelID: String)
+
+    public var message: String {
+        switch self {
+        case .emptyName:
+            return "Give the profile a name."
+        case .unknownStreamingProvider(let modelID):
+            return "“\(modelID)” is not a streaming model the app can route to. "
+                + "Use a provider/model identifier from a supported live provider, or pick a catalogue model."
+        case .unsupportedPolishModel(let modelID):
+            return "“\(modelID)” is not a polish model the app can run. Pick a catalogue model."
+        }
+    }
+}
+
+public enum DictationProfileValidator {
+    public static func issues(for profile: DictationProfile) -> [DictationProfileIssue] {
+        var issues: [DictationProfileIssue] = []
+        if profile.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append(.emptyName)
+        }
+        if let override = profile.resolvedTranscriptionOverride,
+           override.routing == .remoteStreaming,
+           !isRoutableStreamingModel(override.modelID) {
+            issues.append(.unknownStreamingProvider(modelID: override.modelID))
+        }
+        if let polishModel = trimmedNonEmpty(profile.polishModelID), !isSupportedPolishModel(polishModel) {
+            issues.append(.unsupportedPolishModel(modelID: polishModel))
+        }
+        return issues
+    }
+
+    /// Whether the live-transcription pipeline can start `modelID`: a catalogue entry, or a
+    /// custom identifier under a known live provider prefix.
+    public static func isRoutableStreamingModel(_ modelID: String) -> Bool {
+        let trimmed = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        if ModelCatalog.liveTranscription.contains(where: { $0.id.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            return true
+        }
+        return LiveTranscriptionRouting.route(for: trimmed) != nil
+    }
+
+    /// Whether the post-processing pipeline runs `modelID` as given — exactly the
+    /// identifiers `ModelCatalog.normalizedPostProcessingModel` preserves.
+    public static func isSupportedPolishModel(_ modelID: String) -> Bool {
+        let trimmed = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return ModelCatalog.normalizedPostProcessingModel(trimmed) == trimmed
+    }
+
+    private static func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Tests/SpeakAppTests/ProfileEditorDraftTests.swift
+++ b/Tests/SpeakAppTests/ProfileEditorDraftTests.swift
@@ -125,6 +125,51 @@ final class ProfileEditorDraftTests: XCTestCase {
     XCTAssertEqual(draft.profile(id: saved.id), saved)
   }
 
+  func testLocalChoice_storesLocalBatchRouting() {
+    var draft = ProfileEditorDraft()
+    draft.name = "Private notes"
+    draft.transcriptionChoice = .local
+    draft.localModel = " local/whisperkit/tiny "
+
+    let profile = draft.profile(id: nil)
+
+    XCTAssertEqual(profile.transcriptionModelID, "local/whisperkit/tiny")
+    XCTAssertEqual(profile.transcriptionRouting, .localBatch)
+    XCTAssertTrue(draft.canSave)
+  }
+
+  func testDraft_reopensALocalProfileAsLocal_andSavesItUnchanged() {
+    // Opening and saving a local-model profile must not convert it to remote
+    // batch: the stored identifier would then be sent to a cloud provider.
+    let defaults = UserDefaults(suiteName: "ProfileEditorDraftTests-\(UUID().uuidString)")!
+    let settings = AppSettings(defaults: defaults)
+    for saved in [
+      DictationProfile(
+        id: UUID(), name: "Explicit", transcriptionModelID: "local/whisperkit/tiny", transcriptionRouting: .localBatch
+      ),
+      DictationProfile(id: UUID(), name: "Legacy", transcriptionModelID: "local/whisperkit/base")
+    ] {
+      let draft = ProfileEditorDraft(profile: saved, settings: settings)
+
+      XCTAssertEqual(draft.transcriptionChoice, .local, saved.name)
+      XCTAssertEqual(draft.localModel, saved.transcriptionModelID, saved.name)
+      let reopened = draft.profile(id: saved.id)
+      XCTAssertEqual(reopened.transcriptionModelID, saved.transcriptionModelID, saved.name)
+      XCTAssertEqual(reopened.transcriptionRouting, .localBatch, saved.name)
+      XCTAssertTrue(draft.canSave, saved.name)
+    }
+  }
+
+  func testLocalIdentifierUnderRemoteBatch_blocksSaving() {
+    var draft = ProfileEditorDraft()
+    draft.name = "Mismatch"
+    draft.transcriptionChoice = .batch
+    draft.batchModel = "local/whisperkit/tiny"
+
+    XCTAssertEqual(draft.issues, [.localModelUnderRemoteRouting(modelID: "local/whisperkit/tiny")])
+    XCTAssertFalse(draft.canSave)
+  }
+
   func testDraft_keepsAProfilesIdentityOnSave() {
     let id = UUID()
     var draft = ProfileEditorDraft()

--- a/Tests/SpeakAppTests/ProfileEditorDraftTests.swift
+++ b/Tests/SpeakAppTests/ProfileEditorDraftTests.swift
@@ -1,0 +1,134 @@
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// What the profile editor stores and refuses, so a saved profile runs
+/// exactly as displayed (issue #690).
+@MainActor
+final class ProfileEditorDraftTests: XCTestCase {
+  func testStreamingChoice_storesExplicitStreamingRouting() {
+    var draft = ProfileEditorDraft()
+    draft.name = " Slack "
+    draft.transcriptionChoice = .streaming
+    draft.streamingModel = " deepgram/nova-4-custom-streaming "
+
+    let profile = draft.profile(id: nil)
+
+    XCTAssertEqual(profile.name, "Slack")
+    XCTAssertEqual(profile.transcriptionModelID, "deepgram/nova-4-custom-streaming")
+    XCTAssertEqual(profile.transcriptionRouting, .remoteStreaming)
+    XCTAssertTrue(draft.canSave)
+  }
+
+  func testBatchChoice_storesBatchRouting_andDefaultStoresNone() {
+    var draft = ProfileEditorDraft()
+    draft.name = "Email"
+    draft.transcriptionChoice = .batch
+    draft.batchModel = "openai/whisper-1"
+    XCTAssertEqual(draft.profile(id: nil).transcriptionRouting, .remoteBatch)
+
+    draft.transcriptionChoice = .useDefault
+    let profile = draft.profile(id: nil)
+    XCTAssertNil(profile.transcriptionModelID)
+    XCTAssertNil(profile.transcriptionRouting)
+  }
+
+  func testUnroutableCustomStreamingModel_blocksSaving() {
+    var draft = ProfileEditorDraft()
+    draft.name = "Odd"
+    draft.transcriptionChoice = .streaming
+    draft.streamingModel = "acme/fast-streaming"
+
+    XCTAssertEqual(draft.issues, [.unknownStreamingProvider(modelID: "acme/fast-streaming")])
+    XCTAssertFalse(draft.canSave)
+  }
+
+  func testEmptyName_blocksSaving() {
+    var draft = ProfileEditorDraft()
+    draft.name = "   "
+    XCTAssertEqual(draft.issues, [.emptyName])
+    XCTAssertFalse(draft.canSave)
+  }
+
+  func testRulesCleanup_dropsPromptLanguageAndLexiconControls() {
+    var draft = ProfileEditorDraft()
+    draft.name = "Rules"
+    draft.polishChoice = .enabled
+    draft.polishModel = LocalPostProcessingModelManager.builtInRulesModelID
+    draft.useCustomPrompt = true
+    draft.customPrompt = "Be terse."
+    draft.outputLanguage = "French"
+    draft.includeLexiconDirectives = true
+    draft.includeContextTags = true
+
+    XCTAssertTrue(draft.usesRulesCleanup)
+    let profile = draft.profile(id: nil)
+    XCTAssertEqual(profile.polishEnabled, true)
+    XCTAssertEqual(profile.polishModelID, LocalPostProcessingModelManager.builtInRulesModelID)
+    XCTAssertNil(profile.polishPrompt)
+    XCTAssertNil(profile.polishOutputLanguage)
+    XCTAssertNil(profile.polishIncludeLexiconDirectives)
+    XCTAssertNil(profile.polishIncludeContextTags)
+    XCTAssertTrue(draft.canSave)
+  }
+
+  func testLLMPolish_storesPromptLanguageAndLexiconControls() {
+    var draft = ProfileEditorDraft()
+    draft.name = "Polished"
+    draft.polishChoice = .enabled
+    draft.polishModel = ModelCatalog.defaultPostProcessingModel
+    draft.useCustomPrompt = true
+    draft.customPrompt = " Be terse. "
+    draft.outputLanguage = "French"
+    draft.includeLexiconDirectives = false
+    draft.includeContextTags = true
+
+    XCTAssertFalse(draft.usesRulesCleanup)
+    let profile = draft.profile(id: nil)
+    XCTAssertEqual(profile.polishPrompt, "Be terse.")
+    XCTAssertEqual(profile.polishOutputLanguage, "French")
+    XCTAssertEqual(profile.polishIncludeLexiconDirectives, false)
+    XCTAssertEqual(profile.polishIncludeContextTags, true)
+  }
+
+  func testPolishNotOverridden_storesNoPolishFields() {
+    for choice in [ProfilePolishChoice.useDefault, .disabled] {
+      var draft = ProfileEditorDraft()
+      draft.name = "Plain"
+      draft.polishChoice = choice
+      draft.polishModel = ModelCatalog.defaultPostProcessingModel
+      draft.useCustomPrompt = true
+      draft.customPrompt = "ignored"
+
+      let profile = draft.profile(id: nil)
+      XCTAssertEqual(profile.polishEnabled, choice == .disabled ? false : nil)
+      XCTAssertNil(profile.polishModelID)
+      XCTAssertNil(profile.polishPrompt)
+    }
+  }
+
+  func testDraft_reopensACustomStreamingProfileAsStreaming() {
+    let defaults = UserDefaults(suiteName: "ProfileEditorDraftTests-\(UUID().uuidString)")!
+    let settings = AppSettings(defaults: defaults)
+    let saved = DictationProfile(
+      id: UUID(),
+      name: "Custom",
+      transcriptionModelID: "deepgram/nova-4-custom-streaming",
+      transcriptionRouting: .remoteStreaming
+    )
+
+    let draft = ProfileEditorDraft(profile: saved, settings: settings)
+
+    XCTAssertEqual(draft.transcriptionChoice, .streaming)
+    XCTAssertEqual(draft.streamingModel, "deepgram/nova-4-custom-streaming")
+    XCTAssertEqual(draft.profile(id: saved.id), saved)
+  }
+
+  func testDraft_keepsAProfilesIdentityOnSave() {
+    let id = UUID()
+    var draft = ProfileEditorDraft()
+    draft.name = "Same"
+    XCTAssertEqual(draft.profile(id: id).id, id)
+  }
+}

--- a/Tests/SpeakAppTests/SessionProfileApplierTests.swift
+++ b/Tests/SpeakAppTests/SessionProfileApplierTests.swift
@@ -1,0 +1,335 @@
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// Profile overrides must execute exactly as configured for one session and
+/// leave the user's own settings — including any they changed during the
+/// session — intact afterwards (issue #690).
+@MainActor
+final class SessionProfileApplierTests: XCTestCase {
+  private let bundleID = "com.example.editor"
+  private let livePolishModel = "deepgram/nova-3-streaming"
+
+  private var alternativePolishModel: String {
+    ModelCatalog.postProcessing.first {
+      $0.id != ModelCatalog.defaultPostProcessingModel && !$0.id.hasPrefix("local/")
+    }?.id ?? ModelCatalog.defaultPostProcessingModel
+  }
+
+  // MARK: - Polish versus speed mode
+
+  func testPolishProfile_runsEndOfSessionPolishEvenWhenTheUserUsesLivePolish() {
+    let harness = makeHarness()
+    harness.settings.transcriptionMode = .liveNative
+    harness.settings.liveTranscriptionModel = livePolishModel
+    harness.settings.speedMode = .livePolish
+    XCTAssertFalse(harness.settings.postProcessingEnabled, "Live Polish disables end-of-session polish")
+
+    let profile = DictationProfile(
+      name: "Polished",
+      matchers: [.bundleID(bundleID)],
+      polishEnabled: true,
+      polishModelID: alternativePolishModel
+    )
+    harness.begin(profile)
+
+    XCTAssertEqual(harness.settings.speedMode, .instant, "Profile polish needs the instant speed mode")
+    XCTAssertTrue(
+      harness.settings.postProcessingEnabled,
+      "The override must not be rejected by the speed-mode invariant"
+    )
+    XCTAssertEqual(harness.settings.postProcessingModel, alternativePolishModel)
+    XCTAssertEqual(harness.applier.activeProfileName, "Polished")
+    XCTAssertEqual(
+      harness.persistedSettings.speedMode, .livePolish,
+      "The temporary speed mode is session-only and never persisted"
+    )
+    XCTAssertFalse(harness.persistedSettings.postProcessingEnabled)
+
+    harness.end()
+
+    XCTAssertEqual(harness.settings.speedMode, .livePolish)
+    XCTAssertFalse(harness.settings.postProcessingEnabled)
+    XCTAssertEqual(harness.settings.postProcessingModel, ModelCatalog.defaultPostProcessingModel)
+    XCTAssertNil(harness.applier.activeProfileName)
+  }
+
+  func testDisablingPolishProfile_restoresTheUsersEnabledPolish() {
+    let harness = makeHarness()
+    harness.settings.postProcessingEnabled = true
+
+    harness.begin(DictationProfile(name: "Raw", matchers: [.bundleID(bundleID)], polishEnabled: false))
+    XCTAssertFalse(harness.settings.postProcessingEnabled)
+
+    harness.end()
+    XCTAssertTrue(harness.settings.postProcessingEnabled)
+  }
+
+  // MARK: - Mid-session edits
+
+  func testSettingsChangedDuringTheSession_surviveRestore() {
+    let harness = makeHarness()
+    harness.settings.postProcessingModel = ModelCatalog.defaultPostProcessingModel
+    harness.settings.postProcessingIncludeContextTags = true
+    let profile = DictationProfile(
+      name: "Profile",
+      matchers: [.bundleID(bundleID)],
+      polishEnabled: true,
+      polishModelID: alternativePolishModel,
+      polishIncludeContextTags: false
+    )
+    harness.begin(profile)
+    XCTAssertEqual(harness.settings.postProcessingModel, alternativePolishModel)
+
+    // The user changes an overridden setting and an untouched one while recording.
+    harness.settings.postProcessingModel = "local/post-processing/rules"
+    harness.settings.postProcessingTemperature = 0.9
+
+    harness.end()
+
+    XCTAssertEqual(
+      harness.settings.postProcessingModel, "local/post-processing/rules",
+      "A value the user chose during the session is theirs, not the profile's to undo"
+    )
+    XCTAssertEqual(harness.persistedSettings.postProcessingModel, "local/post-processing/rules")
+    XCTAssertTrue(harness.settings.postProcessingIncludeContextTags, "Untouched overrides are still restored")
+    XCTAssertEqual(harness.settings.postProcessingTemperature, 0.9)
+  }
+
+  func testSpeedModeChangedDuringTheSession_isKept() {
+    let harness = makeHarness()
+    harness.settings.transcriptionMode = .liveNative
+    harness.settings.liveTranscriptionModel = livePolishModel
+    harness.settings.speedMode = .instant
+    harness.settings.postProcessingEnabled = true
+
+    harness.begin(DictationProfile(name: "Polished", matchers: [.bundleID(bundleID)], polishEnabled: true))
+    harness.settings.speedMode = .livePolish
+
+    harness.end()
+
+    XCTAssertEqual(harness.settings.speedMode, .livePolish)
+    XCTAssertFalse(harness.settings.postProcessingEnabled, "Live Polish, chosen mid-session, still excludes polish")
+  }
+
+  // MARK: - Transcription routing
+
+  func testCustomStreamingModel_withExplicitRouting_isAppliedAsLive() {
+    let harness = makeHarness()
+    harness.settings.transcriptionMode = .batchRemote
+    let originalLiveModel = harness.settings.liveTranscriptionModel
+    let profile = DictationProfile(
+      name: "Custom streaming",
+      matchers: [.bundleID(bundleID)],
+      transcriptionModelID: "deepgram/nova-4-custom-streaming",
+      transcriptionRouting: .remoteStreaming
+    )
+
+    harness.begin(profile)
+
+    XCTAssertEqual(harness.settings.transcriptionMode, .liveNative)
+    XCTAssertEqual(harness.settings.liveTranscriptionModel, "deepgram/nova-4-custom-streaming")
+    XCTAssertEqual(harness.persistedSettings.liveTranscriptionModel, originalLiveModel)
+
+    harness.end()
+
+    XCTAssertEqual(harness.settings.transcriptionMode, .batchRemote)
+    XCTAssertEqual(harness.settings.liveTranscriptionModel, originalLiveModel)
+  }
+
+  func testLegacyProfileWithoutRouting_derivesFromTheIdentifier() {
+    let harness = makeHarness()
+    harness.begin(
+      DictationProfile(name: "Legacy batch", matchers: [.bundleID(bundleID)], transcriptionModelID: "openai/whisper-1")
+    )
+    XCTAssertEqual(harness.settings.transcriptionMode, .batchRemote)
+    XCTAssertEqual(harness.settings.batchTranscriptionModel, "openai/whisper-1")
+    harness.end()
+
+    harness.begin(
+      DictationProfile(
+        name: "Legacy local", matchers: [.bundleID(bundleID)], transcriptionModelID: "local/whisperkit/tiny"
+      )
+    )
+    XCTAssertEqual(harness.settings.transcriptionMode, .localModel)
+    XCTAssertEqual(harness.settings.localTranscriptionMode, .batch)
+    XCTAssertEqual(harness.settings.localTranscriptionModel, "local/whisperkit/tiny")
+    harness.end()
+  }
+
+  // MARK: - Polish model and rules cleanup
+
+  func testUnsupportedPolishModel_isSkippedWhilePolishStillRuns() {
+    let harness = makeHarness()
+    harness.settings.postProcessingEnabled = false
+    let profile = DictationProfile(
+      name: "Odd model", matchers: [.bundleID(bundleID)], polishEnabled: true, polishModelID: "unknown/model"
+    )
+
+    harness.begin(profile)
+
+    XCTAssertTrue(harness.settings.postProcessingEnabled)
+    XCTAssertEqual(
+      harness.settings.postProcessingModel, ModelCatalog.defaultPostProcessingModel,
+      "A model the app cannot run is not applied; the user's model stays"
+    )
+  }
+
+  func testRulesCleanupModel_doesNotApplyPromptLanguageOrLexiconOverrides() {
+    let harness = makeHarness()
+    harness.settings.postProcessingOutputLanguage = "English"
+    harness.settings.postProcessingIncludeLexiconDirectives = true
+    let profile = DictationProfile(
+      name: "Rules",
+      matchers: [.bundleID(bundleID)],
+      polishEnabled: true,
+      polishModelID: "local/post-processing/rules",
+      polishPrompt: "Be terse.",
+      polishOutputLanguage: "French",
+      polishIncludeLexiconDirectives: false
+    )
+
+    harness.begin(profile)
+
+    XCTAssertEqual(harness.settings.postProcessingModel, "local/post-processing/rules")
+    XCTAssertNil(harness.postProcessing.sessionPromptOverride)
+    XCTAssertEqual(harness.settings.postProcessingOutputLanguage, "English")
+    XCTAssertTrue(harness.settings.postProcessingIncludeLexiconDirectives)
+  }
+
+  func testPromptOverride_isAppliedForLLMModelsAndClearedOnEnd() {
+    let harness = makeHarness()
+    let profile = DictationProfile(
+      name: "Prompted",
+      matchers: [.bundleID(bundleID)],
+      polishEnabled: true,
+      polishModelID: alternativePolishModel,
+      polishPrompt: "Rewrite as bullet points.",
+      polishOutputLanguage: "French"
+    )
+
+    harness.begin(profile)
+    XCTAssertEqual(harness.postProcessing.sessionPromptOverride, "Rewrite as bullet points.")
+    XCTAssertEqual(harness.settings.postProcessingOutputLanguage, "French")
+
+    harness.end()
+    XCTAssertNil(harness.postProcessing.sessionPromptOverride)
+    XCTAssertNotEqual(harness.settings.postProcessingOutputLanguage, "French")
+  }
+
+  // MARK: - Lifecycle
+
+  func testNoMatchingProfile_changesNothing() {
+    let harness = makeHarness()
+    let before = harness.snapshot()
+
+    harness.applier.begin(
+      settings: harness.settings,
+      postProcessing: harness.postProcessing,
+      profiles: [DictationProfile(name: "Other", matchers: [.bundleID("com.other.app")], polishEnabled: false)],
+      frontmostBundleID: bundleID
+    )
+
+    XCTAssertNil(harness.applier.activeProfileName)
+    XCTAssertEqual(harness.snapshot(), before)
+  }
+
+  func testBeginWhileActive_restoresThePreviousOverridesFirst_andEndIsIdempotent() {
+    let harness = makeHarness()
+    harness.settings.preferredLocaleIdentifier = "en_US"
+    harness.begin(DictationProfile(name: "First", matchers: [.bundleID(bundleID)], languageIdentifier: "fr_FR"))
+    XCTAssertEqual(harness.settings.preferredLocaleIdentifier, "fr_FR")
+
+    harness.begin(DictationProfile(name: "Second", matchers: [.bundleID(bundleID)], polishEnabled: false))
+    XCTAssertEqual(harness.settings.preferredLocaleIdentifier, "en_US", "The first profile's override was undone")
+    XCTAssertEqual(harness.applier.activeProfileName, "Second")
+
+    harness.end()
+    harness.end()
+    XCTAssertEqual(harness.settings.preferredLocaleIdentifier, "en_US")
+    XCTAssertNil(harness.applier.activeProfileName)
+  }
+
+  // MARK: - Helpers
+
+  private struct SettingsSnapshot: Equatable {
+    let transcriptionMode: AppSettings.TranscriptionMode
+    let liveModel: String
+    let batchModel: String
+    let speedMode: AppSettings.SpeedMode
+    let polishEnabled: Bool
+    let polishModel: String
+    let locale: String
+  }
+
+  @MainActor
+  private final class Harness {
+    let defaults: UserDefaults
+    let settings: AppSettings
+    let postProcessing: PostProcessingManager
+    let applier = SessionProfileApplier()
+    private let bundleID: String
+
+    init(bundleID: String) {
+      let suiteName = "SessionProfileApplierTests-\(UUID().uuidString)"
+      let defaults = UserDefaults(suiteName: suiteName)!
+      defaults.removePersistentDomain(forName: suiteName)
+      self.defaults = defaults
+      self.settings = AppSettings(defaults: defaults)
+      self.bundleID = bundleID
+      let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(suiteName, isDirectory: true)
+      self.postProcessing = PostProcessingManager(
+        client: StubChatClient(),
+        settings: settings,
+        personalLexicon: PersonalLexiconService(store: PersonalLexiconStore(baseDirectory: directory))
+      )
+    }
+
+    /// Settings as another launch would read them from the same defaults.
+    var persistedSettings: AppSettings { AppSettings(defaults: defaults) }
+
+    func begin(_ profile: DictationProfile) {
+      applier.begin(
+        settings: settings, postProcessing: postProcessing, profiles: [profile], frontmostBundleID: bundleID
+      )
+    }
+
+    func end() {
+      applier.end(settings: settings, postProcessing: postProcessing)
+    }
+
+    func snapshot() -> SettingsSnapshot {
+      SettingsSnapshot(
+        transcriptionMode: settings.transcriptionMode,
+        liveModel: settings.liveTranscriptionModel,
+        batchModel: settings.batchTranscriptionModel,
+        speedMode: settings.speedMode,
+        polishEnabled: settings.postProcessingEnabled,
+        polishModel: settings.postProcessingModel,
+        locale: settings.preferredLocaleIdentifier
+      )
+    }
+  }
+
+  private func makeHarness() -> Harness {
+    Harness(bundleID: bundleID)
+  }
+}
+
+private final class StubChatClient: ChatLLMClient {
+  func sendChat(
+    systemPrompt: String?,
+    messages: [ChatMessage],
+    model: String,
+    temperature: Double
+  ) async throws -> ChatResponse {
+    ChatResponse(
+      messages: messages + [ChatMessage(role: .assistant, content: "stub")],
+      finishReason: "stop",
+      cost: nil,
+      rawPayload: nil
+    )
+  }
+}

--- a/Tests/SpeakCoreTests/DictationProfileValidationTests.swift
+++ b/Tests/SpeakCoreTests/DictationProfileValidationTests.swift
@@ -39,6 +39,33 @@ final class DictationProfileValidationTests: XCTestCase {
         XCTAssertNil(DictationProfile(name: "Blank", transcriptionModelID: "  ").resolvedTranscriptionOverride)
     }
 
+    func testLocalRoutingAndLocalIdentifiers_mustAgree() {
+        let localUnderLocal = DictationProfile(
+            name: "Local", transcriptionModelID: "local/whisperkit/tiny", transcriptionRouting: .localBatch
+        )
+        XCTAssertEqual(DictationProfileValidator.issues(for: localUnderLocal), [])
+
+        // A local identifier stored under remote batch would be sent to a cloud provider.
+        let localUnderRemote = DictationProfile(
+            name: "Mismatch", transcriptionModelID: "local/whisperkit/tiny", transcriptionRouting: .remoteBatch
+        )
+        XCTAssertEqual(
+            DictationProfileValidator.issues(for: localUnderRemote),
+            [.localModelUnderRemoteRouting(modelID: "local/whisperkit/tiny")]
+        )
+
+        // Local routing can only run a downloaded local model.
+        let remoteUnderLocal = DictationProfile(
+            name: "Mismatch", transcriptionModelID: "openai/whisper-1", transcriptionRouting: .localBatch
+        )
+        XCTAssertEqual(
+            DictationProfileValidator.issues(for: remoteUnderLocal),
+            [.unknownLocalModel(modelID: "openai/whisper-1")]
+        )
+        XCTAssertFalse(DictationProfileIssue.unknownLocalModel(modelID: "x").message.isEmpty)
+        XCTAssertFalse(DictationProfileIssue.localModelUnderRemoteRouting(modelID: "x").message.isEmpty)
+    }
+
     func testCodable_roundTripsRoutingAndDecodesLegacyProfilesWithoutIt() throws {
         let profile = DictationProfile(
             name: "Slack",

--- a/Tests/SpeakCoreTests/DictationProfileValidationTests.swift
+++ b/Tests/SpeakCoreTests/DictationProfileValidationTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+
+@testable import SpeakCore
+
+/// Routing metadata and save-time validation for dictation profiles (issue #690).
+final class DictationProfileValidationTests: XCTestCase {
+    private var catalogueLiveModel: String {
+        ModelCatalog.liveTranscription.first { LiveTranscriptionRouting.route(for: $0.id) != nil }?.id
+            ?? "deepgram/nova-3-streaming"
+    }
+
+    // MARK: - Routing
+
+    func testDerivedRouting_matchesTheLegacyDerivation() {
+        XCTAssertEqual(DictationProfile.derivedTranscriptionRouting(for: catalogueLiveModel), .remoteStreaming)
+        XCTAssertEqual(DictationProfile.derivedTranscriptionRouting(for: "local/whisperkit/tiny"), .localBatch)
+        XCTAssertEqual(DictationProfile.derivedTranscriptionRouting(for: "openai/whisper-1"), .remoteBatch)
+        XCTAssertEqual(
+            DictationProfile.derivedTranscriptionRouting(for: "deepgram/nova-4-custom-streaming"),
+            .remoteBatch,
+            "Without metadata an unlisted streaming id is still batch: that is the bug explicit routing fixes"
+        )
+    }
+
+    func testResolvedOverride_prefersExplicitRouting() {
+        let explicit = DictationProfile(
+            name: "Custom",
+            transcriptionModelID: "deepgram/nova-4-custom-streaming",
+            transcriptionRouting: .remoteStreaming
+        )
+        XCTAssertEqual(explicit.resolvedTranscriptionOverride?.routing, .remoteStreaming)
+        XCTAssertEqual(explicit.resolvedTranscriptionOverride?.modelID, "deepgram/nova-4-custom-streaming")
+
+        let legacy = DictationProfile(name: "Legacy", transcriptionModelID: " openai/whisper-1 ")
+        XCTAssertEqual(legacy.resolvedTranscriptionOverride?.routing, .remoteBatch)
+        XCTAssertEqual(legacy.resolvedTranscriptionOverride?.modelID, "openai/whisper-1")
+
+        XCTAssertNil(DictationProfile(name: "Default").resolvedTranscriptionOverride)
+        XCTAssertNil(DictationProfile(name: "Blank", transcriptionModelID: "  ").resolvedTranscriptionOverride)
+    }
+
+    func testCodable_roundTripsRoutingAndDecodesLegacyProfilesWithoutIt() throws {
+        let profile = DictationProfile(
+            name: "Slack",
+            matchers: [.bundleID("com.tinyspeck.slackmacgap")],
+            transcriptionModelID: "deepgram/nova-4-custom-streaming",
+            transcriptionRouting: .remoteStreaming
+        )
+        let decoded = try DictationProfile.decodeList(DictationProfile.encodeList([profile]))
+        XCTAssertEqual(decoded, [profile])
+        XCTAssertEqual(decoded.first?.transcriptionRouting, .remoteStreaming)
+
+        let legacyJSON = """
+        [{"id":"\(UUID().uuidString)","name":"Legacy","matchers":[],"transcriptionModelID":"openai/whisper-1"}]
+        """
+        let legacy = try DictationProfile.decodeList(Data(legacyJSON.utf8))
+        XCTAssertNil(legacy.first?.transcriptionRouting)
+        XCTAssertEqual(legacy.first?.resolvedTranscriptionOverride?.routing, .remoteBatch)
+    }
+
+    func testCodable_dropsUnknownRoutingInsteadOfFailing() throws {
+        let json = """
+        [{"id":"\(UUID().uuidString)","name":"Future","matchers":[],"transcriptionModelID":"x/y",\
+        "transcriptionRouting":"quantumStreaming"}]
+        """
+        let decoded = try DictationProfile.decodeList(Data(json.utf8))
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertNil(decoded.first?.transcriptionRouting)
+    }
+
+    // MARK: - Validation
+
+    func testValidator_acceptsCatalogueAndRoutableCustomStreamingModels() {
+        let catalogue = DictationProfile(
+            name: "Catalogue", transcriptionModelID: catalogueLiveModel, transcriptionRouting: .remoteStreaming
+        )
+        XCTAssertEqual(DictationProfileValidator.issues(for: catalogue), [])
+
+        let custom = DictationProfile(
+            name: "Custom",
+            transcriptionModelID: "deepgram/nova-4-custom-streaming",
+            transcriptionRouting: .remoteStreaming
+        )
+        XCTAssertEqual(DictationProfileValidator.issues(for: custom), [])
+        XCTAssertTrue(DictationProfileValidator.isRoutableStreamingModel("deepgram/nova-4-custom-streaming"))
+    }
+
+    func testValidator_rejectsStreamingModelsWithoutALiveProvider() {
+        let profile = DictationProfile(
+            name: "Unknown", transcriptionModelID: "acme/fast-streaming", transcriptionRouting: .remoteStreaming
+        )
+        XCTAssertEqual(
+            DictationProfileValidator.issues(for: profile),
+            [.unknownStreamingProvider(modelID: "acme/fast-streaming")]
+        )
+        XCTAssertFalse(DictationProfileValidator.isRoutableStreamingModel("acme/fast-streaming"))
+        XCTAssertFalse(DictationProfileValidator.isRoutableStreamingModel("no-provider"))
+    }
+
+    func testValidator_batchRoutingDoesNotRequireALiveProvider() {
+        let profile = DictationProfile(
+            name: "Batch", transcriptionModelID: "acme/fast", transcriptionRouting: .remoteBatch
+        )
+        XCTAssertEqual(DictationProfileValidator.issues(for: profile), [])
+    }
+
+    func testValidator_polishModelMustBeOneTheAppRuns() {
+        XCTAssertTrue(DictationProfileValidator.isSupportedPolishModel(ModelCatalog.defaultPostProcessingModel))
+        XCTAssertTrue(DictationProfileValidator.isSupportedPolishModel("local/post-processing/rules"))
+        XCTAssertFalse(DictationProfileValidator.isSupportedPolishModel("unknown/model"))
+        XCTAssertFalse(DictationProfileValidator.isSupportedPolishModel(""))
+
+        let profile = DictationProfile(name: "Polish", polishEnabled: true, polishModelID: "unknown/model")
+        XCTAssertEqual(
+            DictationProfileValidator.issues(for: profile),
+            [.unsupportedPolishModel(modelID: "unknown/model")]
+        )
+    }
+
+    func testValidator_requiresAName() {
+        XCTAssertEqual(DictationProfileValidator.issues(for: DictationProfile(name: "  ")), [.emptyName])
+        XCTAssertFalse(DictationProfileIssue.emptyName.message.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #690.

Dictation profiles could save combinations that did not execute as configured: polish silently rejected under Live Polish, custom streaming models demoted to batch, custom polish models normalised to `openai/gpt-5-mini`, and prompt/language/lexicon controls shown for the rules cleaner that ignores them.

## What changes

**Explicit polish strategy** — a profile with `polishEnabled == true` means end-of-session post-processing. `SessionProfileApplier` now switches the session to the instant speed mode before enabling polish (the `postProcessingEnabled` setter rejects `true` under any other mode), with persistence suppressed like every other override, and restores the user's speed mode afterwards.

**Session overrides isolated from mid-session edits (#642 coordination)** — the applier no longer restores a whole snapshot. Every override remembers the value it replaced and the value it set; `end()` restores a setting only while it still holds the applied value. A setting the user changed in Settings during the recording is kept together with the persistence its own setter performed, so in-memory and stored values no longer diverge. Speed mode and `postProcessingEnabled` are tracked even when the profile did not set them directly, because the transcription setters' invariants can move them.

**Explicit transcription routing** — `DictationProfile.transcriptionRouting` (`remoteStreaming` / `remoteBatch` / `localBatch`) is stored by the editor from the user's choice; the applier routes by it. Profiles saved by older builds have no routing and keep the previous catalogue-based derivation (`resolvedTranscriptionOverride`). A custom streaming identifier is therefore applied as a live model, and re-opens in the editor as "Remote Streaming".

**Validation shared by editor and applier** — `DictationProfileValidator`: a streaming override must be a catalogue model or a custom identifier under a known live provider (`LiveTranscriptionRouting.route(for:)`); a polish model must be one `ModelCatalog.normalizedPostProcessingModel` preserves; the name must be non-empty. The editor shows the issues and disables Save; the polish picker no longer accepts custom identifiers (`allowsCustom: false`, matching the main settings pickers); the applier skips a polish model it cannot run and logs it, while still enabling polish.

**Rules cleaner** — when the built-in rules cleanup model is selected the editor hides the custom prompt, output language and lexicon/context controls, explains why, and does not store them; the applier never applies them for that model.

**Editor state as a value** — `ProfileEditorDraft` holds the editor's state and owns the save-time rules (`profile(id:)`, `issues`, `usesRulesCleanup`), so they are unit-tested without SwiftUI; `ProfileEditorView` binds to it.

## Tests

- `SessionProfileApplierTests` (SpeakAppTests) — polish profile under Live Polish runs end-of-session polish and restores the mode without persisting it; disabling profile restores enabled polish; mid-session edits to an overridden setting are kept (and persisted) while untouched overrides are restored; a mid-session speed-mode change is kept; custom streaming model with explicit routing applies as live and restores; legacy profiles without routing derive as before; unsupported polish model skipped while polish still runs; rules model applies no prompt/language/lexicon overrides; prompt override applied and cleared; no matching profile changes nothing; `begin` while active restores first, `end` is idempotent.
- `DictationProfileValidationTests` (SpeakCoreTests) — derived routing, explicit routing precedence, Codable round-trip, legacy JSON without routing, unknown routing value dropped, validator cases.
- `ProfileEditorDraftTests` — routing stored per choice, unroutable custom streaming model blocks save, empty name blocks save, rules cleaner drops hidden controls, LLM polish stores them, no polish fields when not overridden, custom streaming profile re-opens as streaming, identity preserved.

`MainManager` invokes `end()` from the single `activeSession` teardown path for success, cancellation and failure; the applier's restore contract is what these tests cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile editing for transcription routing and polishing options.
  * Added validation with clear messages for missing names, unavailable transcription providers, and unsupported polishing models.
  * Added support for saving and restoring explicit transcription routing choices.
  * Added contextual profile editor guidance and issue reporting.
* **Bug Fixes**
  * Temporary profile settings now restore safely without overwriting changes made during a session.
  * Built-in rules cleanup no longer exposes irrelevant configuration controls.
* **Tests**
  * Added coverage for profile editing, validation, routing, persistence, and session setting restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->