### PR TITLE
feat(mac): install, update and remove the standalone speak CLI from Settings

### DIFF
--- a/Docs/automation.md
+++ b/Docs/automation.md
@@ -124,7 +124,24 @@ automation (speak CLI and MCP)**. Until then every client gets
 
 ### Install
 
-The CLI ships inside the app bundle and is symlinked by the Homebrew cask:
+**From the app (recommended):** Settings → General → **Automation CLI** → *Install CLI*.
+The app downloads the release's standalone `speak` build for your Mac's
+architecture, verifies the signed release manifest, the archive's size and
+SHA-256, the executable's architecture and its Developer ID signature, then
+installs it atomically at:
+
+```text
+~/Library/Application Support/SpeakApp/bin/speak
+```
+
+No administrator rights are needed and your shell profile is never edited.
+The card offers *Copy PATH command* — paste that line into `~/.zshrc` (or
+symlink the binary, e.g. `ln -s "$HOME/Library/Application Support/SpeakApp/bin/speak" ~/.local/bin/speak`).
+*Check for update* fetches the latest manifest; *Uninstall* removes only the
+files the installer wrote. A failed download or verification never replaces a
+working CLI.
+
+The CLI also ships inside the app bundle and is symlinked by the Homebrew cask:
 
 ```bash
 brew install --cask crmitchelmore/tap/justspeaktoit

--- a/Sources/SpeakApp/Services/MachOArchitectures.swift
+++ b/Sources/SpeakApp/Services/MachOArchitectures.swift
@@ -33,13 +33,16 @@ enum MachOArchitectures {
         let magic = header.readUInt32(at: 0, bigEndian: true)
         switch magic {
         case fatMagic, fatCigam:
-            let count = Int(header.readUInt32(at: 4, bigEndian: true))
+            // A fat header is big-endian on disk; a byte-swapped magic means
+            // every field of this header is byte-swapped too.
+            let fieldsAreBigEndian = magic == fatMagic
+            let count = Int(header.readUInt32(at: 4, bigEndian: fieldsAreBigEndian))
             guard count > 0, count < 64 else { throw ReadError.notMachO }
             var archs: Set<String> = []
             for index in 0..<count {
                 let offset = 8 + index * 20
                 guard header.count >= offset + 4 else { throw ReadError.notMachO }
-                archs.insert(name(forCPUType: header.readUInt32(at: offset, bigEndian: true)))
+                archs.insert(name(forCPUType: header.readUInt32(at: offset, bigEndian: fieldsAreBigEndian)))
             }
             return archs
         case machMagic64, machMagic32:

--- a/Sources/SpeakApp/Services/MachOArchitectures.swift
+++ b/Sources/SpeakApp/Services/MachOArchitectures.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Reads the CPU slices a Mach-O file contains from its headers, so an
+/// installer can confirm a downloaded executable is built for this Mac
+/// before replacing anything (issue #775).
+enum MachOArchitectures {
+    private static let fatMagic: UInt32 = 0xCAFE_BABE
+    private static let fatCigam: UInt32 = 0xBEBA_FECA
+    private static let machMagic64: UInt32 = 0xFEED_FACF
+    private static let machCigam64: UInt32 = 0xCFFA_EDFE
+    private static let machMagic32: UInt32 = 0xFEED_FACE
+    private static let machCigam32: UInt32 = 0xCEFA_EDFE
+    private static let cpuTypeIntel64: UInt32 = 0x0100_0007
+    private static let cpuTypeARM64: UInt32 = 0x0100_000C
+
+    enum ReadError: LocalizedError, Equatable {
+        case notMachO
+
+        var errorDescription: String? { "The downloaded file is not a macOS executable." }
+    }
+
+    static func architectures(of fileURL: URL) throws -> Set<String> {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+        let header = try handle.read(upToCount: 4096) ?? Data()
+        return try architectures(in: header)
+    }
+
+    /// Parses the leading bytes of a file: a thin Mach-O header, or a fat
+    /// header followed by its architecture table.
+    static func architectures(in header: Data) throws -> Set<String> {
+        guard header.count >= 8 else { throw ReadError.notMachO }
+        let magic = header.readUInt32(at: 0, bigEndian: true)
+        switch magic {
+        case fatMagic, fatCigam:
+            let count = Int(header.readUInt32(at: 4, bigEndian: true))
+            guard count > 0, count < 64 else { throw ReadError.notMachO }
+            var archs: Set<String> = []
+            for index in 0..<count {
+                let offset = 8 + index * 20
+                guard header.count >= offset + 4 else { throw ReadError.notMachO }
+                archs.insert(name(forCPUType: header.readUInt32(at: offset, bigEndian: true)))
+            }
+            return archs
+        case machMagic64, machMagic32:
+            // The magic read as-is, so the file's fields are big-endian.
+            return [name(forCPUType: header.readUInt32(at: 4, bigEndian: true))]
+        case machCigam64, machCigam32:
+            // Byte-swapped magic: a little-endian file (every modern Mac binary).
+            return [name(forCPUType: header.readUInt32(at: 4, bigEndian: false))]
+        default:
+            throw ReadError.notMachO
+        }
+    }
+
+    private static func name(forCPUType cpuType: UInt32) -> String {
+        switch cpuType {
+        case cpuTypeARM64: return "arm64"
+        case cpuTypeIntel64: return "x86_64"
+        default: return "cputype-\(cpuType)"
+        }
+    }
+}
+
+private extension Data {
+    func readUInt32(at offset: Int, bigEndian: Bool) -> UInt32 {
+        let bytes = self[startIndex + offset..<startIndex + offset + 4]
+        var value: UInt32 = 0
+        for byte in bytes {
+            value = (value << 8) | UInt32(byte)
+        }
+        return bigEndian ? value : value.byteSwapped
+    }
+}

--- a/Sources/SpeakApp/Services/SpeakCLIInstaller.swift
+++ b/Sources/SpeakApp/Services/SpeakCLIInstaller.swift
@@ -1,0 +1,297 @@
+import Foundation
+import SpeakCore
+
+/// Installs, updates and removes the standalone `speak` CLI under the user's
+/// Application Support folder, without administrator rights and without
+/// touching shell startup files (issue #775).
+///
+/// Every download is verified completely — signed manifest, byte count,
+/// SHA-256, Mach-O architecture and Developer ID signature — in a temporary
+/// location before the installed executable is replaced atomically, so a
+/// failed install can never leave a partial or untrusted binary in place.
+@MainActor
+final class SpeakCLIInstaller: ObservableObject {
+  static let shared = SpeakCLIInstaller()
+
+  /// What the installer owns on disk, recorded next to the executable.
+  struct InstalledCLI: Codable, Equatable {
+    let version: String
+    let architecture: String
+    let sha256: String
+    let automationSchemaVersion: Int
+    let installedAt: Date
+  }
+
+  enum Phase: Equatable {
+    case downloading(Double?)
+    case verifying
+    case installing
+  }
+
+  enum State: Equatable {
+    case notInstalled
+    /// No CLI can be offered right now (not published yet, or built for a
+    /// protocol this app does not speak). The message explains which.
+    case unavailable(String)
+    case installing(Phase)
+    case installed(InstalledCLI)
+    case updateAvailable(installed: InstalledCLI, latest: String)
+    /// The previous installation, if any, is untouched.
+    case failed(String, installed: InstalledCLI?)
+
+    var installed: InstalledCLI? {
+      switch self {
+      case .installed(let cli), .updateAvailable(let cli, _), .failed(_, let cli?): return cli
+      default: return nil
+      }
+    }
+
+    var isBusy: Bool {
+      if case .installing = self { return true }
+      return false
+    }
+  }
+
+  static let executableName = "speak"
+  static let recordName = "installed.json"
+
+  @Published private(set) var state: State = .notInstalled
+  @Published private(set) var latestVersion: String?
+
+  let dependencies: SpeakCLIInstallerDependencies
+  private let fileManager: FileManager
+  private let logger = SpeakLogger.logger(category: "SpeakCLIInstaller")
+
+  init(
+    dependencies: SpeakCLIInstallerDependencies = .live,
+    fileManager: FileManager = .default
+  ) {
+    self.dependencies = dependencies
+    self.fileManager = fileManager
+    refresh()
+  }
+
+  var executableURL: URL {
+    dependencies.installDirectory.appendingPathComponent(Self.executableName)
+  }
+
+  private var recordURL: URL {
+    dependencies.installDirectory.appendingPathComponent(Self.recordName)
+  }
+
+  /// Shell line users paste into their own profile; the installer never edits it for them.
+  var pathCommand: String {
+    "export PATH=\"\(dependencies.installDirectory.path):$PATH\""
+  }
+
+  /// Whether the installed CLI speaks the automation protocol this app speaks.
+  func isCompatible(_ cli: InstalledCLI) -> Bool {
+    cli.automationSchemaVersion == dependencies.automationSchemaVersion
+  }
+
+  // MARK: - State
+
+  /// Re-reads what is installed, without touching the network.
+  func refresh() {
+    guard !state.isBusy else { return }
+    if let installed = readRecord() {
+      if let latestVersion, latestVersion != installed.version {
+        state = .updateAvailable(installed: installed, latest: latestVersion)
+      } else {
+        state = .installed(installed)
+      }
+    } else {
+      state = .notInstalled
+    }
+  }
+
+  func checkForUpdate() async {
+    guard !state.isBusy else { return }
+    do {
+      let manifest = try await fetchVerifiedManifest()
+      latestVersion = manifest.version
+      guard let installed = readRecord() else {
+        state = .notInstalled
+        return
+      }
+      state = manifest.version == installed.version
+        ? .installed(installed)
+        : .updateAvailable(installed: installed, latest: manifest.version)
+    } catch {
+      if readRecord() == nil {
+        state = .unavailable(error.localizedDescription)
+      } else {
+        state = .failed(error.localizedDescription, installed: readRecord())
+      }
+    }
+  }
+
+  // MARK: - Install
+
+  func install() async {
+    guard !state.isBusy else { return }
+    let previous = readRecord()
+    var scratch: URL?
+    defer { if let scratch { try? fileManager.removeItem(at: scratch) } }
+    do {
+      state = .installing(.downloading(nil))
+      let manifest = try await fetchVerifiedManifest()
+      latestVersion = manifest.version
+      let architecture = dependencies.hardwareArchitecture()
+      guard let asset = manifest.asset(for: architecture) else {
+        throw SpeakCLIInstallerError.noAssetForArchitecture(architecture)
+      }
+      guard manifest.automationSchemaVersion == dependencies.automationSchemaVersion else {
+        throw SpeakCLIInstallerError.incompatibleProtocol(
+          cli: manifest.automationSchemaVersion, app: dependencies.automationSchemaVersion)
+      }
+
+      let archive = try await dependencies.download(asset.url) { [weak self] fraction in
+        Task { @MainActor [weak self] in
+          guard let self, case .installing(.downloading) = self.state else { return }
+          self.state = .installing(.downloading(fraction))
+        }
+      }
+      scratch = archive.deletingLastPathComponent()
+
+      state = .installing(.verifying)
+      try Self.verifyArchive(archive, against: asset)
+      let executable = try await dependencies.extractExecutable(archive, archive.deletingLastPathComponent())
+      let slices = try MachOArchitectures.architectures(of: executable)
+      guard slices == [architecture] else {
+        throw SpeakCLIInstallerError.wrongArchitecture(expected: architecture, found: slices.sorted())
+      }
+      try dependencies.verifyCodeSignature(executable)
+
+      state = .installing(.installing)
+      let record = InstalledCLI(
+        version: manifest.version,
+        architecture: architecture,
+        sha256: asset.sha256,
+        automationSchemaVersion: manifest.automationSchemaVersion,
+        installedAt: Self.installationDate()
+      )
+      try place(executable, record: record)
+      state = .installed(record)
+      logger.info("Installed speak CLI \(manifest.version, privacy: .public) (\(architecture, privacy: .public))")
+    } catch {
+      logger.error("speak CLI install failed: \(error.localizedDescription, privacy: .public)")
+      state = .failed(error.localizedDescription, installed: previous)
+    }
+  }
+
+  /// Removes only what the installer wrote: the executable and its record.
+  /// The directory is removed only when nothing else is left in it.
+  func uninstall() {
+    guard !state.isBusy else { return }
+    do {
+      for url in [executableURL, recordURL] where fileManager.fileExists(atPath: url.path) {
+        try fileManager.removeItem(at: url)
+      }
+      let remaining = (try? fileManager.contentsOfDirectory(atPath: dependencies.installDirectory.path)) ?? []
+      if remaining.isEmpty {
+        try? fileManager.removeItem(at: dependencies.installDirectory)
+      }
+      state = .notInstalled
+    } catch {
+      state = .failed(error.localizedDescription, installed: readRecord())
+    }
+  }
+
+  // MARK: - Steps
+
+  private func fetchVerifiedManifest() async throws -> SpeakCLIManifest {
+    let manifestData = try await dependencies.fetchData(dependencies.manifestURL)
+    let signatureData = try await dependencies.fetchData(dependencies.signatureURL)
+    let signature = String(bytes: signatureData, encoding: .utf8) ?? ""
+    return try SpeakCLIManifestVerifier.verifiedManifest(
+      manifestData: manifestData,
+      signatureBase64: signature,
+      publicKeyBase64: dependencies.publicKeyBase64
+    )
+  }
+
+  /// The record round-trips through ISO 8601 without fractional seconds, so
+  /// the timestamp is stored at whole-second precision from the start and the
+  /// in-memory record equals the one read back after a relaunch.
+  static func installationDate(now: Date = Date()) -> Date {
+    Date(timeIntervalSince1970: now.timeIntervalSince1970.rounded(.down))
+  }
+
+  private static func verifyArchive(_ archive: URL, against asset: SpeakCLIManifest.Asset) throws {
+    let attributes = try FileManager.default.attributesOfItem(atPath: archive.path)
+    let byteCount = (attributes[.size] as? NSNumber)?.intValue ?? -1
+    guard byteCount == asset.byteCount else {
+      throw SpeakCLIInstallerError.sizeMismatch(expected: asset.byteCount, actual: byteCount)
+    }
+    let digest = try SpeakCLIInstallerDependencies.sha256Hex(of: archive)
+    guard digest.caseInsensitiveCompare(asset.sha256) == .orderedSame else {
+      throw SpeakCLIInstallerError.checksumMismatch
+    }
+  }
+
+  /// Moves the verified executable into place. The replacement is a single
+  /// rename, so a concurrent `speak` invocation sees either the old or the
+  /// new binary, never a partial one.
+  private func place(_ executable: URL, record: InstalledCLI) throws {
+    try fileManager.createDirectory(
+      at: dependencies.installDirectory,
+      withIntermediateDirectories: true,
+      attributes: [.posixPermissions: 0o700]
+    )
+    try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+    // The download carries a quarantine flag; the executable has just been
+    // verified against the manifest and this team's Developer ID, so clear it
+    // rather than have Gatekeeper block a terminal launch.
+    removexattr(executable.path, "com.apple.quarantine", 0)
+
+    if fileManager.fileExists(atPath: executableURL.path) {
+      _ = try fileManager.replaceItemAt(executableURL, withItemAt: executable)
+    } else {
+      try fileManager.moveItem(at: executable, to: executableURL)
+    }
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    try encoder.encode(record).write(to: recordURL, options: .atomic)
+  }
+
+  private func readRecord() -> InstalledCLI? {
+    guard fileManager.isExecutableFile(atPath: executableURL.path),
+      let data = fileManager.contents(atPath: recordURL.path)
+    else { return nil }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try? decoder.decode(InstalledCLI.self, from: data)
+  }
+}
+
+enum SpeakCLIInstallerError: LocalizedError, Equatable {
+  case noAssetForArchitecture(String)
+  case incompatibleProtocol(cli: Int, app: Int)
+  case sizeMismatch(expected: Int, actual: Int)
+  case checksumMismatch
+  case wrongArchitecture(expected: String, found: [String])
+  case codeSignatureRejected(String)
+  case extractionFailed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .noAssetForArchitecture(let architecture):
+      return "This release has no speak CLI build for \(architecture) Macs."
+    case .incompatibleProtocol(let cli, let app):
+      return "This speak CLI speaks automation protocol v\(cli) but the app speaks v\(app). Update the app first."
+    case .sizeMismatch(let expected, let actual):
+      return "The download was \(actual) bytes but the release manifest expects \(expected). Nothing was installed."
+    case .checksumMismatch:
+      return "The download's SHA-256 does not match the release manifest. Nothing was installed."
+    case .wrongArchitecture(let expected, let found):
+      return "The download is built for \(found.joined(separator: ", ")) but this Mac needs \(expected). "
+        + "Nothing was installed."
+    case .codeSignatureRejected(let detail):
+      return "The download is not signed by Just Speak to It's developer (\(detail)). Nothing was installed."
+    case .extractionFailed(let detail):
+      return "The download could not be unpacked: \(detail)."
+    }
+  }
+}

--- a/Sources/SpeakApp/Services/SpeakCLIInstaller.swift
+++ b/Sources/SpeakApp/Services/SpeakCLIInstaller.swift
@@ -245,15 +245,30 @@ final class SpeakCLIInstaller: ObservableObject {
     // rather than have Gatekeeper block a terminal launch.
     removexattr(executable.path, "com.apple.quarantine", 0)
 
+    // The record is encoded and staged next to its final path before the
+    // executable moves, so an encoding or disk problem surfaces while the
+    // previous installation is still intact. After the executable is
+    // replaced the staged record is committed with a single rename; if even
+    // that fails, the stale record is removed rather than left describing a
+    // binary that is no longer on disk.
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    let stagedRecordURL = recordURL.appendingPathExtension("staged")
+    try encoder.encode(record).write(to: stagedRecordURL, options: .atomic)
+
     if fileManager.fileExists(atPath: executableURL.path) {
       _ = try fileManager.replaceItemAt(executableURL, withItemAt: executable)
     } else {
       try fileManager.moveItem(at: executable, to: executableURL)
     }
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    encoder.dateEncodingStrategy = .iso8601
-    try encoder.encode(record).write(to: recordURL, options: .atomic)
+    do {
+      try dependencies.commitRecord(stagedRecordURL, recordURL)
+    } catch {
+      try? fileManager.removeItem(at: recordURL)
+      try? fileManager.removeItem(at: stagedRecordURL)
+      throw error
+    }
   }
 
   private func readRecord() -> InstalledCLI? {

--- a/Sources/SpeakApp/Services/SpeakCLIInstallerDependencies.swift
+++ b/Sources/SpeakApp/Services/SpeakCLIInstallerDependencies.swift
@@ -20,6 +20,9 @@ struct SpeakCLIInstallerDependencies {
   var verifyCodeSignature: @Sendable (URL) throws -> Void
   /// `arm64` on Apple Silicon hardware (even under Rosetta), `x86_64` on Intel.
   var hardwareArchitecture: @Sendable () -> String
+  /// Moves the staged installation record over the final one in a single
+  /// rename (a seam so tests can fail the commit after the executable moved).
+  var commitRecord: @Sendable (_ staged: URL, _ final: URL) throws -> Void = Self.commitRecord
   /// Sparkle's Ed25519 public key from Info.plist, which also signs the manifest.
   var publicKeyBase64: String?
   var automationSchemaVersion: Int
@@ -189,6 +192,15 @@ struct SpeakCLIInstallerDependencies {
       return "arm64"
     }
     return "x86_64"
+  }
+
+  /// Replaces `final` with `staged` atomically (a rename on the same volume).
+  static func commitRecord(staged: URL, final: URL) throws {
+    if FileManager.default.fileExists(atPath: final.path) {
+      _ = try FileManager.default.replaceItemAt(final, withItemAt: staged)
+    } else {
+      try FileManager.default.moveItem(at: staged, to: final)
+    }
   }
 
   static func sha256Hex(of fileURL: URL) throws -> String {

--- a/Sources/SpeakApp/Services/SpeakCLIInstallerDependencies.swift
+++ b/Sources/SpeakApp/Services/SpeakCLIInstallerDependencies.swift
@@ -1,0 +1,203 @@
+import CryptoKit
+import Foundation
+import Security
+import SpeakCore
+
+/// Everything `SpeakCLIInstaller` needs from the outside world — network,
+/// archive extraction, code-signing verification and the machine's
+/// architecture — so the install flow is testable end to end without a
+/// network, the Security framework or a real release (issue #775).
+struct SpeakCLIInstallerDependencies {
+  typealias ProgressHandler = @Sendable (Double) -> Void
+
+  /// Fetches a small release asset (the manifest and its signature).
+  var fetchData: @Sendable (URL) async throws -> Data
+  /// Downloads an archive to a temporary file, reporting fractional progress.
+  var download: @Sendable (URL, @escaping ProgressHandler) async throws -> URL
+  /// Extracts the single `speak` executable from a zip archive into `directory`.
+  var extractExecutable: @Sendable (_ archive: URL, _ directory: URL) async throws -> URL
+  /// Throws unless the executable carries a valid Developer ID signature from this app's team.
+  var verifyCodeSignature: @Sendable (URL) throws -> Void
+  /// `arm64` on Apple Silicon hardware (even under Rosetta), `x86_64` on Intel.
+  var hardwareArchitecture: @Sendable () -> String
+  /// Sparkle's Ed25519 public key from Info.plist, which also signs the manifest.
+  var publicKeyBase64: String?
+  var automationSchemaVersion: Int
+  var manifestURL: URL
+  var signatureURL: URL
+  /// Where the CLI is installed: `<Application Support>/SpeakApp/bin`.
+  var installDirectory: URL
+
+  static var live: SpeakCLIInstallerDependencies {
+    let releases = URL(string: "https://github.com/crmitchelmore/justspeaktoit/releases/latest/download/")!
+    let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+      ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
+    return SpeakCLIInstallerDependencies(
+      fetchData: { url in
+        let (data, response) = try await URLSession.shared.data(from: url)
+        try Self.checkStatus(response, for: url)
+        return data
+      },
+      download: { url, progress in
+        try await Self.downloadToTemporaryFile(url, progress: progress)
+      },
+      extractExecutable: { archive, directory in
+        try await Self.extract(archive, into: directory)
+      },
+      verifyCodeSignature: { executable in
+        try Self.verifyDeveloperIDSignature(of: executable)
+      },
+      hardwareArchitecture: { Self.hardwareArchitecture },
+      publicKeyBase64: Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String,
+      automationSchemaVersion: AutomationSchema.currentVersion,
+      manifestURL: releases.appendingPathComponent(SpeakCLIManifest.manifestAssetName),
+      signatureURL: releases.appendingPathComponent(SpeakCLIManifest.signatureAssetName),
+      installDirectory: support
+        .appendingPathComponent("SpeakApp", isDirectory: true)
+        .appendingPathComponent("bin", isDirectory: true)
+    )
+  }
+
+  // MARK: - Live implementations
+
+  enum TransportError: LocalizedError {
+    case httpStatus(Int, URL)
+    case notPublished(URL)
+
+    var errorDescription: String? {
+      switch self {
+      case .httpStatus(let status, let url):
+        return "The download of \(url.lastPathComponent) failed with HTTP \(status)."
+      case .notPublished(let url):
+        return "\(url.lastPathComponent) is not published for the latest release yet."
+      }
+    }
+  }
+
+  static func checkStatus(_ response: URLResponse, for url: URL) throws {
+    guard let http = response as? HTTPURLResponse else { return }
+    if http.statusCode == 404 { throw TransportError.notPublished(url) }
+    guard (200..<300).contains(http.statusCode) else { throw TransportError.httpStatus(http.statusCode, url) }
+  }
+
+  private static func downloadToTemporaryFile(_ url: URL, progress: @escaping ProgressHandler) async throws -> URL {
+    let (bytes, response) = try await URLSession.shared.bytes(from: url)
+    try checkStatus(response, for: url)
+    let expected = response.expectedContentLength
+    let destination = FileManager.default.temporaryDirectory
+      .appendingPathComponent("speak-cli-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+    let fileURL = destination.appendingPathComponent(url.lastPathComponent)
+    FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+    let handle = try FileHandle(forWritingTo: fileURL)
+    defer { try? handle.close() }
+
+    var buffer = Data()
+    buffer.reserveCapacity(256 * 1024)
+    var received: Int64 = 0
+    for try await byte in bytes {
+      buffer.append(byte)
+      if buffer.count >= 256 * 1024 {
+        try handle.write(contentsOf: buffer)
+        received += Int64(buffer.count)
+        buffer.removeAll(keepingCapacity: true)
+        if expected > 0 { progress(min(1, Double(received) / Double(expected))) }
+      }
+    }
+    if !buffer.isEmpty {
+      try handle.write(contentsOf: buffer)
+      received += Int64(buffer.count)
+    }
+    progress(1)
+    return fileURL
+  }
+
+  private static func extract(_ archive: URL, into directory: URL) async throws -> URL {
+    try await withCheckedThrowingContinuation { continuation in
+      DispatchQueue.global(qos: .utility).async {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        process.arguments = ["-x", "-k", archive.path, directory.path]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+          try process.run()
+          process.waitUntilExit()
+          guard process.terminationStatus == 0 else {
+            throw SpeakCLIInstallerError.extractionFailed("ditto exited with status \(process.terminationStatus)")
+          }
+          let executable = directory.appendingPathComponent("speak")
+          guard FileManager.default.isExecutableFile(atPath: executable.path) else {
+            throw SpeakCLIInstallerError.extractionFailed("the archive does not contain a speak executable")
+          }
+          continuation.resume(returning: executable)
+        } catch {
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  /// Requires a valid signature anchored at Apple with this app's own team
+  /// identifier on the leaf certificate, so only a CLI from the same developer
+  /// is ever placed on the user's PATH.
+  static func verifyDeveloperIDSignature(of executable: URL) throws {
+    guard let teamIdentifier = currentTeamIdentifier() else {
+      throw SpeakCLIInstallerError.codeSignatureRejected(
+        "this app is not signed with a team identifier, so it cannot vouch for a downloaded executable")
+    }
+    var staticCode: SecStaticCode?
+    guard SecStaticCodeCreateWithPath(executable as CFURL, [], &staticCode) == errSecSuccess, let staticCode else {
+      throw SpeakCLIInstallerError.codeSignatureRejected("the executable could not be opened for signature checks")
+    }
+    let requirementText = "anchor apple generic and certificate leaf[subject.OU] = \"\(teamIdentifier)\""
+    var requirement: SecRequirement?
+    guard SecRequirementCreateWithString(requirementText as CFString, [], &requirement) == errSecSuccess,
+      let requirement
+    else {
+      throw SpeakCLIInstallerError.codeSignatureRejected("the signing requirement could not be built")
+    }
+    var error: Unmanaged<CFError>?
+    let status = SecStaticCodeCheckValidityWithErrors(staticCode, [], requirement, &error)
+    guard status == errSecSuccess else {
+      let detail = error?.takeRetainedValue().localizedDescription ?? "status \(status)"
+      throw SpeakCLIInstallerError.codeSignatureRejected(detail)
+    }
+  }
+
+  private static func currentTeamIdentifier() -> String? {
+    var code: SecCode?
+    guard SecCodeCopySelf([], &code) == errSecSuccess, let code else { return nil }
+    var staticCode: SecStaticCode?
+    guard SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess, let staticCode else { return nil }
+    var information: CFDictionary?
+    let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
+    guard SecCodeCopySigningInformation(staticCode, flags, &information) == errSecSuccess,
+      let info = information as? [String: Any],
+      let team = info[kSecCodeInfoTeamIdentifier as String] as? String,
+      !team.isEmpty
+    else { return nil }
+    return team
+  }
+
+  /// The hardware architecture, not the process's: a universal app translated
+  /// by Rosetta still installs the arm64 CLI on an Apple Silicon Mac.
+  static var hardwareArchitecture: String {
+    var value: Int32 = 0
+    var size = MemoryLayout<Int32>.size
+    if sysctlbyname("hw.optional.arm64", &value, &size, nil, 0) == 0, value == 1 {
+      return "arm64"
+    }
+    return "x86_64"
+  }
+
+  static func sha256Hex(of fileURL: URL) throws -> String {
+    let handle = try FileHandle(forReadingFrom: fileURL)
+    defer { try? handle.close() }
+    var hasher = SHA256()
+    while let data = try handle.read(upToCount: 4 * 1024 * 1024), !data.isEmpty {
+      hasher.update(data: data)
+    }
+    return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+  }
+}

--- a/Sources/SpeakApp/SettingsView.swift
+++ b/Sources/SpeakApp/SettingsView.swift
@@ -29,6 +29,7 @@ struct SettingsView: View {
   @ObservedObject var sherpaRuntime = SherpaOnnxRuntimeManager.shared
   #endif
   @ObservedObject var localPostProcessingModels = LocalPostProcessingModelManager.shared
+  @ObservedObject var cliInstaller = SpeakCLIInstaller.shared
   let tab: SettingsTab
   @Binding var sidebarSelection: SidebarItem?
   @State var newAPIKeyValue: String = ""

--- a/Sources/SpeakApp/Views/Settings/SettingsView+AutomationCLI.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+AutomationCLI.swift
@@ -1,0 +1,167 @@
+import AppKit
+import SpeakCore
+import SwiftUI
+
+// MARK: - Automation CLI card (issue #775)
+
+extension SettingsView {
+  /// Installs, updates and removes the standalone `speak` CLI. Shown only on
+  /// channels that may place executable code in the user's Application
+  /// Support folder.
+  @ViewBuilder
+  var automationCLICard: some View {
+    if DistributionChannel.current.supportsStandaloneCLIInstaller {
+      SettingsCard(title: "Automation CLI", systemImage: "terminal.fill", tint: Color.brandLagoon) {
+        VStack(alignment: .leading, spacing: 12) {
+          Text(
+            "The \"speak\" command-line tool runs dictation from the terminal or an AI agent: "
+              + "transcribe files, listen, stop, read history, check status, and serve MCP. "
+              + "It installs into your Application Support folder — no administrator rights, "
+              + "and your shell profile is never edited for you."
+          )
+          .font(.callout)
+          .foregroundStyle(.secondary)
+
+          automationCLIStatus
+          automationCLIActions
+        }
+      }
+      .speakTooltip("Install the standalone speak CLI for terminal and agent automation.")
+    }
+  }
+
+  @ViewBuilder
+  private var automationCLIStatus: some View {
+    switch cliInstaller.state {
+    case .notInstalled:
+      SettingsInlineInfo(
+        title: "Not installed",
+        message: "Install the CLI to use speak from the terminal, scripts, or MCP clients.",
+        systemImage: "terminal"
+      )
+    case .unavailable(let message):
+      SettingsInlineInfo(title: "Not available", message: message, systemImage: "exclamationmark.circle")
+    case .installing(let phase):
+      automationCLIProgress(for: phase)
+    case .installed(let cli):
+      automationCLIInstalledDetails(cli, updateAvailable: nil)
+    case .updateAvailable(let cli, let latest):
+      automationCLIInstalledDetails(cli, updateAvailable: latest)
+    case .failed(let message, let installed):
+      SettingsInlineInfo(
+        title: installed == nil ? "Installation failed" : "Update failed",
+        message: installed == nil
+          ? message
+          : "\(message) The previously installed CLI is still in place.",
+        systemImage: "xmark.octagon"
+      )
+      if let installed {
+        automationCLIInstalledDetails(installed, updateAvailable: nil)
+      }
+    }
+  }
+
+  private func automationCLIProgress(for phase: SpeakCLIInstaller.Phase) -> some View {
+    HStack(spacing: 10) {
+      switch phase {
+      case .downloading(let fraction?):
+        ProgressView(value: fraction).frame(maxWidth: 220)
+        Text("Downloading \(Int(fraction * 100))%")
+      case .downloading(nil):
+        ProgressView().controlSize(.small)
+        Text("Downloading")
+      case .verifying:
+        ProgressView().controlSize(.small)
+        Text("Verifying signature and checksum")
+      case .installing:
+        ProgressView().controlSize(.small)
+        Text("Installing")
+      }
+    }
+    .font(.callout)
+    .foregroundStyle(.secondary)
+    .accessibilityElement(children: .combine)
+  }
+
+  private func automationCLIInstalledDetails(
+    _ cli: SpeakCLIInstaller.InstalledCLI,
+    updateAvailable: String?
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      LabeledContent("Version", value: cli.version)
+      LabeledContent("Architecture", value: cli.architecture)
+      LabeledContent("Path") {
+        Text(cliInstaller.executableURL.path)
+          .font(.caption.monospaced())
+          .textSelection(.enabled)
+      }
+      if let updateAvailable {
+        SettingsInlineInfo(
+          title: "Update available",
+          message: "Version \(updateAvailable) of the CLI is published. The app itself is not changed.",
+          systemImage: "arrow.down.circle"
+        )
+      }
+      if !cliInstaller.isCompatible(cli) {
+        SettingsInlineInfo(
+          title: "Protocol mismatch",
+          message: "This CLI speaks automation protocol v\(cli.automationSchemaVersion); the app speaks "
+            + "v\(cliInstaller.dependencies.automationSchemaVersion). Update the CLI.",
+          systemImage: "exclamationmark.triangle"
+        )
+      }
+    }
+    .font(.callout)
+  }
+
+  @ViewBuilder
+  private var automationCLIActions: some View {
+    let state = cliInstaller.state
+    HStack(spacing: 8) {
+      switch state {
+      case .notInstalled, .unavailable:
+        Button("Install CLI") { Task { await cliInstaller.install() } }
+          .buttonStyle(.borderedProminent)
+          .disabled(state.isBusy)
+        Button("Check again") { Task { await cliInstaller.checkForUpdate() } }
+          .buttonStyle(.bordered)
+      case .installing:
+        EmptyView()
+      case .installed:
+        Button("Check for update") { Task { await cliInstaller.checkForUpdate() } }
+          .buttonStyle(.bordered)
+        automationCLIPathButtons
+        Button("Uninstall", role: .destructive) { cliInstaller.uninstall() }
+          .buttonStyle(.bordered)
+      case .updateAvailable:
+        Button("Update CLI") { Task { await cliInstaller.install() } }
+          .buttonStyle(.borderedProminent)
+        automationCLIPathButtons
+        Button("Uninstall", role: .destructive) { cliInstaller.uninstall() }
+          .buttonStyle(.bordered)
+      case .failed(_, let installed):
+        Button(installed == nil ? "Retry install" : "Retry update") { Task { await cliInstaller.install() } }
+          .buttonStyle(.borderedProminent)
+        if installed != nil {
+          automationCLIPathButtons
+          Button("Uninstall", role: .destructive) { cliInstaller.uninstall() }
+            .buttonStyle(.bordered)
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var automationCLIPathButtons: some View {
+    Button("Copy PATH command") {
+      NSPasteboard.general.clearContents()
+      NSPasteboard.general.setString(cliInstaller.pathCommand, forType: .string)
+    }
+    .buttonStyle(.bordered)
+    .speakTooltip(cliInstaller.pathCommand)
+    Button("Reveal in Finder") {
+      NSWorkspace.shared.activateFileViewerSelecting([cliInstaller.executableURL])
+    }
+    .buttonStyle(.bordered)
+  }
+}

--- a/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
@@ -545,6 +545,8 @@ extension SettingsView {
       }
       .speakTooltip("Control Speak from scripts, the terminal, or an AI agent over a local socket.")
 
+      automationCLICard
+
       SettingsCard(title: "Housekeeping", systemImage: "tray.full", tint: Color.brandAccentWarm) {
         VStack(alignment: .leading, spacing: 12) {
           HStack(alignment: .top, spacing: 12) {

--- a/Sources/SpeakAutomationKit/SpeakCLIVersion.swift
+++ b/Sources/SpeakAutomationKit/SpeakCLIVersion.swift
@@ -1,27 +1,36 @@
 import Foundation
+import MachO
 
 /// Version reported by `speak --version` and by the MCP `serverInfo`.
 ///
-/// Resolved from the enclosing app bundle when the CLI runs from inside
-/// `JustSpeakToIt.app`, so the shipped binary can never disagree with the app it
-/// talks to. Homebrew links the same embedded binary, so the fallback only
-/// applies to unpackaged development builds.
+/// Resolution order:
+/// 1. A version the release build linked into the executable itself (a
+///    `__TEXT,__speak_ver` section), so a standalone CLI installed under
+///    Application Support or by Homebrew describes itself without any bundle
+///    around it (issue #775).
+/// 2. The enclosing `JustSpeakToIt.app` bundle, for the CLI embedded at
+///    `Contents/MacOS/speak`, so it can never disagree with the app it talks to.
+/// 3. A development fallback for unpackaged builds.
 public enum SpeakCLIVersion {
     static let fallback = "0.0.0-dev"
+    /// Section the release build creates with `-sectcreate __TEXT __speak_ver <file>`.
+    public static let embeddedSectionSegment = "__TEXT"
+    public static let embeddedSectionName = "__speak_ver"
 
     public static var current: String {
         Self.resolve()
     }
 
-    /// `speak` is a plain executable, so `Bundle.main` describes the binary rather
-    /// than the app that contains it. When the binary is the one embedded at
-    /// `JustSpeakToIt.app/Contents/MacOS/speak`, walk up to that bundle and read
-    /// its version; otherwise this is an unpackaged development build.
     static func resolve(
+        embeddedVersion: () -> Data? = Self.embeddedVersionData,
+        mainBundleVersion: () -> String? = Self.mainBundleVersion,
         executableURL: URL? = Bundle.main.executableURL,
         bundleLoader: (URL) -> Bundle? = Bundle.init(url:)
     ) -> String {
-        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String, !version.isEmpty {
+        if let embedded = embeddedVersion().flatMap(Self.parseEmbeddedVersion) {
+            return embedded
+        }
+        if let version = mainBundleVersion(), !version.isEmpty {
             return version
         }
         guard let executableURL else { return self.fallback }
@@ -36,5 +45,32 @@ public enum SpeakCLIVersion {
             return self.fallback
         }
         return version
+    }
+
+    /// The version of the bundle this process runs from, when it has one.
+    static func mainBundleVersion() -> String? {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+
+    /// The linked section's bytes are a version string, possibly padded with
+    /// whitespace or NUL bytes; anything else is ignored.
+    static func parseEmbeddedVersion(_ data: Data) -> String? {
+        let trimmed = data.prefix { $0 != 0 }
+        guard let text = String(data: Data(trimmed), encoding: .utf8) else { return nil }
+        let version = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !version.isEmpty, version.count <= 64,
+              version.allSatisfy({ $0.isLetter || $0.isNumber || ".-+".contains($0) })
+        else { return nil }
+        return version
+    }
+
+    /// Reads `__TEXT,__speak_ver` from the main executable image, if present.
+    static func embeddedVersionData() -> Data? {
+        guard let header = _dyld_get_image_header(0) else { return nil }
+        var size: UInt = 0
+        guard let bytes = header.withMemoryRebound(to: mach_header_64.self, capacity: 1, { header64 in
+            getsectiondata(header64, embeddedSectionSegment, embeddedSectionName, &size)
+        }), size > 0 else { return nil }
+        return Data(bytes: bytes, count: Int(size))
     }
 }

--- a/Sources/SpeakCore/DistributionChannel.swift
+++ b/Sources/SpeakCore/DistributionChannel.swift
@@ -82,6 +82,10 @@ public enum ChannelFeature: String, Sendable, CaseIterable {
     /// External runtimes (llama.cpp / sherpa-onnx) that install or spawn executable
     /// code and therefore cannot be offered in the App Store sandbox.
     case externalLocalModelRuntime
+    /// Downloading and installing the standalone `speak` CLI into the user's
+    /// Application Support folder — executable code the App Store sandbox
+    /// cannot place or run (issue #775).
+    case standaloneCLIInstaller
     /// Automatically prompting the user for Accessibility. Sandboxed builds cannot show the
     /// Accessibility prompt (`AXIsProcessTrustedWithOptions` is inert under the sandbox), so the
     /// user must add the app manually in System Settings. Input Monitoring is unaffected — it
@@ -110,7 +114,7 @@ public extension DistributionChannel {
     /// Whether `feature` is available in this build.
     func supports(_ feature: ChannelFeature) -> Bool {
         switch feature {
-        case .selfUpdate, .externalLocalModelRuntime, .automaticAccessibilityPrompt,
+        case .selfUpdate, .externalLocalModelRuntime, .standaloneCLIInstaller, .automaticAccessibilityPrompt,
              .accessibilityTextInsertion, .crossChannelMessaging:
             return self == .direct
         case .iCloudSync, .encryptedCloudKitKeySync:
@@ -133,6 +137,9 @@ public extension DistributionChannel {
 
     /// Installable executable local runtimes such as sherpa-onnx and llama.cpp (direct only).
     var supportsExternalLocalModelRuntime: Bool { supports(.externalLocalModelRuntime) }
+
+    /// Whether this build can install the standalone `speak` CLI (direct only).
+    var supportsStandaloneCLIInstaller: Bool { supports(.standaloneCLIInstaller) }
 
     /// Whether the app can auto-prompt for Accessibility.
     /// When `false` (App Store), guide the user to add the app manually instead.

--- a/Sources/SpeakCore/SpeakCLIManifest.swift
+++ b/Sources/SpeakCore/SpeakCLIManifest.swift
@@ -1,0 +1,117 @@
+import CryptoKit
+import Foundation
+
+/// Describes the standalone `speak` CLI assets published alongside a macOS
+/// release, so the app can install and update the CLI independently of the
+/// app bundle (issue #775).
+///
+/// The manifest is published as a release asset next to a detached Ed25519
+/// signature made with the same key that signs Sparkle updates, so the app
+/// verifies it with the `SUPublicEDKey` it already ships. Only a manifest that
+/// verifies is trusted for the per-asset byte counts and SHA-256 digests.
+public struct SpeakCLIManifest: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
+    /// Release asset names; the manifest and its signature sit next to the CLI archives.
+    public static let manifestAssetName = "speak-cli-manifest.json"
+    public static let signatureAssetName = "speak-cli-manifest.json.sig"
+
+    public struct Asset: Codable, Equatable, Sendable {
+        /// `arm64` or `x86_64`, matching `uname -m` on the target Mac.
+        public let architecture: String
+        public let url: URL
+        public let byteCount: Int
+        /// Lowercase hex SHA-256 of the archive at `url`.
+        public let sha256: String
+
+        public init(architecture: String, url: URL, byteCount: Int, sha256: String) {
+            self.architecture = architecture
+            self.url = url
+            self.byteCount = byteCount
+            self.sha256 = sha256
+        }
+    }
+
+    public let schemaVersion: Int
+    /// Marketing version of the CLI, identical to the app release it shipped with.
+    public let version: String
+    /// `AutomationSchema.currentVersion` the CLI was built against.
+    public let automationSchemaVersion: Int
+    public let assets: [Asset]
+
+    public init(
+        schemaVersion: Int = SpeakCLIManifest.currentSchemaVersion,
+        version: String,
+        automationSchemaVersion: Int,
+        assets: [Asset]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.version = version
+        self.automationSchemaVersion = automationSchemaVersion
+        self.assets = assets
+    }
+
+    public func asset(for architecture: String) -> Asset? {
+        assets.first { $0.architecture.caseInsensitiveCompare(architecture) == .orderedSame }
+    }
+
+    /// Asset names as the release workflow publishes them.
+    public static func archiveName(version: String, architecture: String) -> String {
+        "speak-\(version)-\(architecture).zip"
+    }
+}
+
+public enum SpeakCLIManifestError: LocalizedError, Equatable {
+    case invalidPublicKey
+    case invalidSignature
+    case signatureMismatch
+    case unsupportedSchema(Int)
+    case malformed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidPublicKey:
+            return "The app's update signing key is missing or malformed, so the CLI manifest cannot be verified."
+        case .invalidSignature:
+            return "The CLI manifest signature is malformed."
+        case .signatureMismatch:
+            return "The CLI manifest signature does not match. The download was not trusted."
+        case .unsupportedSchema(let version):
+            return "The CLI manifest uses format \(version), which this app does not understand. Update the app."
+        case .malformed(let detail):
+            return "The CLI manifest could not be read: \(detail)"
+        }
+    }
+}
+
+public enum SpeakCLIManifestVerifier {
+    /// Verifies `signatureBase64` (an Ed25519 signature over the exact manifest
+    /// bytes, as produced by Sparkle's `sign_update`) against the Sparkle
+    /// public key, then decodes the manifest. Nothing in the manifest is used
+    /// before the signature checks out.
+    public static func verifiedManifest(
+        manifestData: Data,
+        signatureBase64: String,
+        publicKeyBase64: String?
+    ) throws -> SpeakCLIManifest {
+        guard let publicKeyBase64,
+              let keyBytes = Data(base64Encoded: publicKeyBase64.trimmingCharacters(in: .whitespacesAndNewlines)),
+              let publicKey = try? Curve25519.Signing.PublicKey(rawRepresentation: keyBytes)
+        else { throw SpeakCLIManifestError.invalidPublicKey }
+        guard let signature = Data(base64Encoded: signatureBase64.trimmingCharacters(in: .whitespacesAndNewlines)),
+              signature.count == 64
+        else { throw SpeakCLIManifestError.invalidSignature }
+        guard publicKey.isValidSignature(signature, for: manifestData) else {
+            throw SpeakCLIManifestError.signatureMismatch
+        }
+        let manifest: SpeakCLIManifest
+        do {
+            manifest = try JSONDecoder().decode(SpeakCLIManifest.self, from: manifestData)
+        } catch {
+            throw SpeakCLIManifestError.malformed(error.localizedDescription)
+        }
+        guard manifest.schemaVersion == SpeakCLIManifest.currentSchemaVersion else {
+            throw SpeakCLIManifestError.unsupportedSchema(manifest.schemaVersion)
+        }
+        return manifest
+    }
+}

--- a/Tests/SpeakAppTests/MachOArchitecturesTests.swift
+++ b/Tests/SpeakAppTests/MachOArchitecturesTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import XCTest
+
+@testable import SpeakApp
+
+/// The installer refuses a wrong-architecture executable by reading Mach-O
+/// headers directly (issue #775).
+final class MachOArchitecturesTests: XCTestCase {
+  func testThinLittleEndianHeader_reportsItsSlice() throws {
+    XCTAssertEqual(try MachOArchitectures.architectures(in: MachOFixtures.thin(architecture: "arm64")), ["arm64"])
+    XCTAssertEqual(try MachOArchitectures.architectures(in: MachOFixtures.thin(architecture: "x86_64")), ["x86_64"])
+  }
+
+  func testFatHeader_reportsEverySlice() throws {
+    XCTAssertEqual(
+      try MachOArchitectures.architectures(in: MachOFixtures.fat(["x86_64", "arm64"])),
+      ["arm64", "x86_64"]
+    )
+  }
+
+  func testNonMachOData_isRejected() {
+    XCTAssertThrowsError(try MachOArchitectures.architectures(in: Data("#!/bin/sh\necho hi\n".utf8)))
+    XCTAssertThrowsError(try MachOArchitectures.architectures(in: Data([0xCA, 0xFE])))
+  }
+
+  func testSystemBinary_isReadable() throws {
+    let slices = try MachOArchitectures.architectures(of: URL(fileURLWithPath: "/bin/ls"))
+    XCTAssertFalse(slices.isEmpty)
+    XCTAssertTrue(slices.isSubset(of: ["arm64", "x86_64"]))
+  }
+}
+
+/// Synthetic Mach-O headers shared with the installer tests.
+enum MachOFixtures {
+  private static let cpuTypes: [String: UInt32] = ["arm64": 0x0100_000C, "x86_64": 0x0100_0007]
+
+  /// A 64-bit little-endian thin header (magic 0xFEEDFACF stored byte-swapped) with padding.
+  static func thin(architecture: String) -> Data {
+    var data = Data([0xCF, 0xFA, 0xED, 0xFE])
+    data.append(littleEndian(cpuTypes[architecture] ?? 0))
+    data.append(Data(repeating: 0, count: 24))
+    return data
+  }
+
+  /// A fat header (always big-endian) with one entry per slice.
+  static func fat(_ architectures: [String]) -> Data {
+    var data = Data([0xCA, 0xFE, 0xBA, 0xBE])
+    data.append(bigEndian(UInt32(architectures.count)))
+    for architecture in architectures {
+      data.append(bigEndian(cpuTypes[architecture] ?? 0))
+      data.append(Data(repeating: 0, count: 16))
+    }
+    return data
+  }
+
+  private static func bigEndian(_ value: UInt32) -> Data {
+    Data([UInt8(value >> 24 & 0xFF), UInt8(value >> 16 & 0xFF), UInt8(value >> 8 & 0xFF), UInt8(value & 0xFF)])
+  }
+
+  private static func littleEndian(_ value: UInt32) -> Data {
+    Data([UInt8(value & 0xFF), UInt8(value >> 8 & 0xFF), UInt8(value >> 16 & 0xFF), UInt8(value >> 24 & 0xFF)])
+  }
+}

--- a/Tests/SpeakAppTests/MachOArchitecturesTests.swift
+++ b/Tests/SpeakAppTests/MachOArchitecturesTests.swift
@@ -18,6 +18,17 @@ final class MachOArchitecturesTests: XCTestCase {
     )
   }
 
+  func testByteSwappedFatHeader_reportsEverySlice() throws {
+    // FAT_CIGAM: the magic reads byte-swapped, so the count and every
+    // cputype are little-endian too. Reading them big-endian turns a
+    // one-slice header into a count of 16,777,216 and rejects the file.
+    XCTAssertEqual(try MachOArchitectures.architectures(in: MachOFixtures.fatSwapped(["arm64"])), ["arm64"])
+    XCTAssertEqual(
+      try MachOArchitectures.architectures(in: MachOFixtures.fatSwapped(["x86_64", "arm64"])),
+      ["arm64", "x86_64"]
+    )
+  }
+
   func testNonMachOData_isRejected() {
     XCTAssertThrowsError(try MachOArchitectures.architectures(in: Data("#!/bin/sh\necho hi\n".utf8)))
     XCTAssertThrowsError(try MachOArchitectures.architectures(in: Data([0xCA, 0xFE])))
@@ -48,6 +59,17 @@ enum MachOFixtures {
     data.append(bigEndian(UInt32(architectures.count)))
     for architecture in architectures {
       data.append(bigEndian(cpuTypes[architecture] ?? 0))
+      data.append(Data(repeating: 0, count: 16))
+    }
+    return data
+  }
+
+  /// A byte-swapped fat header (FAT_CIGAM): every field little-endian.
+  static func fatSwapped(_ architectures: [String]) -> Data {
+    var data = Data([0xBE, 0xBA, 0xFE, 0xCA])
+    data.append(littleEndian(UInt32(architectures.count)))
+    for architecture in architectures {
+      data.append(littleEndian(cpuTypes[architecture] ?? 0))
       data.append(Data(repeating: 0, count: 16))
     }
     return data

--- a/Tests/SpeakAppTests/SpeakCLIInstallerTestWorld.swift
+++ b/Tests/SpeakAppTests/SpeakCLIInstallerTestWorld.swift
@@ -1,0 +1,188 @@
+import CryptoKit
+import Foundation
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// A fake release: signed manifest, downloadable archives whose "executable"
+/// is a synthetic Mach-O header, and switches to corrupt each verification step.
+@MainActor
+final class FakeReleaseWorld {
+  let installDirectory: URL
+  let signingKey = Curve25519.Signing.PrivateKey()
+  var hardwareArchitecture: String
+  var automationSchemaVersion: Int
+  /// Architecture of the executable inside the archive built for this Mac;
+  /// defaults to the hardware's, and is changed to simulate a mislabelled asset.
+  var executableArchitecture: String { didSet { servedManifest = nil } }
+  var corruptByteCount = false { didSet { servedManifest = nil } }
+  var corruptDigest = false { didSet { servedManifest = nil } }
+  var tamperManifest = false
+  var manifestPublished = true
+  private let signatureGate = SignatureGate()
+  private(set) var downloadedURLs: [URL] = []
+  /// The manifest bytes a real server keeps serving for one published state,
+  /// so the detached signature covers exactly what the manifest fetch returned.
+  private var servedManifest: Data?
+
+  /// The code-signing check runs synchronously off the main actor, so its
+  /// switch and counter live behind a lock rather than on this class.
+  var rejectSignature: Bool {
+    get { signatureGate.reject }
+    set { signatureGate.reject = newValue }
+  }
+
+  var signatureChecks: Int { signatureGate.checks }
+  private var version: String
+  private var archives: [String: Data] = [:]
+  private let root: URL
+
+  init(
+    version: String,
+    hardwareArchitecture: String = "arm64",
+    automationSchemaVersion: Int = AutomationSchema.currentVersion
+  ) throws {
+    self.version = version
+    self.hardwareArchitecture = hardwareArchitecture
+    self.executableArchitecture = hardwareArchitecture
+    self.automationSchemaVersion = automationSchemaVersion
+    root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("speak-cli-installer-tests-\(UUID().uuidString)", isDirectory: true)
+    installDirectory = root.appendingPathComponent("bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    publish(version: version)
+  }
+
+  deinit {
+    try? FileManager.default.removeItem(at: root)
+  }
+
+  var executableBytes: Data { executableBytes(for: version) }
+
+  func executableBytes(for version: String) -> Data {
+    var data = MachOFixtures.thin(architecture: executableArchitecture)
+    data.append(Data("speak \(version)".utf8))
+    return data
+  }
+
+  /// Publishes a new release version with fresh archives for both architectures.
+  func publish(version: String) {
+    self.version = version
+    servedManifest = nil
+    for architecture in ["arm64", "x86_64"] {
+      var payload = MachOFixtures.thin(architecture: architecture)
+      payload.append(Data("speak \(version)".utf8))
+      // The "zip" is the executable bytes themselves; extraction copies them.
+      archives[SpeakCLIManifest.archiveName(version: version, architecture: architecture)] = payload
+    }
+  }
+
+  private func manifestData() throws -> Data {
+    let assets = ["arm64", "x86_64"].map { architecture -> SpeakCLIManifest.Asset in
+      let name = SpeakCLIManifest.archiveName(version: version, architecture: architecture)
+      var archive = archives[name] ?? Data()
+      if architecture == hardwareArchitecture {
+        archive = executableBytes
+        archives[name] = archive
+      }
+      let digest = SHA256.hash(data: archive).map { String(format: "%02x", $0) }.joined()
+      return SpeakCLIManifest.Asset(
+        architecture: architecture,
+        url: URL(string: "https://example.com/releases/\(name)")!,
+        byteCount: archive.count + (corruptByteCount ? 1 : 0),
+        sha256: corruptDigest ? String(repeating: "0", count: 64) : digest
+      )
+    }
+    let manifest = SpeakCLIManifest(
+      version: version, automationSchemaVersion: automationSchemaVersion, assets: assets
+    )
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    return try encoder.encode(manifest)
+  }
+
+  private func currentManifest() throws -> Data {
+    if let servedManifest { return servedManifest }
+    let data = try manifestData()
+    servedManifest = data
+    return data
+  }
+
+  func makeInstaller() -> SpeakCLIInstaller {
+    let dependencies = SpeakCLIInstallerDependencies(
+      fetchData: { [weak self] url in
+        guard let self else { throw CancellationError() }
+        return try await self.fetch(url)
+      },
+      download: { [weak self] url, progress in
+        guard let self else { throw CancellationError() }
+        return try await self.download(url, progress: progress)
+      },
+      extractExecutable: { archive, directory in
+        let executable = directory.appendingPathComponent("speak")
+        try FileManager.default.copyItem(at: archive, to: executable)
+        return executable
+      },
+      verifyCodeSignature: { [signatureGate] _ in
+        signatureGate.recordCheck()
+        if signatureGate.reject {
+          throw SpeakCLIInstallerError.codeSignatureRejected("test rejection")
+        }
+      },
+      hardwareArchitecture: { [hardwareArchitecture] in hardwareArchitecture },
+      publicKeyBase64: signingKey.publicKey.rawRepresentation.base64EncodedString(),
+      automationSchemaVersion: AutomationSchema.currentVersion,
+      manifestURL: URL(string: "https://example.com/releases/speak-cli-manifest.json")!,
+      signatureURL: URL(string: "https://example.com/releases/speak-cli-manifest.json.sig")!,
+      installDirectory: installDirectory
+    )
+    return SpeakCLIInstaller(dependencies: dependencies)
+  }
+
+  private func fetch(_ url: URL) async throws -> Data {
+    guard manifestPublished else {
+      throw SpeakCLIInstallerDependencies.TransportError.notPublished(url)
+    }
+    let manifest = try currentManifest()
+    switch url.lastPathComponent {
+    case SpeakCLIManifest.manifestAssetName:
+      return tamperManifest ? manifest + Data(" ".utf8) : manifest
+    case SpeakCLIManifest.signatureAssetName:
+      return Data(try signingKey.signature(for: manifest).base64EncodedString().utf8)
+    default:
+      throw SpeakCLIInstallerDependencies.TransportError.httpStatus(404, url)
+    }
+  }
+
+  private func download(_ url: URL, progress: @escaping @Sendable (Double) -> Void) async throws -> URL {
+    downloadedURLs.append(url)
+    guard let payload = archives[url.lastPathComponent] else {
+      throw SpeakCLIInstallerDependencies.TransportError.httpStatus(404, url)
+    }
+    let directory = root.appendingPathComponent("download-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let file = directory.appendingPathComponent(url.lastPathComponent)
+    try payload.write(to: file)
+    progress(1)
+    return file
+  }
+}
+
+/// Lock-protected switch and counter for the synchronous code-signing seam.
+final class SignatureGate: @unchecked Sendable {
+  private let lock = NSLock()
+  private var rejectValue = false
+  private var checkCount = 0
+
+  var reject: Bool {
+    get { lock.withLock { rejectValue } }
+    set { lock.withLock { rejectValue = newValue } }
+  }
+
+  var checks: Int { lock.withLock { checkCount } }
+
+  func recordCheck() {
+    lock.withLock { checkCount += 1 }
+  }
+}

--- a/Tests/SpeakAppTests/SpeakCLIInstallerTestWorld.swift
+++ b/Tests/SpeakAppTests/SpeakCLIInstallerTestWorld.swift
@@ -21,7 +21,15 @@ final class FakeReleaseWorld {
   var tamperManifest = false
   var manifestPublished = true
   private let signatureGate = SignatureGate()
+  private let recordGate = SignatureGate()
   private(set) var downloadedURLs: [URL] = []
+
+  /// When set, committing the installation record fails after the executable
+  /// has already been replaced — the hardest point for consistency.
+  var failRecordCommit: Bool {
+    get { recordGate.reject }
+    set { recordGate.reject = newValue }
+  }
   /// The manifest bytes a real server keeps serving for one published state,
   /// so the detached signature covers exactly what the manifest fetch returned.
   private var servedManifest: Data?
@@ -131,6 +139,10 @@ final class FakeReleaseWorld {
         }
       },
       hardwareArchitecture: { [hardwareArchitecture] in hardwareArchitecture },
+      commitRecord: { [recordGate] staged, final in
+        if recordGate.reject { throw CocoaError(.fileWriteUnknown) }
+        try SpeakCLIInstallerDependencies.commitRecord(staged: staged, final: final)
+      },
       publicKeyBase64: signingKey.publicKey.rawRepresentation.base64EncodedString(),
       automationSchemaVersion: AutomationSchema.currentVersion,
       manifestURL: URL(string: "https://example.com/releases/speak-cli-manifest.json")!,

--- a/Tests/SpeakAppTests/SpeakCLIInstallerTests.swift
+++ b/Tests/SpeakAppTests/SpeakCLIInstallerTests.swift
@@ -1,0 +1,217 @@
+import CryptoKit
+import Foundation
+import SpeakCore
+import XCTest
+
+@testable import SpeakApp
+
+/// The standalone CLI install flow must verify everything before touching the
+/// installed executable, replace it atomically, keep a working installation
+/// on failure, and remove only what it owns (issue #775).
+@MainActor
+final class SpeakCLIInstallerTests: XCTestCase {
+  private typealias Installed = SpeakCLIInstaller.InstalledCLI
+
+  // MARK: - Install
+
+  func testInstall_verifiesManifestArchiveArchitectureAndSignatureThenInstalls() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    let installer = world.makeInstaller()
+    XCTAssertEqual(installer.state, .notInstalled)
+
+    await installer.install()
+
+    guard case .installed(let cli) = installer.state else {
+      return XCTFail("Expected installed, got \(installer.state)")
+    }
+    XCTAssertEqual(cli.version, "2.62.0")
+    XCTAssertEqual(cli.architecture, "arm64")
+    XCTAssertEqual(cli.automationSchemaVersion, AutomationSchema.currentVersion)
+    XCTAssertTrue(FileManager.default.isExecutableFile(atPath: installer.executableURL.path))
+    XCTAssertEqual(try Data(contentsOf: installer.executableURL), world.executableBytes)
+    XCTAssertEqual(world.signatureChecks, 1)
+    XCTAssertEqual(installer.latestVersion, "2.62.0")
+    XCTAssertTrue(installer.pathCommand.hasPrefix("export PATH=\"\(world.installDirectory.path):$PATH\""))
+
+    // A fresh installer instance reads the record back without any network access.
+    let reloaded = world.makeInstaller()
+    XCTAssertEqual(reloaded.state, .installed(cli))
+  }
+
+  func testInstall_choosesTheAssetForTheHardwareArchitecture() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0", hardwareArchitecture: "x86_64")
+    let installer = world.makeInstaller()
+
+    await installer.install()
+
+    guard case .installed(let cli) = installer.state else {
+      return XCTFail("Expected installed, got \(installer.state)")
+    }
+    XCTAssertEqual(cli.architecture, "x86_64")
+    XCTAssertEqual(world.downloadedURLs.map(\.lastPathComponent), ["speak-2.62.0-x86_64.zip"])
+  }
+
+  func testInstall_refusesSizeMismatchBeforeInstalling() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    world.corruptByteCount = true
+    let installer = world.makeInstaller()
+
+    await installer.install()
+
+    guard case .failed(let message, let installed) = installer.state else {
+      return XCTFail("Expected failed, got \(installer.state)")
+    }
+    XCTAssertTrue(message.contains("bytes"), message)
+    XCTAssertNil(installed)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: installer.executableURL.path))
+    XCTAssertEqual(world.signatureChecks, 0, "Nothing is signature-checked after a size mismatch")
+  }
+
+  func testInstall_refusesChecksumMismatch() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    world.corruptDigest = true
+    let installer = world.makeInstaller()
+
+    await installer.install()
+
+    guard case .failed(let message, _) = installer.state else {
+      return XCTFail("Expected failed, got \(installer.state)")
+    }
+    XCTAssertTrue(message.contains("SHA-256"), message)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: installer.executableURL.path))
+  }
+
+  func testInstall_refusesTamperedManifest() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    world.tamperManifest = true
+    let installer = world.makeInstaller()
+
+    await installer.install()
+
+    guard case .failed(let message, _) = installer.state else {
+      return XCTFail("Expected failed, got \(installer.state)")
+    }
+    XCTAssertTrue(message.contains("signature"), message)
+    XCTAssertTrue(world.downloadedURLs.isEmpty, "An untrusted manifest must not trigger any download")
+  }
+
+  func testInstall_refusesWrongArchitectureBinary() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    world.executableArchitecture = "x86_64"
+    let installer = world.makeInstaller()
+
+    await installer.install()
+
+    guard case .failed(let message, _) = installer.state else {
+      return XCTFail("Expected failed, got \(installer.state)")
+    }
+    XCTAssertTrue(message.contains("built for x86_64"), message)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: installer.executableURL.path))
+  }
+
+  func testInstall_refusesRejectedCodeSignature() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    world.rejectSignature = true
+    let installer = world.makeInstaller()
+
+    await installer.install()
+
+    guard case .failed(let message, _) = installer.state else {
+      return XCTFail("Expected failed, got \(installer.state)")
+    }
+    XCTAssertTrue(message.contains("not signed"), message)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: installer.executableURL.path))
+  }
+
+  func testInstall_refusesIncompatibleAutomationProtocol() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0", automationSchemaVersion: AutomationSchema.currentVersion + 1)
+    let installer = world.makeInstaller()
+
+    await installer.install()
+
+    guard case .failed(let message, _) = installer.state else {
+      return XCTFail("Expected failed, got \(installer.state)")
+    }
+    XCTAssertTrue(message.contains("protocol"), message)
+    XCTAssertTrue(world.downloadedURLs.isEmpty)
+  }
+
+  func testInstall_whenTheReleaseHasNoCLIYet_reportsUnavailableAfterCheck() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    world.manifestPublished = false
+    let installer = world.makeInstaller()
+
+    await installer.checkForUpdate()
+    guard case .unavailable(let message) = installer.state else {
+      return XCTFail("Expected unavailable, got \(installer.state)")
+    }
+    XCTAssertTrue(message.contains("not published"), message)
+
+    await installer.install()
+    guard case .failed = installer.state else {
+      return XCTFail("Expected failed, got \(installer.state)")
+    }
+  }
+
+  // MARK: - Update
+
+  func testUpdate_replacesTheExecutableAndKeepsTheOldOneWhenTheNewOneFails() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    let installer = world.makeInstaller()
+    await installer.install()
+    guard case .installed(let first) = installer.state else { return XCTFail("install failed") }
+
+    world.publish(version: "2.63.0")
+    await installer.checkForUpdate()
+    XCTAssertEqual(installer.state, .updateAvailable(installed: first, latest: "2.63.0"))
+
+    // The new build is rejected: the 2.62.0 executable must survive untouched.
+    world.rejectSignature = true
+    await installer.install()
+    guard case .failed(_, let kept) = installer.state else { return XCTFail("Expected failed") }
+    XCTAssertEqual(kept, first)
+    XCTAssertEqual(try Data(contentsOf: installer.executableURL), world.executableBytes(for: "2.62.0"))
+
+    world.rejectSignature = false
+    await installer.install()
+    guard case .installed(let second) = installer.state else { return XCTFail("Expected installed") }
+    XCTAssertEqual(second.version, "2.63.0")
+    XCTAssertEqual(try Data(contentsOf: installer.executableURL), world.executableBytes(for: "2.63.0"))
+  }
+
+  // MARK: - Uninstall
+
+  func testUninstall_removesOnlyOwnedFiles() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    let installer = world.makeInstaller()
+    await installer.install()
+    let foreign = world.installDirectory.appendingPathComponent("user-script.sh")
+    try Data("#!/bin/sh\n".utf8).write(to: foreign)
+
+    installer.uninstall()
+
+    XCTAssertEqual(installer.state, .notInstalled)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: installer.executableURL.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: foreign.path), "Files the installer did not write stay")
+    XCTAssertTrue(FileManager.default.fileExists(atPath: world.installDirectory.path))
+
+    try FileManager.default.removeItem(at: foreign)
+    await installer.install()
+    installer.uninstall()
+    XCTAssertFalse(
+      FileManager.default.fileExists(atPath: world.installDirectory.path),
+      "An empty install directory is removed"
+    )
+  }
+
+  func testCompatibility_flagsACLIBuiltForAnotherProtocol() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    let installer = world.makeInstaller()
+    let stale = Installed(
+      version: "1.0.0", architecture: "arm64", sha256: "", automationSchemaVersion: 0, installedAt: Date()
+    )
+    XCTAssertFalse(installer.isCompatible(stale))
+    await installer.install()
+    XCTAssertTrue(installer.isCompatible(try XCTUnwrap(installer.state.installed)))
+  }
+}

--- a/Tests/SpeakAppTests/SpeakCLIInstallerTests.swift
+++ b/Tests/SpeakAppTests/SpeakCLIInstallerTests.swift
@@ -179,6 +179,33 @@ final class SpeakCLIInstallerTests: XCTestCase {
     XCTAssertEqual(try Data(contentsOf: installer.executableURL), world.executableBytes(for: "2.63.0"))
   }
 
+  func testUpdate_whenTheRecordCannotBeCommitted_neverDescribesTheWrongBinary() async throws {
+    let world = try FakeReleaseWorld(version: "2.62.0")
+    let installer = world.makeInstaller()
+    await installer.install()
+    guard case .installed(let first) = installer.state else { return XCTFail("install failed") }
+
+    // The new executable lands but its record cannot be committed: the old
+    // record must not survive to describe a binary that is no longer there.
+    world.publish(version: "2.63.0")
+    world.failRecordCommit = true
+    await installer.install()
+    guard case .failed(_, let installed) = installer.state else { return XCTFail("Expected failed") }
+    XCTAssertEqual(installed, first, "the failure reports what was installed before the attempt")
+    XCTAssertEqual(try Data(contentsOf: installer.executableURL), world.executableBytes(for: "2.63.0"))
+    let recordPath = world.installDirectory.appendingPathComponent("installed.json").path
+    XCTAssertFalse(FileManager.default.fileExists(atPath: recordPath))
+    installer.refresh()
+    XCTAssertEqual(installer.state, .notInstalled, "without a trustworthy record nothing claims to be installed")
+
+    // A retry with a working disk recovers fully.
+    world.failRecordCommit = false
+    await installer.install()
+    guard case .installed(let second) = installer.state else { return XCTFail("Expected installed") }
+    XCTAssertEqual(second.version, "2.63.0")
+    XCTAssertEqual(world.makeInstaller().state, .installed(second))
+  }
+
   // MARK: - Uninstall
 
   func testUninstall_removesOnlyOwnedFiles() async throws {

--- a/Tests/SpeakAutomationKitTests/SpeakCLIVersionTests.swift
+++ b/Tests/SpeakAutomationKitTests/SpeakCLIVersionTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import XCTest
+
+@testable import SpeakAutomationKit
+
+/// `speak --version` must describe a standalone binary from the version linked
+/// into it, fall back to the enclosing app bundle for the embedded CLI, and
+/// never invent a version (issue #775).
+final class SpeakCLIVersionTests: XCTestCase {
+    func testEmbeddedVersion_winsWhenPresent() {
+        let version = SpeakCLIVersion.resolve(
+            embeddedVersion: { Data("2.62.0\n\u{0}\u{0}".utf8) },
+            mainBundleVersion: { "9.9.9" },
+            executableURL: URL(fileURLWithPath: "/Applications/JustSpeakToIt.app/Contents/MacOS/speak"),
+            bundleLoader: { _ in nil }
+        )
+        XCTAssertEqual(version, "2.62.0")
+    }
+
+    func testWithoutEmbeddedVersion_fallsBackToTheDevelopmentVersion() {
+        // A bare executable under Application Support: no linked version, no
+        // bundle of its own, no enclosing app. Nothing can vouch for a version.
+        let version = SpeakCLIVersion.resolve(
+            embeddedVersion: { nil },
+            mainBundleVersion: { nil },
+            executableURL: URL(fileURLWithPath: "/Users/me/Library/Application Support/SpeakApp/bin/speak"),
+            bundleLoader: { _ in nil }
+        )
+        XCTAssertEqual(version, "0.0.0-dev")
+    }
+
+    func testWithoutEmbeddedVersion_usesTheEnclosingAppBundle() throws {
+        let bundle = try XCTUnwrap(Bundle(for: SpeakCLIVersionTests.self) as Bundle?)
+        let version = SpeakCLIVersion.resolve(
+            embeddedVersion: { nil },
+            mainBundleVersion: { nil },
+            executableURL: URL(fileURLWithPath: "/Applications/JustSpeakToIt.app/Contents/MacOS/speak"),
+            bundleLoader: { url in url.lastPathComponent == "JustSpeakToIt.app" ? bundle : nil }
+        )
+        XCTAssertEqual(version, bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0-dev")
+    }
+
+    func testEmbeddedSection_rejectsGarbage() {
+        XCTAssertNil(SpeakCLIVersion.parseEmbeddedVersion(Data()))
+        XCTAssertNil(SpeakCLIVersion.parseEmbeddedVersion(Data([0xFF, 0xFE, 0x00])))
+        XCTAssertNil(SpeakCLIVersion.parseEmbeddedVersion(Data("   \n".utf8)))
+        XCTAssertNil(SpeakCLIVersion.parseEmbeddedVersion(Data("2.62.0; rm -rf /".utf8)))
+        XCTAssertEqual(
+            SpeakCLIVersion.parseEmbeddedVersion(Data(" 2.62.0-beta.1+build7 ".utf8)),
+            "2.62.0-beta.1+build7"
+        )
+    }
+
+    func testSectionNames_matchTheReleaseBuildFlags() {
+        XCTAssertEqual(SpeakCLIVersion.embeddedSectionSegment, "__TEXT")
+        XCTAssertEqual(SpeakCLIVersion.embeddedSectionName, "__speak_ver")
+    }
+
+    func testDevelopmentBuild_hasNoEmbeddedSection() {
+        // The test binary is not linked with -sectcreate, so the live reader must return nil, not crash.
+        XCTAssertNil(SpeakCLIVersion.embeddedVersionData())
+    }
+}

--- a/Tests/SpeakCoreTests/SpeakCLIManifestTests.swift
+++ b/Tests/SpeakCoreTests/SpeakCLIManifestTests.swift
@@ -1,0 +1,124 @@
+import CryptoKit
+import Foundation
+import XCTest
+
+@testable import SpeakCore
+
+/// The CLI manifest is trusted only when its detached Ed25519 signature
+/// verifies against the Sparkle public key (issue #775).
+final class SpeakCLIManifestTests: XCTestCase {
+    private let signingKey = Curve25519.Signing.PrivateKey()
+    private var publicKeyBase64: String { signingKey.publicKey.rawRepresentation.base64EncodedString() }
+
+    private func makeManifest(version: String = "2.62.0", schema: Int = SpeakCLIManifest.currentSchemaVersion)
+        -> SpeakCLIManifest {
+        SpeakCLIManifest(
+            schemaVersion: schema,
+            version: version,
+            automationSchemaVersion: AutomationSchema.currentVersion,
+            assets: [
+                .init(
+                    architecture: "arm64",
+                    url: URL(string: "https://example.com/speak-\(version)-arm64.zip")!,
+                    byteCount: 1234,
+                    sha256: String(repeating: "a", count: 64)
+                ),
+                .init(
+                    architecture: "x86_64",
+                    url: URL(string: "https://example.com/speak-\(version)-x86_64.zip")!,
+                    byteCount: 2345,
+                    sha256: String(repeating: "b", count: 64)
+                )
+            ]
+        )
+    }
+
+    private func sign(_ data: Data) throws -> String {
+        try signingKey.signature(for: data).base64EncodedString()
+    }
+
+    func testVerifiedManifest_acceptsAValidSignature() throws {
+        let manifest = makeManifest()
+        let data = try JSONEncoder().encode(manifest)
+
+        let verified = try SpeakCLIManifestVerifier.verifiedManifest(
+            manifestData: data, signatureBase64: try sign(data), publicKeyBase64: publicKeyBase64
+        )
+
+        XCTAssertEqual(verified, manifest)
+        XCTAssertEqual(verified.asset(for: "ARM64")?.byteCount, 1234, "Architecture lookup is case-insensitive")
+        XCTAssertNil(verified.asset(for: "riscv"))
+    }
+
+    func testVerifiedManifest_rejectsTamperedBytes() throws {
+        let data = try JSONEncoder().encode(makeManifest())
+        let signature = try sign(data)
+        var tampered = try JSONEncoder().encode(makeManifest(version: "9.9.9"))
+        tampered.append(contentsOf: [0x20])
+
+        XCTAssertThrowsError(
+            try SpeakCLIManifestVerifier.verifiedManifest(
+                manifestData: tampered, signatureBase64: signature, publicKeyBase64: publicKeyBase64
+            )
+        ) { error in
+            XCTAssertEqual(error as? SpeakCLIManifestError, .signatureMismatch)
+        }
+    }
+
+    func testVerifiedManifest_rejectsAnotherKeyAndMalformedInputs() throws {
+        let data = try JSONEncoder().encode(makeManifest())
+        let signature = try sign(data)
+        let otherKey = Curve25519.Signing.PrivateKey().publicKey.rawRepresentation.base64EncodedString()
+
+        XCTAssertThrowsError(
+            try SpeakCLIManifestVerifier.verifiedManifest(
+                manifestData: data, signatureBase64: signature, publicKeyBase64: otherKey
+            )
+        ) { XCTAssertEqual($0 as? SpeakCLIManifestError, .signatureMismatch) }
+        XCTAssertThrowsError(
+            try SpeakCLIManifestVerifier.verifiedManifest(
+                manifestData: data, signatureBase64: signature, publicKeyBase64: nil
+            )
+        ) { XCTAssertEqual($0 as? SpeakCLIManifestError, .invalidPublicKey) }
+        XCTAssertThrowsError(
+            try SpeakCLIManifestVerifier.verifiedManifest(
+                manifestData: data, signatureBase64: "not base64!", publicKeyBase64: publicKeyBase64
+            )
+        ) { XCTAssertEqual($0 as? SpeakCLIManifestError, .invalidSignature) }
+    }
+
+    func testVerifiedManifest_rejectsFutureSchemaEvenWhenSigned() throws {
+        let data = try JSONEncoder().encode(makeManifest(schema: 2))
+
+        XCTAssertThrowsError(
+            try SpeakCLIManifestVerifier.verifiedManifest(
+                manifestData: data, signatureBase64: try sign(data), publicKeyBase64: publicKeyBase64
+            )
+        ) { XCTAssertEqual($0 as? SpeakCLIManifestError, .unsupportedSchema(2)) }
+    }
+
+    func testVerifiedManifest_reportsMalformedJSONAfterSignatureCheck() throws {
+        let data = Data("{not json".utf8)
+
+        XCTAssertThrowsError(
+            try SpeakCLIManifestVerifier.verifiedManifest(
+                manifestData: data, signatureBase64: try sign(data), publicKeyBase64: publicKeyBase64
+            )
+        ) { error in
+            guard case .malformed? = error as? SpeakCLIManifestError else {
+                return XCTFail("Expected malformed, got \(error)")
+            }
+        }
+    }
+
+    func testArchiveName_andAssetNames_areStable() {
+        XCTAssertEqual(SpeakCLIManifest.archiveName(version: "2.62.0", architecture: "arm64"), "speak-2.62.0-arm64.zip")
+        XCTAssertEqual(SpeakCLIManifest.manifestAssetName, "speak-cli-manifest.json")
+        XCTAssertEqual(SpeakCLIManifest.signatureAssetName, "speak-cli-manifest.json.sig")
+    }
+
+    func testStandaloneCLIInstaller_isDirectChannelOnly() {
+        XCTAssertTrue(DistributionChannel.direct.supportsStandaloneCLIInstaller)
+        XCTAssertFalse(DistributionChannel.appStore.supportsStandaloneCLIInstaller)
+    }
+}


### PR DESCRIPTION
Part of #775 (the app side). The pipeline side — publishing standalone `speak` assets with a signed manifest, dropping the embedded CLI from the primary DMG, and the Homebrew formula/cask migration — follows as a second PR stacked on #784, since both edit the release workflow.

## What changes

**Settings → General → Automation CLI card** (direct channel only, `ChannelFeature.standaloneCLIInstaller`) with the states from the issue: *Not installed* (Install CLI / Check again), *Downloading / Verifying / Installing* with determinate progress where the server reports a length, *Installed* (version, architecture, path; Check for update, Copy PATH command, Reveal in Finder, Uninstall), *Update available* (Update CLI), *Failed* (retry; the previous installation is explicitly reported as still in place), and *Not available* when the latest release has no CLI manifest yet. The card lists the supported commands and states that no administrator rights are needed and the shell profile is never edited.

**`SpeakCLIInstaller`** — one state machine with injectable seams (`SpeakCLIInstallerDependencies`: fetch, download with progress, extraction, code-signature check, hardware architecture). Install flow, in order, all in a scratch directory: fetch `speak-cli-manifest.json` + `.sig` from `releases/latest/download/` → verify the detached Ed25519 signature with the Sparkle `SUPublicEDKey` the app already ships → pick the asset for the **hardware** architecture (`hw.optional.arm64`, so a Rosetta-translated app still installs the arm64 CLI) → refuse a CLI built for another automation protocol version → download → byte count → SHA-256 → extract → Mach-O slices must equal exactly the expected architecture → `SecStaticCodeCheckValidity` against `anchor apple generic and certificate leaf[subject.OU] = "<this app's team identifier>"` → clear quarantine → `replaceItemAt` (single rename) → `installed.json` record. Any failure leaves a working installation untouched. Uninstall removes only the executable and record, and the directory only if nothing else is in it.

Install location is `~/Library/Application Support/SpeakApp/bin/speak` — the directory the app actually owns (the issue's example named `JustSpeakToIt/`, which nothing in the app creates; the cask's `zap` list is the only place that path appears and is addressed in the pipeline PR).

**`SpeakCLIManifest` / `SpeakCLIManifestVerifier`** (SpeakCore) — the published contract: schema version, CLI version, `automationSchemaVersion`, per-architecture assets (URL, byte count, SHA-256). Asset names fixed here so the pipeline PR produces exactly them: `speak-<version>-<arch>.zip`, `speak-cli-manifest.json`, `speak-cli-manifest.json.sig`.

**`SpeakCLIVersion`** — a standalone binary now describes itself: the release build will link the version into a `__TEXT,__speak_ver` section (`-sectcreate`), read here first; the embedded-in-app bundle lookup and the `0.0.0-dev` fallback remain. The linker flag itself lands with the pipeline PR.

**`MachOArchitectures`** — reads thin/fat Mach-O headers so the installer can refuse a wrong-architecture binary without shelling out to `lipo`.

Docs: `Docs/automation.md` install section describes the in-app installer, the PATH command and the optional symlink.

## Tests

- `SpeakCLIManifestTests` — valid signature accepted; tampered bytes, another key, missing key, malformed signature, future schema, malformed JSON rejected; asset lookup and names; channel gate.
- `SpeakCLIInstallerTests` — full install against a fake signed release (synthetic Mach-O executables); hardware-architecture asset choice; size mismatch, checksum mismatch, tampered manifest (no download attempted), wrong architecture, rejected code signature, incompatible protocol — each refused with nothing installed; unpublished manifest → *Not available*; update replaces the executable and a failed update keeps the old one; uninstall removes only owned files and an empty directory; compatibility flag.
- `MachOArchitecturesTests` — little-endian thin headers, fat headers, non-Mach-O rejection, a real system binary.
- `SpeakCLIVersionTests` — embedded section wins, fallback without a bundle, garbage rejected, section names, no section in the test binary.

## Notes for review

- Until the pipeline PR publishes the manifest, the card shows *Not available — speak-cli-manifest.json is not published for the latest release yet* and the app keeps working exactly as today (the embedded CLI and Homebrew link are unchanged by this PR).
- Code-signing verification requires the running app to be signed with a team identifier; unsigned development builds refuse to install (by design — they cannot vouch for a download).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Automation CLI installer in Settings for supported builds.
  - Install or update the architecture-specific `speak` command without administrator access.
  - View installation status, version, architecture, and executable location.
  - Copy the required PATH command, reveal the installation in Finder, or uninstall the CLI.
  - Downloads are verified for authenticity, integrity, compatibility, and architecture before installation.

- **Documentation**
  - Expanded CLI installation guidance, including PATH setup, updates, uninstalling, and safe failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->