### PR TITLE
ci(release): ship arm64 as the primary macOS download with a universal legacy build

### DIFF
--- a/.github/actions/package-mac-release/action.yml
+++ b/.github/actions/package-mac-release/action.yml
@@ -1,0 +1,308 @@
+name: Package macOS release variant
+description: >-
+  Archive, export, embed the speak CLI, sign, verify, notarise, staple and
+  package one architecture variant of the direct-distribution app: `arm64`
+  (the primary download) or `universal` (the legacy download every Mac can
+  run). Issue #774.
+
+inputs:
+  variant:
+    description: "arm64 (primary) or universal (legacy)"
+    required: true
+  version:
+    description: Marketing version being built
+    required: true
+  apple-id:
+    description: Apple ID used for notarisation
+    required: true
+  apple-id-password:
+    description: App-specific password for the Apple ID
+    required: true
+  apple-team-id:
+    description: Developer team identifier
+    required: true
+  app-store-connect-issuer-id:
+    description: App Store Connect API issuer identifier
+    required: true
+  app-store-connect-key-id:
+    description: App Store Connect API key identifier
+    required: true
+
+outputs:
+  app-path:
+    description: Path to the notarised, stapled app bundle
+    value: ${{ steps.paths.outputs.app-path }}
+  dmg-path:
+    description: Path to the notarised, stapled DMG
+    value: ${{ steps.paths.outputs.dmg-path }}
+  archive-path:
+    description: Path to the xcarchive (for dSYM upload)
+    value: ${{ steps.paths.outputs.archive-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve variant (${{ inputs.variant }})
+      id: paths
+      shell: bash
+      run: |
+        PRODUCT_NAME="${PRODUCT_NAME:-JustSpeakToIt}"
+        case "${{ inputs.variant }}" in
+          arm64) ARCHS="arm64" ;;
+          universal) ARCHS="arm64 x86_64" ;;
+          *)
+            echo "::error::Unknown release variant '${{ inputs.variant }}' (expected arm64 or universal)"
+            exit 1
+            ;;
+        esac
+        WORK="$RUNNER_TEMP/${{ inputs.variant }}"
+        mkdir -p "$WORK"
+        {
+          echo "archs=$ARCHS"
+          echo "work=$WORK"
+          echo "archive-path=$WORK/$PRODUCT_NAME.xcarchive"
+          echo "export-path=$WORK/export"
+          echo "app-path=$WORK/export/$PRODUCT_NAME.app"
+          echo "dmg-path=$WORK/$PRODUCT_NAME-${{ inputs.variant }}.dmg"
+        } >> "$GITHUB_OUTPUT"
+        echo "Packaging variant '${{ inputs.variant }}' (ARCHS=$ARCHS) under $WORK"
+
+    - name: Build Release Archive (${{ inputs.variant }})
+      shell: bash
+      run: |
+        # Archive unsigned to avoid automatic-development signing on CI runners.
+        # Distribution signing and profile resolution happens at export time.
+        # ARCHS selects the slices this variant ships; ONLY_ACTIVE_ARCH=NO keeps
+        # the universal variant universal on an arm64 runner.
+        xcodebuild archive \
+          -workspace "$WORKSPACE" \
+          -scheme "$SCHEME" \
+          -configuration Release \
+          -archivePath "${{ steps.paths.outputs.archive-path }}" \
+          -destination "generic/platform=macOS" \
+          CODE_SIGN_STYLE=Manual \
+          CODE_SIGN_IDENTITY="-" \
+          CODE_SIGNING_ALLOWED=NO \
+          PRODUCT_BUNDLE_IDENTIFIER=com.justspeaktoit.mac \
+          ENABLE_HARDENED_RUNTIME=YES \
+          ARCHS="${{ steps.paths.outputs.archs }}" \
+          ONLY_ACTIVE_ARCH=NO
+
+    - name: Verify archived release notes (${{ inputs.variant }})
+      shell: bash
+      run: |
+        APP_PATH="${{ steps.paths.outputs.archive-path }}/Products/Applications/$PRODUCT_NAME.app"
+        CATALOGUE_PATH=$(find "$APP_PATH" -name ReleaseNotes.json -print -quit)
+        if [ -z "$CATALOGUE_PATH" ]; then
+          echo "::error::Archived app does not contain ReleaseNotes.json"
+          exit 1
+        fi
+        node scripts/update-release-notes-catalogue.mjs \
+          --verify \
+          --platform mac \
+          --version "${{ inputs.version }}" \
+          --catalogue "$CATALOGUE_PATH"
+
+    - name: Export App (${{ inputs.variant }}, Developer ID)
+      shell: bash
+      run: |
+        WORK="${{ steps.paths.outputs.work }}"
+        cat > "$WORK/ExportOptions.plist" << EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>method</key>
+            <string>developer-id</string>
+            <key>teamID</key>
+            <string>${{ inputs.apple-team-id }}</string>
+            <key>signingStyle</key>
+            <string>automatic</string>
+            <key>signingCertificate</key>
+            <string>Developer ID Application</string>
+        </dict>
+        </plist>
+        EOF
+
+        xcodebuild -exportArchive \
+          -archivePath "${{ steps.paths.outputs.archive-path }}" \
+          -exportOptionsPlist "$WORK/ExportOptions.plist" \
+          -exportPath "${{ steps.paths.outputs.export-path }}" \
+          -allowProvisioningUpdates \
+          -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_${{ inputs.app-store-connect-key-id }}.p8 \
+          -authenticationKeyID ${{ inputs.app-store-connect-key-id }} \
+          -authenticationKeyIssuerID "${{ inputs.app-store-connect-issuer-id }}" \
+          ENABLE_HARDENED_RUNTIME=YES \
+          OTHER_CODE_SIGN_FLAGS="--options runtime"
+
+    - name: Embed speak CLI (${{ inputs.variant }})
+      shell: bash
+      run: |
+        APP_PATH="${{ steps.paths.outputs.app-path }}"
+        chmod +x scripts/build-speak-cli.sh
+        ./scripts/build-speak-cli.sh "$APP_PATH" "Developer ID Application" "${{ inputs.variant }}"
+
+    - name: Verify Hardened Runtime (${{ inputs.variant }})
+      shell: bash
+      run: |
+        APP_PATH="${{ steps.paths.outputs.app-path }}"
+        MAIN_BINARY="$APP_PATH/Contents/MacOS/$PRODUCT_NAME"
+
+        # Exported app signs correctly for Developer ID but omits runtime option.
+        # Re-sign the main binary with runtime, then refresh app bundle signature.
+        codesign --force --timestamp --options runtime \
+          --sign "Developer ID Application" \
+          --entitlements Config/SpeakMacOS.entitlements \
+          "$MAIN_BINARY"
+
+        codesign --force --timestamp \
+          --sign "Developer ID Application" \
+          --options runtime \
+          --entitlements Config/SpeakMacOS.entitlements \
+          "$APP_PATH"
+
+        CODESIGN_INFO=$(codesign -dv --verbose=4 "$MAIN_BINARY" 2>&1)
+        echo "$CODESIGN_INFO"
+        echo "$CODESIGN_INFO" | grep -q "runtime"
+
+    - name: Verify Architecture (${{ inputs.variant }})
+      shell: bash
+      run: |
+        chmod +x scripts/verify-architecture.sh
+        ./scripts/verify-architecture.sh "${{ steps.paths.outputs.app-path }}" "${{ inputs.variant }}"
+
+    - name: Verify App Launches (${{ inputs.variant }}, Pre-Notarisation)
+      shell: bash
+      run: |
+        echo "Verifying signed app launches without crashing..."
+        chmod +x scripts/verify-launch.sh
+        ./scripts/verify-launch.sh "${{ steps.paths.outputs.app-path }}"
+
+    - name: Notarize App (${{ inputs.variant }})
+      shell: bash
+      env:
+        APPLE_ID: ${{ inputs.apple-id }}
+        APPLE_ID_PASSWORD: ${{ inputs.apple-id-password }}
+        APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
+      run: |
+        APP_PATH="${{ steps.paths.outputs.app-path }}"
+        WORK="${{ steps.paths.outputs.work }}"
+
+        # Create ZIP for notarization
+        ditto -c -k --keepParent "$APP_PATH" "$WORK/$PRODUCT_NAME.zip"
+
+        # Submit for notarization (don't wait, use polling to avoid timeout)
+        set +e
+        SUBMIT_OUTPUT=$(xcrun notarytool submit "$WORK/$PRODUCT_NAME.zip" \
+          --apple-id "$APPLE_ID" \
+          --password "$APPLE_ID_PASSWORD" \
+          --team-id "$APPLE_TEAM_ID" 2>&1)
+        SUBMIT_EXIT_CODE=$?
+        set -e
+
+        echo "$SUBMIT_OUTPUT"
+
+        if [ $SUBMIT_EXIT_CODE -ne 0 ]; then
+          echo "Initial notarization submission failed"
+          exit $SUBMIT_EXIT_CODE
+        fi
+
+        SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | grep -E "^\s*id:" | head -1 | awk '{print $2}')
+        if [ -z "$SUBMISSION_ID" ]; then
+          echo "Failed to parse notarization submission ID"
+          exit 1
+        fi
+        echo "Submission ID: $SUBMISSION_ID"
+
+        # Poll for completion with retries
+        MAX_ATTEMPTS=120  # 60 minutes max (30s intervals)
+        ATTEMPT=0
+        while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+          ATTEMPT=$((ATTEMPT + 1))
+          echo "Checking status (attempt $ATTEMPT/$MAX_ATTEMPTS)..."
+
+          STATUS_OUTPUT=$(xcrun notarytool info "$SUBMISSION_ID" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" 2>&1) || true
+
+          echo "$STATUS_OUTPUT"
+
+          if echo "$STATUS_OUTPUT" | grep -q "status: Accepted"; then
+            echo "Notarization accepted!"
+            break
+          elif echo "$STATUS_OUTPUT" | grep -q "status: Invalid"; then
+            echo "=== Notarization Failed ==="
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_ID_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" || true
+            exit 1
+          elif echo "$STATUS_OUTPUT" | grep -q "status: In Progress"; then
+            echo "Still in progress, waiting 30s..."
+            sleep 30
+          else
+            echo "Unknown status or network error, retrying in 30s..."
+            sleep 30
+          fi
+        done
+
+        if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+          echo "Notarization timed out after $MAX_ATTEMPTS attempts"
+          exit 1
+        fi
+
+        # Staple the notarization ticket
+        bash scripts/retry-staple.sh "$APP_PATH"
+
+    - name: Verify Entitlements (${{ inputs.variant }}, Post-Sign)
+      shell: bash
+      run: |
+        chmod +x scripts/verify-entitlements.sh
+        ./scripts/verify-entitlements.sh "${{ steps.paths.outputs.app-path }}"
+
+    - name: Verify Gatekeeper Acceptance (${{ inputs.variant }})
+      shell: bash
+      run: |
+        # A stapled Developer ID app must assess as accepted, the way Gatekeeper
+        # judges it on a user's Mac after download.
+        spctl --assess --type execute --verbose=2 "${{ steps.paths.outputs.app-path }}"
+
+    - name: Verify App Launches (${{ inputs.variant }}, Post-Notarisation)
+      shell: bash
+      run: |
+        echo "Verifying notarised+stapled app launches without crashing..."
+        chmod +x scripts/verify-launch.sh
+        ./scripts/verify-launch.sh "${{ steps.paths.outputs.app-path }}"
+
+    - name: Create DMG (${{ inputs.variant }})
+      shell: bash
+      env:
+        APPLE_ID: ${{ inputs.apple-id }}
+        APPLE_ID_PASSWORD: ${{ inputs.apple-id-password }}
+        APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
+      run: |
+        APP_PATH="${{ steps.paths.outputs.app-path }}"
+        DMG_PATH="${{ steps.paths.outputs.dmg-path }}"
+        VERSION="${{ inputs.version }}"
+
+        # Use custom DMG creation script for beautiful installer. Its scratch
+        # files live under RUNNER_TEMP, so point it at this variant's directory
+        # to keep the two variants apart.
+        chmod +x scripts/create-dmg.sh
+        RUNNER_TEMP="${{ steps.paths.outputs.work }}" ./scripts/create-dmg.sh "$APP_PATH" "$DMG_PATH" "$VERSION"
+
+        # Notarize the DMG
+        xcrun notarytool submit "$DMG_PATH" \
+          --apple-id "$APPLE_ID" \
+          --password "$APPLE_ID_PASSWORD" \
+          --team-id "$APPLE_TEAM_ID" \
+          --wait
+
+        bash scripts/retry-staple.sh "$DMG_PATH"
+
+    - name: Record Sizes (${{ inputs.variant }})
+      shell: bash
+      run: |
+        chmod +x scripts/record-release-size.sh
+        ./scripts/record-release-size.sh "${{ inputs.variant }}" "${{ steps.paths.outputs.app-path }}" "${{ steps.paths.outputs.dmg-path }}"

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -19,11 +19,12 @@ env:
 jobs:
   build-and-release:
     runs-on: macos-15
-    # Archive + app notarisation polling (up to 60 min) + DMG notarisation and publication.
-    timeout-minutes: 180
+    # Two archives (arm64 primary + universal legacy), each with app
+    # notarisation polling (up to 60 min) and DMG notarisation, then publication.
+    timeout-minutes: 240
     permissions:
       contents: write
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -66,19 +67,19 @@ jobs:
           # Create temporary keychain
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-          
+
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          
+
           # Import certificate
           CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
           echo -n "$APPLE_DEVELOPER_ID_APPLICATION" | base64 --decode -o $CERTIFICATE_PATH
-          
+
           security import $CERTIFICATE_PATH -P "$APPLE_DEVELOPER_ID_APPLICATION_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
-          
+
           # Clean up
           rm -f $CERTIFICATE_PATH
 
@@ -162,214 +163,60 @@ jobs:
             --tag "${GITHUB_REF_NAME}" \
             --notes-file "$RUNNER_TEMP/release-notes.md"
 
-      - name: Build Release Archive
+      - name: Start artefact size summary
         run: |
-          # Archive unsigned to avoid automatic-development signing on CI runners.
-          # Distribution signing and profile resolution happens at export time.
-          xcodebuild archive \
-            -workspace "$WORKSPACE" \
-            -scheme "$SCHEME" \
-            -configuration Release \
-            -archivePath $RUNNER_TEMP/$PRODUCT_NAME.xcarchive \
-            -destination "generic/platform=macOS" \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_ALLOWED=NO \
-            PRODUCT_BUNDLE_IDENTIFIER=com.justspeaktoit.mac \
-            ENABLE_HARDENED_RUNTIME=YES
+          {
+            echo "## Release artefacts (v${{ steps.version.outputs.version }}, build ${BUILD_NUMBER})"
+            echo ""
+            echo "| Variant | DMG | Installed app | Main executable | speak CLI | Archs |"
+            echo "|---|---:|---:|---:|---:|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Verify archived release notes
+      # Two downloads per release (issue #774): the arm64-only primary that
+      # Apple Silicon Macs download and update to, and the universal legacy
+      # build that Intel Macs — and every install that predates per-architecture
+      # artefacts — keep receiving through the original appcast.xml feed.
+      - name: Package arm64 primary
+        id: arm64
+        uses: ./.github/actions/package-mac-release
+        with:
+          variant: arm64
+          version: ${{ steps.version.outputs.version }}
+          apple-id: ${{ secrets.APPLE_ID }}
+          apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          app-store-connect-issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          app-store-connect-key-id: ${{ env.APP_STORE_CONNECT_KEY_ID }}
+
+      - name: Package universal legacy
+        id: universal
+        uses: ./.github/actions/package-mac-release
+        with:
+          variant: universal
+          version: ${{ steps.version.outputs.version }}
+          apple-id: ${{ secrets.APPLE_ID }}
+          apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          app-store-connect-issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          app-store-connect-key-id: ${{ env.APP_STORE_CONNECT_KEY_ID }}
+
+      - name: Publish artefact paths
         run: |
-          APP_PATH="$RUNNER_TEMP/$PRODUCT_NAME.xcarchive/Products/Applications/$PRODUCT_NAME.app"
-          CATALOGUE_PATH=$(find "$APP_PATH" -name ReleaseNotes.json -print -quit)
-          if [ -z "$CATALOGUE_PATH" ]; then
-            echo "::error::Archived app does not contain ReleaseNotes.json"
-            exit 1
-          fi
-          node scripts/update-release-notes-catalogue.mjs \
-            --verify \
-            --platform mac \
-            --version "${{ steps.version.outputs.version }}" \
-            --catalogue "$CATALOGUE_PATH"
+          {
+            echo "DMG_PATH=${{ steps.arm64.outputs.dmg-path }}"
+            echo "APP_PATH=${{ steps.arm64.outputs.app-path }}"
+            echo "ARCHIVE_PATH=${{ steps.arm64.outputs.archive-path }}"
+            echo "LEGACY_DMG_PATH=${{ steps.universal.outputs.dmg-path }}"
+            echo "LEGACY_APP_PATH=${{ steps.universal.outputs.app-path }}"
+            echo "LEGACY_ARCHIVE_PATH=${{ steps.universal.outputs.archive-path }}"
+          } >> "$GITHUB_ENV"
 
-      - name: Export App (Developer ID / Ad-Hoc)
-        env:
-          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-        run: |
-          # Create export options plist for Developer ID distribution
-          cat > $RUNNER_TEMP/ExportOptions.plist << EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>method</key>
-              <string>developer-id</string>
-              <key>teamID</key>
-              <string>${{ secrets.APPLE_TEAM_ID }}</string>
-              <key>signingStyle</key>
-              <string>automatic</string>
-              <key>signingCertificate</key>
-              <string>Developer ID Application</string>
-          </dict>
-          </plist>
-          EOF
-          
-          xcodebuild -exportArchive \
-            -archivePath $RUNNER_TEMP/$PRODUCT_NAME.xcarchive \
-            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist \
-            -exportPath $RUNNER_TEMP/export \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_${{ env.APP_STORE_CONNECT_KEY_ID }}.p8 \
-            -authenticationKeyID ${{ env.APP_STORE_CONNECT_KEY_ID }} \
-            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
-            ENABLE_HARDENED_RUNTIME=YES \
-            OTHER_CODE_SIGN_FLAGS="--options runtime"
-
-      - name: Embed speak CLI
-        run: |
-          APP_PATH="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
-          chmod +x scripts/build-speak-cli.sh
-          ./scripts/build-speak-cli.sh "$APP_PATH" "Developer ID Application"
-
-      - name: Verify Hardened Runtime
-        run: |
-          APP_PATH="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
-          MAIN_BINARY="$APP_PATH/Contents/MacOS/$PRODUCT_NAME"
-
-          # Exported app signs correctly for Developer ID but omits runtime option.
-          # Re-sign the main binary with runtime, then refresh app bundle signature.
-          codesign --force --timestamp --options runtime \
-            --sign "Developer ID Application" \
-            --entitlements Config/SpeakMacOS.entitlements \
-            "$MAIN_BINARY"
-
-          codesign --force --timestamp \
-            --sign "Developer ID Application" \
-            --options runtime \
-            --entitlements Config/SpeakMacOS.entitlements \
-            "$APP_PATH"
-
-          CODESIGN_INFO=$(codesign -dv --verbose=4 "$MAIN_BINARY" 2>&1)
-          echo "$CODESIGN_INFO"
-          echo "$CODESIGN_INFO" | grep -q "runtime"
-
-      - name: Verify App Launches (Pre-Notarisation)
-        run: |
-          APP_PATH="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
-          echo "Verifying signed app launches without crashing..."
-          chmod +x scripts/verify-launch.sh
-          ./scripts/verify-launch.sh "$APP_PATH"
-
-      - name: Notarize App
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          APP_PATH="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
-          
-          # Create ZIP for notarization
-          ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/$PRODUCT_NAME.zip"
-          
-          # Submit for notarization (don't wait, use polling to avoid timeout)
-          set +e
-          SUBMIT_OUTPUT=$(xcrun notarytool submit "$RUNNER_TEMP/$PRODUCT_NAME.zip" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_ID_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" 2>&1)
-          SUBMIT_EXIT_CODE=$?
-          set -e
-
-          echo "$SUBMIT_OUTPUT"
-
-          if [ $SUBMIT_EXIT_CODE -ne 0 ]; then
-            echo "Initial notarization submission failed"
-            exit $SUBMIT_EXIT_CODE
-          fi
-
-          SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | grep -E "^\s*id:" | head -1 | awk '{print $2}')
-          if [ -z "$SUBMISSION_ID" ]; then
-            echo "Failed to parse notarization submission ID"
-            exit 1
-          fi
-          echo "Submission ID: $SUBMISSION_ID"
-          
-          # Poll for completion with retries
-          MAX_ATTEMPTS=120  # 60 minutes max (30s intervals)
-          ATTEMPT=0
-          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-            ATTEMPT=$((ATTEMPT + 1))
-            echo "Checking status (attempt $ATTEMPT/$MAX_ATTEMPTS)..."
-            
-            STATUS_OUTPUT=$(xcrun notarytool info "$SUBMISSION_ID" \
-              --apple-id "$APPLE_ID" \
-              --password "$APPLE_ID_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" 2>&1) || true
-            
-            echo "$STATUS_OUTPUT"
-            
-            if echo "$STATUS_OUTPUT" | grep -q "status: Accepted"; then
-              echo "Notarization accepted!"
-              break
-            elif echo "$STATUS_OUTPUT" | grep -q "status: Invalid"; then
-              echo "=== Notarization Failed ==="
-              xcrun notarytool log "$SUBMISSION_ID" \
-                --apple-id "$APPLE_ID" \
-                --password "$APPLE_ID_PASSWORD" \
-                --team-id "$APPLE_TEAM_ID" || true
-              exit 1
-            elif echo "$STATUS_OUTPUT" | grep -q "status: In Progress"; then
-              echo "Still in progress, waiting 30s..."
-              sleep 30
-            else
-              echo "Unknown status or network error, retrying in 30s..."
-              sleep 30
-            fi
-          done
-          
-          if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
-            echo "Notarization timed out after $MAX_ATTEMPTS attempts"
-            exit 1
-          fi
-          
-          # Staple the notarization ticket
-          bash scripts/retry-staple.sh "$APP_PATH"
-
-      - name: Verify Entitlements (Post-Sign)
-        run: |
-          APP_PATH="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
-          chmod +x scripts/verify-entitlements.sh
-          ./scripts/verify-entitlements.sh "$APP_PATH"
-
-      - name: Verify App Launches (Post-Notarisation)
-        run: |
-          APP_PATH="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
-          echo "Verifying notarised+stapled app launches without crashing..."
-          chmod +x scripts/verify-launch.sh
-          ./scripts/verify-launch.sh "$APP_PATH"
-
-      - name: Create DMG
-        run: |
-          APP_PATH="$RUNNER_TEMP/export/$PRODUCT_NAME.app"
-          DMG_PATH="$RUNNER_TEMP/$PRODUCT_NAME-${{ steps.version.outputs.version }}.dmg"
-          VERSION="${{ steps.version.outputs.version }}"
-          
-          # Use custom DMG creation script for beautiful installer
-          chmod +x scripts/create-dmg.sh
-          ./scripts/create-dmg.sh "$APP_PATH" "$DMG_PATH" "$VERSION"
-          
-          # Notarize the DMG
-          xcrun notarytool submit "$DMG_PATH" \
-            --apple-id "${{ secrets.APPLE_ID }}" \
-            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
-            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-            --wait
-          
-          bash scripts/retry-staple.sh "$DMG_PATH"
-          
-          echo "DMG_PATH=$DMG_PATH" >> $GITHUB_ENV
-
-      - name: Generate Appcast for Sparkle Updates
+      # One feed per download. The legacy feed keeps its historical name and
+      # asset because every shipped build carries it in Info.plist, and the
+      # release-notes tooling reads it for every past release; the app picks
+      # the arm64 feed at runtime only when it runs natively on Apple Silicon
+      # (UpdateFeedSelection).
+      - name: Generate Appcasts for Sparkle Updates
         if: startsWith(github.ref, 'refs/tags/mac-v')
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
@@ -378,19 +225,37 @@ jobs:
           # Use timestamp-based build number (set in Stamp Version step)
           # This ensures sparkle:version matches CFBundleVersion for proper update detection
           BUILD_NUMBER="${{ env.BUILD_NUMBER }}"
-          DMG_PATH="${{ env.DMG_PATH }}"
-          
+
           chmod +x scripts/generate-appcast.sh
+          ./scripts/generate-appcast.sh \
+            "$VERSION" \
+            "$BUILD_NUMBER" \
+            "$LEGACY_DMG_PATH" \
+            "$SPARKLE_PRIVATE_KEY" \
+            "$RUNNER_TEMP/release-notes.html" \
+            "https://justspeaktoit.com/appcast.xml" > "$RUNNER_TEMP/appcast.xml"
           ./scripts/generate-appcast.sh \
             "$VERSION" \
             "$BUILD_NUMBER" \
             "$DMG_PATH" \
             "$SPARKLE_PRIVATE_KEY" \
-            "$RUNNER_TEMP/release-notes.html" > "$RUNNER_TEMP/appcast.xml"
-          
+            "$RUNNER_TEMP/release-notes.html" \
+            "https://justspeaktoit.com/appcast-arm64.xml" > "$RUNNER_TEMP/appcast-arm64.xml"
+
+          # Each feed must offer its own download: the legacy feed the universal
+          # DMG, the Apple Silicon feed the arm64 DMG. A mix-up here would offer
+          # an arm64-only build to an Intel Mac.
+          grep -q "releases/download/mac-v${VERSION}/$(basename "$LEGACY_DMG_PATH")" "$RUNNER_TEMP/appcast.xml"
+          grep -q "releases/download/mac-v${VERSION}/$(basename "$DMG_PATH")" "$RUNNER_TEMP/appcast-arm64.xml"
+          ! grep -q "$(basename "$DMG_PATH")" "$RUNNER_TEMP/appcast.xml"
+          ! grep -q "$(basename "$LEGACY_DMG_PATH")" "$RUNNER_TEMP/appcast-arm64.xml"
+
           echo "APPCAST_PATH=$RUNNER_TEMP/appcast.xml" >> "$GITHUB_ENV"
-          echo "Generated appcast.xml:"
+          echo "ARM64_APPCAST_PATH=$RUNNER_TEMP/appcast-arm64.xml" >> "$GITHUB_ENV"
+          echo "Generated appcast.xml (legacy, universal):"
           cat "$RUNNER_TEMP/appcast.xml"
+          echo "Generated appcast-arm64.xml (Apple Silicon):"
+          cat "$RUNNER_TEMP/appcast-arm64.xml"
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/mac-v')
@@ -398,7 +263,9 @@ jobs:
         with:
           files: |
             ${{ env.DMG_PATH }}
+            ${{ env.LEGACY_DMG_PATH }}
             ${{ env.APPCAST_PATH }}
+            ${{ env.ARM64_APPCAST_PATH }}
           body_path: ${{ runner.temp }}/release-notes.md
           generate_release_notes: false
           draft: false
@@ -417,9 +284,9 @@ jobs:
             sentry-cli releases new "justspeaktoit-mac@${VERSION}+${BUILD_NUMBER}"
             sentry-cli releases set-commits "justspeaktoit-mac@${VERSION}+${BUILD_NUMBER}" --auto
             sentry-cli releases finalize "justspeaktoit-mac@${VERSION}+${BUILD_NUMBER}"
-            # Upload dSYMs for symbolication
-            sentry-cli debug-files upload --include-sources \
-              "$RUNNER_TEMP/$PRODUCT_NAME.xcarchive/dSYMs"
+            # Upload dSYMs for symbolication (both variants share the build number)
+            sentry-cli debug-files upload --include-sources "$ARCHIVE_PATH/dSYMs"
+            sentry-cli debug-files upload --include-sources "$LEGACY_ARCHIVE_PATH/dSYMs"
           else
             echo "sentry-cli not found, skipping release creation"
           fi
@@ -430,23 +297,28 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          DMG_PATH="${{ env.DMG_PATH }}"
-          SHA256=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
-          
+          ARM64_SHA256=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
+          UNIVERSAL_SHA256=$(shasum -a 256 "$LEGACY_DMG_PATH" | awk '{print $1}')
+
           echo "==> Updating Homebrew tap for version $VERSION"
-          echo "    SHA256: $SHA256"
-          
+          echo "    arm64 SHA256:     $ARM64_SHA256"
+          echo "    universal SHA256: $UNIVERSAL_SHA256"
+
           # Clone the tap repo
           git clone https://x-access-token:${GH_TOKEN}@github.com/crmitchelmore/homebrew-justspeaktoit.git /tmp/homebrew-tap
           cd /tmp/homebrew-tap
-          
-          # Update the cask file
+
+          # Update the cask file: Apple Silicon Macs get the arm64 download,
+          # Intel Macs the universal legacy download (issue #774). The bundled
+          # speak CLI matches the app's own slices in both.
           cat > Casks/justspeaktoit.rb << EOF
           cask "justspeaktoit" do
-            version "$VERSION"
-            sha256 "$SHA256"
+            arch arm: "arm64", intel: "universal"
 
-            url "https://github.com/crmitchelmore/justspeaktoit/releases/download/mac-v#{version}/JustSpeakToIt-#{version}.dmg"
+            version "$VERSION"
+            sha256 arm: "$ARM64_SHA256", intel: "$UNIVERSAL_SHA256"
+
+            url "https://github.com/crmitchelmore/justspeaktoit/releases/download/mac-v#{version}/JustSpeakToIt-#{arch}.dmg"
             name "Just Speak to It"
             desc "Native macOS voice transcription with on-device or cloud processing"
             homepage "https://justspeaktoit.com"
@@ -468,22 +340,24 @@ jobs:
             ]
           end
           EOF
-          
+
           # Commit and push
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/justspeaktoit.rb
           git commit -m "Update Just Speak to It to v$VERSION"
           git push
-          
+
           echo "==> Homebrew tap updated successfully"
 
-      - name: Upload Artifact (for manual builds)
+      - name: Upload Artifacts (for manual builds)
         if: "!startsWith(github.ref, 'refs/tags/mac-v')"
         uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ env.PRODUCT_NAME }}-${{ steps.version.outputs.version }}
