### PR TITLE
ci(release): publish the standalone speak CLI and drop it from the arm64 download

### DIFF
--- a/.github/actions/package-mac-release/action.yml
+++ b/.github/actions/package-mac-release/action.yml
@@ -1,14 +1,19 @@
 name: Package macOS release variant
 description: >-
-  Archive, export, embed the speak CLI, sign, verify, notarise, staple and
-  package one architecture variant of the direct-distribution app: `arm64`
-  (the primary download) or `universal` (the legacy download every Mac can
-  run). Issue #774.
+  Archive, export, sign, verify, notarise, staple and package one architecture
+  variant of the direct-distribution app: `arm64` (the primary download) or
+  `universal` (the legacy download every Mac can run). Issue #774. The legacy
+  variant still embeds the speak CLI; the primary ships without it and the CLI
+  is published separately (issue #775).
 
 inputs:
   variant:
     description: "arm64 (primary) or universal (legacy)"
     required: true
+  embed-cli:
+    description: "true to embed the speak CLI at Contents/MacOS/speak, false to ship without it"
+    required: false
+    default: "true"
   version:
     description: Marketing version being built
     required: true
@@ -136,11 +141,24 @@ runs:
           OTHER_CODE_SIGN_FLAGS="--options runtime"
 
     - name: Embed speak CLI (${{ inputs.variant }})
+      if: inputs.embed-cli == 'true'
       shell: bash
       run: |
         APP_PATH="${{ steps.paths.outputs.app-path }}"
         chmod +x scripts/build-speak-cli.sh
         ./scripts/build-speak-cli.sh "$APP_PATH" "Developer ID Application" "${{ inputs.variant }}"
+
+    - name: Confirm no embedded speak CLI (${{ inputs.variant }})
+      if: inputs.embed-cli != 'true'
+      shell: bash
+      run: |
+        # Acceptance for issue #775: the primary download carries no speak binary.
+        APP_PATH="${{ steps.paths.outputs.app-path }}"
+        if [ -e "$APP_PATH/Contents/MacOS/speak" ]; then
+          echo "::error::Contents/MacOS/speak is present in the ${{ inputs.variant }} build"
+          exit 1
+        fi
+        echo "No speak CLI embedded in the ${{ inputs.variant }} build"
 
     - name: Verify Hardened Runtime (${{ inputs.variant }})
       shell: bash
@@ -169,7 +187,12 @@ runs:
       shell: bash
       run: |
         chmod +x scripts/verify-architecture.sh
-        ./scripts/verify-architecture.sh "${{ steps.paths.outputs.app-path }}" "${{ inputs.variant }}"
+        if [ "${{ inputs.embed-cli }}" = "true" ]; then
+          CLI_MODE="embedded-cli"
+        else
+          CLI_MODE="no-embedded-cli"
+        fi
+        ./scripts/verify-architecture.sh "${{ steps.paths.outputs.app-path }}" "${{ inputs.variant }}" "$CLI_MODE"
 
     - name: Verify App Launches (${{ inputs.variant }}, Pre-Notarisation)
       shell: bash

--- a/.github/actions/publish-speak-cli/action.yml
+++ b/.github/actions/publish-speak-cli/action.yml
@@ -1,0 +1,177 @@
+name: Build and verify standalone speak CLI assets
+description: >-
+  Build the standalone `speak` CLI for arm64 and x86_64, sign, notarise and
+  verify each archive, then write and sign the release manifest the app's
+  installer and the Homebrew formula consume. Issue #775. Shared by the
+  release workflow and the stand-alone publish-speak-cli workflow so a failed
+  CLI publication can be retried without rebuilding the app.
+
+inputs:
+  version:
+    description: Marketing version being built (matches the mac-v tag)
+    required: true
+  signing-identity:
+    description: codesign identity for the executable
+    required: false
+    default: Developer ID Application
+  apple-id:
+    description: Apple ID used for notarisation
+    required: true
+  apple-id-password:
+    description: App-specific password for the Apple ID
+    required: true
+  apple-team-id:
+    description: Developer team identifier
+    required: true
+  sparkle-private-key:
+    description: Base64 Sparkle Ed25519 private key; the manifest is left unsigned when empty
+    required: false
+    default: ""
+  output-dir:
+    description: Directory receiving the archives and manifest
+    required: false
+    default: ""
+
+outputs:
+  arm64-zip:
+    description: Path to speak-<version>-arm64.zip
+    value: ${{ steps.paths.outputs.arm64-zip }}
+  x86_64-zip:
+    description: Path to speak-<version>-x86_64.zip
+    value: ${{ steps.paths.outputs.x86_64-zip }}
+  manifest:
+    description: Path to speak-cli-manifest.json
+    value: ${{ steps.paths.outputs.manifest }}
+  signature:
+    description: Path to speak-cli-manifest.json.sig (empty when unsigned)
+    value: ${{ steps.manifest.outputs.signature }}
+  automation-schema-version:
+    description: AutomationSchema.currentVersion the CLI was built against
+    value: ${{ steps.schema.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve CLI asset paths
+      id: paths
+      shell: bash
+      run: |
+        OUTPUT_DIR="${{ inputs.output-dir }}"
+        if [ -z "$OUTPUT_DIR" ]; then
+          OUTPUT_DIR="$RUNNER_TEMP/speak-cli"
+        fi
+        mkdir -p "$OUTPUT_DIR"
+        VERSION="${{ inputs.version }}"
+        {
+          echo "output-dir=$OUTPUT_DIR"
+          echo "arm64-zip=$OUTPUT_DIR/speak-${VERSION}-arm64.zip"
+          echo "x86_64-zip=$OUTPUT_DIR/speak-${VERSION}-x86_64.zip"
+          echo "manifest=$OUTPUT_DIR/speak-cli-manifest.json"
+        } >> "$GITHUB_OUTPUT"
+        {
+          echo ""
+          echo "### speak CLI assets (v${VERSION})"
+          echo ""
+          echo "| Arch | Compressed | Installed | Version |"
+          echo "|---|---:|---:|---|"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Resolve automation protocol version
+      id: schema
+      shell: bash
+      run: |
+        # The manifest records the protocol this build speaks so the app can
+        # refuse a CLI from another era before downloading it.
+        SCHEMA_VERSION="$(sed -n 's/^[[:space:]]*public static let currentVersion = \([0-9][0-9]*\).*$/\1/p' \
+          Sources/SpeakCore/AutomationProtocol.swift | head -n 1)"
+        if [ -z "$SCHEMA_VERSION" ]; then
+          echo "::error::AutomationSchema.currentVersion not found in Sources/SpeakCore/AutomationProtocol.swift"
+          exit 1
+        fi
+        echo "version=$SCHEMA_VERSION" >> "$GITHUB_OUTPUT"
+        echo "Automation protocol version: $SCHEMA_VERSION"
+
+    - name: Build speak (arm64)
+      shell: bash
+      run: |
+        chmod +x scripts/build-speak-cli-standalone.sh
+        ./scripts/build-speak-cli-standalone.sh arm64 "${{ inputs.version }}" \
+          "${{ steps.paths.outputs.output-dir }}" "${{ inputs.signing-identity }}"
+
+    - name: Build speak (x86_64)
+      shell: bash
+      run: |
+        ./scripts/build-speak-cli-standalone.sh x86_64 "${{ inputs.version }}" \
+          "${{ steps.paths.outputs.output-dir }}" "${{ inputs.signing-identity }}"
+
+    - name: Notarise speak archives
+      shell: bash
+      env:
+        APPLE_ID: ${{ inputs.apple-id }}
+        APPLE_ID_PASSWORD: ${{ inputs.apple-id-password }}
+        APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
+      run: |
+        # A bare executable cannot be stapled; Gatekeeper checks the ticket
+        # online, which verify-speak-cli.sh --notarised exercises below.
+        for archive in "${{ steps.paths.outputs.arm64-zip }}" "${{ steps.paths.outputs.x86_64-zip }}"; do
+          echo "==> Notarising $(basename "$archive")"
+          OUTPUT="$(xcrun notarytool submit "$archive" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait --timeout 45m 2>&1)"
+          echo "$OUTPUT"
+          if ! grep -q "status: Accepted" <<< "$OUTPUT"; then
+            SUBMISSION_ID="$(grep -E "^\s*id:" <<< "$OUTPUT" | head -1 | awk '{print $2}')"
+            if [ -n "$SUBMISSION_ID" ]; then
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --apple-id "$APPLE_ID" --password "$APPLE_ID_PASSWORD" --team-id "$APPLE_TEAM_ID" || true
+            fi
+            echo "::error::Notarisation of $(basename "$archive") was not accepted"
+            exit 1
+          fi
+        done
+
+    - name: Verify speak archives
+      shell: bash
+      run: |
+        chmod +x scripts/verify-speak-cli.sh
+        ./scripts/verify-speak-cli.sh "${{ steps.paths.outputs.arm64-zip }}" arm64 "${{ inputs.version }}" --notarised
+        ./scripts/verify-speak-cli.sh "${{ steps.paths.outputs.x86_64-zip }}" x86_64 "${{ inputs.version }}" --notarised
+
+    - name: Generate and sign CLI manifest
+      id: manifest
+      shell: bash
+      env:
+        SPARKLE_PRIVATE_KEY: ${{ inputs.sparkle-private-key }}
+      run: |
+        chmod +x scripts/generate-cli-manifest.sh scripts/sparkle-sign-file.sh
+        ./scripts/generate-cli-manifest.sh "${{ inputs.version }}" "${{ steps.schema.outputs.version }}" \
+          "${{ steps.paths.outputs.output-dir }}" \
+          "${{ steps.paths.outputs.arm64-zip }}" "${{ steps.paths.outputs.x86_64-zip }}"
+        MANIFEST="${{ steps.paths.outputs.manifest }}"
+        if [ -f "$MANIFEST.sig" ]; then
+          echo "signature=$MANIFEST.sig" >> "$GITHUB_OUTPUT"
+        else
+          echo "signature=" >> "$GITHUB_OUTPUT"
+          echo "::warning::speak CLI manifest is unsigned (no Sparkle private key supplied)"
+        fi
+        echo "Manifest:"
+        cat "$MANIFEST"
+
+    - name: Verify CLI manifest against the app's public key
+      shell: bash
+      run: |
+        # The app verifies with SUPublicEDKey from its Info.plist; check the
+        # published pair the same way before anything is uploaded.
+        MANIFEST="${{ steps.paths.outputs.manifest }}"
+        SIGNATURE="${{ steps.manifest.outputs.signature }}"
+        if [ -n "$SIGNATURE" ]; then
+          PUBLIC_KEY="$(/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" Config/AppInfo.plist)"
+        else
+          SIGNATURE="-"
+          PUBLIC_KEY="-"
+        fi
+        swift scripts/verify-cli-manifest.swift "$MANIFEST" "$SIGNATURE" "$PUBLIC_KEY" \
+          "${{ inputs.version }}" "${{ steps.schema.outputs.version }}" \
+          "${{ steps.paths.outputs.arm64-zip }}" "${{ steps.paths.outputs.x86_64-zip }}"

--- a/.github/workflows/publish-speak-cli.yml
+++ b/.github/workflows/publish-speak-cli.yml
@@ -1,0 +1,114 @@
+name: Publish speak CLI
+
+# Rebuilds and publishes the standalone speak CLI assets for an existing
+# macOS release (issue #775). The release workflow publishes them with every
+# mac-v tag; when that optional step fails, run this with the same version to
+# add the assets, the signed manifest and the Homebrew formula without
+# rebuilding the app.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Released version to publish the CLI for (e.g. 2.62.0; the mac-v tag must exist)'
+        required: true
+
+env:
+  APP_STORE_CONNECT_KEY_ID: S747NJ9DZY
+
+jobs:
+  publish-cli:
+    runs-on: macos-15
+    timeout-minutes: 120
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: refs/tags/mac-v${{ github.event.inputs.version }}
+          fetch-depth: 0
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Resolve Swift Package Dependencies
+        run: |
+          # Fetches Sparkle's artifact bundle, whose sign_update signs the manifest.
+          swift package resolve
+
+      - name: Import Code Signing Certificate
+        env:
+          APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+          APPLE_DEVELOPER_ID_APPLICATION_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          echo -n "$APPLE_DEVELOPER_ID_APPLICATION" | base64 --decode -o $CERTIFICATE_PATH
+          security import $CERTIFICATE_PATH -P "$APPLE_DEVELOPER_ID_APPLICATION_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+          rm -f $CERTIFICATE_PATH
+
+      - name: Start artefact size summary
+        run: |
+          echo "## speak CLI publication (v${{ github.event.inputs.version }})" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build, notarise and verify speak CLI assets
+        id: cli
+        uses: ./.github/actions/publish-speak-cli
+        with:
+          version: ${{ github.event.inputs.version }}
+          apple-id: ${{ secrets.APPLE_ID }}
+          apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          sparkle-private-key: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+
+      - name: Upload CLI assets to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          gh release view "mac-v$VERSION" --json tagName --jq .tagName
+          gh release upload "mac-v$VERSION" --clobber \
+            "${{ steps.cli.outputs.arm64-zip }}" \
+            "${{ steps.cli.outputs.x86_64-zip }}" \
+            "${{ steps.cli.outputs.manifest }}" \
+            "${{ steps.cli.outputs.signature }}"
+
+      - name: Update Homebrew Tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          # The app DMGs are unchanged: keep the cask's existing digests and
+          # add the formula for this release's CLI archives.
+          TAP_DIR="$RUNNER_TEMP/homebrew-tap"
+          git clone --quiet "https://x-access-token:${GH_TOKEN}@github.com/crmitchelmore/homebrew-justspeaktoit.git" "$TAP_DIR"
+          CASK="$TAP_DIR/Casks/justspeaktoit.rb"
+          CASK_VERSION="$(sed -n 's/^  version "\(.*\)"$/\1/p' "$CASK")"
+          if [ "$CASK_VERSION" != "$VERSION" ]; then
+            echo "::error::The tap's cask is at $CASK_VERSION, not $VERSION; run the release workflow first"
+            exit 1
+          fi
+          ARM64_SHA256="$(sed -n 's/^  sha256 arm: "\([0-9a-f]*\)".*$/\1/p' "$CASK")"
+          UNIVERSAL_SHA256="$(sed -n 's/^  sha256 arm: "[0-9a-f]*", intel: "\([0-9a-f]*\)"$/\1/p' "$CASK")"
+          CLI_ARM64_SHA256="$(shasum -a 256 "${{ steps.cli.outputs.arm64-zip }}" | awk '{print $1}')"
+          CLI_X86_64_SHA256="$(shasum -a 256 "${{ steps.cli.outputs.x86_64-zip }}" | awk '{print $1}')"
+          chmod +x scripts/update-homebrew-tap.sh
+          TAP_DIR="$TAP_DIR" ./scripts/update-homebrew-tap.sh "$VERSION" "$ARM64_SHA256" "$UNIVERSAL_SHA256" \
+            "$CLI_ARM64_SHA256" "$CLI_X86_64_SHA256"
+
+      - name: Cleanup Keychain
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -20,10 +20,13 @@ jobs:
   build-and-release:
     runs-on: macos-15
     # Two archives (arm64 primary + universal legacy), each with app
-    # notarisation polling (up to 60 min) and DMG notarisation, then publication.
+    # notarisation polling (up to 60 min) and DMG notarisation, then the
+    # standalone CLI archives (two more notarisations) and publication.
     timeout-minutes: 240
     permissions:
       contents: write
+      # A failed optional CLI publication is surfaced as an issue, not a failed release.
+      issues: write
 
     steps:
       - name: Checkout
@@ -176,11 +179,14 @@ jobs:
       # Apple Silicon Macs download and update to, and the universal legacy
       # build that Intel Macs — and every install that predates per-architecture
       # artefacts — keep receiving through the original appcast.xml feed.
+      # The primary ships without the speak CLI, which is published as
+      # standalone assets below (issue #775); the legacy build keeps embedding it.
       - name: Package arm64 primary
         id: arm64
         uses: ./.github/actions/package-mac-release
         with:
           variant: arm64
+          embed-cli: "false"
           version: ${{ steps.version.outputs.version }}
           apple-id: ${{ secrets.APPLE_ID }}
           apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
@@ -193,6 +199,7 @@ jobs:
         uses: ./.github/actions/package-mac-release
         with:
           variant: universal
+          embed-cli: "true"
           version: ${{ steps.version.outputs.version }}
           apple-id: ${{ secrets.APPLE_ID }}
           apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
@@ -210,6 +217,60 @@ jobs:
             echo "LEGACY_APP_PATH=${{ steps.universal.outputs.app-path }}"
             echo "LEGACY_ARCHIVE_PATH=${{ steps.universal.outputs.archive-path }}"
           } >> "$GITHUB_ENV"
+
+      # Standalone speak CLI assets (issue #775): arm64 and x86_64 archives plus
+      # the signed manifest the in-app installer reads. Optional by design — a
+      # failure here must not block the app release, so it is surfaced below and
+      # retried with the publish-speak-cli workflow.
+      - name: Build, notarise and verify speak CLI assets
+        id: cli
+        continue-on-error: true
+        uses: ./.github/actions/publish-speak-cli
+        with:
+          version: ${{ steps.version.outputs.version }}
+          apple-id: ${{ secrets.APPLE_ID }}
+          apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          sparkle-private-key: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+
+      - name: Publish speak CLI asset paths
+        if: steps.cli.outcome == 'success'
+        run: |
+          {
+            echo "CLI_ARM64_ZIP=${{ steps.cli.outputs.arm64-zip }}"
+            echo "CLI_X86_64_ZIP=${{ steps.cli.outputs.x86_64-zip }}"
+            echo "CLI_MANIFEST=${{ steps.cli.outputs.manifest }}"
+            echo "CLI_MANIFEST_SIG=${{ steps.cli.outputs.signature }}"
+          } >> "$GITHUB_ENV"
+
+      - name: Surface speak CLI publication failure
+        if: steps.cli.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "::error::speak CLI assets were not published for v${VERSION}; the app release continues without them"
+          {
+            echo ""
+            echo "> ⚠️ **speak CLI assets were not published for v${VERSION}.** The app release is unaffected."
+            echo "> Re-run the *Publish speak CLI* workflow with version \`${VERSION}\` once the cause is fixed."
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$GITHUB_REF" == refs/tags/mac-v* ]]; then
+            TITLE="speak CLI assets missing for mac-v${VERSION}"
+            EXISTING="$(gh issue list --state open --search "\"$TITLE\" in:title" --json number --jq '.[0].number')"
+            if [ -z "$EXISTING" ]; then
+              gh issue create --title "$TITLE" --body "$(cat <<EOF
+          The optional speak CLI publication step failed in the release run for mac-v${VERSION}: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          The app DMGs, appcasts and cask were published normally. Until the CLI assets exist, the in-app installer shows *Not available* for this release and the Homebrew formula stays at the previous version.
+
+          **Retry:** fix the cause, then run the *Publish speak CLI* workflow (\`publish-speak-cli.yml\`) with version \`${VERSION}\`. It rebuilds, notarises and verifies the archives from the tag, uploads them with the signed manifest to the existing release, and updates the tap. Refs #775.
+          EOF
+          )" || echo "::warning::Could not open the follow-up issue"
+            else
+              echo "Follow-up issue #$EXISTING is already open"
+            fi
+          fi
 
       # One feed per download. The legacy feed keeps its historical name and
       # asset because every shipped build carries it in Info.plist, and the
@@ -261,11 +322,18 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/mac-v')
         uses: softprops/action-gh-release@v3
         with:
+          # The CLI entries are empty when publication failed; unmatched
+          # entries are skipped (fail_on_unmatched_files is off) so the app
+          # release still goes out.
           files: |
             ${{ env.DMG_PATH }}
             ${{ env.LEGACY_DMG_PATH }}
             ${{ env.APPCAST_PATH }}
             ${{ env.ARM64_APPCAST_PATH }}
+            ${{ env.CLI_ARM64_ZIP }}
+            ${{ env.CLI_X86_64_ZIP }}
+            ${{ env.CLI_MANIFEST }}
+            ${{ env.CLI_MANIFEST_SIG }}
           body_path: ${{ runner.temp }}/release-notes.md
           generate_release_notes: false
           draft: false
@@ -304,51 +372,24 @@ jobs:
           echo "    arm64 SHA256:     $ARM64_SHA256"
           echo "    universal SHA256: $UNIVERSAL_SHA256"
 
-          # Clone the tap repo
-          git clone https://x-access-token:${GH_TOKEN}@github.com/crmitchelmore/homebrew-justspeaktoit.git /tmp/homebrew-tap
-          cd /tmp/homebrew-tap
+          # The cask gets the per-architecture DMGs (issue #774) and depends on
+          # the speak formula, which is written from this release's standalone
+          # CLI archives when they were published (issue #775). Without them
+          # the formula is left untouched.
+          CLI_SHAS=()
+          if [ -n "${CLI_ARM64_ZIP:-}" ] && [ -n "${CLI_X86_64_ZIP:-}" ]; then
+            CLI_SHAS=(
+              "$(shasum -a 256 "$CLI_ARM64_ZIP" | awk '{print $1}')"
+              "$(shasum -a 256 "$CLI_X86_64_ZIP" | awk '{print $1}')"
+            )
+            echo "    speak arm64 SHA256:  ${CLI_SHAS[0]}"
+            echo "    speak x86_64 SHA256: ${CLI_SHAS[1]}"
+          else
+            echo "    speak CLI archives not published; formula unchanged"
+          fi
 
-          # Update the cask file: Apple Silicon Macs get the arm64 download,
-          # Intel Macs the universal legacy download (issue #774). The bundled
-          # speak CLI matches the app's own slices in both.
-          cat > Casks/justspeaktoit.rb << EOF
-          cask "justspeaktoit" do
-            arch arm: "arm64", intel: "universal"
-
-            version "$VERSION"
-            sha256 arm: "$ARM64_SHA256", intel: "$UNIVERSAL_SHA256"
-
-            url "https://github.com/crmitchelmore/justspeaktoit/releases/download/mac-v#{version}/JustSpeakToIt-#{arch}.dmg"
-            name "Just Speak to It"
-            desc "Native macOS voice transcription with on-device or cloud processing"
-            homepage "https://justspeaktoit.com"
-
-            livecheck do
-              url :url
-              strategy :github_latest
-            end
-
-            depends_on macos: ">= :sonoma"
-
-            app "JustSpeakToIt.app"
-            binary "#{appdir}/JustSpeakToIt.app/Contents/MacOS/speak"
-
-            zap trash: [
-              "~/Library/Application Support/JustSpeakToIt",
-              "~/Library/Caches/com.justspeaktoit.app",
-              "~/Library/Preferences/com.justspeaktoit.app.plist",
-            ]
-          end
-          EOF
-
-          # Commit and push
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Casks/justspeaktoit.rb
-          git commit -m "Update Just Speak to It to v$VERSION"
-          git push
-
-          echo "==> Homebrew tap updated successfully"
+          chmod +x scripts/update-homebrew-tap.sh
+          ./scripts/update-homebrew-tap.sh "$VERSION" "$ARM64_SHA256" "$UNIVERSAL_SHA256" "${CLI_SHAS[@]}"
 
       - name: Upload Artifacts (for manual builds)
         if: "!startsWith(github.ref, 'refs/tags/mac-v')"
@@ -358,6 +399,10 @@ jobs:
           path: |
             ${{ env.DMG_PATH }}
             ${{ env.LEGACY_DMG_PATH }}
+            ${{ env.CLI_ARM64_ZIP }}
+            ${{ env.CLI_X86_64_ZIP }}
+            ${{ env.CLI_MANIFEST }}
+            ${{ env.CLI_MANIFEST_SIG }}
 
       - name: Cleanup Keychain
         if: always()

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ brew tap crmitchelmore/justspeaktoit
 brew install --cask justspeaktoit
 ```
 
-Homebrew installs the right build for your Mac automatically.
+Homebrew installs the right build for your Mac automatically, along with the
+standalone `speak` automation CLI (`brew install crmitchelmore/justspeaktoit/speak`
+installs just the CLI). Direct downloads can add the CLI later from
+Settings → General → Automation CLI.
 
 ### Direct download
 

--- a/scripts/build-speak-cli-standalone.sh
+++ b/scripts/build-speak-cli-standalone.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Build the standalone `speak` CLI for one architecture and package it as the
+# release asset the in-app installer and the Homebrew formula consume
+# (issue #775).
+#
+# Usage: ./scripts/build-speak-cli-standalone.sh <arm64|x86_64> <version> <output-dir> [signing-identity]
+#
+# Produces <output-dir>/speak-<version>-<arch>.zip holding a single `speak`
+# executable at the archive root, built for exactly that architecture, with the
+# release version linked into a `__TEXT,__speak_ver` section so the binary
+# describes itself without an app bundle around it (SpeakCLIVersion). With a
+# signing identity the executable is signed with the hardened runtime; the
+# caller notarises the archive.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARCH="${1:-}"
+VERSION="${2:-}"
+OUTPUT_DIR="${3:-}"
+SIGN_IDENTITY="${4:-}"
+
+usage() {
+    echo "Usage: $0 <arm64|x86_64> <version> <output-dir> [signing-identity]" >&2
+    exit 1
+}
+
+[[ -n "$ARCH" && -n "$VERSION" && -n "$OUTPUT_DIR" ]] || usage
+
+case "$ARCH" in
+    arm64|x86_64) ;;
+    *)
+        echo "error: unknown architecture '$ARCH' (expected arm64 or x86_64)" >&2
+        exit 1
+        ;;
+esac
+
+# The same shape SpeakCLIVersion.parseEmbeddedVersion accepts.
+if [[ ! "$VERSION" =~ ^[A-Za-z0-9.+-]{1,64}$ ]]; then
+    echo "error: version '$VERSION' is not a plain version string" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd -P)"
+ARCHIVE_PATH="$OUTPUT_DIR/speak-${VERSION}-${ARCH}.zip"
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+VERSION_FILE="$SCRATCH/speak_ver"
+printf '%s' "$VERSION" > "$VERSION_FILE"
+
+cd "$ROOT_DIR"
+# Each slice is built on its own, as build-speak-cli.sh does (issue #759); the
+# linker flags create the version section in this product's executable only.
+echo "==> Building speak (release, $ARCH, version $VERSION)"
+swift build --product speak --configuration release --arch "$ARCH" \
+    -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __speak_ver -Xlinker "$VERSION_FILE"
+BUILT_BINARY="$(swift build --product speak --configuration release --arch "$ARCH" \
+    -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __speak_ver -Xlinker "$VERSION_FILE" \
+    --show-bin-path)/speak"
+if [[ ! -f "$BUILT_BINARY" ]]; then
+    echo "error: built binary missing at $BUILT_BINARY" >&2
+    exit 1
+fi
+
+STAGE="$SCRATCH/stage"
+mkdir -p "$STAGE"
+BINARY="$STAGE/speak"
+cp "$BUILT_BINARY" "$BINARY"
+chmod 755 "$BINARY"
+
+# Exactly one slice: the installer refuses anything else, so fail here instead.
+BUILT_ARCHS="$(lipo -archs "$BINARY")"
+if [[ "$BUILT_ARCHS" != "$ARCH" ]]; then
+    echo "error: built binary contains [$BUILT_ARCHS] but must contain exactly [$ARCH]" >&2
+    exit 1
+fi
+
+# The version section must read back as the version, byte for byte.
+EMBEDDED_VERSION="$(xcrun segedit "$BINARY" -extract __TEXT __speak_ver "$SCRATCH/extracted" \
+    && tr -d '\0' < "$SCRATCH/extracted")"
+if [[ "$EMBEDDED_VERSION" != "$VERSION" ]]; then
+    echo "error: __TEXT,__speak_ver reads '$EMBEDDED_VERSION', expected '$VERSION'" >&2
+    exit 1
+fi
+echo "==> Linked version section: $EMBEDDED_VERSION"
+
+if [[ -n "$SIGN_IDENTITY" ]]; then
+    echo "==> Signing with '$SIGN_IDENTITY' (hardened runtime)"
+    codesign --force --timestamp --options runtime --sign "$SIGN_IDENTITY" "$BINARY"
+    codesign --verify --strict --verbose=2 "$BINARY"
+    codesign -dv --verbose=4 "$BINARY" 2>&1 | grep -q "runtime"
+    echo "==> Hardened runtime confirmed"
+else
+    echo "==> Skipping codesign (no identity supplied)"
+fi
+
+# A native slice must run and report the linked version; x86_64 runs through
+# Rosetta where it is installed and is otherwise verified by its section only.
+can_run=false
+if [[ "$ARCH" == "$(uname -m)" ]]; then
+    can_run=true
+elif [[ "$ARCH" == "x86_64" ]] && arch -x86_64 /usr/bin/true 2>/dev/null; then
+    can_run=true
+fi
+if [[ "$can_run" == true ]]; then
+    REPORTED="$("$BINARY" --version)"
+    if [[ "$REPORTED" != "speak $VERSION" ]]; then
+        echo "error: 'speak --version' printed '$REPORTED', expected 'speak $VERSION'" >&2
+        exit 1
+    fi
+    echo "==> $REPORTED"
+else
+    echo "==> $ARCH cannot run on this machine; skipped the --version check"
+fi
+
+# Archive the executable at the root, the way the app extracts it
+# (ditto -x -k <archive> <dir> must yield <dir>/speak) and Homebrew installs it.
+rm -f "$ARCHIVE_PATH"
+ditto -c -k --norsrc --noextattr --noqtn "$STAGE" "$ARCHIVE_PATH"
+
+CHECK="$SCRATCH/check"
+mkdir -p "$CHECK"
+ditto -x -k "$ARCHIVE_PATH" "$CHECK"
+ENTRIES="$(find "$CHECK" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort | tr '\n' ' ' | sed 's/ $//')"
+if [[ "$ENTRIES" != "speak" ]]; then
+    echo "error: archive root must contain only 'speak' (found: $ENTRIES)" >&2
+    exit 1
+fi
+if ! cmp -s "$BINARY" "$CHECK/speak"; then
+    echo "error: archive round trip altered the executable" >&2
+    exit 1
+fi
+
+bytes() { stat -f%z "$1"; }
+megabytes() { awk -v b="$1" 'BEGIN { printf "%.1f", b / 1048576 }'; }
+ARCHIVE_BYTES="$(bytes "$ARCHIVE_PATH")"
+BINARY_BYTES="$(bytes "$BINARY")"
+echo "==> $(basename "$ARCHIVE_PATH"): $(megabytes "$ARCHIVE_BYTES") MB compressed," \
+    "$(megabytes "$BINARY_BYTES") MB installed"
+
+# One Markdown row per asset; the workflow writes the table header.
+ROW="| $ARCH | $(megabytes "$ARCHIVE_BYTES") MB | $(megabytes "$BINARY_BYTES") MB | $VERSION |"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "$ROW" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo "$ARCHIVE_PATH"

