### PR TITLE
fix(mac): never report a finished automation command as timed out; harden the flaky CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,8 +189,11 @@ jobs:
             -quiet \
             2>&1 | tee "$RUNNER_TEMP/ios-tests.log" | tail -50
 
+      # Both diagnostics also run when the job is cancelled (a superseded push
+      # cancels in-progress runs): a partial log still names the assertion
+      # that had already failed.
       - name: Show failing assertions
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         run: |
           echo "::group::Assertion failures and crashes from the iOS test log"
           grep -nE 'error: |Fatal error|Assertion Failure|Failed to (get|find|launch)|Restarting after|crashed' \
@@ -198,7 +201,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload iOS test results
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@v7.0.1
         with:
           name: ios-test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,8 @@ jobs:
         run: tuist generate --no-open
 
       - name: Test iOS App and Action Button Settings
+        # The full log is kept: `tail` only shows the closing summary, which
+        # names a failed test without the assertion that failed (issue #793).
         run: |
           set -o pipefail
           xcodebuild test \
@@ -182,9 +184,28 @@ jobs:
             -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
             -only-testing:SpeakiOSTests \
             -only-testing:SpeakiOSUITests \
+            -resultBundlePath "$RUNNER_TEMP/SpeakiOS.xcresult" \
             -skipPackagePluginValidation \
             -quiet \
-            2>&1 | tail -50
+            2>&1 | tee "$RUNNER_TEMP/ios-tests.log" | tail -50
+
+      - name: Show failing assertions
+        if: failure()
+        run: |
+          echo "::group::Assertion failures and crashes from the iOS test log"
+          grep -nE 'error: |Fatal error|Assertion Failure|Failed to (get|find|launch)|Restarting after|crashed' \
+            "$RUNNER_TEMP/ios-tests.log" | head -200 || echo "(none matched)"
+          echo "::endgroup::"
+
+      - name: Upload iOS test results
+        if: failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: ios-test-results
+          path: |
+            ${{ runner.temp }}/SpeakiOS.xcresult
+            ${{ runner.temp }}/ios-tests.log
+          if-no-files-found: ignore
 
       - name: Build watchOS App (feature-flagged)
         # The watch app target only exists when generated with