-          path: ${{ env.DMG_PATH }}
+          path: |
+            ${{ env.DMG_PATH }}
+            ${{ env.LEGACY_DMG_PATH }}
 
       - name: Cleanup Keychain
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Releases are **fully automated** via conventional commits:
 
 1. Push to `main` with a releasable commit type (`feat:`, `fix:`, `perf:`, or breaking change)
 2. `auto-release.yml` determines the version bump and creates a `mac-v*` tag
-3. `release-mac.yml` builds, notarises, publishes to GitHub Releases, updates appcast.xml, and updates Homebrew tap
+3. `release-mac.yml` builds two downloads — `JustSpeakToIt-arm64.dmg` (Apple Silicon, primary) and `JustSpeakToIt-universal.dmg` (Intel/legacy) — notarises both, publishes them with `appcast.xml` (universal feed) and `appcast-arm64.xml` (Apple Silicon feed) to GitHub Releases, records their sizes in the job summary, and updates the per-architecture Homebrew cask
 
 Manual releases are still possible by creating and pushing a `mac-v*` tag directly.
 
@@ -50,7 +50,7 @@ The `VERSION` file is a **hint** used as fallback when no macOS tag is present. 
 ### Post-Release Support
 
 When a user reports that a freshly shipped macOS release won't install or launch, perform the remediation directly when the environment permits filesystem/app actions; otherwise provide these exact steps for the user to run locally:
-1. Download the latest `mac-v*` DMG.
+1. Download the latest `mac-v*` DMG for the user's Mac: `JustSpeakToIt-arm64.dmg` on Apple Silicon, `JustSpeakToIt-universal.dmg` on Intel.
 2. Back up the existing app to a persistent location, e.g. `mv /Applications/JustSpeakToIt.app ~/Desktop/JustSpeakToIt.app.bak-$(date +%s)`.
 3. Replace `/Applications/JustSpeakToIt.app` with the app from the DMG.
 4. Verify launch locally (e.g. `open -n /Applications/JustSpeakToIt.app`) before asking the user to retry.

--- a/Docs/sparkle-setup.md
+++ b/Docs/sparkle-setup.md
@@ -69,6 +69,18 @@ The app checks `https://justspeaktoit.com/appcast.xml`. Cloudflare Pages redirec
 
 GitHub resolves `latest` to the newest non-draft, non-prerelease release, so test or prerelease tags do not replace the production feed.
 
+### Architecture Feeds
+Each release publishes two downloads and two feeds (issue #774):
+
+| Feed | Download | Who follows it |
+|------|----------|----------------|
+| `https://justspeaktoit.com/appcast.xml` | `JustSpeakToIt-universal.dmg` (arm64 + x86_64) | Intel Macs, Rosetta-translated processes, and every install made before the split (it is the `SUFeedURL` baked into every build) |
+| `https://justspeaktoit.com/appcast-arm64.xml` | `JustSpeakToIt-arm64.dmg` (arm64 only) | Builds running natively on Apple Silicon |
+
+`UpdateFeedSelection` picks the feed at runtime through `SPUUpdaterDelegate.feedURLString(for:)`; `UpdateFeedSelectionTests` cover the decision. The legacy feed keeps its historical name because shipped builds carry it in Info.plist and the release-notes tooling reads `appcast.xml` for every past release. Keep the exact redirects for both feeds ahead of the `/index.html` rewrite in `landing-page/_redirects`.
+
+The release workflow asserts that each feed's enclosure names its own DMG, so an arm64-only build can never be offered through the universal feed.
+
 ## Testing
 
 1. Build and run the app locally

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ brew tap crmitchelmore/justspeaktoit
 brew install --cask justspeaktoit
 ```
 
+Homebrew installs the right build for your Mac automatically.
+
+### Direct download
+
+Every release on the [Releases page](https://github.com/crmitchelmore/justspeaktoit/releases/latest) ships two DMGs:
+
+- **Apple Silicon (recommended):** `JustSpeakToIt-arm64.dmg` — the primary download, arm64 only.
+- **Intel Macs (legacy):** `JustSpeakToIt-universal.dmg` — a universal build that also runs on Apple Silicon, kept for Intel Macs and for existing installs.
+
+Apple Silicon installs update to arm64-only builds; Intel installs keep receiving the universal build. Both update paths are notarised and signed.
+
 ### Build from Source
 
 ```bash

--- a/Sources/SpeakApp/Services/UpdateFeedSelection.swift
+++ b/Sources/SpeakApp/Services/UpdateFeedSelection.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Chooses which Sparkle feed a running build follows (issue #774).
+///
+/// Every build ships the legacy feed (`appcast.xml`, which offers the
+/// universal DMG any Mac can run) in its Info.plist — including installs that
+/// predate per-architecture downloads. A process running natively on Apple
+/// Silicon switches to the arm64 feed; an Intel Mac, or a universal build
+/// translated by Rosetta, stays on the universal feed, so an arm64-only update
+/// is never offered where it could not run. Any other configured feed (a test
+/// feed, for instance) is left untouched.
+enum UpdateFeedSelection {
+    static let legacyFeedURL = "https://justspeaktoit.com/appcast.xml"
+    static let appleSiliconFeedURL = "https://justspeaktoit.com/appcast-arm64.xml"
+
+    static func feedURL(
+        configuredFeedURL: String?,
+        machineArchitecture: String,
+        isTranslated: Bool
+    ) -> String? {
+        guard configuredFeedURL == legacyFeedURL else { return configuredFeedURL }
+        guard machineArchitecture == "arm64", !isTranslated else { return legacyFeedURL }
+        return appleSiliconFeedURL
+    }
+
+    /// The feed for this process, derived from the bundle's `SUFeedURL`.
+    static var current: String? {
+        feedURL(
+            configuredFeedURL: Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String,
+            machineArchitecture: machineArchitecture,
+            isTranslated: isRunningUnderRosetta
+        )
+    }
+
+    /// The CPU architecture this process runs as (`arm64` or `x86_64`).
+    static var machineArchitecture: String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        return withUnsafeBytes(of: &systemInfo.machine) { buffer in
+            let bytes = Array(buffer.prefix { $0 != 0 })
+            return String(bytes: bytes, encoding: .utf8) ?? ""
+        }
+    }
+
+    /// Whether this process is an x86_64 binary translated by Rosetta on an
+    /// Apple Silicon Mac.
+    static var isRunningUnderRosetta: Bool {
+        var translated: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        guard sysctlbyname("sysctl.proc_translated", &translated, &size, nil, 0) == 0 else { return false }
+        return translated == 1
+    }
+}

--- a/Sources/SpeakApp/Services/UpdaterManager.swift
+++ b/Sources/SpeakApp/Services/UpdaterManager.swift
@@ -95,6 +95,12 @@ final class UpdaterManager: NSObject, ObservableObject {
 
 #if !APP_STORE
 extension UpdaterManager: SPUUpdaterDelegate {
+    /// Apple Silicon Macs follow the arm64 feed; everything else keeps the
+    /// universal feed baked into Info.plist (issue #774).
+    nonisolated func feedURLString(for updater: SPUUpdater) -> String? {
+        UpdateFeedSelection.current
+    }
+
     nonisolated func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
         Task { @MainActor in
             self.latestVersion = item.displayVersionString

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -53,8 +53,10 @@ final class DistributionBuildIdentityTests: XCTestCase {
     }
 
     func testDirectMacRelease_retriesStaplingAcceptedNotarizationTickets() throws {
-        let workflow = try String(
-            contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-mac.yml"),
+        // Per-variant packaging lives in the composite action the workflow calls
+        // once per download (issue #774).
+        let packaging = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/actions/package-mac-release/action.yml"),
             encoding: .utf8
         )
         let retryScript = try String(
@@ -62,8 +64,8 @@ final class DistributionBuildIdentityTests: XCTestCase {
             encoding: .utf8
         )
 
-        XCTAssertTrue(workflow.contains("bash scripts/retry-staple.sh \"$APP_PATH\""))
-        XCTAssertTrue(workflow.contains("bash scripts/retry-staple.sh \"$DMG_PATH\""))
+        XCTAssertTrue(packaging.contains("bash scripts/retry-staple.sh \"$APP_PATH\""))
+        XCTAssertTrue(packaging.contains("bash scripts/retry-staple.sh \"$DMG_PATH\""))
         XCTAssertTrue(retryScript.contains("stapler staple"))
         XCTAssertTrue(retryScript.contains("stapler validate"))
         XCTAssertTrue(retryScript.contains("STAPLE_MAX_ATTEMPTS:-6"))
@@ -434,7 +436,134 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(script.contains("swift build --product speak --configuration release --arch x86_64"))
         XCTAssertTrue(script.contains("lipo -create"))
         XCTAssertTrue(script.contains("lipo -archs"))
-        XCTAssertTrue(script.contains("universal speak binary is missing"))
+        XCTAssertTrue(script.contains("speak binary is missing"))
+        // The arm64 primary download embeds an arm64-only CLI, and a slice the
+        // variant does not promise fails the build (issue #774).
+        XCTAssertTrue(script.contains("VARIANT=\"${3:-universal}\""))
+        XCTAssertTrue(script.contains("arm64) REQUIRED_ARCHS=\"arm64\""))
+        XCTAssertTrue(script.contains("universal) REQUIRED_ARCHS=\"arm64 x86_64\""))
+        XCTAssertTrue(script.contains("speak binary must not contain"))
+    }
+
+    // MARK: - arm64 primary + universal legacy downloads (issue #774)
+
+    func testDirectMacRelease_packagesTheArm64PrimaryAndUniversalLegacyVariants() throws {
+        let workflow = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-mac.yml"),
+            encoding: .utf8
+        )
+        let packaging = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/actions/package-mac-release/action.yml"),
+            encoding: .utf8
+        )
+
+        XCTAssertEqual(workflow.components(separatedBy: "uses: ./.github/actions/package-mac-release").count - 1, 2)
+        XCTAssertTrue(workflow.contains("variant: arm64"))
+        XCTAssertTrue(workflow.contains("variant: universal"))
+        XCTAssertTrue(packaging.contains("arm64) ARCHS=\"arm64\""))
+        XCTAssertTrue(packaging.contains("universal) ARCHS=\"arm64 x86_64\""))
+        XCTAssertTrue(packaging.contains("ARCHS=\"${{ steps.paths.outputs.archs }}\""))
+        XCTAssertTrue(packaging.contains("ONLY_ACTIVE_ARCH=NO"))
+        XCTAssertTrue(packaging.contains("dmg-path=$WORK/$PRODUCT_NAME-${{ inputs.variant }}.dmg"))
+        let embedCLI = "./scripts/build-speak-cli.sh \"$APP_PATH\" \"Developer ID Application\" "
+            + "\"${{ inputs.variant }}\""
+        XCTAssertTrue(packaging.contains(embedCLI))
+        // The two builds must not share scratch space.
+        XCTAssertTrue(packaging.contains("RUNNER_TEMP=\"${{ steps.paths.outputs.work }}\" ./scripts/create-dmg.sh"))
+    }
+
+    func testDirectMacRelease_verifiesArchitectureGatekeeperAndRecordsSizes() throws {
+        let packaging = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/actions/package-mac-release/action.yml"),
+            encoding: .utf8
+        )
+        let workflow = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-mac.yml"),
+            encoding: .utf8
+        )
+        let architectureScript = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("scripts/verify-architecture.sh"),
+            encoding: .utf8
+        )
+        let sizeScript = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("scripts/record-release-size.sh"),
+            encoding: .utf8
+        )
+
+        let verifyArchitecture = "./scripts/verify-architecture.sh \"${{ steps.paths.outputs.app-path }}\" "
+            + "\"${{ inputs.variant }}\""
+        XCTAssertTrue(packaging.contains(verifyArchitecture))
+        XCTAssertTrue(packaging.contains("spctl --assess --type execute"))
+        XCTAssertTrue(packaging.contains("./scripts/record-release-size.sh"))
+        XCTAssertTrue(workflow.contains("GITHUB_STEP_SUMMARY"))
+
+        XCTAssertTrue(architectureScript.contains("lipo -archs"))
+        XCTAssertTrue(architectureScript.contains("Contents/MacOS/JustSpeakToIt"))
+        XCTAssertTrue(architectureScript.contains("Contents/MacOS/speak"))
+        XCTAssertTrue(architectureScript.contains("must contain exactly"))
+        XCTAssertTrue(sizeScript.contains("GITHUB_STEP_SUMMARY"))
+        XCTAssertTrue(sizeScript.contains("du -sk"))
+    }
+
+    func testDirectMacRelease_publishesOneFeedAndOneCaskArchitecturePerDownload() throws {
+        let workflow = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(".github/workflows/release-mac.yml"),
+            encoding: .utf8
+        )
+        let appcastScript = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("scripts/generate-appcast.sh"),
+            encoding: .utf8
+        )
+
+        // Legacy feed keeps its name and serves the universal DMG; the arm64 feed serves the arm64 DMG.
+        let continuation = " \\\n            "
+        let legacyFeed = [
+            "\"$LEGACY_DMG_PATH\"", "\"$SPARKLE_PRIVATE_KEY\"", "\"$RUNNER_TEMP/release-notes.html\"",
+            "\"https://justspeaktoit.com/appcast.xml\" > \"$RUNNER_TEMP/appcast.xml\""
+        ].joined(separator: continuation)
+        let arm64Feed = [
+            "\"$DMG_PATH\"", "\"$SPARKLE_PRIVATE_KEY\"", "\"$RUNNER_TEMP/release-notes.html\"",
+            "\"https://justspeaktoit.com/appcast-arm64.xml\" > \"$RUNNER_TEMP/appcast-arm64.xml\""
+        ].joined(separator: continuation)
+        XCTAssertTrue(workflow.contains(legacyFeed))
+        XCTAssertTrue(workflow.contains(arm64Feed))
+        XCTAssertTrue(workflow.contains("! grep -q \"$(basename \"$DMG_PATH\")\" \"$RUNNER_TEMP/appcast.xml\""))
+        XCTAssertTrue(appcastScript.contains("FEED_URL=\"${6:-https://justspeaktoit.com/appcast.xml}\""))
+        XCTAssertTrue(appcastScript.contains("<link>${FEED_URL}</link>"))
+
+        // Both downloads and both feeds are release assets.
+        let releaseAssets = [
+            "${{ env.DMG_PATH }}", "${{ env.LEGACY_DMG_PATH }}",
+            "${{ env.APPCAST_PATH }}", "${{ env.ARM64_APPCAST_PATH }}"
+        ].joined(separator: "\n            ")
+        XCTAssertTrue(workflow.contains(releaseAssets))
+
+        // The cask hands each architecture its own download and checksum.
+        XCTAssertTrue(workflow.contains("arch arm: \"arm64\", intel: \"universal\""))
+        XCTAssertTrue(workflow.contains("sha256 arm: \"$ARM64_SHA256\", intel: \"$UNIVERSAL_SHA256\""))
+        XCTAssertTrue(workflow.contains("releases/download/mac-v#{version}/JustSpeakToIt-#{arch}.dmg"))
+    }
+
+    func testLandingPageRedirects_routeBothFeedsAndDownloadsAheadOfTheIndexRewrite() throws {
+        let redirects = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("landing-page/_redirects"),
+            encoding: .utf8
+        )
+        let lines = redirects.components(separatedBy: "\n")
+        func index(of prefix: String) -> Int? { lines.firstIndex { $0.hasPrefix(prefix) } }
+
+        let legacyFeed = try XCTUnwrap(index(of: "/appcast.xml "))
+        let arm64Feed = try XCTUnwrap(index(of: "/appcast-arm64.xml "))
+        let appleSiliconDownload = try XCTUnwrap(index(of: "/download/mac "))
+        let intelDownload = try XCTUnwrap(index(of: "/download/mac-intel "))
+        let indexRewrite = try XCTUnwrap(index(of: "/index.html "))
+
+        XCTAssertTrue(lines[arm64Feed].contains("releases/latest/download/appcast-arm64.xml"))
+        XCTAssertTrue(lines[appleSiliconDownload].contains("releases/latest/download/JustSpeakToIt-arm64.dmg"))
+        XCTAssertTrue(lines[intelDownload].contains("releases/latest/download/JustSpeakToIt-universal.dmg"))
+        for rule in [legacyFeed, arm64Feed, appleSiliconDownload, intelDownload] {
+            XCTAssertLessThan(rule, indexRewrite, "exact redirects must precede the index rewrite")
+        }
     }
 
     func testIOSReleaseWorkflowRequiresAnExplicitSemanticVersion() throws {

--- a/Tests/SpeakAppTests/UpdateFeedSelectionTests.swift
+++ b/Tests/SpeakAppTests/UpdateFeedSelectionTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+@testable import SpeakApp
+
+/// An arm64-only update may only be offered to a process running natively on
+/// Apple Silicon; every other configuration keeps the universal feed (#774).
+final class UpdateFeedSelectionTests: XCTestCase {
+    private let legacy = UpdateFeedSelection.legacyFeedURL
+    private let appleSilicon = UpdateFeedSelection.appleSiliconFeedURL
+
+    func testNativeAppleSilicon_followsTheArm64Feed() {
+        XCTAssertEqual(
+            UpdateFeedSelection.feedURL(configuredFeedURL: legacy, machineArchitecture: "arm64", isTranslated: false),
+            appleSilicon
+        )
+    }
+
+    func testIntel_keepsTheUniversalFeed() {
+        XCTAssertEqual(
+            UpdateFeedSelection.feedURL(configuredFeedURL: legacy, machineArchitecture: "x86_64", isTranslated: false),
+            legacy
+        )
+    }
+
+    func testRosettaTranslatedProcess_keepsTheUniversalFeed() {
+        // A universal build running as x86_64 under Rosetta reports arm64 hardware
+        // but must not be handed an arm64-only update it cannot verify it can run.
+        XCTAssertEqual(
+            UpdateFeedSelection.feedURL(configuredFeedURL: legacy, machineArchitecture: "arm64", isTranslated: true),
+            legacy
+        )
+    }
+
+    func testCustomOrMissingFeed_isLeftUntouched() {
+        let custom = "https://example.com/test-appcast.xml"
+        XCTAssertEqual(
+            UpdateFeedSelection.feedURL(configuredFeedURL: custom, machineArchitecture: "arm64", isTranslated: false),
+            custom
+        )
+        XCTAssertNil(
+            UpdateFeedSelection.feedURL(configuredFeedURL: nil, machineArchitecture: "arm64", isTranslated: false)
+        )
+    }
+
+    func testMachineArchitecture_isAKnownValue() {
+        XCTAssertTrue(["arm64", "x86_64"].contains(UpdateFeedSelection.machineArchitecture))
+    }
+
+    func testShippedInfoPlist_keepsTheUniversalFeedAsTheFailSafeDefault() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let plist = try String(contentsOf: root.appendingPathComponent("Config/AppInfo.plist"), encoding: .utf8)
+        XCTAssertTrue(
+            plist.contains("<string>\(legacy)</string>"),
+            "If feed selection ever fails, an arm64 build must fall back to a feed every Mac can run"
+        )
+    }
+}