--- a/scripts/generate-cli-manifest.sh
+++ b/scripts/generate-cli-manifest.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Write the speak CLI release manifest the app's installer reads
+# (SpeakCLIManifest, issue #775), and sign it with the Sparkle key when one is
+# supplied so the app can verify it with the SUPublicEDKey it already ships.
+#
+# Usage: ./scripts/generate-cli-manifest.sh <version> <automation-schema-version> <output-dir> <zip>...
+#
+# Environment:
+#   SPARKLE_PRIVATE_KEY  base64 Ed25519 private key; when set, writes
+#                        speak-cli-manifest.json.sig next to the manifest.
+#
+# Each <zip> must be named speak-<version>-<arch>.zip (as produced by
+# build-speak-cli-standalone.sh); its release URL, byte count and SHA-256 are
+# recorded. The manifest bytes are what the signature covers, so the file is
+# written once and never reformatted afterwards.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${1:-}"
+SCHEMA_VERSION="${2:-}"
+OUTPUT_DIR="${3:-}"
+shift 3 2>/dev/null || true
+
+if [[ -z "$VERSION" || -z "$SCHEMA_VERSION" || -z "$OUTPUT_DIR" || $# -eq 0 ]]; then
+    echo "Usage: $0 <version> <automation-schema-version> <output-dir> <zip>..." >&2
+    exit 1
+fi
+if [[ ! "$SCHEMA_VERSION" =~ ^[0-9]+$ ]]; then
+    echo "error: automation schema version '$SCHEMA_VERSION' is not a number" >&2
+    exit 1
+fi
+
+RELEASE_URL="https://github.com/crmitchelmore/justspeaktoit/releases/download/mac-v${VERSION}"
+MANIFEST_SCHEMA_VERSION=1
+
+mkdir -p "$OUTPUT_DIR"
+MANIFEST_PATH="$OUTPUT_DIR/speak-cli-manifest.json"
+SIGNATURE_PATH="$MANIFEST_PATH.sig"
+
+ASSETS=""
+SEEN_ARCHS=""
+for archive in "$@"; do
+    if [[ ! -f "$archive" ]]; then
+        echo "error: archive not found: $archive" >&2
+        exit 1
+    fi
+    name="$(basename "$archive")"
+    prefix="speak-${VERSION}-"
+    if [[ "$name" != "$prefix"*.zip ]]; then
+        echo "error: $name is not named speak-${VERSION}-<arch>.zip" >&2
+        exit 1
+    fi
+    arch="${name#"$prefix"}"
+    arch="${arch%.zip}"
+    case "$arch" in
+        arm64|x86_64) ;;
+        *)
+            echo "error: unsupported architecture '$arch' in $name" >&2
+            exit 1
+            ;;
+    esac
+    if [[ " $SEEN_ARCHS " == *" $arch "* ]]; then
+        echo "error: more than one archive for $arch" >&2
+        exit 1
+    fi
+    SEEN_ARCHS="$SEEN_ARCHS $arch"
+
+    byte_count="$(stat -f%z "$archive")"
+    sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+    asset="$(printf '    {"architecture": "%s", "url": "%s/%s", "byteCount": %s, "sha256": "%s"}' \
+        "$arch" "$RELEASE_URL" "$name" "$byte_count" "$sha256")"
+    if [[ -n "$ASSETS" ]]; then
+        ASSETS="$ASSETS,"$'\n'"$asset"
+    else
+        ASSETS="$asset"
+    fi
+    echo "==> $name: $byte_count bytes, sha256 $sha256" >&2
+done
+
+cat > "$MANIFEST_PATH" << EOF
+{
+  "schemaVersion": ${MANIFEST_SCHEMA_VERSION},
+  "version": "${VERSION}",
+  "automationSchemaVersion": ${SCHEMA_VERSION},
+  "assets": [
+${ASSETS}
+  ]
+}
+EOF
+echo "==> Wrote $MANIFEST_PATH" >&2
+
+rm -f "$SIGNATURE_PATH"
+if [[ -n "${SPARKLE_PRIVATE_KEY:-}" ]]; then
+    "$ROOT_DIR/scripts/sparkle-sign-file.sh" "$SPARKLE_PRIVATE_KEY" "$MANIFEST_PATH" > "$SIGNATURE_PATH"
+    echo "==> Wrote $SIGNATURE_PATH" >&2
+else
+    echo "==> SPARKLE_PRIVATE_KEY not set; manifest left unsigned" >&2
+fi
+
+echo "$MANIFEST_PATH"

