### PR TITLE
fix(core): restore the public initialisers removed by #777 and #782

### DIFF
--- a/Sources/SpeakCore/DictationProfile.swift
+++ b/Sources/SpeakCore/DictationProfile.swift
@@ -88,7 +88,7 @@ public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
         polishIncludeLexiconDirectives: Bool? = nil,
         polishIncludeContextTags: Bool? = nil,
         languageIdentifier: String? = nil,
-        transcriptionRouting: DictationProfileTranscriptionRouting? = nil
+        transcriptionRouting: DictationProfileTranscriptionRouting?
     ) {
         self.id = id
         self.name = name
@@ -102,6 +102,39 @@ public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
         self.polishIncludeLexiconDirectives = polishIncludeLexiconDirectives
         self.polishIncludeContextTags = polishIncludeContextTags
         self.languageIdentifier = languageIdentifier
+    }
+
+    /// The pre-#690 initializer, kept for source and API compatibility (#791).
+    /// A profile created this way carries no explicit routing, so the applier
+    /// derives it from the model identifier exactly as it does for profiles
+    /// saved before routing metadata existed.
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        matchers: [DictationProfileMatcher] = [],
+        transcriptionModelID: String? = nil,
+        polishEnabled: Bool? = nil,
+        polishModelID: String? = nil,
+        polishPrompt: String? = nil,
+        polishOutputLanguage: String? = nil,
+        polishIncludeLexiconDirectives: Bool? = nil,
+        polishIncludeContextTags: Bool? = nil,
+        languageIdentifier: String? = nil
+    ) {
+        self.init(
+            id: id,
+            name: name,
+            matchers: matchers,
+            transcriptionModelID: transcriptionModelID,
+            polishEnabled: polishEnabled,
+            polishModelID: polishModelID,
+            polishPrompt: polishPrompt,
+            polishOutputLanguage: polishOutputLanguage,
+            polishIncludeLexiconDirectives: polishIncludeLexiconDirectives,
+            polishIncludeContextTags: polishIncludeContextTags,
+            languageIdentifier: languageIdentifier,
+            transcriptionRouting: nil
+        )
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/SpeakCore/DictationProfile.swift
+++ b/Sources/SpeakCore/DictationProfile.swift
@@ -88,7 +88,7 @@ public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
         polishIncludeLexiconDirectives: Bool? = nil,
         polishIncludeContextTags: Bool? = nil,
         languageIdentifier: String? = nil,
-        transcriptionRouting: DictationProfileTranscriptionRouting?
+        transcriptionRouting: DictationProfileTranscriptionRouting? = nil
     ) {
         self.id = id
         self.name = name
@@ -107,7 +107,9 @@ public struct DictationProfile: Codable, Equatable, Identifiable, Sendable {
     /// The pre-#690 initializer, kept for source and API compatibility (#791).
     /// A profile created this way carries no explicit routing, so the applier
     /// derives it from the model identifier exactly as it does for profiles
-    /// saved before routing metadata existed.
+    /// saved before routing metadata existed. Calls without `transcriptionRouting:`
+    /// resolve here (fewer parameters win); calls with it use the designated
+    /// initializer.
     public init(
         id: UUID = UUID(),
         name: String,

--- a/Sources/SpeakCore/KeyboardHandoff.swift
+++ b/Sources/SpeakCore/KeyboardHandoff.swift
@@ -58,9 +58,15 @@ public final class KeyboardHandoffStore: @unchecked Sendable {
     /// Injectable for deterministic tests. Passing `nil` models a missing or
     /// inaccessible App Group. Tests pass explicit roles to model the two
     /// processes as two independent store instances.
-    public init(defaults: UserDefaults?, role: Role = .detected) {
+    public init(defaults: UserDefaults?, role: Role) {
         self.defaults = defaults
         self.role = role
+    }
+
+    /// The pre-v4 initializer, kept for source and API compatibility (#790):
+    /// the role is detected from the running process, exactly as `shared` does.
+    public convenience init(defaults: UserDefaults?) {
+        self.init(defaults: defaults, role: .detected)
     }
 
     public var isAvailable: Bool {

--- a/Sources/SpeakCore/KeyboardHandoff.swift
+++ b/Sources/SpeakCore/KeyboardHandoff.swift
@@ -58,13 +58,15 @@ public final class KeyboardHandoffStore: @unchecked Sendable {
     /// Injectable for deterministic tests. Passing `nil` models a missing or
     /// inaccessible App Group. Tests pass explicit roles to model the two
     /// processes as two independent store instances.
-    public init(defaults: UserDefaults?, role: Role) {
+    public init(defaults: UserDefaults?, role: Role = .detected) {
         self.defaults = defaults
         self.role = role
     }
 
     /// The pre-v4 initializer, kept for source and API compatibility (#790):
     /// the role is detected from the running process, exactly as `shared` does.
+    /// Swift resolves `init(defaults:)` calls to this overload (no defaulted
+    /// parameter is needed), so both symbols stay usable.
     public convenience init(defaults: UserDefaults?) {
         self.init(defaults: defaults, role: .detected)
     }

--- a/Sources/SpeakCore/VoiceEditPolicy.swift
+++ b/Sources/SpeakCore/VoiceEditPolicy.swift
@@ -58,6 +58,14 @@ public enum VoiceEditPolicy {
         return text
     }
 
+    /// The pre-#673 shape, kept for source and API compatibility: a rewrite
+    /// with no spoken instruction, so every accidental wrapper is removed.
+    /// Calls without `instruction:` resolve here; the designated overload
+    /// above takes the instruction into account.
+    public static func normalizedRewrite(_ raw: String, original: String) -> String {
+        normalizedRewrite(raw, original: original, instruction: "")
+    }
+
     // MARK: - Private helpers
 
     private struct VoiceEditPayload: Encodable {

--- a/Tests/SpeakCoreTests/PublicAPICompatibilityFixtureTests.swift
+++ b/Tests/SpeakCoreTests/PublicAPICompatibilityFixtureTests.swift
@@ -20,4 +20,54 @@ final class PublicAPICompatibilityFixtureTests: XCTestCase {
         XCTAssertFalse(keychain.title.isEmpty)
     }
 
+    func testKeyboardHandoffStore_keepsThePre777Initializer() throws {
+        // #790: `init(defaults:)` was removed by the v4 handoff layout; it is
+        // back, detecting the role from the process like `shared` does, and
+        // drives the same store as the explicit-role initializer.
+        let suite = "PublicAPICompatibility.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let store = KeyboardHandoffStore(defaults: defaults)
+        XCTAssertTrue(store.isAvailable)
+        XCTAssertFalse(KeyboardHandoffStore(defaults: nil).isAvailable)
+
+        let request = try store.createRequest()
+        let explicitRole = KeyboardHandoffStore(defaults: defaults, role: .containingApp)
+        XCTAssertEqual(explicitRole.activeRecord()?.requestID, request.requestID)
+        XCTAssertEqual(try explicitRole.markRecording(requestID: request.requestID).phase, .recording)
+        XCTAssertEqual(store.activeRecord()?.phase, .recording)
+    }
+
+    func testDictationProfile_keepsThePre782Initializer() {
+        // #791: the initializer without `transcriptionRouting:` is back; a
+        // profile created through it derives its routing from the identifier,
+        // as profiles saved before routing metadata existed always have.
+        let profile = DictationProfile(
+            id: UUID(),
+            name: "Legacy",
+            matchers: [DictationProfileMatcher(value: "com.example.app")],
+            transcriptionModelID: "local/whisperkit/tiny",
+            polishEnabled: true,
+            polishModelID: "openai/gpt-5-mini",
+            polishPrompt: "Tidy this.",
+            polishOutputLanguage: "en",
+            polishIncludeLexiconDirectives: true,
+            polishIncludeContextTags: false,
+            languageIdentifier: "en_GB"
+        )
+
+        XCTAssertNil(profile.transcriptionRouting)
+        XCTAssertEqual(profile.resolvedTranscriptionOverride?.routing, .localBatch)
+        XCTAssertEqual(profile.resolvedTranscriptionOverride?.modelID, "local/whisperkit/tiny")
+        XCTAssertEqual(profile.polishModelID, "openai/gpt-5-mini")
+        XCTAssertEqual(profile.languageIdentifier, "en_GB")
+
+        let routed = DictationProfile(
+            name: "Explicit",
+            transcriptionModelID: "deepgram/nova-4-custom-streaming",
+            transcriptionRouting: .remoteStreaming
+        )
+        XCTAssertEqual(routed.resolvedTranscriptionOverride?.routing, .remoteStreaming)
+    }
 }


### PR DESCRIPTION
Fixes #790 and #791.

The **Public API compatibility** job failed on #777 and #782 but is not a required check, and the train's merge gate only looked at the required ones, so both merged with a removed public constructor in `SpeakCore`. (The merge helper now refuses any PR with a failed check unless a flake is explicitly documented.)

## Changes

- `KeyboardHandoffStore.init(defaults:)` is back as a convenience initializer that detects the role from the process (exactly what `shared` does). `init(defaults:role:)` keeps its defaulted role; Swift resolves `init(defaults:)` calls to the overload that needs no default argument, so the two coexist without ambiguity and the gate sees the current symbol unchanged.
- `DictationProfile`'s pre-#690 initializer (without `transcriptionRouting:`) is back, delegating to the designated initializer with `transcriptionRouting: nil` — such a profile derives its routing from the identifier, as every profile saved before routing metadata existed does. The designated initializer keeps its default; calls without the argument resolve to the restored overload.
- `VoiceEditPolicy.normalizedRewrite(_:original:)` (renamed by #673's instruction-aware overload) is restored the same way — the gate flagged it against the pre-#777 baseline.

## Verification

- `PublicAPICompatibilityFixtureTests` (plain `import SpeakCore`, the external-consumer surface) covers both restored initializers.
- Handoff, profile, editor-draft, applier and Voice Edit policy suites: 101 tests green; `make lint` clean.
- `scripts/check-api-compatibility.sh origin/main`: no breaking changes in any product. Against the pre-#777 baseline (`d7aebac8`) the only remaining findings are the two `ChannelFeature` enum cases added by #673 and #775 — additions a shim cannot cover; whether a public `CaseIterable` enum gaining cases counts as breaking for this repository is a policy call, raised on #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved compatibility with earlier dictation profile, keyboard handoff, and voice editing APIs.
  * Maintained legacy routing behavior and keyboard handoff state management.
  * Preserved existing text rewrite behavior when no additional instructions are provided.

* **Tests**
  * Added coverage verifying legacy API behavior, routing, availability, shared state, and recording transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->