--- a/landing-page/_redirects
+++ b/landing-page/_redirects
@@ -1,2 +1,5 @@
 /appcast.xml   https://github.com/crmitchelmore/justspeaktoit/releases/latest/download/appcast.xml   302
+/appcast-arm64.xml   https://github.com/crmitchelmore/justspeaktoit/releases/latest/download/appcast-arm64.xml   302
+/download/mac   https://github.com/crmitchelmore/justspeaktoit/releases/latest/download/JustSpeakToIt-arm64.dmg   302
+/download/mac-intel   https://github.com/crmitchelmore/justspeaktoit/releases/latest/download/JustSpeakToIt-universal.dmg   302
 /index.html   /   200

--- a/scripts/build-speak-cli.sh
+++ b/scripts/build-speak-cli.sh
@@ -1,20 +1,25 @@
 #!/usr/bin/env bash
 # Build the `speak` automation CLI and embed it inside JustSpeakToIt.app.
 #
-# Usage: ./scripts/build-speak-cli.sh <path-to-JustSpeakToIt.app> [signing-identity]
+# Usage: ./scripts/build-speak-cli.sh <path-to-JustSpeakToIt.app> [signing-identity] [arm64|universal]
 #
 # The CLI is a thin client for the automation socket the app exposes, so it must
 # ship with the app rather than as an independent download: the Homebrew cask
 # links `Contents/MacOS/speak` onto the user's PATH.
