### PR TITLE
ci(release): stop assessing the bare speak executable with spctl

### DIFF
--- a/.github/actions/publish-speak-cli/action.yml
+++ b/.github/actions/publish-speak-cli/action.yml
@@ -111,8 +111,10 @@ runs:
         APPLE_ID_PASSWORD: ${{ inputs.apple-id-password }}
         APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
       run: |
-        # A bare executable cannot be stapled; Gatekeeper checks the ticket
-        # online, which verify-speak-cli.sh --notarised exercises below.
+        # A bare executable cannot be stapled and Gatekeeper cannot assess one
+        # (`spctl` answers "does not seem to be an app"), so notarytool's
+        # Accepted status here is the notarisation proof for the CLI; the
+        # verification below checks the archive and the Developer ID signature.
         for archive in "${{ steps.paths.outputs.arm64-zip }}" "${{ steps.paths.outputs.x86_64-zip }}"; do
           echo "==> Notarising $(basename "$archive")"
           OUTPUT="$(xcrun notarytool submit "$archive" \

--- a/scripts/verify-speak-cli.sh
+++ b/scripts/verify-speak-cli.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 # Verify a standalone speak CLI release archive the way the app's installer
 # will (issue #775): a single `speak` at the archive root, exactly the promised
-# architecture, the release version linked in, a Developer ID signature with
-# the hardened runtime that satisfies the installer's requirement, and — once
-# notarised — Gatekeeper acceptance.
+# architecture, the release version linked in, and a Developer ID signature
+# with the hardened runtime that satisfies the installer's requirement.
+#
+# Notarisation of a bare executable cannot be checked here: `spctl --assess`
+# only assesses bundles, installers and disk images and answers "does not seem
+# to be an app" for a Mach-O file, and a ticket cannot be stapled to one. The
+# caller proves notarisation from `notarytool`'s Accepted status at submission;
+# `--notarised` records that the archive is expected to be in that state.
 #
 # Usage: ./scripts/verify-speak-cli.sh <zip> <arm64|x86_64> <version> [--signed] [--notarised]
 #
 #   --signed     fail unless the executable carries a Developer ID signature
-#   --notarised  also require Gatekeeper to accept the executable (implies --signed)
+#   --notarised  the caller has notarised the archive (implies --signed)
 
 set -euo pipefail
 
@@ -93,8 +98,10 @@ else
 fi
 
 if [[ "$REQUIRE_NOTARISED" == true ]]; then
-    spctl --assess --type execute --verbose=2 "$BINARY"
-    echo "==> Gatekeeper accepts speak"
+    # Gatekeeper cannot assess a bare executable (see the header); the
+    # Developer ID requirement above plus the caller's notarytool acceptance
+    # are the checks that apply to a CLI.
+    echo "==> notarised by the caller (notarytool Accepted); Gatekeeper assessment does not apply to a bare executable"
 fi
 
 can_run=false


### PR DESCRIPTION
Fixes the failure behind #794 (first CLI-bearing release, mac-v2.63.0): both `speak` archives built, signed and were **notarised** (`notarytool` Accepted), but `verify-speak-cli.sh --notarised` then ran `spctl --assess --type execute` on the bare executable, and Gatekeeper answered *rejected (the code is valid but does not seem to be an app)* — `spctl` only assesses bundles, installers and disk images. The publication step therefore skipped (as designed) and the issue was auto-opened.

`--notarised` now records that the caller notarised the archive (it still implies the Developer ID signature check against the installer's own requirement) instead of running an assessment that can never pass for a Mach-O file; the action's comment explains that notarytool's Accepted status is the proof for a CLI.

After this merges (`ci:` — no release), *Publish speak CLI* will be dispatched for the affected releases to add their CLI assets, manifest and the `speak` formula.

Refs #775 #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b