### PR TITLE
test(mac): add fast core journey regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
     if: github.event_name == 'pull_request'
     outputs:
       package: ${{ steps.filter.outputs.package }}
+      core-journey: ${{ steps.filter.outputs.core-journey }}
     steps:
       - name: Filter changed paths
         # No checkout needed: on pull_request events the action lists changed
@@ -122,6 +123,46 @@ jobs:
               - 'Tests/**'
               - 'Config/**'
               - '.github/workflows/ci.yml'
+            core-journey:
+              - 'Package.swift'
+              - 'Package.resolved'
+              - 'Sources/SpeakApp/**'
+              - 'Sources/SpeakCore/**'
+              - 'Sources/SpeakHotKeys/**'
+              - 'Tests/SpeakAppTests/**'
+              - 'Tests/SpeakCoreTests/**'
+              - 'Tests/SpeakHotKeysTests/**'
+              - 'scripts/run-core-journey-e2e.sh'
+              - '.github/workflows/ci.yml'
+
+  core-journey-e2e:
+    name: Core Dictation Journey (≤10m)
+    runs-on: macos-latest
+    timeout-minutes: 10
+    needs: release-paths
+    if: needs.release-paths.outputs.core-journey == 'true'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Cache Swift packages
+        uses: actions/cache@v6
+        with:
+          path: .build
+          key: ${{ runner.os }}-swift-core-journey-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-core-journey-
+            ${{ runner.os }}-swift-
+
+      - name: Run core journey gate
+        run: scripts/run-core-journey-e2e.sh
+
+      - name: Upload stage diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: core-journey-e2e-${{ github.run_attempt }}
+          path: .artifacts/core-journey-e2e
+          if-no-files-found: error
 
   release-validation:
     name: Build & Test (Release)

--- a/Docs/core-journey-e2e.md
+++ b/Docs/core-journey-e2e.md
@@ -1,0 +1,42 @@
+# Core dictation journey regression gate
+
+Run the required hermetic gate with:
+
+```sh
+scripts/run-core-journey-e2e.sh
+```
+
+It has an eight-minute test-command budget and CI has a ten-minute wall-clock
+timeout. The gate uses fixed in-memory HTTP/stream events and isolated defaults
+and pasteboards; it requires no microphone, provider network, API key, or paid
+service. Logs and timing are written to `.artifacts/core-journey-e2e/` and are
+uploaded by CI even when the command fails.
+
+## Covered contracts
+
+- Hardware hotkey down/up balance, reset, bounce, and cancellation.
+- Batch provider success/error payload handling, including missing and rejected
+  credentials.
+- Streaming partial/final reconciliation, timeouts, and late events.
+- Post-processing off/on, empty input, local processing, and cloud stub use.
+- Streaming delivery exactly once without stale or duplicate partial text.
+- Empty output preserving the clipboard and unavailable direct insertion
+  falling back to it.
+- Captured-target delivery, including a changed focused field being delivered
+  with a warning rather than becoming a session error.
+- Successful recovery after deadline and failure paths through the automation
+  boundary.
+
+These are process-boundary contract tests, not a claim that GitHub's unsigned
+runner can grant Accessibility or synthesize the physical Fn key. A signed app
+smoke on real macOS remains the release check for Terminal Secure Keyboard Entry.
+The fixture-app/UI layer described in #802 can be promoted once its permission
+bootstrap is reliable on cold hosted runners; it must reuse this same command
+and budget rather than creating a second required gate.
+
+## Updating the gate
+
+Keep only one representative journey per external branch here. Put
+combinatorial cases in the owning suite. Never add live credentials, network,
+blind retries, or sleeps. A failure must name the owning XCTest and the CI log
+must always be uploaded.

--- a/scripts/run-core-journey-e2e.sh
+++ b/scripts/run-core-journey-e2e.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fast, hermetic regression gate for the external contracts that make up the
+# macOS dictation journey. Keep this list intentionally small: detailed edge
+# cases remain in their owning suites, while this gate proves every user-visible
+# boundary on every relevant PR.
+readonly budget_seconds="${CORE_JOURNEY_BUDGET_SECONDS:-480}"
+readonly artifacts_dir="${CORE_JOURNEY_ARTIFACTS_DIR:-.artifacts/core-journey-e2e}"
+readonly filter='GestureDetectorTests|LiveTextInserterStreamingTests|PostProcessingManagerTests|OpenAITranscriptionProviderErrorTests|MissingLiveAPIKeyAlertTests|TextOutputTests|StreamingClientContractTests|AutomationIntentSupportTests'
+
+mkdir -p "$artifacts_dir"
+started_at="$(date +%s)"
+
+python3 - "$budget_seconds" "$artifacts_dir/test.log" "$filter" <<'PY'
+import subprocess
+import sys
+
+budget = int(sys.argv[1])
+log_path = sys.argv[2]
+test_filter = sys.argv[3]
+command = ["swift", "test", "--filter", test_filter]
+
+with open(log_path, "w", encoding="utf-8") as log:
+    log.write("command: " + " ".join(command) + "\n")
+    log.flush()
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=budget,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        output = error.stdout or ""
+        if isinstance(output, bytes):
+            output = output.decode("utf-8", errors="replace")
+        log.write(output)
+        print(output, end="")
+        print(f"Core journey gate exceeded its {budget}s test budget.", file=sys.stderr)
+        raise SystemExit(124)
+
+    log.write(result.stdout)
+    print(result.stdout, end="")
+    raise SystemExit(result.returncode)
+PY
+
+elapsed="$(( $(date +%s) - started_at ))"
+printf 'core_journey_elapsed_seconds=%s\n' "$elapsed" | tee "$artifacts_dir/timing.txt"
+if (( elapsed > budget_seconds )); then
+  echo "Core journey gate took ${elapsed}s; budget is ${budget_seconds}s." >&2
+  exit 124
+fi
+


### PR DESCRIPTION
## Summary
- add a path-filtered `Core Dictation Journey (≤10m)` required CI gate
- exercise 83 hermetic production contract tests across hotkey, batch/streaming, post-processing, credentials, output fallback, captured-target warnings, and recovery
- enforce an 8-minute command budget inside the 10-minute CI timeout
- always upload the complete test log and measured wall time
- document the simulated/OS-real boundary and the remaining signed Terminal smoke

## Verification
- `scripts/run-core-journey-e2e.sh` — 83 tests passed; 8 seconds locally including incremental build
- `make lint` — 0 violations
- workflow YAML parsed successfully
- `git diff --check`

## Scope
This is the fast deterministic PR gate and harness foundation from #802. GitHub-hosted unsigned runners cannot prove physical Fn handling under Terminal Secure Keyboard Entry; that remains the signed-build smoke. The fixture-app/UI promotion remains tracked in the epic rather than being falsely represented by synthetic CI permissions.

Refs #802