+#
+# The embedded CLI always matches the app's own slices (issue #774): the arm64
+# primary download embeds an arm64-only CLI and the universal legacy download
+# embeds a universal one. The default is universal.
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_PATH="${1:-}"
 SIGN_IDENTITY="${2:-}"
+VARIANT="${3:-universal}"
 
 if [[ -z "$APP_PATH" ]]; then
-    echo "Usage: $0 <path-to-JustSpeakToIt.app> [signing-identity]" >&2
+    echo "Usage: $0 <path-to-JustSpeakToIt.app> [signing-identity] [arm64|universal]" >&2
     exit 1
 fi
 
@@ -23,48 +28,72 @@ if [[ ! -d "$APP_PATH" ]]; then
     exit 1
 fi
 
+case "$VARIANT" in
+    arm64) REQUIRED_ARCHS="arm64" ;;
+    universal) REQUIRED_ARCHS="arm64 x86_64" ;;
+    *)
+        echo "error: unknown variant '$VARIANT' (expected arm64 or universal)" >&2
+        exit 1
+        ;;
+esac
+
 # Resolve before the cd below, so a relative app path keeps pointing at the
 # bundle the caller meant.
 APP_PATH="$(cd "$APP_PATH" && pwd -P)"
 
 cd "$ROOT_DIR"