--- a/scripts/record-release-size.sh
+++ b/scripts/record-release-size.sh
@@ -35,10 +35,16 @@ DMG_BYTES="$(bytes "$DMG_PATH")"
 APP_KB="$(du -sk "$APP_PATH" | awk '{print $1}')"
 APP_BYTES=$((APP_KB * 1024))
 MAIN_BYTES="$(bytes "$MAIN_BINARY")"
-CLI_BYTES="$(bytes "$CLI_BINARY")"
 ARCHS="$(lipo -archs "$MAIN_BINARY")"
+# The primary download no longer embeds the CLI (issue #775); its standalone
+# archives are measured by build-speak-cli-standalone.sh.
+if [[ -f "$CLI_BINARY" ]]; then
+    CLI_CELL="$(megabytes "$(bytes "$CLI_BINARY")") MB"
+else
+    CLI_CELL="not embedded"
+fi
 
-ROW="| $VARIANT | $(megabytes "$DMG_BYTES") MB | $(megabytes "$APP_BYTES") MB | $(megabytes "$MAIN_BYTES") MB | $(megabytes "$CLI_BYTES") MB | $ARCHS |"
+ROW="| $VARIANT | $(megabytes "$DMG_BYTES") MB | $(megabytes "$APP_BYTES") MB | $(megabytes "$MAIN_BYTES") MB | $CLI_CELL | $ARCHS |"
 echo "$ROW"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/scripts/sparkle-sign-file.sh
