### PR TITLE
ci(release): republish the CLI with the current pipeline, not the tag's

### DIFF
--- a/.github/workflows/publish-speak-cli.yml
+++ b/.github/workflows/publish-speak-cli.yml
@@ -30,6 +30,25 @@ jobs:
           ref: refs/tags/mac-v${{ github.event.inputs.version }}
           fetch-depth: 0
 
+      - name: Use the current pipeline scripts
+        run: |
+          # The CLI is built from the tag's sources, but the publication
+          # pipeline itself — build, verify, manifest, tap scripts and the
+          # composite action — comes from main, so a pipeline fix can
+          # republish a release whose own run failed (the point of this
+          # workflow). The first republish attempt for 2.63.1 reran the
+          # tag's broken verification script instead.
+          git fetch --no-tags origin main
+          git checkout origin/main -- \
+            scripts/build-speak-cli-standalone.sh \
+            scripts/verify-speak-cli.sh \
+            scripts/generate-cli-manifest.sh \
+            scripts/sparkle-sign-file.sh \
+            scripts/verify-cli-manifest.swift \
+            scripts/update-homebrew-tap.sh \
+            .github/actions/publish-speak-cli
+          git status --short
+
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/publish-speak-cli.yml
+++ b/.github/workflows/publish-speak-cli.yml
@@ -37,8 +37,10 @@ jobs:
           # composite action — comes from main, so a pipeline fix can
           # republish a release whose own run failed (the point of this
           # workflow). The first republish attempt for 2.63.1 reran the
-          # tag's broken verification script instead.
-          git fetch --no-tags origin main
+          # tag's broken verification script instead. The explicit refspec
+          # updates refs/remotes/origin/main itself rather than relying on
+          # git's opportunistic remote-tracking update of a bare `fetch main`.
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           git checkout origin/main -- \
             scripts/build-speak-cli-standalone.sh \
             scripts/verify-speak-cli.sh \

--- a/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
+++ b/Tests/SpeakAppTests/DistributionBuildIdentityTests.swift
@@ -587,6 +587,14 @@ final class DistributionBuildIdentityTests: XCTestCase {
         XCTAssertTrue(retryWorkflow.contains("grep -oE 'arm: *\"[0-9a-f]{64}\"'"))
         XCTAssertTrue(retryWorkflow.contains("grep -oE 'intel: *\"[0-9a-f]{64}\"'"))
         XCTAssertTrue(retryWorkflow.contains("Could not read the DMG digests"))
+        // It builds the CLI from the tag but runs the pipeline files from
+        // main, fetched into the remote-tracking ref it then checks out from.
+        XCTAssertTrue(retryWorkflow.contains("ref: refs/tags/mac-v${{ github.event.inputs.version }}"))
+        XCTAssertTrue(retryWorkflow.contains(
+            "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main"
+        ))
+        XCTAssertTrue(retryWorkflow.contains("git checkout origin/main -- \\\n            scripts/"))
+        XCTAssertTrue(retryWorkflow.contains("            .github/actions/publish-speak-cli\n"))
 
         // Signing tools never arrive through an unverified download while the
         // private key is on disk.


### PR DESCRIPTION
The republish for 2.63.1 (run 32597334242) failed on the very check #796 removed: `publish-speak-cli.yml` checks out the release tag and then ran the *tag's* `verify-speak-cli.sh` and composite action. A retry workflow for a failed pipeline step has to use the pipeline as it is now.

After the tag checkout, the workflow now takes the pipeline files from `main` — `build-speak-cli-standalone.sh`, `verify-speak-cli.sh`, `generate-cli-manifest.sh`, `sparkle-sign-file.sh`, `verify-cli-manifest.swift`, `update-homebrew-tap.sh` and `.github/actions/publish-speak-cli` — while the CLI itself is still built from the tag's sources (and the manifest's automation schema version is read from the tag's `AutomationProtocol.swift`).

`ci:` change, no release. Once merged, *Publish speak CLI* is dispatched again for 2.63.1.

Refs #775 #794 #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b