### PR TITLE
fix(mac): restore Terminal hotkey and warn on target changes

### DIFF
--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -1190,11 +1190,18 @@ final class MainManager: ObservableObject {
         return
       }
 
-      // Start monitoring for user corrections (auto-corrections feature)
       let focusedElement = session.outputTarget?.focusedElement ?? getFocusedElement()
       let appName = session.outputTarget?.applicationName
         ?? NSWorkspace.shared.frontmostApplication?.localizedName
-      autoCorrectionTracker.startMonitoring(insertedText: finalText, element: focusedElement, app: appName)
+      // A warning means delivery proceeded without proving the current field.
+      // Do not associate Voice Edit/correction tracking with the stale capture.
+      if outputWarning == nil {
+        autoCorrectionTracker.startMonitoring(
+          insertedText: finalText,
+          element: focusedElement,
+          app: appName
+        )
+      }
 
       session.outputDelivered = Date()
 

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -1125,6 +1125,7 @@ final class MainManager: ObservableObject {
 
       // Handle live text insertion finalization
       var liveFinalizationResult: LiveTextInserter.FinalizationResult = .deferred
+      var outputWarning: Error?
       if liveTextInserter.isActive {
         liveFinalizationResult = liveTextInserter.applyPolishedFinal(finalText)
         liveTextInserter.end()
@@ -1144,6 +1145,7 @@ final class MainManager: ObservableObject {
       case .deferred:
         let output = SmartTextOutput(permissionsManager: permissionsManager, appSettings: appSettings)
         let outputResult = output.output(text: finalText, target: session.outputTarget)
+        outputWarning = outputResult.warning
         session.outputMethod = outputResult.method
         if outputResult.error == nil {
           recordInsertion(of: finalText, range: outputResult.insertedRange, target: session.outputTarget)
@@ -1199,6 +1201,14 @@ final class MainManager: ObservableObject {
       session.events.append(
         HistoryEvent(kind: .outputDelivered, description: "Output delivered successfully")
       )
+      if let outputWarning {
+        session.events.append(
+          HistoryEvent(
+            kind: .outputDelivered,
+            description: "Delivery warning: \(outputWarning.localizedDescription)"
+          )
+        )
+      }
       session.destination = appName
       session.lexiconContext = makeLexiconContext(for: finalText, destination: appName)
       if let summary = session.personalCorrections {
@@ -1213,15 +1223,13 @@ final class MainManager: ObservableObject {
         lastErrorMessage = notice.message
         state = .failed(notice.message)
       } else {
-        if let stopToFinalMs = SessionLatencyMetrics.milliseconds(
-          from: session.stopRequested, to: session.outputDelivered
-        ) {
-          hudManager.finishSuccess(
-            message: "Delivered in \(SessionLatencyMetrics.formattedMilliseconds(stopToFinalMs))"
+        hudManager.finishSuccess(
+          message: Self.deliverySuccessMessage(
+            warning: outputWarning,
+            stopRequested: session.stopRequested,
+            delivered: session.outputDelivered
           )
-        } else {
-          hudManager.finishSuccess(message: "Delivered")
-        }
+        )
         state = .completed(historyItem)
       }
 
@@ -1238,6 +1246,23 @@ final class MainManager: ObservableObject {
       )
       cleanupAfterFailure(message: error.localizedDescription, preserveFile: true)
     }
+  }
+
+  private static func deliverySuccessMessage(
+    warning: Error?,
+    stopRequested: Date?,
+    delivered: Date?
+  ) -> String {
+    if let warning {
+      return "Delivered — \(warning.localizedDescription)"
+    }
+    guard let stopToFinalMs = SessionLatencyMetrics.milliseconds(
+      from: stopRequested,
+      to: delivered
+    ) else {
+      return "Delivered"
+    }
+    return "Delivered in \(SessionLatencyMetrics.formattedMilliseconds(stopToFinalMs))"
   }
   // swiftlint:enable cyclomatic_complexity function_body_length
 
@@ -1346,6 +1371,7 @@ final class MainManager: ObservableObject {
         let historyItem = session.buildHistoryItem(finalText: finalText)
         await historyManager.append(historyItem)
       } else {
+        recordDeliveryWarning(outputResult.warning, on: session)
         session.events.append(
           HistoryEvent(kind: .outputDelivered, description: "Retry output delivered successfully")
         )
@@ -1355,7 +1381,7 @@ final class MainManager: ObservableObject {
         let historyItem = session.buildHistoryItem(finalText: finalText)
         await historyManager.append(historyItem)
         clearRetryData()
-        hudManager.finishSuccess(message: "Retry Delivered")
+        hudManager.finishSuccess(message: Self.retryDeliverySuccessMessage(warning: outputResult.warning))
         state = .completed(historyItem)
       }
 
@@ -1382,6 +1408,20 @@ final class MainManager: ObservableObject {
     }
 
     activeSession = nil
+  }
+
+  private func recordDeliveryWarning(_ warning: Error?, on session: ActiveSession) {
+    guard let warning else { return }
+    session.events.append(
+      HistoryEvent(
+        kind: .outputDelivered,
+        description: "Delivery warning: \(warning.localizedDescription)"
+      )
+    )
+  }
+
+  private static func retryDeliverySuccessMessage(warning: Error?) -> String {
+    warning.map { "Retry delivered — \($0.localizedDescription)" } ?? "Retry Delivered"
   }
 
   // swiftlint:disable:next cyclomatic_complexity function_body_length

--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -37,6 +37,7 @@ private let logger = SpeakLogger.logger(category: "TextOutput")
 struct TextOutputResult {
   let method: HistoryTrigger.OutputMethod
   let error: Error?
+  let warning: Error?
   /// Where the text landed in the focused field, when the delivery path can
   /// tell. Voice Edit's "last dictation" fallback edits this exact range
   /// (issue #673).
@@ -45,10 +46,12 @@ struct TextOutputResult {
   init(
     method: HistoryTrigger.OutputMethod,
     error: Error?,
+    warning: Error? = nil,
     insertedRange: VoiceEditTextRange? = nil
   ) {
     self.method = method
     self.error = error
+    self.warning = warning
     self.insertedRange = insertedRange
   }
 }
@@ -368,6 +371,7 @@ struct PasteTextOutput: TextOutputting {
     }
 
     var insertedRange: VoiceEditTextRange?
+    var deliveryWarning: Error?
     if canPasteIntoOtherApps {
       let destination = Self.eventDestination(for: target)
       guard destination != .none else {
@@ -378,11 +382,14 @@ struct PasteTextOutput: TextOutputting {
       }
       // PID-directed events reach the captured *process*, not the captured
       // *field*: focus moved to another field in the same app (a different
-      // Slack conversation, say) would receive the paste. Withhold the
-      // keystroke unless the captured field provably still owns focus; the
-      // transcript stays on the clipboard with the reason (issue #707).
+      // Slack conversation, say) may receive the paste. Surface that as a
+      // warning, but honour the user's preference to deliver anyway.
       if let target, let identityError = fieldIdentityError(for: target) {
-        return TextOutputResult(method: .clipboard, error: identityError)
+        deliveryWarning = identityError
+        let warningDescription = identityError.localizedDescription
+        logger.warning(
+          "Output target changed; continuing paste into captured process: \(warningDescription, privacy: .public)"
+        )
       }
       // Read before the paste replaces the selection; the pasted text starts
       // where the selection started.
@@ -396,7 +403,12 @@ struct PasteTextOutput: TextOutputting {
       scheduleClipboardRestore(previousContents, on: pasteboard)
     }
 
-    return TextOutputResult(method: .clipboard, error: nil, insertedRange: insertedRange)
+    return TextOutputResult(
+      method: .clipboard,
+      error: nil,
+      warning: deliveryWarning,
+      insertedRange: insertedRange
+    )
   }
 
   /// Where `text` will land in the captured field, when Accessibility lets us

--- a/Sources/SpeakApp/TextOutput.swift
+++ b/Sources/SpeakApp/TextOutput.swift
@@ -393,7 +393,9 @@ struct PasteTextOutput: TextOutputting {
       }
       // Read before the paste replaces the selection; the pasted text starts
       // where the selection started.
-      insertedRange = pasteLandingRange(in: target, for: text)
+      if deliveryWarning == nil {
+        insertedRange = pasteLandingRange(in: target, for: text)
+      }
       guard simulatePasteShortcut(destination: destination) else {
         return TextOutputResult(method: .clipboard, error: TextOutputError.pasteShortcutUnavailable)
       }

--- a/Sources/SpeakHotKeys/FnKeyBackend.swift
+++ b/Sources/SpeakHotKeys/FnKeyBackend.swift
@@ -24,6 +24,7 @@ final class FnKeyBackend {
   private var localMonitor: Any?
   private var eventTap: CFMachPort?
   private var eventTapRunLoopSource: CFRunLoopSource?
+  private var hardwareStateTimer: Timer?
   private var fnIsPressed = false
 
   @discardableResult
@@ -41,6 +42,7 @@ final class FnKeyBackend {
     }
 
     let eventTapStarted = startEventTap()
+    startHardwareStatePolling()
     return eventTapStarted || globalMonitor != nil
   }
 
@@ -54,6 +56,8 @@ final class FnKeyBackend {
       self.localMonitor = nil
     }
     stopEventTap()
+    hardwareStateTimer?.invalidate()
+    hardwareStateTimer = nil
     fnIsPressed = false
   }
 
@@ -70,6 +74,7 @@ final class FnKeyBackend {
     if let tap = eventTap {
       CGEvent.tapEnable(tap: tap, enable: false)
     }
+    hardwareStateTimer?.invalidate()
   }
 
   // MARK: - NSEvent Handling (Fallback)
@@ -140,6 +145,26 @@ final class FnKeyBackend {
       CGEvent.tapEnable(tap: tap, enable: false)
     }
     eventTap = nil
+  }
+
+  /// Terminal and other secure-input clients can temporarily starve event-tap
+  /// and global-monitor callbacks. Poll the Fn hardware state independently so
+  /// the configured shortcut still receives balanced down/up edges there.
+  private func startHardwareStatePolling() {
+    hardwareStateTimer?.invalidate()
+    let timer = Timer(timeInterval: 0.02, repeats: true) { [weak self] _ in
+      MainActor.assumeIsolated {
+        self?.reconcileHardwareState()
+      }
+    }
+    hardwareStateTimer = timer
+    RunLoop.main.add(timer, forMode: .common)
+  }
+
+  private func reconcileHardwareState() {
+    let flagsDown = CGEventSource.flagsState(.hidSystemState).contains(.maskSecondaryFn)
+    let keyDown = CGEventSource.keyState(.hidSystemState, key: functionKeyCode)
+    updateFnState(isDown: flagsDown || keyDown, source: "hardwarePoll")
   }
 
   private func handleCGEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {

--- a/Tests/SpeakAppTests/TextOutputTests.swift
+++ b/Tests/SpeakAppTests/TextOutputTests.swift
@@ -308,6 +308,7 @@ final class ClipboardFieldIdentityPolicyTests: XCTestCase {
 
     XCTAssertEqual(result.method, .clipboard)
     XCTAssertNil(result.error)
+    XCTAssertNil(result.insertedRange)
     guard let warning = result.warning as? TextOutputError,
           case .capturedFieldChanged = warning
     else {

--- a/Tests/SpeakAppTests/TextOutputTests.swift
+++ b/Tests/SpeakAppTests/TextOutputTests.swift
@@ -281,6 +281,42 @@ final class TextOutputTests: XCTestCase {
 
 final class ClipboardFieldIdentityPolicyTests: XCTestCase {
   @MainActor
+  func testPasteOutput_changedCapturedField_PastesWithWarningInsteadOfError() {
+    let suiteName = "com.speakapp.text-output-tests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    let pasteboard = NSPasteboard(name: NSPasteboard.Name(suiteName))
+    defer {
+      pasteboard.clearContents()
+      UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+    let settings = AppSettings(defaults: defaults)
+    settings.textOutputMethod = .smart
+    let output = PasteTextOutput(
+      permissionsManager: PermissionsManager(statusProvider: { _ in .granted }),
+      appSettings: settings,
+      pasteboard: pasteboard
+    )
+    let changedTarget = TextOutputTarget(
+      processIdentifier: ProcessInfo.processInfo.processIdentifier,
+      applicationName: "Tests",
+      bundleIdentifier: nil,
+      applicationLaunchDate: nil,
+      focusedElement: AXUIElementCreateApplication(1)
+    )
+
+    let result = output.output(text: "Paste despite target warning", target: changedTarget)
+
+    XCTAssertEqual(result.method, .clipboard)
+    XCTAssertNil(result.error)
+    guard let warning = result.warning as? TextOutputError,
+          case .capturedFieldChanged = warning
+    else {
+      return XCTFail("Expected the changed target to be reported as a warning")
+    }
+    XCTAssertEqual(pasteboard.string(forType: .string), "Paste despite target warning")
+  }
+
+  @MainActor
   func testExactFieldIdentity_isOnlyRequiredForSmartModeWithAccessibility() {
     XCTAssertFalse(
       PasteTextOutput.requiresExactFieldIdentity(
@@ -321,6 +357,16 @@ final class ClipboardFieldIdentityPolicyTests: XCTestCase {
       capturedApplicationIsFrontmost: true
     ) else {
       return XCTFail("A positive field change must remain fail-closed")
+    }
+  }
+
+  @MainActor
+  func testChangedFieldIsAWarningPolicyRatherThanBlockingPaste() {
+    guard case .capturedFieldChanged? = PasteTextOutput.fieldIdentityError(
+      confirmation: .fieldChanged,
+      capturedApplicationIsFrontmost: true
+    ) else {
+      return XCTFail("A changed target should still be surfaced as a delivery warning")
     }
   }
 }


### PR DESCRIPTION
## Summary

- add independent Fn hardware-state polling so Terminal secure-input mode cannot starve hotkey detection
- keep existing event-tap and NSEvent paths, with edge deduplication shared across all three inputs
- downgrade captured output-target changes from blocking delivery errors to warnings
- continue Command-V delivery to the originally captured process and surface the warning in the HUD/history

## Why

Terminal can suppress the event callbacks that previously triggered the so-called hardware fallback, leaving the Fn hotkey undetected. Separately, target-identity changes currently withhold an otherwise recoverable paste; the user explicitly prefers delivery with a warning because pasted text still requires a subsequent user action in relevant messaging/composer workflows.

## Verification

- `swift test --filter TextOutputTests` (16 passed)
- `swift test --filter ClipboardFieldIdentityPolicyTests` (4 passed)
- `swift test --filter SpeakHotKeysTests` (6 passed)
- `make lint` (0 violations)
- `git diff --check`

## Manual verification requested

- Fn hold/tap/double-tap while Terminal is frontmost, including Secure Keyboard Entry
- start recording in one field, change focus before delivery, confirm paste proceeds and warning is shown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Delivery warnings are now preserved in session history and shown in success messages.
  - Clipboard fallback continues pasting when the focused field changes, while clearly reporting a warning.
  - Improved Fn key state tracking when system input monitoring is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->