--- a/Sources/SpeakApp/Transport/AutomationDeadline.swift
+++ b/Sources/SpeakApp/Transport/AutomationDeadline.swift
@@ -32,14 +32,20 @@ enum AutomationDeadline {
             let gate = Gate(continuation: continuation)
             let deadline = Task.detached {
                 try? await Task.sleep(for: .seconds(seconds))
+                // A cancelled timer lost the race. Without this guard the sleep
+                // returns the instant the command cancels it, and on a starved
+                // machine the timer could reach the gate before the command's own
+                // result did — reporting a finished command as timed out.
+                guard !Task.isCancelled else { return }
                 await gate.settle(nil)
             }
             Task.detached {
                 let response = await work.value
-                // Releases the timer as soon as it can no longer win, rather than
-                // leaving it asleep for the remainder of a long deadline.
-                deadline.cancel()
+                // Settle first, so the result is what answers the waiter; then
+                // release the timer rather than leaving it asleep for the rest of
+                // a long deadline.
                 await gate.settle(response)
+                deadline.cancel()
             }
         }
         return outcome ?? .failure(

--- a/Sources/SpeakApp/Transport/AutomationDeadline.swift
+++ b/Sources/SpeakApp/Transport/AutomationDeadline.swift
@@ -28,6 +28,20 @@ enum AutomationDeadline {
         id: String,
         command: AutomationCommand
     ) async -> AutomationResponse {
+        await value(of: work, within: seconds, id: id, command: command, beforeSettling: nil)
+    }
+
+    /// Test seam: `beforeSettling` runs once the command has completed and before
+    /// its result reaches the gate, with the timer task in hand, so a test can
+    /// force the interleaving a starved CI runner produced — a cancelled timer
+    /// that runs to completion ahead of the result.
+    static func value(
+        of work: Task<AutomationResponse, Never>,
+        within seconds: TimeInterval,
+        id: String,
+        command: AutomationCommand,
+        beforeSettling: (@Sendable (Task<Void, Never>) async -> Void)?
+    ) async -> AutomationResponse {
         let outcome: AutomationResponse? = await withCheckedContinuation { continuation in
             let gate = Gate(continuation: continuation)
             let deadline = Task.detached {
@@ -41,6 +55,7 @@ enum AutomationDeadline {
             }
             Task.detached {
                 let response = await work.value
+                await beforeSettling?(deadline)
                 // Settle first, so the result is what answers the waiter; then
                 // release the timer rather than leaving it asleep for the rest of
                 // a long deadline.

--- a/Tests/SpeakAppTests/AutomationDeadlineTests.swift
+++ b/Tests/SpeakAppTests/AutomationDeadlineTests.swift
@@ -10,10 +10,32 @@ import XCTest
 /// already finished. The work task cancelled the timer before settling the
 /// gate, so on a starved runner the woken timer could reach the gate first.
 final class AutomationDeadlineTests: XCTestCase {
+    func testCancelledTimerThatRunsToCompletionFirst_doesNotSettleTheGate() async {
+        let work = Task<AutomationResponse, Never> {
+            .success(id: "fast", command: .status, result: AutomationResult(text: "done"))
+        }
+
+        // The CI interleaving, made deterministic: the timer is cancelled and
+        // runs all the way to completion before the finished command's result
+        // reaches the gate. With the old ordering the cancelled sleep returned at
+        // once and the timer settled `nil`, so this reply was `timed_out`.
+        let response = await AutomationDeadline.value(
+            of: work,
+            within: 30,
+            id: "fast",
+            command: .status
+        ) { timer in
+            timer.cancel()
+            await timer.value
+        }
+
+        XCTAssertTrue(response.ok, "A finished command was reported as \(String(describing: response.error))")
+        XCTAssertEqual(response.result?.text, "done")
+    }
+
     func testCommandThatFinishesFirst_isNeverReportedAsTimedOut() async {
-        // Many iterations: the bug was a scheduling race, so one exchange would
-        // prove nothing. With the result settling the gate before the timer is
-        // cancelled, no iteration can see the deadline win.
+        // The unconstrained race, many times over: a guard against regressions in
+        // the task plumbing that the forced interleaving above does not touch.
         for iteration in 0..<300 {
             let work = Task<AutomationResponse, Never> {
                 .success(id: "fast", command: .status, result: AutomationResult(text: "done"))

--- a/Tests/SpeakAppTests/AutomationDeadlineTests.swift
+++ b/Tests/SpeakAppTests/AutomationDeadlineTests.swift
@@ -1,0 +1,57 @@
+#if os(macOS)
+import Foundation
+import SpeakCore
+import XCTest
+@testable import SpeakApp
+
+/// The race between a running command and the caller's deadline (issue #793):
+/// `AutomationServerTests.testRequest_isAnsweredOverTheSocket` failed on CI in
+/// under a second with a well-formed `timed_out` reply for a command that had
+/// already finished. The work task cancelled the timer before settling the
+/// gate, so on a starved runner the woken timer could reach the gate first.
+final class AutomationDeadlineTests: XCTestCase {
+    func testCommandThatFinishesFirst_isNeverReportedAsTimedOut() async {
+        // Many iterations: the bug was a scheduling race, so one exchange would
+        // prove nothing. With the result settling the gate before the timer is
+        // cancelled, no iteration can see the deadline win.
+        for iteration in 0..<300 {
+            let work = Task<AutomationResponse, Never> {
+                .success(id: "fast", command: .status, result: AutomationResult(text: "done"))
+            }
+            let response = await AutomationDeadline.value(of: work, within: 30, id: "fast", command: .status)
+
+            XCTAssertTrue(
+                response.ok,
+                "Iteration \(iteration): a finished command was reported as \(String(describing: response.error))"
+            )
+            XCTAssertEqual(response.result?.text, "done")
+            if !response.ok { break }
+        }
+    }
+
+    func testExpiredDeadline_answersAtTheDeadlineWithoutAbandoningTheCommand() async {
+        let finished = expectation(description: "command still runs to completion")
+        let work = Task<AutomationResponse, Never> {
+            try? await Task.sleep(for: .seconds(1))
+            finished.fulfill()
+            return .success(id: "slow", command: .stopDictation, result: AutomationResult(text: "late"))
+        }
+
+        let clock = ContinuousClock()
+        let started = clock.now
+        let response = await AutomationDeadline.value(of: work, within: 0.2, id: "slow", command: .stopDictation)
+        let elapsed = clock.now - started
+
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(response.id, "slow")
+        XCTAssertEqual(response.command, .stopDictation)
+        XCTAssertEqual(response.error?.code, .timedOut)
+        XCTAssertLessThan(elapsed, .seconds(0.9), "The timeout must be answered at the deadline, not after the command")
+
+        // The late result settles an already-answered gate: a no-op, not a second resume.
+        await fulfillment(of: [finished], timeout: 5)
+        let late = await work.value
+        XCTAssertEqual(late.result?.text, "late")
+    }
+}
+#endif

--- a/Tests/SpeakAppTests/AutomationServerTests.swift
+++ b/Tests/SpeakAppTests/AutomationServerTests.swift
@@ -49,7 +49,9 @@ final class AutomationServerTests: XCTestCase {
     func testRequest_isAnsweredOverTheSocket() async throws {
         let response = try await self.send(AutomationRequest(id: "req-1", command: .status))
 
-        XCTAssertTrue(response.ok)
+        // The error is the diagnosis when this fails: on CI it once carried a
+        // `timed_out` for a command that had finished (issue #793).
+        XCTAssertTrue(response.ok, "Round trip answered with \(String(describing: response.error))")
         XCTAssertEqual(response.id, "req-1")
         XCTAssertEqual(response.command, .status)
         XCTAssertEqual(response.result?.text, "handled-status")

--- a/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
+++ b/Tests/SpeakiOSUITests/ActionButtonSettingsUITests.swift
@@ -3,56 +3,87 @@ import XCTest
 final class ActionButtonSettingsUITests: XCTestCase {
     private var app: XCUIApplication!
 
+    /// Generous on purpose: these waits only cost time when an element is
+    /// missing, and this class runs first in the UI bundle, on a simulator that
+    /// is still cold on a loaded CI runner (issue #793).
+    private static let launchTimeout: TimeInterval = 60
+    private static let elementTimeout: TimeInterval = 15
+
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_GB"]
         app.launch()
+        // `launch()` returns when the process is up, not when the first screen
+        // has rendered; tapping a tab that is not there yet fails the test
+        // without a useful message.
+        XCTAssertTrue(
+            app.buttons["Settings"].waitForExistence(timeout: Self.launchTimeout),
+            "The Settings tab did not appear within \(Int(Self.launchTimeout))s of launch"
+        )
     }
 
     func testActionButtonDestinationCanBeConfigured() {
         app.buttons["Settings"].tap()
 
         let hardwareTriggerLink = app.buttons["hardwareTriggerSettingsLink"]
-        XCTAssertTrue(scrollUpUntilExists(hardwareTriggerLink))
+        XCTAssertTrue(scrollUpUntilExists(hardwareTriggerLink), "hardwareTriggerSettingsLink not found in Settings")
         hardwareTriggerLink.tap()
 
-        XCTAssertTrue(app.navigationBars["Action Button & Shortcuts"].waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            app.navigationBars["Action Button & Shortcuts"].waitForExistence(timeout: Self.elementTimeout),
+            "Action Button & Shortcuts screen did not open"
+        )
 
         let historyDestination = app.buttons["Save to History Only"]
-        XCTAssertTrue(historyDestination.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            historyDestination.waitForExistence(timeout: Self.elementTimeout),
+            "Save to History Only destination not offered"
+        )
         historyDestination.tap()
 
         let clipboardGuidance = app.staticTexts.matching(
             NSPredicate(format: "label CONTAINS %@", "Do not add a separate Copy to Clipboard action")
         ).firstMatch
-        XCTAssertTrue(scrollUpUntilExists(clipboardGuidance))
-        XCTAssertTrue(scrollUpUntilExists(app.buttons["openShortcutsAppButton"]))
+        XCTAssertTrue(scrollUpUntilExists(clipboardGuidance), "Clipboard guidance not shown for the history choice")
+        XCTAssertTrue(scrollUpUntilExists(app.buttons["openShortcutsAppButton"]), "openShortcutsAppButton not found")
 
         app.navigationBars.buttons.element(boundBy: 0).tap()
-        XCTAssertTrue(app.staticTexts["Save to History Only"].waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            app.staticTexts["Save to History Only"].waitForExistence(timeout: Self.elementTimeout),
+            "Settings did not reflect the chosen destination after going back"
+        )
     }
 
     func testModelPickersExposeCredentialReadiness() {
         app.buttons["Settings"].tap()
 
         let locationPicker = app.segmentedControls["transcriptionLocationPicker"]
-        XCTAssertTrue(scrollUpUntilExists(locationPicker))
+        XCTAssertTrue(scrollUpUntilExists(locationPicker), "transcriptionLocationPicker not found in Settings")
 
         let localModelPicker = app.descendants(matching: .any)["appleOnDeviceModelPicker"]
-        XCTAssertTrue(localModelPicker.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            localModelPicker.waitForExistence(timeout: Self.elementTimeout),
+            "appleOnDeviceModelPicker not found"
+        )
         localModelPicker.tap()
 
         let noKeyStatus = app.descendants(matching: .any).matching(
             NSPredicate(format: "label CONTAINS %@", "No API key required")
         ).firstMatch
-        XCTAssertTrue(noKeyStatus.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            noKeyStatus.waitForExistence(timeout: Self.elementTimeout),
+            "Local model picker did not state that no API key is required"
+        )
 
         app.navigationBars.buttons.element(boundBy: 0).tap()
         locationPicker.buttons["Remote"].tap()
 
         let remoteModelPicker = app.descendants(matching: .any)["remoteStreamingModelPicker"]
-        XCTAssertTrue(remoteModelPicker.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            remoteModelPicker.waitForExistence(timeout: Self.elementTimeout),
+            "remoteStreamingModelPicker not found after switching to Remote"
+        )
         remoteModelPicker.tap()
 
         let readyOrMissingStatus = app.descendants(matching: .any).matching(
@@ -62,7 +93,10 @@ final class ActionButtonSettingsUITests: XCTestCase {
                 "API key is not set"
             )
         ).firstMatch
-        XCTAssertTrue(readyOrMissingStatus.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            readyOrMissingStatus.waitForExistence(timeout: Self.elementTimeout),
+            "Remote model picker did not state whether the API key is set"
+        )
     }
 
     #if IOS_KEYBOARD_FEATURE
@@ -70,29 +104,47 @@ final class ActionButtonSettingsUITests: XCTestCase {
         app.buttons["Settings"].tap()
 
         let keyboardSetupLink = app.buttons["keyboardSetupLink"]
-        XCTAssertTrue(scrollUpUntilExists(keyboardSetupLink))
+        XCTAssertTrue(scrollUpUntilExists(keyboardSetupLink), "keyboardSetupLink not found in Settings")
         keyboardSetupLink.tap()
 
-        XCTAssertTrue(app.navigationBars["Just Speak Keyboard"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["openKeyboardSettingsButton"].waitForExistence(timeout: 5))
-        XCTAssertTrue(scrollUpUntilExists(app.staticTexts["Why Full Access?"]))
-        XCTAssertTrue(scrollUpUntilExists(app.staticTexts["Where It Won’t Appear"]))
+        XCTAssertTrue(
+            app.navigationBars["Just Speak Keyboard"].waitForExistence(timeout: Self.elementTimeout),
+            "Just Speak Keyboard screen did not open"
+        )
+        XCTAssertTrue(
+            app.buttons["openKeyboardSettingsButton"].waitForExistence(timeout: Self.elementTimeout),
+            "openKeyboardSettingsButton not found"
+        )
+        XCTAssertTrue(scrollUpUntilExists(app.staticTexts["Why Full Access?"]), "Full Access explanation not shown")
+        XCTAssertTrue(scrollUpUntilExists(app.staticTexts["Where It Won’t Appear"]), "Availability note not shown")
     }
     #else
     func testKeyboardOnboardingIsHiddenWhenFeatureIsDisabled() {
         app.buttons["Settings"].tap()
 
-        XCTAssertFalse(scrollUpUntilExists(app.buttons["keyboardSetupLink"]))
+        // Proving absence is the one place a long wait is pure cost.
+        XCTAssertFalse(
+            scrollUpUntilExists(app.buttons["keyboardSetupLink"], initialTimeout: 2, settleTimeout: 1),
+            "keyboardSetupLink must not appear when the keyboard feature is disabled"
+        )
     }
     #endif
 
-    private func scrollUpUntilExists(_ element: XCUIElement, maxSwipes: Int = 6) -> Bool {
-        if element.waitForExistence(timeout: 1) {
+    /// Waits for `element`, swiping up between attempts. The first wait covers a
+    /// screen that is still laying out; the settle wait covers the scroll
+    /// animation. Both return as soon as the element exists.
+    private func scrollUpUntilExists(
+        _ element: XCUIElement,
+        initialTimeout: TimeInterval = 5,
+        settleTimeout: TimeInterval = 2,
+        maxSwipes: Int = 6
+    ) -> Bool {
+        if element.waitForExistence(timeout: initialTimeout) {
             return true
         }
         for _ in 0..<maxSwipes {
             app.swipeUp()
-            if element.waitForExistence(timeout: 1) {
+            if element.waitForExistence(timeout: settleTimeout) {
                 return true
             }
         }


### PR DESCRIPTION
Closes #793.

## The macOS flake was a real bug
`AutomationServerTests.testRequest_isAnsweredOverTheSocket` failed on #785's first CI attempt (run 32593214897, attempt 1) **in 0.869 s** with a well-formed failure reply: `ok == false`, `result == nil`, while the `id`/`command` assertions and `handledCommands == [.status]` passed. By elimination that reply is `AutomationDeadline`'s `timed_out` — the only failure the server can produce with the right id and command after the handler ran — and it cannot come from the 15 s default deadline in under a second.

`AutomationDeadline.value` raced a sleeping timer task against the command and the work task did `deadline.cancel()` **before** `await gate.settle(response)`. A cancelled `Task.sleep` returns at once, the timer went on to `gate.settle(nil)`, and on a starved runner (the worker preempted between `cancel()` and `settle`) the timer reached the gate first. A client would then retry with the same id and collect the cached result, so no command was lost — but a finished command was reported as timed out.

Fix: settle with the result first, then cancel the timer; a cancelled timer returns without touching the gate. `AutomationDeadlineTests` pins it with 300 iterations plus the expired-deadline path (answered at the deadline, command not abandoned). `testRequest_isAnsweredOverTheSocket` now prints the error it received.

Reproduced deterministically: `AutomationDeadline.value` has an internal `beforeSettling` test seam (runs after the command completes, before its result reaches the gate, with the timer task in hand). `testCancelledTimerThatRunsToCompletionFirst_doesNotSettleTheGate` cancels the timer there and awaits it, so the cancelled timer runs to completion ahead of the result — the CI interleaving. That test fails under the old ordering (a `timed_out` reply) and passes with the fix; the 300-iteration loop stays as a plumbing guard.

## The iOS flake: cold simulator, and CI hid the detail
`ActionButtonSettingsUITests.testActionButtonDestinationCanBeConfigured` (failed on #766 and #778's first attempts) is the first test in the UI bundle on a simulator that is still cold. The class now waits for the root tab after `launch()` (60 s), uses 15 s element waits and a 5 s/2 s scroll search (they return as soon as the element exists, so green runs do not get slower; the absence check keeps short waits), and names the element in every assertion.

The job log only said `ActionButtonSettingsUITests.testActionButtonDestinationCanBeConfigured()` because the step ran `xcodebuild … -quiet | tail -50`. The step now tees the full log, a failure-only step prints the `error:`/crash lines, and the `.xcresult` + log are uploaded as `ios-test-results`, so the next failure names the assertion.

## Verification
- `swift test --filter 'AutomationDeadlineTests|AutomationServerTests'`: 10 tests pass.
- `swiftc -typecheck` of the UI test file against the iOS simulator SDK in both `IOS_KEYBOARD_FEATURE` shapes; strict SwiftLint clean; `ci.yml` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmeJQEKGyTssUw6Eiu2k5b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition that could incorrectly report completed commands as timed out.
  * Ensured timeout responses are returned promptly while allowing late command results to complete safely.

* **Tests**
  * Added coverage for command completion and deadline behavior.
  * Improved diagnostics for socket and iOS interface test failures.

* **Chores**
  * CI now preserves detailed iOS test logs and result bundles for failed runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->