### PR TITLE
fix(mac): restore clipboard delivery without AX field

### DIFF
--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -156,6 +156,20 @@ struct TextOutputTarget {
     }
     return .confirmed
   }
+
+  /// Clipboard delivery must still work for users who deliberately have not
+  /// granted Accessibility access. In that mode macOS will not expose a field
+  /// identity, so the strongest safe check available is that the captured app
+  /// is still the frontmost app. This preserves the pre-2.61 clipboard path
+  /// without allowing a paste into a different application.
+  func capturedApplicationIsFrontmost(
+    frontmostProcessIdentifier: pid_t? = NSWorkspace.shared.frontmostApplication?.processIdentifier
+  ) -> Bool {
+    guard isApplicationRunning, let processIdentifier, let frontmostProcessIdentifier else {
+      return false
+    }
+    return processIdentifier == frontmostProcessIdentifier
+  }
 }
 
 @MainActor
@@ -367,21 +381,8 @@ struct PasteTextOutput: TextOutputting {
       // Slack conversation, say) would receive the paste. Withhold the
       // keystroke unless the captured field provably still owns focus; the
       // transcript stays on the clipboard with the reason (issue #707).
-      if let target {
-        switch target.confirmCapturedFieldOwnsFocus() {
-        case .confirmed:
-          break
-        case .fieldUnavailable:
-          return TextOutputResult(
-            method: .clipboard,
-            error: TextOutputError.capturedFieldUnavailable
-          )
-        case .fieldChanged:
-          return TextOutputResult(
-            method: .clipboard,
-            error: TextOutputError.capturedFieldChanged
-          )
-        }
+      if let target, let identityError = fieldIdentityError(for: target) {
+        return TextOutputResult(method: .clipboard, error: identityError)
       }
       // Read before the paste replaces the selection; the pasted text starts
       // where the selection started.
@@ -411,6 +412,37 @@ struct PasteTextOutput: TextOutputting {
 
   static func hasDeliverableText(_ text: String) -> Bool {
     !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  static func requiresExactFieldIdentity(
+    textOutputMethod: AppSettings.TextOutputMethod,
+    accessibilityGranted: Bool
+  ) -> Bool {
+    textOutputMethod != .clipboardOnly && accessibilityGranted
+  }
+
+  /// Enforces exact field identity for Smart-mode fallback when Accessibility
+  /// is available. Explicit Clipboard mode intentionally uses process-level
+  /// identity, as does any installation without Accessibility permission.
+  /// Both cases retain the legacy Command-V workflow while refusing to paste
+  /// after the user switches to another application.
+  private func fieldIdentityError(for target: TextOutputTarget) -> TextOutputError? {
+    permissionsManager.refresh(.accessibility)
+    let accessibilityGranted = permissionsManager.status(for: .accessibility).isGranted
+    guard Self.requiresExactFieldIdentity(
+      textOutputMethod: appSettings.textOutputMethod,
+      accessibilityGranted: accessibilityGranted
+    ) else {
+      return target.capturedApplicationIsFrontmost() ? nil : .capturedFieldChanged
+    }
+    switch target.confirmCapturedFieldOwnsFocus() {
+    case .confirmed:
+      return nil
+    case .fieldUnavailable:
+      return .capturedFieldUnavailable
+    case .fieldChanged:
+      return .capturedFieldChanged
+    }
   }
 
   private func simulatePasteShortcut(destination: EventDestination) -> Bool {

--- a/Tests/SpeakAppTests/TextOutputTests.swift
+++ b/Tests/SpeakAppTests/TextOutputTests.swift
@@ -269,6 +269,17 @@ final class TextOutputTests: XCTestCase {
     XCTAssertFalse(target.capturedApplicationIsFrontmost(frontmostProcessIdentifier: nil))
   }
 
+  func testHotKeyMonitoringState_displayNames_AreActionable() {
+    XCTAssertEqual(HotKeyMonitoringState.active.displayName, "Active")
+    XCTAssertEqual(
+      HotKeyMonitoringState.inputMonitoringRequired.displayName,
+      "Needs Input Monitoring"
+    )
+    XCTAssertEqual(HotKeyMonitoringState.registrationFailed.displayName, "Reconnect Required")
+  }
+}
+
+final class ClipboardFieldIdentityPolicyTests: XCTestCase {
   @MainActor
   func testExactFieldIdentity_isOnlyRequiredForSmartModeWithAccessibility() {
     XCTAssertFalse(
@@ -289,14 +300,5 @@ final class TextOutputTests: XCTestCase {
         accessibilityGranted: true
       )
     )
-  }
-
-  func testHotKeyMonitoringState_displayNames_AreActionable() {
-    XCTAssertEqual(HotKeyMonitoringState.active.displayName, "Active")
-    XCTAssertEqual(
-      HotKeyMonitoringState.inputMonitoringRequired.displayName,
-      "Needs Input Monitoring"
-    )
-    XCTAssertEqual(HotKeyMonitoringState.registrationFailed.displayName, "Reconnect Required")
   }
 }

--- a/Tests/SpeakAppTests/TextOutputTests.swift
+++ b/Tests/SpeakAppTests/TextOutputTests.swift
@@ -181,9 +181,11 @@ final class TextOutputTests: XCTestCase {
       pasteboard.clearContents()
       UserDefaults.standard.removePersistentDomain(forName: suiteName)
     }
+    let settings = AppSettings(defaults: defaults)
+    settings.textOutputMethod = .smart
     let output = PasteTextOutput(
       permissionsManager: PermissionsManager(statusProvider: { _ in .granted }),
-      appSettings: AppSettings(defaults: defaults),
+      appSettings: settings,
       pasteboard: pasteboard
     )
 
@@ -254,6 +256,38 @@ final class TextOutputTests: XCTestCase {
         currentFocus: { AXUIElementCreateApplication(ownPid) }
       ),
       .confirmed
+    )
+  }
+
+  @MainActor
+  func testCapturedApplicationIsFrontmost_requiresSameRunningProcess() {
+    let ownPid = ProcessInfo.processInfo.processIdentifier
+    let target = makeRunningTarget(focusedElement: nil)
+
+    XCTAssertTrue(target.capturedApplicationIsFrontmost(frontmostProcessIdentifier: ownPid))
+    XCTAssertFalse(target.capturedApplicationIsFrontmost(frontmostProcessIdentifier: 1))
+    XCTAssertFalse(target.capturedApplicationIsFrontmost(frontmostProcessIdentifier: nil))
+  }
+
+  @MainActor
+  func testExactFieldIdentity_isOnlyRequiredForSmartModeWithAccessibility() {
+    XCTAssertFalse(
+      PasteTextOutput.requiresExactFieldIdentity(
+        textOutputMethod: .clipboardOnly,
+        accessibilityGranted: true
+      )
+    )
+    XCTAssertFalse(
+      PasteTextOutput.requiresExactFieldIdentity(
+        textOutputMethod: .smart,
+        accessibilityGranted: false
+      )
+    )
+    XCTAssertTrue(
+      PasteTextOutput.requiresExactFieldIdentity(
+        textOutputMethod: .smart,
+        accessibilityGranted: true
+      )
     )
   }
 


### PR DESCRIPTION
## Summary
- restore Command-V delivery for explicit Clipboard mode when Accessibility does not expose a focused field
- require the captured application to remain frontmost before pasting
- retain exact captured-field protection for Smart mode when Accessibility is available

## Regression
Versions after 2.60.6 could report “The field where recording started could not be identified” and withhold paste delivery for clipboard users, even though the transcript had been written to the clipboard.

## Verification
- swift test --filter TextOutputTests (16 tests passed)
- SwiftFormat lint on changed files
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard delivery when exact field identity is unavailable.
  * Smart output mode now validates the active application appropriately before completing a paste.
  * Clipboard-only mode and installations without Accessibility access now use a more reliable frontmost-application check.
* **Tests**
  * Expanded coverage for output-mode behavior, frontmost application matching, and accessibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->