-# The two slices are built separately and joined with lipo: a single swift
-# build invocation passing both arch flags fails to plan the package graph
+# The slices are built separately and joined with lipo: a single swift build
+# invocation passing both arch flags fails to plan the package graph
 # ("duplicate key found: ID(moduleName: \"CommandLineTool\", packageIdentity:
 # swiftformat)") because the SwiftFormat plugin dependency is modelled once
 # per architecture (issue #759).
 echo "==> Building speak (release, arm64)"
 swift build --product speak --configuration release --arch arm64
-echo "==> Building speak (release, x86_64)"
-swift build --product speak --configuration release --arch x86_64
-
 ARM64_BINARY="$(swift build --product speak --configuration release \
     --arch arm64 --show-bin-path)/speak"
-X86_64_BINARY="$(swift build --product speak --configuration release \
-    --arch x86_64 --show-bin-path)/speak"
-
-for slice in "$ARM64_BINARY" "$X86_64_BINARY"; do
-    if [[ ! -f "$slice" ]]; then
-        echo "error: built binary missing at $slice" >&2
-        exit 1
-    fi
-done
 
 BINARY_PATH="$(mktemp -d)/speak"
-echo "==> Creating universal binary"
-lipo -create "$ARM64_BINARY" "$X86_64_BINARY" -output "$BINARY_PATH"
+if [[ "$VARIANT" == "universal" ]]; then
+    echo "==> Building speak (release, x86_64)"
+    swift build --product speak --configuration release --arch x86_64
+    X86_64_BINARY="$(swift build --product speak --configuration release \
+        --arch x86_64 --show-bin-path)/speak"
 
