### PR TITLE
fix(mac): continue clipboard fallback when AX field is unavailable

### DIFF
--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -435,11 +435,25 @@ struct PasteTextOutput: TextOutputting {
     ) else {
       return target.capturedApplicationIsFrontmost() ? nil : .capturedFieldChanged
     }
-    switch target.confirmCapturedFieldOwnsFocus() {
+    return Self.fieldIdentityError(
+      confirmation: target.confirmCapturedFieldOwnsFocus(),
+      capturedApplicationIsFrontmost: target.capturedApplicationIsFrontmost()
+    )
+  }
+
+  static func fieldIdentityError(
+    confirmation: TextOutputTarget.CapturedFieldConfirmation,
+    capturedApplicationIsFrontmost: Bool
+  ) -> TextOutputError? {
+    switch confirmation {
     case .confirmed:
       return nil
     case .fieldUnavailable:
-      return .capturedFieldUnavailable
+      // Some apps do not expose a focused AX element even though the user has
+      // granted Accessibility permission. Treat that the same as Clipboard
+      // mode: continue only while the captured app is still frontmost. A
+      // positive field mismatch remains fail-closed below.
+      return capturedApplicationIsFrontmost ? nil : .capturedFieldChanged
     case .fieldChanged:
       return .capturedFieldChanged
     }

--- a/Tests/SpeakAppTests/TextOutputTests.swift
+++ b/Tests/SpeakAppTests/TextOutputTests.swift
@@ -301,4 +301,26 @@ final class ClipboardFieldIdentityPolicyTests: XCTestCase {
       )
     )
   }
+
+  @MainActor
+  func testUnavailableFieldFallsBackToFrontmostCapturedApplication() {
+    XCTAssertNil(
+      PasteTextOutput.fieldIdentityError(
+        confirmation: .fieldUnavailable,
+        capturedApplicationIsFrontmost: true
+      )
+    )
+    guard case .capturedFieldChanged? = PasteTextOutput.fieldIdentityError(
+      confirmation: .fieldUnavailable,
+      capturedApplicationIsFrontmost: false
+    ) else {
+      return XCTFail("A missing field must not paste after the captured app loses focus")
+    }
+    guard case .capturedFieldChanged? = PasteTextOutput.fieldIdentityError(
+      confirmation: .fieldChanged,
+      capturedApplicationIsFrontmost: true
+    ) else {
+      return XCTFail("A positive field change must remain fail-closed")
+    }
+  }
 }

--- a/Tests/SpeakAppTests/TextOutputTests.swift
+++ b/Tests/SpeakAppTests/TextOutputTests.swift
@@ -173,7 +173,7 @@ final class TextOutputTests: XCTestCase {
   }
 
   @MainActor
-  func testPasteOutput_capturedTargetWithoutElement_WithholdsPasteAndKeepsClipboard() {
+  func testPasteOutput_capturedTargetWithoutElement_UsesApplicationFallbackAndKeepsClipboard() {
     let suiteName = "com.speakapp.text-output-tests.\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: suiteName)!
     let pasteboard = NSPasteboard(name: NSPasteboard.Name(suiteName))
@@ -192,8 +192,8 @@ final class TextOutputTests: XCTestCase {
     let result = output.output(text: "Withheld transcript", target: makeRunningTarget(focusedElement: nil))
 
     XCTAssertEqual(result.method, .clipboard)
-    guard case .some(TextOutputError.capturedFieldUnavailable) = result.error else {
-      return XCTFail("Expected capturedFieldUnavailable, got \(String(describing: result.error))")
+    if case .some(TextOutputError.capturedFieldUnavailable) = result.error {
+      XCTFail("A missing AX field should use the captured-application fallback")
     }
     XCTAssertEqual(pasteboard.string(forType: .string), "Withheld transcript")
   }


### PR DESCRIPTION
## Summary
- continue clipboard paste when Accessibility cannot expose the captured field but the original app is still frontmost
- retain fail-closed behaviour when the app changes or a positive field mismatch is observed
- cover the missing-field fallback policy with focused tests

## Verification
- `swift test --filter ClipboardFieldIdentityPolicyTests`
- `make lint`

Follow-up to #800 after confirming v2.63.4 could still stop in Smart mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart paste behavior when the captured field cannot be identified.
  * Paste now proceeds when the original app remains active, while correctly blocking changes to the field or loss of app focus.
* **Tests**
  * Added coverage for valid and invalid captured-field scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->