+++ b/scripts/sparkle-sign-file.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Sign a file with the Sparkle EdDSA (Ed25519) private key and print the
+# base64 signature: the same signature sign_update writes into an appcast's
+# sparkle:edSignature, so anything holding the app's SUPublicEDKey can verify
+# it. Used for the speak CLI release manifest (issue #775).
+#
+# Usage: ./scripts/sparkle-sign-file.sh <private-key-base64> <file>
+
+set -euo pipefail
+
+PRIVATE_KEY_BASE64="${1:-}"
+FILE="${2:-}"
+
+if [[ -z "$PRIVATE_KEY_BASE64" || -z "$FILE" ]]; then
+    echo "Usage: $0 <private-key-base64> <file>" >&2
+    exit 1
+fi
+if [[ ! -f "$FILE" ]]; then
+    echo "error: file not found: $FILE" >&2
+    exit 1
+fi
+
+# sign_update reads the raw base64 string from the key file, not decoded bytes
+# (the same convention as generate-appcast.sh).
+PRIVATE_KEY_FILE="$(mktemp)"
+trap 'rm -f "$PRIVATE_KEY_FILE"' EXIT
+echo "$PRIVATE_KEY_BASE64" > "$PRIVATE_KEY_FILE"
+
+SIGN_UPDATE=""
+if [[ -f ".build/artifacts/sparkle/Sparkle/bin/sign_update" ]]; then
+    SIGN_UPDATE=".build/artifacts/sparkle/Sparkle/bin/sign_update"
+elif command -v sign_update &> /dev/null; then
+    SIGN_UPDATE="sign_update"
+else
+    echo "sign_update not found, downloading Sparkle tools..." >&2
+    SPARKLE_VERSION="2.8.1"
+    SPARKLE_TOOLS="$(mktemp -d)"
+    curl -sL "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" \
+        | tar xJ -C "$SPARKLE_TOOLS"
+    SIGN_UPDATE="$SPARKLE_TOOLS/bin/sign_update"
+fi
+
+OUTPUT="$("$SIGN_UPDATE" --ed-key-file "$PRIVATE_KEY_FILE" "$FILE")"
+SIGNATURE="$(sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p' <<< "$OUTPUT" | head -n 1)"
+if [[ -z "$SIGNATURE" ]]; then
+    echo "error: sign_update produced no signature for $FILE" >&2
+    echo "$OUTPUT" >&2
+    exit 1
+fi
+
+printf '%s\n' "$SIGNATURE"

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Rewrite the Homebrew tap for a release: the app cask (per-architecture DMGs,
+# issue #774) and the standalone speak CLI formula (issue #775).
+#
+# Usage: ./scripts/update-homebrew-tap.sh <version> <arm64-dmg-sha256> <universal-dmg-sha256> \
+#            [<cli-arm64-zip-sha256> <cli-x86_64-zip-sha256>]
+#
+# Environment:
+#   GH_TOKEN   token with push access to the tap (required unless TAP_DIR is a
+#              clone the caller will push, or DRY_RUN is set)
+#   TAP_DIR    existing clone of the tap to update in place (default: a fresh
+#              clone under a temporary directory)
+#   TAP_REPO   GitHub repository of the tap (default crmitchelmore/homebrew-justspeaktoit)
+#   DRY_RUN    when set, writes and syntax-checks the files but neither commits nor pushes
+#
+# The CLI shas are optional so that a failed CLI publication never blocks the
+# app release: without them the formula is left as it is and the cask only
+# depends on it when a formula already exists in the tap.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+ARM64_SHA256="${2:-}"
+UNIVERSAL_SHA256="${3:-}"
+CLI_ARM64_SHA256="${4:-}"
+CLI_X86_64_SHA256="${5:-}"
+TAP_REPO="${TAP_REPO:-crmitchelmore/homebrew-justspeaktoit}"
+
+if [[ -z "$VERSION" || -z "$ARM64_SHA256" || -z "$UNIVERSAL_SHA256" ]]; then
+    echo "Usage: $0 <version> <arm64-dmg-sha256> <universal-dmg-sha256> [<cli-arm64-sha256> <cli-x86_64-sha256>]" >&2
+    exit 1
+fi
+if [[ -n "$CLI_ARM64_SHA256" && -z "$CLI_X86_64_SHA256" ]] || [[ -z "$CLI_ARM64_SHA256" && -n "$CLI_X86_64_SHA256" ]]; then
+    echo "error: supply both CLI shas or neither" >&2
+    exit 1
+fi
+for sha in "$ARM64_SHA256" "$UNIVERSAL_SHA256" $CLI_ARM64_SHA256 $CLI_X86_64_SHA256; do
+    if [[ ! "$sha" =~ ^[0-9a-f]{64}$ ]]; then
+        echo "error: '$sha' is not a lowercase hex SHA-256" >&2
+        exit 1
+    fi
+done
+
+if [[ -z "${TAP_DIR:-}" ]]; then
+    if [[ -z "${GH_TOKEN:-}" && -z "${DRY_RUN:-}" ]]; then
+        echo "error: GH_TOKEN is required to clone and push the tap" >&2
+        exit 1
+    fi
+    TAP_DIR="$(mktemp -d)/homebrew-tap"
+    if [[ -n "${GH_TOKEN:-}" ]]; then
+        git clone --quiet "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" "$TAP_DIR"
+    else
+        git clone --quiet "https://github.com/${TAP_REPO}.git" "$TAP_DIR"
+    fi
+fi
+cd "$TAP_DIR"
+mkdir -p Casks Formula
+
+PUBLISH_CLI=false
+if [[ -n "$CLI_ARM64_SHA256" ]]; then
+    PUBLISH_CLI=true
+fi
+
+RELEASE_URL="https://github.com/crmitchelmore/justspeaktoit/releases/download/mac-v#{version}"
+
+if [[ "$PUBLISH_CLI" == true ]]; then
+    echo "==> Writing Formula/speak.rb for $VERSION"
+    cat > Formula/speak.rb << EOF
+class Speak < Formula
+  desc "Terminal and agent automation client for Just Speak to It"
+  homepage "https://justspeaktoit.com"
+  version "$VERSION"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^mac-v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
+  end
+
+  depends_on macos: :sonoma
+
+  on_macos do
+    on_arm do
+      url "${RELEASE_URL}/speak-#{version}-arm64.zip"
+      sha256 "$CLI_ARM64_SHA256"
+    end
+
+    on_intel do
+      url "${RELEASE_URL}/speak-#{version}-x86_64.zip"
+      sha256 "$CLI_X86_64_SHA256"
+    end
+  end
+
+  def install
+    bin.install "speak"
+  end
+
+  def caveats
+    <<~EOS
+      speak talks to the Just Speak to It app over its local automation socket;
+      install the app (brew install --cask justspeaktoit) and enable Automation
+      in its Settings.
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/speak --version")
+  end
+end
+EOF
+fi
+
+# The cask depends on the formula once the tap carries one, so every Homebrew
+# install gets the standalone CLI rather than a link into the app bundle.
+CASK_CLI_DEPENDENCY=""
+if [[ -f Formula/speak.rb ]]; then
+    CASK_CLI_DEPENDENCY=$'\n  depends_on formula: "crmitchelmore/justspeaktoit/speak"'
+fi
+
+echo "==> Writing Casks/justspeaktoit.rb for $VERSION"
+cat > Casks/justspeaktoit.rb << EOF
+cask "justspeaktoit" do
+  arch arm: "arm64", intel: "universal"
+
+  version "$VERSION"
+  sha256 arm:   "$ARM64_SHA256",
+         intel: "$UNIVERSAL_SHA256"
+
+  url "${RELEASE_URL}/JustSpeakToIt-#{arch}.dmg"
+  name "Just Speak to It"
+  desc "Voice transcription with on-device or cloud processing"
+  homepage "https://justspeaktoit.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :sonoma${CASK_CLI_DEPENDENCY}
+
+  app "JustSpeakToIt.app"
+
+  zap trash: [
+    "~/Library/Application Support/SpeakApp",
+    "~/Library/Caches/com.justspeaktoit.mac",
+    "~/Library/Preferences/com.justspeaktoit.mac.plist",
+  ]
+end
+EOF
+
+for file in Casks/justspeaktoit.rb Formula/speak.rb; do
+    [[ -f "$file" ]] || continue
+    chmod 644 "$file"
+    ruby -c "$file" > /dev/null
+    echo "==> $file:"
+    cat "$file"
+done
+
+if [[ -n "${DRY_RUN:-}" ]]; then
+    echo "==> DRY_RUN set; not committing"
+    exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add Casks/justspeaktoit.rb
+if [[ "$PUBLISH_CLI" == true ]]; then
+    git add Formula/speak.rb
+fi
+if git diff --cached --quiet; then
+    echo "==> Tap already up to date for $VERSION"
+    exit 0
+fi
+git commit --quiet -m "Update Just Speak to It to v$VERSION"
+git push --quiet
+echo "==> Homebrew tap updated for $VERSION"

--- a/scripts/verify-architecture.sh
+++ b/scripts/verify-architecture.sh
@@ -2,22 +2,34 @@
 # Verify that a packaged JustSpeakToIt.app contains exactly the CPU slices its
 # release variant promises (issue #774).
 #
-# Usage: ./scripts/verify-architecture.sh <path-to-JustSpeakToIt.app> <arm64|universal>
+# Usage: ./scripts/verify-architecture.sh <path-to-JustSpeakToIt.app> <arm64|universal> [embedded-cli|no-embedded-cli]
 #
-# The main executable and the embedded `speak` CLI are enforced: the arm64
-# primary download must not carry an x86_64 slice, and the universal legacy
-# download must carry both. Embedded frameworks are reported for the log but
-# not enforced; third-party binaries (Sparkle) ship universal.
+# The main executable is enforced: the arm64 primary download must not carry
+# an x86_64 slice, and the universal legacy download must carry both. The
+# embedded `speak` CLI is enforced the same way when the variant ships one
+# (`embedded-cli`, the default, for the legacy download) and must be absent
+# when it does not (`no-embedded-cli`: the primary download distributes the CLI
+# separately, issue #775). Embedded frameworks are reported for the log but not
+# enforced; third-party binaries (Sparkle) ship universal.
 
 set -euo pipefail
 
 APP_PATH="${1:-}"
 VARIANT="${2:-}"
+CLI_MODE="${3:-embedded-cli}"
 
 if [[ -z "$APP_PATH" || -z "$VARIANT" ]]; then
-    echo "Usage: $0 <path-to-JustSpeakToIt.app> <arm64|universal>" >&2
+    echo "Usage: $0 <path-to-JustSpeakToIt.app> <arm64|universal> [embedded-cli|no-embedded-cli]" >&2
     exit 1
 fi
+
+case "$CLI_MODE" in
+    embedded-cli|no-embedded-cli) ;;
+    *)
+        echo "error: unknown CLI mode '$CLI_MODE' (expected embedded-cli or no-embedded-cli)" >&2
+        exit 1
+        ;;
+esac
 
 if [[ ! -d "$APP_PATH" ]]; then
     echo "error: app bundle not found at $APP_PATH" >&2