-# Deterministic validation: the embedded CLI must contain both slices, so a
-# regression back to a single-arch binary fails the release here, not on a
-# user's machine.
-UNIVERSAL_ARCHS="$(lipo -archs "$BINARY_PATH")"
-for required_arch in arm64 x86_64; do
-    if [[ " $UNIVERSAL_ARCHS " != *" $required_arch "* ]]; then
-        echo "error: universal speak binary is missing $required_arch (got: $UNIVERSAL_ARCHS)" >&2
+    for slice in "$ARM64_BINARY" "$X86_64_BINARY"; do
+        if [[ ! -f "$slice" ]]; then
+            echo "error: built binary missing at $slice" >&2
+            exit 1
+        fi
+    done
+
+    echo "==> Creating universal binary"
+    lipo -create "$ARM64_BINARY" "$X86_64_BINARY" -output "$BINARY_PATH"
+else
+    if [[ ! -f "$ARM64_BINARY" ]]; then
+        echo "error: built binary missing at $ARM64_BINARY" >&2
+        exit 1
+    fi
+    cp "$ARM64_BINARY" "$BINARY_PATH"
+fi
+
+# Deterministic validation: the embedded CLI must contain exactly the slices
+# its variant promises, so a regression (a single-arch universal binary, or an
+# x86_64 slice leaking into the arm64 download) fails the release here, not on
+# a user's machine.
+EMBEDDED_ARCHS="$(lipo -archs "$BINARY_PATH")"
+for required_arch in $REQUIRED_ARCHS; do
+    if [[ " $EMBEDDED_ARCHS " != *" $required_arch "* ]]; then
+        echo "error: $VARIANT speak binary is missing $required_arch (got: $EMBEDDED_ARCHS)" >&2
         exit 1
     fi
 done
-echo "==> Universal binary contains: $UNIVERSAL_ARCHS"
+for present_arch in $EMBEDDED_ARCHS; do
+    if [[ " $REQUIRED_ARCHS " != *" $present_arch "* ]]; then
+        echo "error: $VARIANT speak binary must not contain $present_arch (got: $EMBEDDED_ARCHS)" >&2
+        exit 1
+    fi
+done
+echo "==> $VARIANT binary contains: $EMBEDDED_ARCHS"
 
 DESTINATION="$APP_PATH/Contents/MacOS/speak"
 echo "==> Embedding $BINARY_PATH -> $DESTINATION"

--- a/scripts/generate-appcast.sh
+++ b/scripts/generate-appcast.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
-# Generate Sparkle appcast.xml from GitHub release
-# Usage: ./scripts/generate-appcast.sh <version> <build-number> <dmg-path> <private-key-base64> [release-notes-html]
+# Generate a Sparkle appcast from a GitHub release asset.
+# Usage: ./scripts/generate-appcast.sh <version> <build-number> <dmg-path> <private-key-base64> [release-notes-html] [feed-url]
+#
+# Two feeds are generated per release (issue #774): the legacy feed
+# (https://justspeaktoit.com/appcast.xml, universal DMG, which every Mac and
+# every existing install can run) and the Apple Silicon feed
+# (https://justspeaktoit.com/appcast-arm64.xml, arm64-only DMG). The enclosure
+# URL is derived from the DMG's file name, so each feed points at its own asset.
 
 set -e
 
@@ -9,6 +15,7 @@ BUILD_NUMBER="$2"
 DMG_PATH="$3"
 PRIVATE_KEY_BASE64="$4"
 RELEASE_NOTES_HTML_PATH="${5:-}"
+FEED_URL="${6:-https://justspeaktoit.com/appcast.xml}"
 
 if [ -z "$VERSION" ] || [ -z "$BUILD_NUMBER" ] || [ -z "$DMG_PATH" ] || [ -z "$PRIVATE_KEY_BASE64" ]; then
     echo "Usage: $0 <version> <build-number> <dmg-path> <private-key-base64>"
@@ -101,7 +108,7 @@ cat << EOF
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>Just Speak to It Updates</title>
-    <link>https://justspeaktoit.com/appcast.xml</link>
+    <link>${FEED_URL}</link>
     <description>Most recent updates to Just Speak to It</description>
     <language>en</language>
     <item>

