### PR TITLE
chore(site): point the download buttons at the Apple Silicon build with an Intel legacy link

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -187,6 +187,26 @@
       gap: .75rem;
       margin-top: 2rem;
     }
+    .button__note {
+      font-size: .72em;
+      font-weight: 600;
+      opacity: .85;
+      padding: .1em .45em;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, .18);
+    }
+    .hero__alt,
+    .app-choice__alt {
+      margin-top: .75rem;
+      font-size: .9rem;
+      color: var(--muted, #6b6b6b);
+    }
+    .hero__alt a,
+    .app-choice__alt a {
+      color: inherit;
+      text-decoration: underline;
+      text-underline-offset: .15em;
+    }
 
     .product-stage {
       position: relative;
@@ -594,7 +614,7 @@
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .7C5.6.7.4 5.9.4 12.3c0 5.1 3.3 9.4 7.8 10.9.6.1.8-.3.8-.6v-2.2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.3 1 .1-.8.4-1.3.8-1.6-2.5-.3-5.2-1.3-5.2-5.7 0-1.3.4-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.2 1.2a11 11 0 0 1 5.8 0c2.2-1.5 3.2-1.2 3.2-1.2.6 1.6.2 2.8.1 3.1.8.9 1.2 1.9 1.2 3.1 0 4.4-2.7 5.4-5.2 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6a11.6 11.6 0 0 0 7.8-10.9C23.6 5.9 18.4.7 12 .7Z"/></svg>
           <span>GitHub</span>
         </a>
-        <a class="button button--orange nav__download" href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac</a>
+        <a class="button button--orange nav__download" href="/download/mac">Download for Mac</a>
       </div>
     </div>
   </header>
@@ -606,9 +626,10 @@
           <h1>Your voice.<br>Your model.<br>Your words.</h1>
           <p class="hero__lede">Fast, private dictation for Mac, iPhone, and iPad. Run speech models locally, stream with your own provider keys, and paste polished text anywhere.</p>
           <div class="hero__actions">
-            <a class="button button--orange" href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac <span aria-hidden="true">→</span></a>
+            <a class="button button--orange" href="/download/mac">Download for Mac <span class="button__note">Apple Silicon</span> <span aria-hidden="true">→</span></a>
             <a class="button button--outline" href="#models">Explore the models</a>
           </div>
+          <p class="hero__alt">Intel Mac? <a href="/download/mac-intel">Download the legacy universal build</a> — it also runs on Apple Silicon.</p>
         </div>
 
         <div class="product-stage" aria-label="Real screenshots of Just Speak to It on Mac and iPhone">
@@ -661,7 +682,7 @@
       <div class="shell">
         <div class="app-rail reveal">
           <div class="app-rail__lead"><h2 class="section-title">Native on every Apple screen you use.</h2></div>
-          <article class="app-choice" style="--link-color:var(--orange-deep)"><svg class="app-choice__icon" viewBox="0 0 52 52" fill="none" stroke="var(--orange)" stroke-width="2.5" aria-hidden="true"><rect x="8" y="7" width="36" height="27" rx="2"/><path d="M3 42h46M15 34l-4 8m26-8 4 8"/></svg><h3>Mac — Direct download</h3><p>Fast updates and full access to local model support.</p><a href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac →</a></article>
+          <article class="app-choice" style="--link-color:var(--orange-deep)"><svg class="app-choice__icon" viewBox="0 0 52 52" fill="none" stroke="var(--orange)" stroke-width="2.5" aria-hidden="true"><rect x="8" y="7" width="36" height="27" rx="2"/><path d="M3 42h46M15 34l-4 8m26-8 4 8"/></svg><h3>Mac — Direct download</h3><p>Fast updates and full access to local model support.</p><a href="/download/mac">Download for Apple Silicon →</a><p class="app-choice__alt"><a href="/download/mac-intel">Intel Mac (legacy universal build)</a></p></article>
           <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>Mac — App Store</h3><p>Sandboxed store distribution for a familiar install and update path.</p><span class="app-choice__status">Submitted for App Review</span></article>
           <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>iPhone &amp; iPad — App Store</h3><p>Action Button, Shortcuts, Live Activity, and iCloud history.</p><span class="app-choice__status">Submitted for App Review</span></article>
         </div>
@@ -686,7 +707,7 @@
   <footer class="footer">
     <div class="shell footer__main">
       <a class="brand" href="#top"><span class="brand__wave" aria-hidden="true"><i style="--h:10px"></i><i style="--h:20px"></i><i style="--h:28px"></i><i style="--h:18px"></i><i style="--h:25px"></i><i style="--h:13px"></i></span><span>Just Speak to It</span></a>
-      <div class="footer__cta"><h2>Ready when you are.</h2><a class="button button--orange" href="https://github.com/crmitchelmore/justspeaktoit/releases/latest">Download for Mac</a></div>
+      <div class="footer__cta"><h2>Ready when you are.</h2><a class="button button--orange" href="/download/mac">Download for Mac</a></div>
       <nav class="footer__links" aria-label="Footer"><a href="https://github.com/crmitchelmore/justspeaktoit">GitHub</a><a href="/privacy">Privacy</a><a href="mailto:hello@justspeaktoit.com">Contact</a></nav>
     </div>
     <div class="shell footer__legal">© 2026 Chris Mitchelmore. Just Speak to It is open source.</div>


### PR DESCRIPTION
Follow-up to #774 / PR #784. **Draft on purpose — do not merge until both conditions hold:**

1. PR #784 is merged (it adds the `/download/mac` and `/download/mac-intel` Cloudflare redirects this page links to).
2. The first release built by the new pipeline has been published, i.e. `https://github.com/crmitchelmore/justspeaktoit/releases/latest` carries `JustSpeakToIt-arm64.dmg` and `JustSpeakToIt-universal.dmg`. Before that, both redirect targets 404.

## What changes

- Nav, hero and footer "Download for Mac" buttons → `/download/mac` (arm64 DMG); the hero button carries an "Apple Silicon" note.
- Hero: "Intel Mac? Download the legacy universal build — it also runs on Apple Silicon." → `/download/mac-intel`.
- Mac card: "Download for Apple Silicon →" plus a muted "Intel Mac (legacy universal build)" link.
- Small CSS for the note pill and the muted links (uses the existing `--muted` token).

No JS, no API calls: the links resolve through GitHub's `releases/latest/download/<asset>` redirect, so the page never needs to know the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b