### PR TITLE
fix(mac): migrate to Argmax OSS Swift 1.x and keep WhisperKit off the main actor

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/argmax-oss-swift.git",
       "state" : {
-        "revision" : "e2adabbe7d98dc4d0ab9a5b75424ecc42a9cdbef",
-        "version" : "0.18.0"
+        "revision" : "1e2a163736dfa5a198e637ae44c114e1c6d5cc2d",
+        "version" : "1.1.0"
       }
     },
     {
@@ -41,35 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
-        "version" : "1.6.1"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
-        "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -79,15 +52,6 @@
       "state" : {
         "revision" : "e9c34fd54ece006b491a0e6d23fe9a6024b9a828",
         "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
       }
     },
     {
@@ -109,15 +73,6 @@
       }
     },
     {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers.git",
-      "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
-      }
-    },
-    {
       "identity" : "swiftformat",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat.git",
@@ -133,15 +88,6 @@
       "state" : {
         "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
         "version" : "1.11.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,9 @@ let package = Package(
         .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.53.6"),
         .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "9.3.0"),
-        .package(url: "https://github.com/argmaxinc/argmax-oss-swift.git", from: "0.9.0"),
+        // Mirrored in Project.swift (`projectPackages`): Xcode resolves both
+        // graphs together, so the two requirements must agree (issue #757).
+        .package(url: "https://github.com/argmaxinc/argmax-oss-swift.git", from: "1.1.0"),
         .package(
             url: "https://github.com/FluidInference/FluidAudio.git",
             exact: "0.15.5"

--- a/Project.swift
+++ b/Project.swift
@@ -194,10 +194,15 @@ if isAppStoreBuild {
     }
 }
 
+// The `.remote` requirements below must mirror the same packages' requirements
+// in the root Package.swift. Xcode resolves the local package's graph and this
+// list together, and a mismatch fails resolution for every Tuist target
+// (issue #757; Dependabot only edits Package.swift). `ManifestParityTests`
+// enforces this.
 var projectPackages: [Package] = [
     .package(path: .relativeToRoot(".")),
     .remote(url: "https://github.com/getsentry/sentry-cocoa.git", requirement: .upToNextMajor(from: "9.3.0")),
-    .remote(url: "https://github.com/argmaxinc/argmax-oss-swift.git", requirement: .upToNextMajor(from: "0.9.0")),
+    .remote(url: "https://github.com/argmaxinc/argmax-oss-swift.git", requirement: .upToNextMajor(from: "1.1.0")),
     .remote(url: "https://github.com/FluidInference/FluidAudio.git", requirement: .exact("0.15.5"))
 ]
 if !isAppStoreBuild {

--- a/Sources/LocalTranscriptionBenchmark/EngineRunners.swift
+++ b/Sources/LocalTranscriptionBenchmark/EngineRunners.swift
@@ -14,8 +14,9 @@ protocol LocalBenchmarkEngineRunner: AnyObject {
 
 final class WhisperKitBenchmarkRunner: LocalBenchmarkEngineRunner {
     let engine = LocalTranscriptionEngine.whisperKit
-    let runtimeVersion = "argmax-oss-swift 0.18.0"
-    let runtimeCommit: String? = "e2adabbe7d98dc4d0ab9a5b75424ecc42a9cdbef"
+    // Keep in step with the argmax-oss-swift pin in Package.resolved.
+    let runtimeVersion = "argmax-oss-swift 1.1.0"
+    let runtimeCommit: String? = "1e2a163736dfa5a198e637ae44c114e1c6d5cc2d"
     private let pipeline: WhisperKit
 
     init(model: String, modelRepo: String?) async throws {

--- a/Sources/SpeakApp/LocalModelManager.swift
+++ b/Sources/SpeakApp/LocalModelManager.swift
@@ -289,7 +289,7 @@ final class LocalModelManager: ObservableObject {
 
     let start = Date()
     let pipe = try await pipeline(for: model)
-    let whisperResults = try await pipe.transcribe(audioPath: url.path)
+    let whisperResults = try await WhisperKitOffMain.transcribe(pipe, audioPath: url.path)
     let text = cleanTranscriptText(
       whisperResults
       .map(\.text)
@@ -336,7 +336,7 @@ final class LocalModelManager: ObservableObject {
       load: true
     )
     let task = Task<WhisperKit, Error> {
-      try await WhisperKit(config)
+      try await WhisperKitOffMain.load(config)
     }
     loadingPipelines[model.id] = task
     defer { loadingPipelines[model.id] = nil }

--- a/Sources/SpeakApp/WhisperKitLiveStream.swift
+++ b/Sources/SpeakApp/WhisperKitLiveStream.swift
@@ -180,7 +180,8 @@ final class WhisperKitLiveStream: WhisperKitLiveStreaming {
         ) else { return "" }
         var tailOptions = options
         tailOptions.clipTimestamps = []
-        let results = try await pipeline.transcribe(
+        let results = try await WhisperKitOffMain.transcribe(
+            pipeline,
             audioArray: Array(samples[range]),
             decodeOptions: tailOptions
         )

--- a/Sources/SpeakApp/WhisperKitOffMain.swift
+++ b/Sources/SpeakApp/WhisperKitOffMain.swift
@@ -1,0 +1,32 @@
+import Foundation
+import WhisperKit
+
+/// Keeps WhisperKit's model loading and decoding off the main actor.
+///
+/// argmax-oss-swift 1.x builds with `NonisolatedNonsendingByDefault`, so its
+/// async entry points run on the *caller's* actor. Every app call site is
+/// `@MainActor`, which would put multi-second Core ML work on the main thread.
+/// These helpers are nonisolated (SpeakApp is in Swift 5 language mode), so an
+/// `await` on them leaves the main actor before WhisperKit runs. If SpeakApp
+/// ever adopts Swift 6.2 mode, mark them `@concurrent` instead (issue #757).
+enum WhisperKitOffMain {
+  nonisolated static func load(_ config: WhisperKitConfig) async throws -> WhisperKit {
+    try await WhisperKit(config)
+  }
+
+  nonisolated static func transcribe(
+    _ pipeline: WhisperKit,
+    audioArray: [Float],
+    decodeOptions: DecodingOptions?
+  ) async throws -> [TranscriptionResult] {
+    try await pipeline.transcribe(audioArray: audioArray, decodeOptions: decodeOptions)
+  }
+
+  nonisolated static func transcribe(
+    _ pipeline: WhisperKit,
+    audioPath: String,
+    decodeOptions: DecodingOptions? = nil
+  ) async throws -> [TranscriptionResult] {
+    try await pipeline.transcribe(audioPath: audioPath, decodeOptions: decodeOptions)
+  }
+}

--- a/Tests/SpeakCoreTests/ManifestParityTests.swift
+++ b/Tests/SpeakCoreTests/ManifestParityTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import XCTest
+
+/// The root `Package.swift` and Tuist's `Project.swift` declare the same
+/// remote packages. Xcode resolves both graphs together, so a requirement that
+/// differs between them fails dependency resolution for every Tuist target —
+/// which is how Dependabot's argmax-oss-swift 1.1.0 bump broke the iOS legs
+/// while `swift build` passed (issue #757).
+final class ManifestParityTests: XCTestCase {
+    private var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // SpeakCoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+    }
+
+    private func contents(of relativePath: String) throws -> String {
+        try String(contentsOf: repositoryRoot.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    /// `from:` requirement declared for `url` in Package.swift.
+    private func packageRequirement(in manifest: String, url: String) -> String? {
+        let escaped = NSRegularExpression.escapedPattern(for: url)
+        let pattern = #"\.package\(\s*url:\s*"\#(escaped)"\s*,\s*(from|exact):\s*"([^"]+)""#
+        return firstMatch(pattern, in: manifest)
+    }
+
+    /// `.upToNextMajor(from:)` / `.exact(...)` requirement declared for `url` in Project.swift.
+    private func projectRequirement(in manifest: String, url: String) -> String? {
+        let escaped = NSRegularExpression.escapedPattern(for: url)
+        let requirement = #"\.(upToNextMajor\(from|exact\()\s*:?\s*"([^"]+)""#
+        let pattern = #"\.remote\(\s*url:\s*"\#(escaped)"\s*,\s*requirement:\s*"# + requirement
+        return firstMatch(pattern, in: manifest)
+    }
+
+    private func firstMatch(_ pattern: String, in text: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              let range = Range(match.range(at: 2), in: text) else {
+            return nil
+        }
+        return String(text[range])
+    }
+
+    func testRemotePackageRequirements_matchBetweenPackageSwiftAndProjectSwift() throws {
+        let package = try contents(of: "Package.swift")
+        let project = try contents(of: "Project.swift")
+        let shared = [
+            "https://github.com/getsentry/sentry-cocoa.git",
+            "https://github.com/argmaxinc/argmax-oss-swift.git",
+            "https://github.com/FluidInference/FluidAudio.git"
+        ]
+        for url in shared {
+            let packageVersion = try XCTUnwrap(
+                packageRequirement(in: package, url: url), "\(url) missing from Package.swift"
+            )
+            let projectVersion = try XCTUnwrap(
+                projectRequirement(in: project, url: url), "\(url) missing from Project.swift"
+            )
+            XCTAssertEqual(packageVersion, projectVersion, "\(url): Package.swift and Project.swift disagree")
+        }
+    }
+
+    func testArgmaxPin_matchesTheBenchmarkRuntimeVersion() throws {
+        let resolved = try contents(of: "Package.resolved")
+        let runners = try contents(of: "Sources/LocalTranscriptionBenchmark/EngineRunners.swift")
+        let pinnedVersion = try XCTUnwrap(
+            firstMatch(
+                #""identity" : "argmax-oss-swift".*?"(version)" : "([^"]+)""#,
+                in: resolved
+            ),
+            "argmax-oss-swift pin missing from Package.resolved"
+        )
+        XCTAssertTrue(
+            runners.contains("\"argmax-oss-swift \(pinnedVersion)\""),
+            "EngineRunners.runtimeVersion must name the pinned argmax-oss-swift version \(pinnedVersion)"
+        )
+    }
+}


### PR DESCRIPTION
Closes #757. Supersedes Dependabot PR #756.

## Why Dependabot's bump failed

Not an Argmax packaging change: the 1.x manifests contain no binary target at all. #756 bumped `Package.swift` to `from: "1.1.0"` while Tuist's `Project.swift` still declared the same package at `.upToNextMajor(from: "0.9.0")`. Xcode resolves the local package's graph and the `.remote` list together, so every Tuist leg (iOS library, keyboard, watch) failed resolution — and the `CTranscribe` "could not be mapped to an artifact" line was a cascade of that failure (the transcribe.cpp xcframework is unrelated to Argmax and unchanged). `swift build`-based jobs passed on #756 because they only see `Package.swift`.

## What changes

- **Manifest parity** — `Package.swift` and `Project.swift` both require `argmax-oss-swift` `from: "1.1.0"`, with a comment on each pointing at the other. `ManifestParityTests` (SpeakCoreTests) asserts the shared remote requirements (sentry-cocoa, argmax-oss-swift, FluidAudio) match between the two manifests, and that the benchmark's `runtimeVersion` names the pinned argmax version, so the next Dependabot bump fails a unit test instead of an Xcode leg.
- **`Package.resolved`** regenerated at 1.1.0 (`1e2a1637`): Hub/Tokenizers are vendored into ArgmaxCore, so swift-transformers, swift-jinja, swift-crypto, swift-asn1, swift-collections and yyjson leave the graph; swift-argument-parser moves 1.6.1 → 1.8.2.
- **Main-actor isolation** — with Swift ≥ 6.2 toolchains SwiftPM selects Argmax's `Package@swift-6.2.swift`, which enables `NonisolatedNonsendingByDefault`: `WhisperKit(config)` and `transcribe(...)` now run on the *caller's* actor, and every app call site is `@MainActor`. `WhisperKitOffMain` (nonisolated helpers, SpeakApp is Swift 5 mode) routes model loading (`LocalModelManager`), file transcription and the stop-time tail decode (`WhisperKitLiveStream`) off the main actor. Measured in a scratch package during research: 56/56 decode callbacks on the main thread without the hop, 0 with it.
- **Benchmark runner** constants updated to `argmax-oss-swift 1.1.0` / `1e2a1637…`.

Every WhisperKit API we use (`WhisperKitConfig(model:modelRepo:verbose:load:)`, `AudioStreamTranscriber` and its `State`, `DecodingOptions`, `transcribe(audioArray:decodeOptions:)`, `transcribe(audioPath:decodeOptions:)` → `[TranscriptionResult]`, `audioProcessor.audioSamples`, `WhisperKit.sampleRate`, `TranscriptionSegment`) is unchanged in 1.1.0; the removed APIs (optional-returning `transcribe(audioPath:)`, `usePrefillCache`, `supressTokens`, free functions) are not used. Minimum platforms are unchanged (iOS 16 / macOS 13 upstream).

## Verification

- `swift build` (all targets incl. `local-transcription-benchmark` linking WhisperKit + CTranscribe) and full `swift test` locally — see the checklist below for the Tuist legs this PR's CI covers (`Build iOS Library`, `Build iOS Keyboard (direct capture)`, watch).
- `make lint` strict clean.

## Notes for review / QA

- One-time model re-download is possible on first use: 1.x validates the local Hugging Face cache (offline snapshot + hashes) before serving it and falls through to a download if validation fails. The app's `.installed` markers are independent, so the UI may say "installed" while the download runs once. Worth a manual check with an existing model.
- `swift test -c release` (non-required CI job) against 1.1.0 had not been exercised by #756 (it was cancelled); this PR's CI run is the first.
- Dependabot guard rail deliberately not added: the Swift ecosystem's `dependency-name` matching for `ignore` rules is URL-based and easy to get silently wrong; the parity test is the reliable guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b