@@ -53,7 +65,14 @@ check_binary() {
 }
 
 check_binary "$APP_PATH/Contents/MacOS/JustSpeakToIt"
-check_binary "$APP_PATH/Contents/MacOS/speak"
+if [[ "$CLI_MODE" == "embedded-cli" ]]; then
+    check_binary "$APP_PATH/Contents/MacOS/speak"
+elif [[ -e "$APP_PATH/Contents/MacOS/speak" ]]; then
+    echo "error: the $VARIANT variant must not embed Contents/MacOS/speak (the CLI is distributed separately)" >&2
+    exit 1
+else
+    echo "==> speak: not embedded (distributed separately)"
+fi
 
 for framework in "$APP_PATH"/Contents/Frameworks/*.framework; do
     [[ -d "$framework" ]] || continue

--- a/scripts/verify-cli-manifest.swift
+++ b/scripts/verify-cli-manifest.swift
@@ -1,0 +1,122 @@
+#!/usr/bin/env swift
+// Verify a speak CLI release manifest the way SpeakCLIManifestVerifier in the
+// app does (issue #775): the detached Ed25519 signature must check out against
+// the Sparkle public key, and every asset must describe the local archive it
+// names — architecture, byte count and SHA-256 — for this exact release.
+//
+// Usage: swift scripts/verify-cli-manifest.swift <manifest.json> <manifest.json.sig|-> \
+//            <public-key-base64|-> <version> <automation-schema-version> <zip>...
+//
+// Pass "-" for the signature and key to check an unsigned development manifest
+// structurally only; a release manifest must always be checked signed.
+
+import CryptoKit
+import Foundation
+
+struct Asset: Decodable {
+    let architecture: String
+    let url: URL
+    let byteCount: Int
+    let sha256: String
+}
+
+struct Manifest: Decodable {
+    let schemaVersion: Int
+    let version: String
+    let automationSchemaVersion: Int
+    let assets: [Asset]
+}
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data("error: \(message)\n".utf8))
+    exit(1)
+}
+
+let arguments = Array(CommandLine.arguments.dropFirst())
+guard arguments.count >= 6 else {
+    fail("usage: verify-cli-manifest.swift <manifest> <sig|-> <public-key|-> <version> <schema-version> <zip>...")
+}
+let manifestPath = arguments[0]
+let signaturePath = arguments[1]
+let publicKeyBase64 = arguments[2]
+let expectedVersion = arguments[3]
+guard let expectedSchema = Int(arguments[4]) else { fail("automation schema version must be a number") }
+let archives = arguments[5...].map { URL(fileURLWithPath: $0) }
+
+guard let manifestData = FileManager.default.contents(atPath: manifestPath) else {
+    fail("cannot read \(manifestPath)")
+}
+
+// Signature first: nothing in an unverified manifest is trusted.
+if signaturePath != "-" || publicKeyBase64 != "-" {
+    guard signaturePath != "-", publicKeyBase64 != "-" else {
+        fail("both the signature and the public key are required to verify a signed manifest")
+    }
+    guard let signatureText = FileManager.default.contents(atPath: signaturePath)
+        .flatMap({ String(data: $0, encoding: .utf8) })
+    else { fail("cannot read \(signaturePath)") }
+    guard let keyBytes = Data(base64Encoded: publicKeyBase64.trimmingCharacters(in: .whitespacesAndNewlines)),
+          let publicKey = try? Curve25519.Signing.PublicKey(rawRepresentation: keyBytes)
+    else { fail("the public key is not a base64 Ed25519 key") }
+    guard let signature = Data(base64Encoded: signatureText.trimmingCharacters(in: .whitespacesAndNewlines)),
+          signature.count == 64
+    else { fail("the signature file does not hold a base64 Ed25519 signature") }
+    guard publicKey.isValidSignature(signature, for: manifestData) else {
+        fail("the manifest signature does not verify with the supplied public key")
+    }
+    print("==> signature verifies with the Sparkle public key")
+} else {
+    print("==> unsigned manifest: structural checks only")
+}
+
+let manifest: Manifest
+do {
+    manifest = try JSONDecoder().decode(Manifest.self, from: manifestData)
+} catch {
+    fail("the manifest does not decode: \(error)")
+}
+guard manifest.schemaVersion == 1 else { fail("schemaVersion is \(manifest.schemaVersion), expected 1") }
+guard manifest.version == expectedVersion else {
+    fail("manifest version is \(manifest.version), expected \(expectedVersion)")
+}
+guard manifest.automationSchemaVersion == expectedSchema else {
+    fail("automationSchemaVersion is \(manifest.automationSchemaVersion), expected \(expectedSchema)")
+}
+
+let releasePrefix = "https://github.com/crmitchelmore/justspeaktoit/releases/download/mac-v\(expectedVersion)/"
+var remaining = Dictionary(uniqueKeysWithValues: archives.map { ($0.lastPathComponent, $0) })
+var seenArchitectures: Set<String> = []
+for asset in manifest.assets {
+    guard ["arm64", "x86_64"].contains(asset.architecture) else {
+        fail("unsupported architecture \(asset.architecture)")
+    }
+    guard seenArchitectures.insert(asset.architecture).inserted else {
+        fail("\(asset.architecture) is listed more than once")
+    }
+    let name = asset.url.lastPathComponent
+    guard name == "speak-\(expectedVersion)-\(asset.architecture).zip" else {
+        fail("\(asset.architecture) asset is named \(name)")
+    }
+    guard asset.url.absoluteString == releasePrefix + name else {
+        fail("\(name) must be published at \(releasePrefix)\(name), not \(asset.url.absoluteString)")
+    }
+    guard let archive = remaining.removeValue(forKey: name) else {
+        fail("\(name) was not supplied for verification")
+    }
+    guard let data = FileManager.default.contents(atPath: archive.path) else {
+        fail("cannot read \(archive.path)")
+    }
+    guard data.count == asset.byteCount else {
+        fail("\(name) is \(data.count) bytes, manifest says \(asset.byteCount)")
+    }
+    let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    guard digest == asset.sha256.lowercased() else {
+        fail("\(name) SHA-256 is \(digest), manifest says \(asset.sha256)")
+    }
+    print("==> \(name): \(asset.byteCount) bytes, sha256 \(digest)")
+}
+guard remaining.isEmpty else {
+    fail("archives without a manifest entry: \(remaining.keys.sorted().joined(separator: ", "))")
+}
+guard !manifest.assets.isEmpty else { fail("the manifest lists no assets") }
+print("==> manifest verified for speak \(manifest.version) (automation protocol v\(manifest.automationSchemaVersion))")

--- a/scripts/verify-speak-cli.sh
+++ b/scripts/verify-speak-cli.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Verify a standalone speak CLI release archive the way the app's installer
+# will (issue #775): a single `speak` at the archive root, exactly the promised
+# architecture, the release version linked in, a Developer ID signature with
+# the hardened runtime that satisfies the installer's requirement, and — once
+# notarised — Gatekeeper acceptance.
+#
+# Usage: ./scripts/verify-speak-cli.sh <zip> <arm64|x86_64> <version> [--signed] [--notarised]
+#
+#   --signed     fail unless the executable carries a Developer ID signature
+#   --notarised  also require Gatekeeper to accept the executable (implies --signed)
+
+set -euo pipefail
+
+ARCHIVE="${1:-}"
+ARCH="${2:-}"
+VERSION="${3:-}"
+shift 3 2>/dev/null || true
+REQUIRE_SIGNED=false
+REQUIRE_NOTARISED=false
+for flag in "$@"; do
+    case "$flag" in
+        --signed) REQUIRE_SIGNED=true ;;
+        --notarised) REQUIRE_SIGNED=true; REQUIRE_NOTARISED=true ;;
+        *)
+            echo "error: unknown option '$flag'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$ARCHIVE" || -z "$ARCH" || -z "$VERSION" ]]; then
+    echo "Usage: $0 <zip> <arm64|x86_64> <version> [--signed] [--notarised]" >&2
+    exit 1
+fi
+if [[ ! -f "$ARCHIVE" ]]; then
+    echo "error: archive not found: $ARCHIVE" >&2
+    exit 1
+fi
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+ditto -x -k "$ARCHIVE" "$SCRATCH/extract"
+ENTRIES="$(find "$SCRATCH/extract" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort | tr '\n' ' ' | sed 's/ $//')"
+if [[ "$ENTRIES" != "speak" ]]; then
+    echo "error: archive root must contain only 'speak' (found: $ENTRIES)" >&2
+    exit 1
+fi
+BINARY="$SCRATCH/extract/speak"
+if [[ ! -x "$BINARY" ]]; then
+    echo "error: speak is not executable" >&2
+    exit 1
+fi
+
+ARCHS="$(lipo -archs "$BINARY")"
+if [[ "$ARCHS" != "$ARCH" ]]; then
+    echo "error: speak contains [$ARCHS] but must contain exactly [$ARCH]" >&2
+    exit 1
+fi
+echo "==> architecture: $ARCHS"
+
+EMBEDDED_VERSION="$(xcrun segedit "$BINARY" -extract __TEXT __speak_ver "$SCRATCH/version" \
+    && tr -d '\0' < "$SCRATCH/version")"
+if [[ "$EMBEDDED_VERSION" != "$VERSION" ]]; then
+    echo "error: __TEXT,__speak_ver reads '$EMBEDDED_VERSION', expected '$VERSION'" >&2
+    exit 1
+fi
+echo "==> linked version: $EMBEDDED_VERSION"
+
+# SwiftPM ad-hoc signs every executable it links; only a Developer ID
+# signature counts as signed here.
+INFO="$(codesign -dv --verbose=4 "$BINARY" 2>&1 || true)"
+if codesign --verify --strict --verbose=2 "$BINARY" 2>/dev/null && ! grep -q "^Signature=adhoc" <<< "$INFO"; then
+    TEAM="$(sed -n 's/^TeamIdentifier=\(.*\)$/\1/p' <<< "$INFO" | head -n 1)"
+    if [[ -z "$TEAM" || "$TEAM" == "not set" ]]; then
+        echo "error: speak is signed without a team identifier" >&2
+        exit 1
+    fi
+    echo "$INFO" | grep -q "runtime" || {
+        echo "error: speak is signed without the hardened runtime" >&2
+        exit 1
+    }
+    # Exactly the requirement SpeakCLIInstallerDependencies.verifyDeveloperIDSignature applies.
+    codesign --verify --verbose=2 \
+        -R="anchor apple generic and certificate leaf[subject.OU] = \"$TEAM\"" "$BINARY"
+    echo "==> signature: Developer ID, team $TEAM, hardened runtime"
+elif [[ "$REQUIRE_SIGNED" == true ]]; then
+    echo "error: speak is not signed with a Developer ID identity" >&2
+    exit 1
+else
+    echo "==> unsigned or ad-hoc signed (development archive)"
+fi
+
+if [[ "$REQUIRE_NOTARISED" == true ]]; then
+    spctl --assess --type execute --verbose=2 "$BINARY"
+    echo "==> Gatekeeper accepts speak"
+fi
+
+can_run=false
+if [[ "$ARCH" == "$(uname -m)" ]]; then
+    can_run=true
+elif [[ "$ARCH" == "x86_64" ]] && arch -x86_64 /usr/bin/true 2>/dev/null; then
+    can_run=true
+fi
+if [[ "$can_run" == true ]]; then
+    REPORTED="$("$BINARY" --version)"
+    if [[ "$REPORTED" != "speak $VERSION" ]]; then
+        echo "error: 'speak --version' printed '$REPORTED', expected 'speak $VERSION'" >&2
+        exit 1
+    fi
+    echo "==> $REPORTED"
+else
+    echo "==> $ARCH cannot run here; --version check skipped"
+fi
+
+echo "==> $(basename "$ARCHIVE") verified"


### PR DESCRIPTION
Pipeline side of #775, stacked on #784 (both edit the release workflow; this PR's diff is against `ci/774-arm64-primary` and retargets to `main` when #784 merges). The app side is #787.

## What changes

**The arm64 primary download ships without `Contents/MacOS/speak`** (`embed-cli: "false"` on the package action). `verify-architecture.sh` now takes a third argument — `no-embedded-cli` asserts the binary is absent for the primary; `embedded-cli` (default) keeps enforcing its slices for the universal legacy build, which still embeds the CLI so legacy installs keep working as before. `record-release-size.sh` prints *not embedded* instead of failing.

**Standalone CLI assets per release**, built by a new composite action `.github/actions/publish-speak-cli`:

- `scripts/build-speak-cli-standalone.sh <arm64|x86_64> <version> <out> [identity]` — builds one slice, links the release version into a `__TEXT,__speak_ver` section (`-sectcreate`; #787's `SpeakCLIVersion` reads it so the bare binary reports its own version), checks exactly one slice and the section contents, signs with the hardened runtime, runs `speak --version` where the slice can run (x86_64 under Rosetta when present), and archives `speak` alone at the zip root — the layout `SpeakCLIInstaller` extracts and Homebrew installs — verifying the round trip. Prints compressed and installed sizes to the step summary.
- Both archives are **notarised** (`notarytool submit --wait`, accepted status required; bare executables cannot be stapled so Gatekeeper checks the ticket online).
- `scripts/verify-speak-cli.sh` — re-verifies each archive the way the installer will: single root entry, exact slice, linked version, Developer ID signature with team identifier and hardened runtime checked against the installer's own requirement string (`anchor apple generic and certificate leaf[subject.OU] = "<team>"`), `spctl --assess` after notarisation, `--version` output. Ad-hoc (SwiftPM) signatures do not count as signed.
- `scripts/generate-cli-manifest.sh` — writes `speak-cli-manifest.json` (`schemaVersion` 1, `version`, `automationSchemaVersion` read from `AutomationSchema.currentVersion` in source, per-arch `url`/`byteCount`/`sha256`) and, via the new `scripts/sparkle-sign-file.sh` (Sparkle `sign_update`, same key as the appcasts), the detached `speak-cli-manifest.json.sig`.
- `scripts/verify-cli-manifest.swift` — verifies the signature with CryptoKit against `SUPublicEDKey` from `Config/AppInfo.plist` (the exact check the app performs) and that every asset entry matches the local archive byte-for-byte and digest-for-digest, before anything is uploaded.

**Release assets**: the two zips, the manifest and its signature join the DMGs and appcasts. The manifest is fetched by the app from `releases/latest/download/`, so asset names are fixed to what #787 expects (`speak-<version>-<arch>.zip`, `speak-cli-manifest.json[.sig]`).

**Optional by design.** The CLI step runs with `continue-on-error`; on failure the app release completes normally, an `::error` annotation and a step-summary note explain it, and (on tag builds) a follow-up issue *speak CLI assets missing for mac-v<version>* is opened (`issues: write` added to the release job). The new **`publish-speak-cli.yml`** workflow (`workflow_dispatch`, version) rebuilds, notarises and verifies the archives from the existing tag, uploads them to the existing release with `--clobber`, and updates the tap — the independent retry path the issue asks for.

**Homebrew** (`scripts/update-homebrew-tap.sh`, replacing the inline heredoc): the tap gains `Formula/speak.rb` (per-arch `url`/`sha256` under `on_macos`, `bin.install "speak"`, `--version` test, caveat pointing at the app), and the cask drops the `binary` link into the app bundle in favour of `depends_on formula: "crmitchelmore/justspeaktoit/speak"` — that is the migration path for existing Homebrew links: upgrading the cask removes its old `speak` symlink and the formula provides the standalone one, on Intel too (Homebrew users use the independent distribution on both architectures; only non-Homebrew legacy installs keep the embedded copy). If the formula does not exist yet (CLI publication failed on the first release), the cask is written without the dependency and picks it up on the next successful publication. Also fixes the cask's `zap` paths to what the app actually writes (`~/Library/Application Support/SpeakApp`, `com.justspeaktoit.mac`) and the remaining `brew style` offences. Both generated files pass `brew style` with no offences.

README points Homebrew users at the formula; `Docs/automation.md` path examples are updated in a follow-up commit once this is rebased over #787 (that PR rewrites the same section).

## Verification

Local dry run (unsigned, throwaway Ed25519 key, with #787's `SpeakCLIVersion` in place):

- arm64 and x86_64 archives build; the section reads back `9.9.9-test`; `speak --version` prints `speak 9.9.9-test` for the native slice; each zip round-trips to a single `speak`.
- manifest signed with the throwaway key verifies with the derived public key; a one-byte tamper and a wrong automation schema version are refused; the unsigned structural mode works; the manifest decodes with the app's `SpeakCLIManifest` shape.
- `verify-speak-cli.sh --signed` refuses ad-hoc signed binaries.
- `verify-architecture.sh` passes/fails correctly for all mode × presence combinations; `record-release-size.sh` handles both.
- `update-homebrew-tap.sh` dry runs against a clone of the real tap with and without CLI digests; `brew style` clean.
- `bash -n` on every script; YAML parses.

What only CI can exercise: Developer ID signing, notarisation of the CLI zips, the real Sparkle key, the tap push. Plan: after #784's dry run passes and this is rebased, dispatch `release-mac.yml` on this branch with a catalogue version to exercise the CLI step end to end (tag-gated steps stay skipped).

## Merge order

After **#784** (base) and **#787** (the version-section reader; without it the `--version` check in the CLI step fails — gracefully, but the first release would publish no CLI).

Refs #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b