--- a/scripts/record-release-size.sh
+++ b/scripts/record-release-size.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Record the download and install size of one release variant, so growth is
+# visible in every release run (issue #774).
+#
+# Usage: ./scripts/record-release-size.sh <arm64|universal> <path-to-app> <path-to-dmg>
+#
+# Prints one Markdown table row and appends it to $GITHUB_STEP_SUMMARY when
+# running in GitHub Actions. The table header is written by the workflow.
+
+set -euo pipefail
+
+VARIANT="${1:-}"
+APP_PATH="${2:-}"
+DMG_PATH="${3:-}"
+
+if [[ -z "$VARIANT" || -z "$APP_PATH" || -z "$DMG_PATH" ]]; then
+    echo "Usage: $0 <arm64|universal> <path-to-app> <path-to-dmg>" >&2
+    exit 1
+fi
+
+for path in "$APP_PATH" "$DMG_PATH"; do
+    if [[ ! -e "$path" ]]; then
+        echo "error: not found: $path" >&2
+        exit 1
+    fi
+done
+
+MAIN_BINARY="$APP_PATH/Contents/MacOS/JustSpeakToIt"
+CLI_BINARY="$APP_PATH/Contents/MacOS/speak"
+
+bytes() { stat -f%z "$1"; }
+megabytes() { awk -v b="$1" 'BEGIN { printf "%.1f", b / 1048576 }'; }
+
+DMG_BYTES="$(bytes "$DMG_PATH")"
+APP_KB="$(du -sk "$APP_PATH" | awk '{print $1}')"
+APP_BYTES=$((APP_KB * 1024))
+MAIN_BYTES="$(bytes "$MAIN_BINARY")"
+CLI_BYTES="$(bytes "$CLI_BINARY")"
+ARCHS="$(lipo -archs "$MAIN_BINARY")"
+
+ROW="| $VARIANT | $(megabytes "$DMG_BYTES") MB | $(megabytes "$APP_BYTES") MB | $(megabytes "$MAIN_BYTES") MB | $(megabytes "$CLI_BYTES") MB | $ARCHS |"
+echo "$ROW"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "$ROW" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/verify-architecture.sh
+++ b/scripts/verify-architecture.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Verify that a packaged JustSpeakToIt.app contains exactly the CPU slices its
+# release variant promises (issue #774).
+#
+# Usage: ./scripts/verify-architecture.sh <path-to-JustSpeakToIt.app> <arm64|universal>
+#
+# The main executable and the embedded `speak` CLI are enforced: the arm64
+# primary download must not carry an x86_64 slice, and the universal legacy
+# download must carry both. Embedded frameworks are reported for the log but
+# not enforced; third-party binaries (Sparkle) ship universal.
+
+set -euo pipefail
+
+APP_PATH="${1:-}"
+VARIANT="${2:-}"
+
+if [[ -z "$APP_PATH" || -z "$VARIANT" ]]; then
+    echo "Usage: $0 <path-to-JustSpeakToIt.app> <arm64|universal>" >&2
+    exit 1
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "error: app bundle not found at $APP_PATH" >&2
+    exit 1
+fi
+
+case "$VARIANT" in
+    arm64) EXPECTED="arm64" ;;
+    universal) EXPECTED="arm64 x86_64" ;;
+    *)
+        echo "error: unknown variant '$VARIANT' (expected arm64 or universal)" >&2
+        exit 1
+        ;;
+esac
+
+sorted_archs() {
+    tr ' ' '\n' <<<"$1" | sed '/^$/d' | sort | tr '\n' ' ' | sed 's/ $//'
+}
+
+check_binary() {
+    local binary="$1"
+    if [[ ! -f "$binary" ]]; then
+        echo "error: executable missing at $binary" >&2
+        exit 1
+    fi
+    local archs
+    archs="$(lipo -archs "$binary")"
+    if [[ "$(sorted_archs "$archs")" != "$(sorted_archs "$EXPECTED")" ]]; then
+        echo "error: $binary contains [$archs] but the $VARIANT variant must contain exactly [$EXPECTED]" >&2
+        exit 1
+    fi
+    echo "==> $(basename "$binary"): $archs"
+}
+
+check_binary "$APP_PATH/Contents/MacOS/JustSpeakToIt"
+check_binary "$APP_PATH/Contents/MacOS/speak"
+
+for framework in "$APP_PATH"/Contents/Frameworks/*.framework; do
+    [[ -d "$framework" ]] || continue
+    name="$(basename "$framework" .framework)"
+    binary="$framework/$name"
+    [[ -f "$binary" ]] || binary="$framework/Versions/A/$name"
+    [[ -f "$binary" ]] || continue
+    echo "    framework $name: $(lipo -archs "$binary") (not enforced)"
+done
+
+echo "==> Architecture verified for the $VARIANT variant"


### PR DESCRIPTION
Closes #774.

Apple Silicon becomes the normal macOS download and update path; Intel keeps a clearly labelled universal legacy download. Implemented as a release-pipeline change with feed gating, not by thinning the existing DMG, so no Intel install is stranded.

## Design

**Two downloads per release**

| Asset | Slices | Who gets it |
|---|---|---|
| `JustSpeakToIt-arm64.dmg` (primary) | arm64 only, arm64-only `speak` CLI | Apple Silicon downloads, Homebrew on arm, Sparkle on Apple Silicon |
| `JustSpeakToIt-universal.dmg` (legacy) | arm64 + x86_64, universal `speak` CLI | Intel downloads, Homebrew on Intel, Sparkle on Intel / Rosetta, **and every install that predates this change** |

The legacy artefact is universal rather than x86_64-only on purpose: every shipped build carries `SUFeedURL = https://justspeaktoit.com/appcast.xml` in its Info.plist, so that feed must keep offering something any Mac can run. Existing Apple Silicon users therefore update once more through the universal feed and, now carrying the new feed-selection code, move to the arm64 feed at the following release.

**Two feeds** — `appcast.xml` (unchanged name; universal DMG) and `appcast-arm64.xml` (arm64 DMG), both published as release assets and routed by Cloudflare redirects. `UpdateFeedSelection` picks the feed at runtime via `SPUUpdaterDelegate.feedURLString(for:)`: the arm64 feed only for a process running natively on Apple Silicon (`uname` + `sysctl.proc_translated`), the universal feed for Intel and Rosetta-translated processes; a custom/test `SUFeedURL` is left untouched. The workflow asserts each feed's enclosure names its own DMG and never the other, so an arm64-only build cannot be offered through the universal feed.

**Pipeline** — the per-variant work (archive with explicit `ARCHS`/`ONLY_ACTIVE_ARCH=NO`, export, CLI embed, hardened-runtime re-sign, architecture check, launch check, notarise + staple, entitlements, Gatekeeper assessment, launch check, DMG + notarise + staple, size row) moved verbatim into a composite action `.github/actions/package-mac-release` that the workflow calls once per variant with isolated scratch directories. New verification: `scripts/verify-architecture.sh` (main executable and `speak` must contain exactly the variant's slices; embedded frameworks reported), `spctl --assess --type execute` after stapling, and `scripts/record-release-size.sh` writing DMG / installed app / executable / CLI sizes per variant to the job summary. `scripts/build-speak-cli.sh` takes the variant and enforces the exact slice set (an x86_64 slice leaking into the arm64 CLI fails the build). Sentry receives both archives' dSYMs; manual (non-tag) runs upload both DMGs as artefacts.

**Homebrew** — the cask becomes per-architecture (`arch arm: "arm64", intel: "universal"`, `sha256 arm:/intel:`, `JustSpeakToIt-#{arch}.dmg`), so the bundled `speak` CLI always matches the installed app.

**Docs** — README lists both downloads and the update behaviour; `Docs/sparkle-setup.md` documents the two feeds; `AGENTS.md` release/remediation steps name both DMGs.

## Landing page

`_redirects` now also routes `/appcast-arm64.xml`, `/download/mac` (arm64 DMG) and `/download/mac-intel` (universal DMG) through GitHub's `releases/latest/download`. The page's buttons are deliberately **not** switched in this PR: those redirect targets 404 until the first release built by this pipeline exists. Follow-up after that release: point the primary button at `/download/mac` labelled Apple Silicon and add an "Intel (legacy)" link to `/download/mac-intel`.

## Verification

- Unit tests: `UpdateFeedSelectionTests` (native Apple Silicon → arm64 feed; Intel and Rosetta → universal; custom feed untouched; Info.plist keeps the universal feed as the fail-safe default) and new `DistributionBuildIdentityTests` cases (two variant invocations with explicit archs, per-variant CLI embed and scratch dirs, architecture/Gatekeeper/size steps, feed/asset pairing, four release assets, per-arch cask, redirect ordering). Existing workflow-shape tests updated to read the composite action.
- Scripts exercised locally on scaffolded bundles: arm64 and universal CLI embeds, architecture verification for both variants plus both mismatch directions failing, size recording to a step summary.
- Workflow and action YAML parsed; strict lint clean; full `swift test` green.
- **Dry run of the real pipeline** via `workflow_dispatch` on this branch (non-tag path: builds, signs, notarises, staples and packages both variants, uploads both DMGs as artefacts; release/appcast/cask steps are tag-gated and do not run) — see the run linked in the comments.

## Notes for review

- Merge as `ci:` (no release is cut by the merge); the next `fix:`/`feat:` merge produces the first two-artefact release. The landing-page button switch follows that release.
- Release job timeout raised 180 → 240 min to cover two notarisation passes; Sparkle `minimumSystemVersion` and signing/notarisation/stapling/rollback behaviour are unchanged.
- Embedded `Sparkle.framework` stays universal in the arm64 build (third-party binary, ~1 MB); only the app's own executables are enforced arm64-only, which is what the acceptance criterion names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b
