### PR TITLE
feat(analytics): opt-in PostHog EU rollout for direct macOS

### DIFF
--- a/.github/workflows/release-appstore.yml
+++ b/.github/workflows/release-appstore.yml
@@ -298,6 +298,13 @@ jobs:
           expect_info_key_absent SUFeedURL
           expect_info_key_absent SUPublicEDKey
           expect_info_key_absent SUScheduledCheckInterval
+          expect_info_key_absent PostHogProjectKey
+          expect_info_key_absent PostHogHost
+
+          if strings "$APP_PATH/Contents/MacOS/$PRODUCT_NAME" | grep -q 'eu.i.posthog.com'; then
+            echo "::error::PostHog transport symbols must not ship in the App Store build"
+            exit 1
+          fi
 
       - name: Export and Upload to App Store Connect
         env:

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -15,6 +15,9 @@ env:
   PRODUCT_NAME: JustSpeakToIt
   WORKSPACE: "Just Speak to It.xcworkspace"
   APP_STORE_CONNECT_KEY_ID: S747NJ9DZY
+  # Public PostHog ingestion key. The app remains a silent no-op when the
+  # repository secret has not been configured.
+  POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
 
 jobs:
   build-and-release:

--- a/Config/AppInfo.plist
+++ b/Config/AppInfo.plist
@@ -26,6 +26,10 @@
 	<string></string>
 	<key>SpeakDistributionChannel</key>
 	<string>direct</string>
+	<key>PostHogProjectKey</key>
+	<string>$(POSTHOG_PROJECT_KEY)</string>
+	<key>PostHogHost</key>
+	<string>https://eu.i.posthog.com</string>
 	<!-- Export compliance: the app uses only standard, published encryption
 	     (AES-GCM and PBKDF2 via CryptoKit) to protect the user's own API keys for
 	     end-to-end encrypted iCloud/CloudKit key sync, alongside OS-provided HTTPS

--- a/Docs/PRIVACY.md
+++ b/Docs/PRIVACY.md
@@ -92,6 +92,25 @@ items and breadcrumb data before transmission.
 The macOS dashboard's transcription history and usage charts are stored locally;
 they are not product-analytics events sent to the developer.
 
+### Optional product analytics (direct-download macOS only)
+
+The direct-download/Sparkle build offers an explicit opt-in to anonymous product
+analytics hosted in PostHog EU Cloud (Frankfurt). Declining does not affect any
+feature. Until you opt in, the app creates no analytics installation identifier,
+queues no events and makes no PostHog request. You can withdraw consent at any
+time in Settings; doing so immediately stops collection and deletes the local
+analytics identifier and queued events.
+
+The initial rollout sends only daily app activity, onboarding progress and the
+first successful transcription. Properties are selected from a fixed catalogue
+and use coarse buckets. Just Speak to It never sends transcripts, audio, prompts,
+clipboard text, keystrokes, API keys, screen content, names or email addresses.
+Each Mac uses a separate random identifier that is not synced through iCloud and
+is not linked to Sentry. Raw product events are retained for no more than 12
+months and are not used for advertising or cross-company tracking.
+
+The Mac App Store build and all iOS/keyboard targets compile this transport out.
+
 ### iOS diagnostics
 
 The iOS app does not currently initialise Sentry or another
@@ -107,7 +126,7 @@ tracking.
 
 ## Questions?
 
-For privacy questions, contact: [your contact email]
+For privacy questions, contact: [hello@justspeaktoit.com](mailto:hello@justspeaktoit.com)
 
 ---
 

--- a/Project.swift
+++ b/Project.swift
@@ -206,6 +206,8 @@ var projectPackages: [Package] = [
     .remote(url: "https://github.com/FluidInference/FluidAudio.git", requirement: .exact("0.15.5"))
 ]
 if !isAppStoreBuild {
+    macAppSettings["INFOPLIST_KEY_PostHogProjectKey"] = "$(POSTHOG_PROJECT_KEY)"
+    macAppSettings["INFOPLIST_KEY_PostHogHost"] = "https://eu.i.posthog.com"
     projectPackages += [
         .remote(url: "https://github.com/sparkle-project/Sparkle.git", requirement: .upToNextMajor(from: "2.6.0"))
     ]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,10 @@ This app follows these security practices:
   transcript content and API keys are not included.
   The iOS app does not currently initialise Sentry or another developer-operated
   analytics SDK.
+- **Consent-gated product analytics**: The direct-download macOS build can send a
+  small typed event catalogue to PostHog EU only after explicit opt-in. Opt-out
+  purges the random analytics identity and bounded local queue. The transport is
+  compiled out of Mac App Store, iOS and keyboard builds.
 - **Local processing**: Transcription can be performed entirely on-device
 - **Minimal permissions**: Only requests necessary permissions (microphone, accessibility)
 - **Debug UI redaction**: API keys and sensitive headers are automatically redacted in debug displays to prevent accidental exposure in screenshots or screen sharing

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -343,6 +343,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     case selectedHotKey
     case rememberedLocalTranscriptionSource
     case rememberedRemoteTranscriptionMode
+    case analyticsEnabled
   }
 
   private static let defaultLocalTranscriptionModel = "local/whisperkit/tiny"
@@ -854,6 +855,14 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     didSet { store(enableAutomationServer, key: .enableAutomationServer) }
   }
 
+  // MARK: - Analytics
+
+  /// Whether the user has opted into anonymous product analytics (PostHog).
+  /// Defaults to `false` — events are never sent until the user explicitly enables this.
+  @Published var analyticsEnabled: Bool {
+    didSet { store(analyticsEnabled, key: .analyticsEnabled) }
+  }
+
   // MARK: - Auto-Corrections
 
   /// Enable automatic detection of user corrections after transcription
@@ -1169,6 +1178,8 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       defaults.object(forKey: DefaultsKey.enableSendToMac.rawValue) as? Bool ?? false
     enableAutomationServer =
       defaults.object(forKey: DefaultsKey.enableAutomationServer.rawValue) as? Bool ?? false
+    analyticsEnabled =
+      defaults.object(forKey: DefaultsKey.analyticsEnabled.rawValue) as? Bool ?? false
 
     // History Settings
     historyFlushInterval =

--- a/Sources/SpeakApp/MainManager.swift
+++ b/Sources/SpeakApp/MainManager.swift
@@ -72,6 +72,8 @@ final class MainManager: ObservableObject {
   let textProcessor: TranscriptionTextProcessor
   let autoCorrectionTracker: AutoCorrectionTracker
   let profileStore: DictationProfileStore
+  /// Installed by AppEnvironment only for the consent-gated direct analytics transport.
+  var analyticsCapture: ((ProductAnalyticsEvent) -> Void)?
   let logger = SpeakLogger.logger(category: "MainManager")
   private let recordingSoundPlayer = RecordingSoundPlayer()
   /// Applies/reverts per-app dictation profile overrides for a session.
@@ -1238,6 +1240,7 @@ final class MainManager: ObservableObject {
           )
         )
         state = .completed(historyItem)
+        captureFirstTranscriptionSucceededIfNeeded(session: session)
       }
 
       livePolishManager.reset()
@@ -1270,6 +1273,45 @@ final class MainManager: ObservableObject {
       return "Delivered"
     }
     return "Delivered in \(SessionLatencyMetrics.formattedMilliseconds(stopToFinalMs))"
+  }
+
+  private func captureFirstTranscriptionSucceededIfNeeded(session: ActiveSession) {
+    guard appSettings.analyticsEnabled, analyticsCapture != nil else { return }
+    let defaults = UserDefaults.standard
+    let emittedKey = "analytics.firstTranscriptionSucceeded.emitted"
+    guard !defaults.bool(forKey: emittedKey) else { return }
+    guard let modelIdentifier = session.transcriptionResult?.modelIdentifier.lowercased() else { return }
+
+    let provider: AnalyticsProviderType
+    if modelIdentifier.contains("deepgram") {
+      provider = .deepgram
+    } else if modelIdentifier.contains("soniox") {
+      provider = .soniox
+    } else if modelIdentifier.contains("openai") {
+      provider = .openAI
+    } else if modelIdentifier.contains("apple") {
+      provider = .apple
+    } else if modelIdentifier.contains("whisper") || modelIdentifier.contains("fluid") {
+      provider = .local
+    } else {
+      provider = .other
+    }
+
+    let engine: AnalyticsEngineType = appSettings.transcriptionMode == .localModel ? .onDevice : .cloud
+    let installDateKey = "analytics.installDate"
+    let installDate = defaults.object(forKey: installDateKey) as? Date ?? Date()
+    if defaults.object(forKey: installDateKey) == nil { defaults.set(installDate, forKey: installDateKey) }
+    let days = max(0, Calendar.current.dateComponents([.day], from: installDate, to: Date()).day ?? 0)
+    let bucket: AnalyticsDaysSinceInstallBucket
+    switch days {
+    case 0: bucket = .zero
+    case 1: bucket = .one
+    case 2 ... 7: bucket = .twoToSeven
+    case 8 ... 30: bucket = .eightToThirty
+    default: bucket = .overThirty
+    }
+    defaults.set(true, forKey: emittedKey)
+    analyticsCapture?(.firstTranscriptionSucceeded(provider: provider, engine: engine, daysSinceInstall: bucket))
   }
   // swiftlint:enable cyclomatic_complexity function_body_length
 

--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -7,6 +7,37 @@ import SwiftUI
 
 // MARK: - Provider Info for Onboarding
 
+// MARK: - Analytics helpers
+
+extension OnboardingProvider {
+    /// Maps the onboarding provider to the analytics provider type for event capture.
+    var analyticsProviderType: AnalyticsProviderType {
+        switch self {
+        case .deepgram: return .deepgram
+        case .soniox: return .soniox
+        case .openai: return .openAI
+        case .openrouter: return .openRouter
+        case .revai: return .revAI
+        }
+    }
+}
+
+extension OnboardingStep {
+    /// Returns the analytics step used for `onboarding_step_completed` events,
+    /// or `nil` for steps without a direct analytics equivalent.
+    var analyticsStep: AnalyticsOnboardingStep? {
+        switch self {
+        case .welcome: return .welcome
+        case .permissions: return .microphonePermission
+        case .hotkey: return .hotkeySetup
+        case .apiKey: return .providerChoice
+        case .testRecording, .complete: return nil
+        }
+    }
+}
+
+// MARK: - Provider Info for Onboarding
+
 enum OnboardingProvider: String, CaseIterable, Identifiable {
     case deepgram
     case soniox
@@ -381,6 +412,12 @@ struct OnboardingView: View {
                 
                 if state.currentStep == .complete {
                     Button("Get Started") {
+                        if AppEnvironment.shared?.analyticsAvailable == true {
+                            UserDefaults.standard.set(true, forKey: "hasAnsweredAnalyticsConsent")
+                            AppEnvironment.shared?.captureOnboardingCompletedAfterConsent()
+                        } else {
+                            AppEnvironment.shared?.capture(.onboardingCompleted(stepsSkipped: .zero))
+                        }
                         isComplete = true
                     }
                     .buttonStyle(.borderedProminent)
@@ -402,6 +439,9 @@ struct OnboardingView: View {
             .padding(.bottom, 30)
         }
         .frame(width: 600, height: 550)
+        .onAppear {
+            AppEnvironment.shared?.capture(.onboardingStarted(entryPoint: .freshInstall))
+        }
     }
     
     private var canAdvance: Bool {
@@ -422,6 +462,7 @@ struct OnboardingView: View {
     }
     
     private func advanceStep() async {
+        let completedStep = state.currentStep
         switch state.currentStep {
         case .hotkey:
             // Save the selected hotkey to settings
@@ -438,6 +479,11 @@ struct OnboardingView: View {
             if valid {
                 do {
                     try await state.saveAPIKey()
+                    // Track provider configuration
+                    AppEnvironment.shared?.capture(.providerConfigured(
+                        provider: state.selectedProvider.analyticsProviderType,
+                        method: .manual
+                    ))
                     withAnimation {
                         // If using non-Fn hotkey, show test recording; otherwise go to complete
                         if state.selectedHotKey != .fnKey {
@@ -460,6 +506,10 @@ struct OnboardingView: View {
                     state.currentStep = next
                 }
             }
+        }
+        // Track step completion for steps with an analytics mapping
+        if let analyticsStep = completedStep.analyticsStep {
+            AppEnvironment.shared?.capture(.onboardingStepCompleted(step: analyticsStep))
         }
     }
 }
@@ -1182,6 +1232,26 @@ struct CompleteStepView: View {
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .padding(.top, 10)
+
+            if AppEnvironment.shared?.analyticsAvailable == true {
+                Toggle(
+                    "Share anonymous analytics",
+                    isOn: Binding(
+                        get: { state.settings.analyticsEnabled },
+                        set: { state.settings.analyticsEnabled = $0 }
+                    )
+                )
+                    .toggleStyle(.checkbox)
+                    .font(.callout)
+                Text(
+                    "Optional. Never includes transcripts, audio, prompts, clipboard text, "
+                        + "keystrokes, API keys, screen content or personal identity."
+                )
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 440)
+            }
         }
     }
 }

--- a/Sources/SpeakApp/PostHogAnalytics.swift
+++ b/Sources/SpeakApp/PostHogAnalytics.swift
@@ -1,0 +1,146 @@
+#if !APP_STORE
+import Foundation
+import SpeakCore
+
+/// The deliberately small PostHog transport used by direct/Sparkle builds.
+///
+/// The official SDK currently performs an unavoidable remote-config request and
+/// bundles features this app has explicitly ruled out (autocapture, replay,
+/// surveys and error capture). Posting the audited typed payload directly to the
+/// EU `/capture/` endpoint keeps the network surface to one documented request.
+actor PostHogProductAnalyticsSink: ProductAnalyticsSink {
+  private struct Configuration: Sendable {
+    let projectKey: String
+    let endpoint: URL
+
+    static func resolve(
+      bundle: Bundle = .main,
+      environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Configuration? {
+      let key = environment["POSTHOG_PROJECT_KEY"]
+        ?? bundle.object(forInfoDictionaryKey: "PostHogProjectKey") as? String
+      let host = environment["POSTHOG_HOST"]
+        ?? bundle.object(forInfoDictionaryKey: "PostHogHost") as? String
+        ?? "https://eu.i.posthog.com"
+      guard let key, !key.isEmpty, let baseURL = URL(string: host) else { return nil }
+      return Configuration(projectKey: key, endpoint: baseURL.appendingPathComponent("capture"))
+    }
+  }
+
+  private struct QueuedEvent: Codable, Sendable {
+    let createdAt: Date
+    let event: String
+    let distinctID: String
+    let properties: [String: String]
+  }
+
+  private let configuration: Configuration?
+  private let queueURL: URL
+  private let session: URLSession
+  private var queue: [QueuedEvent] = []
+  private var isOpen = false
+
+  nonisolated static var isConfigured: Bool { Configuration.resolve() != nil }
+
+  init(
+    queueURL: URL,
+    session: URLSession = .shared,
+    configuration: (projectKey: String, endpoint: URL)? = nil
+  ) {
+    self.queueURL = queueURL
+    self.session = session
+    self.configuration = configuration.map {
+      Configuration(projectKey: $0.projectKey, endpoint: $0.endpoint)
+    }
+      ?? Configuration.resolve()
+    queue = Self.pruned(Self.loadQueue(from: queueURL))
+  }
+
+  func reopen() async throws {
+    isOpen = true
+    try await flush()
+  }
+
+  func capture(_ payload: ProductAnalyticsPayload) async throws {
+    guard isOpen, configuration != nil else { return }
+    queue.append(QueuedEvent(
+      createdAt: Date(),
+      event: payload.event,
+      distinctID: payload.distinctID?.uuidString ?? "anonymous-counter",
+      properties: payload.properties
+    ))
+    pruneQueue()
+    try persistQueue()
+    try await flush()
+  }
+
+  func purge() async throws {
+    isOpen = false
+    queue.removeAll(keepingCapacity: false)
+    if FileManager.default.fileExists(atPath: queueURL.path) {
+      try FileManager.default.removeItem(at: queueURL)
+    }
+  }
+
+  func close() async { isOpen = false }
+
+  private func flush() async throws {
+    guard isOpen, let configuration else { return }
+    while let next = queue.first {
+      var properties: [String: Any] = next.properties
+      properties["distinct_id"] = next.distinctID
+      properties["$lib"] = "just-speak-to-it"
+      properties["$lib_version"] = "1"
+      properties["timestamp"] = ISO8601DateFormatter().string(from: next.createdAt)
+      let body: [String: Any] = [
+        "api_key": configuration.projectKey,
+        "event": next.event,
+        "properties": properties
+      ]
+      var request = URLRequest(url: configuration.endpoint)
+      request.httpMethod = "POST"
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+      let (_, response) = try await session.data(for: request)
+      guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
+        throw URLError(.badServerResponse)
+      }
+      queue.removeFirst()
+      try persistQueue()
+    }
+  }
+
+  private func pruneQueue(now: Date = Date()) {
+    queue = Self.pruned(queue, now: now)
+  }
+
+  private func persistQueue() throws {
+    if queue.isEmpty {
+      if FileManager.default.fileExists(atPath: queueURL.path) {
+        try FileManager.default.removeItem(at: queueURL)
+      }
+      return
+    }
+    try FileManager.default.createDirectory(
+      at: queueURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try JSONEncoder().encode(queue).write(
+      to: queueURL,
+      options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
+    )
+  }
+
+  private static func loadQueue(from url: URL) -> [QueuedEvent] {
+    guard let data = try? Data(contentsOf: url),
+          let events = try? JSONDecoder().decode([QueuedEvent].self, from: data)
+    else { return [] }
+    return events
+  }
+
+  private static func pruned(_ events: [QueuedEvent], now: Date = Date()) -> [QueuedEvent] {
+    let cutoff = now.addingTimeInterval(-7 * 24 * 60 * 60)
+    return Array(events.filter { $0.createdAt >= cutoff }.suffix(1_000))
+  }
+}
+#endif

--- a/Sources/SpeakApp/SpeakApp.swift
+++ b/Sources/SpeakApp/SpeakApp.swift
@@ -15,6 +15,8 @@ struct SpeakApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var environmentHolder = EnvironmentHolder()
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    @AppStorage("hasAnsweredAnalyticsConsent") private var hasAnsweredAnalyticsConsent = false
+    @State private var showingAnalyticsConsent = false
     @Environment(\.openWindow) private var openWindow
 
     init() {
@@ -44,6 +46,27 @@ struct SpeakApp: App {
                                 if #available(macOS 10.12.2, *) {
                                     environment.installTouchBar()
                                 }
+                                if environment.analyticsAvailable,
+                                   !hasAnsweredAnalyticsConsent {
+                                    showingAnalyticsConsent = true
+                                }
+                            }
+                            .alert("Help improve Just Speak to It?", isPresented: $showingAnalyticsConsent) {
+                                Button("Share Anonymous Analytics") {
+                                    hasAnsweredAnalyticsConsent = true
+                                    environment.settings.analyticsEnabled = true
+                                }
+                                Button("Not Now", role: .cancel) {
+                                    hasAnsweredAnalyticsConsent = true
+                                    environment.settings.analyticsEnabled = false
+                                }
+                            } message: {
+                                Text(
+                                    "Share anonymous usage and reliability data. "
+                                        + "We never collect transcripts, audio, prompts, clipboard text, "
+                                        + "keystrokes, API keys, screen content, or personal identity. "
+                                        + "You can turn this off at any time in Settings."
+                                )
                             }
                     } else {
                         OnboardingView(

--- a/Sources/SpeakApp/Views/Settings/SettingsView+About.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+About.swift
@@ -110,6 +110,23 @@ extension SettingsView {
         }
       }
 
+      if environment.analyticsAvailable {
+        SettingsCard(title: "Privacy", systemImage: "hand.raised", tint: Color.indigo) {
+          VStack(alignment: .leading, spacing: 12) {
+            Toggle("Share anonymous analytics", isOn: $settings.analyticsEnabled)
+            Text(
+              "Helps improve the app using typed usage and reliability events. "
+                + "Transcripts, audio, prompts, clipboard text, keystrokes, API keys, "
+                + "screen content and personal identity are never collected."
+            )
+              .font(.callout)
+              .foregroundStyle(.secondary)
+            Link("Privacy policy", destination: URL(string: "https://justspeaktoit.com/privacy")!)
+              .font(.callout)
+          }
+        }
+      }
+
       SettingsCard(title: "Transfer to iOS", systemImage: "iphone.and.arrow.forward", tint: Color.cyan) {
         VStack(alignment: .leading, spacing: 12) {
           Text("Transfer your API keys and settings to the iOS app by scanning a QR code.")

--- a/Sources/SpeakApp/WireUp.swift
+++ b/Sources/SpeakApp/WireUp.swift
@@ -10,6 +10,7 @@ private let logger = SpeakLogger.logger(category: "WireUp")
 // swiftlint:disable file_length
 
 @MainActor
+// swiftlint:disable:next type_body_length
 final class AppEnvironment: ObservableObject {
   /// Process-wide access point for the App Intents (Shortcuts) surface, set at
   /// bootstrap. Intents can fire before the SwiftUI scene has bootstrapped the
@@ -62,6 +63,10 @@ final class AppEnvironment: ObservableObject {
   /// window (e.g. menu-bar-only mode). Supplied by the SwiftUI scene.
   var reopenMainWindow: (() -> Void)?
   private var statusBarVisibilityObserver: AnyCancellable?
+  /// Product analytics controller — nil when PostHog configuration is absent.
+  private(set) var analytics: ProductAnalyticsController?
+  var analyticsAvailable: Bool { analytics != nil }
+  private var analyticsConsentObserver: AnyCancellable?
   private(set) var menuBarManager: MenuBarManager?
   private(set) var dockMenuManager: DockMenuManager?
   private(set) var servicesProvider: ServicesProvider?
@@ -116,6 +121,53 @@ final class AppEnvironment: ObservableObject {
     self.main = main
     self.transportServer = transportServer
     self.hudPresenter = hudPresenter
+  }
+
+  /// Sets up the product analytics controller and subscribes to settings changes
+  /// so consent state stays in sync with the user's analytics toggle.
+  fileprivate func installAnalytics(_ controller: ProductAnalyticsController) {
+    analytics = controller
+    main.analyticsCapture = { [weak self] event in self?.capture(event) }
+    let initiallyEnabled = settings.analyticsEnabled
+    // Sync the initial consent state and fire the daily-active-user event.
+    Task {
+      try? await controller.setConsent(initiallyEnabled ? .optedIn : .optedOut)
+      // Fire app_active_daily at most once per calendar day.
+      let todayKey = "posthog.lastActiveDailyCaptureDate"
+      let today = Calendar.current.startOfDay(for: Date())
+      let lastCapture = UserDefaults.standard.object(forKey: todayKey) as? Date
+      if initiallyEnabled,
+         lastCapture == nil || !Calendar.current.isDate(lastCapture!, inSameDayAs: today) {
+        try? await controller.capture(.appActiveDaily)
+        UserDefaults.standard.set(today, forKey: todayKey)
+      }
+    }
+    // Keep consent in sync with future settings changes.
+    analyticsConsentObserver = settings.$analyticsEnabled
+      .dropFirst()
+      .receive(on: RunLoop.main)
+      .sink { [weak controller] enabled in
+        guard let controller else { return }
+        Task {
+          try? await controller.setConsent(enabled ? .optedIn : .optedOut)
+          if enabled { try? await controller.capture(.analyticsOptIn(surface: .settings)) }
+        }
+      }
+  }
+
+  /// Capture a product analytics event. No-op when analytics are absent or the
+  /// user has not opted in.
+  func capture(_ event: ProductAnalyticsEvent) {
+    guard let analytics else { return }
+    Task { try? await analytics.capture(event) }
+  }
+
+  func captureOnboardingCompletedAfterConsent() {
+    guard settings.analyticsEnabled, let analytics else { return }
+    Task {
+      try? await analytics.setConsent(.optedIn)
+      try? await analytics.capture(.onboardingCompleted(stepsSkipped: .zero))
+    }
   }
 
   /// Installs the status bar controller and the observer that keeps it in sync
@@ -399,6 +451,7 @@ extension AppEnvironment {
 }
 
 @MainActor
+// swiftlint:disable:next type_body_length
 enum WireUp {
 
   // MARK: - Dependency Injection Options
@@ -590,7 +643,61 @@ enum WireUp {
       await configureDefaultTranscriptionProvider(settings: settings, secureStorage: secureStorage)
     }
 
+    // Analytics
+    if let analyticsController = makeAnalyticsController(settings: settings) {
+      environment.installAnalytics(analyticsController)
+    }
+
     logger.info("AppEnvironment.bootstrap complete")
+  }
+
+  // MARK: - Analytics Factory
+
+  private static func makeAnalyticsController(settings: AppSettings) -> ProductAnalyticsController? {
+    #if APP_STORE
+    return nil
+    #else
+    guard DistributionChannel.current == .direct else { return nil }
+    guard PostHogProductAnalyticsSink.isConfigured else { return nil }
+    let stateURL = (FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+      .first ?? FileManager.default.homeDirectoryForCurrentUser)
+      .appendingPathComponent("SpeakApp/analytics_state.json")
+    let queueURL = stateURL.deletingLastPathComponent().appendingPathComponent("analytics_queue.json")
+    let stateStore = FileProductAnalyticsStateStore(fileURL: stateURL)
+    let context = buildAnalyticsContext()
+    return try? ProductAnalyticsController(
+      context: context,
+      sink: PostHogProductAnalyticsSink(queueURL: queueURL),
+      stateStore: stateStore
+    )
+    #endif
+  }
+
+  private static func buildAnalyticsContext() -> ProductAnalyticsContext {
+    let bundle = Bundle.main
+    let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "0"
+    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+    let osMajorMinor = "\(osVersion.majorVersion).\(osVersion.minorVersion)"
+    let localeCode = Locale.current.language.languageCode?.identifier ?? "en"
+    let distributionChannel: AnalyticsDistributionChannel = DistributionChannel.current == .appStore
+      ? .macAppStore
+      : .direct
+    #if arch(arm64)
+    let arch = "arm64"
+    #else
+    let arch = "x86_64"
+    #endif
+    return ProductAnalyticsContext(
+      platform: .macOS,
+      appVersion: version,
+      build: build,
+      osMajorMinor: osMajorMinor,
+      distributionChannel: distributionChannel,
+      localeLanguageCode: localeCode,
+      architecture: arch
+    )
   }
 
   // MARK: - TTS Factory

--- a/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
+++ b/Tests/SpeakAppTests/AppStoreInfoPlistTests.swift
@@ -23,6 +23,11 @@ final class AppStoreInfoPlistTests: XCTestCase {
         }
     }
 
+    func testAppStorePlist_omitsProductAnalyticsConfiguration() {
+        XCTAssertNil(appStorePlist["PostHogProjectKey"])
+        XCTAssertNil(appStorePlist["PostHogHost"])
+    }
+
     func testAppStorePlist_declaresLocalNetworkUsage() {
         let value = appStorePlist["NSLocalNetworkUsageDescription"] as? String
         let expected = "Just Speak to It uses your local network to connect iPhone and Mac "
@@ -44,6 +49,8 @@ final class AppStoreInfoPlistTests: XCTestCase {
         ]
         var directWithoutSparkle = directPlist!
         sparkleKeys.forEach { directWithoutSparkle.removeValue(forKey: $0) }
+        directWithoutSparkle.removeValue(forKey: "PostHogProjectKey")
+        directWithoutSparkle.removeValue(forKey: "PostHogHost")
         directWithoutSparkle["CFBundleDisplayName"] = "Just Speak to It (App Store)"
         directWithoutSparkle["CFBundleName"] = "Just Speak to It App Store"
         directWithoutSparkle["SpeakDistributionChannel"] = "appStore"

--- a/Tests/SpeakAppTests/PostHogAnalyticsTests.swift
+++ b/Tests/SpeakAppTests/PostHogAnalyticsTests.swift
@@ -1,0 +1,134 @@
+#if !APP_STORE
+@testable import SpeakApp
+import SpeakCore
+import XCTest
+
+final class PostHogAnalyticsTests: XCTestCase {
+  func testCaptureIsSilentUntilSinkIsReopenedAfterConsent() async throws {
+    let recorder = RequestRecorder()
+    let sink = makeSink(recorder: recorder)
+
+    try await sink.capture(makePayload())
+
+    XCTAssertEqual(recorder.requests.count, 0)
+  }
+
+  func testOptedInCaptureUsesOnlyAuditedPostHogCaptureEndpoint() async throws {
+    let recorder = RequestRecorder()
+    let sink = makeSink(recorder: recorder)
+    try await sink.reopen()
+
+    try await sink.capture(makePayload())
+
+    let request = try XCTUnwrap(recorder.requests.first)
+    XCTAssertEqual(request.url?.absoluteString, "https://eu.i.posthog.com/capture")
+    XCTAssertEqual(request.httpMethod, "POST")
+    let bodyData = try XCTUnwrap(request.httpBody)
+    let body = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+    XCTAssertEqual(body["api_key"] as? String, "phc_test")
+    XCTAssertEqual(body["event"] as? String, "app_active_daily")
+    let properties = try XCTUnwrap(body["properties"] as? [String: Any])
+    XCTAssertEqual(properties["platform"] as? String, "macOS")
+    XCTAssertNil(properties["transcript"])
+    XCTAssertNil(properties["audio"])
+  }
+
+  func testPurgeDeletesQueuedEventsAfterWithdrawal() async throws {
+    let queueURL = temporaryQueueURL()
+    let recorder = RequestRecorder(statusCode: 500)
+    let sink = makeSink(queueURL: queueURL, recorder: recorder)
+    try? await sink.reopen()
+    try? await sink.capture(makePayload())
+    XCTAssertTrue(FileManager.default.fileExists(atPath: queueURL.path))
+
+    try await sink.purge()
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: queueURL.path))
+  }
+
+  private func makeSink(
+    queueURL: URL? = nil,
+    recorder: RequestRecorder
+  ) -> PostHogProductAnalyticsSink {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [RecordingURLProtocol.self]
+    RecordingURLProtocol.recorder = recorder
+    return PostHogProductAnalyticsSink(
+      queueURL: queueURL ?? temporaryQueueURL(),
+      session: URLSession(configuration: configuration),
+      configuration: (
+        projectKey: "phc_test",
+        endpoint: URL(string: "https://eu.i.posthog.com/capture")!
+      )
+    )
+  }
+
+  private func makePayload() -> ProductAnalyticsPayload {
+    ProductAnalyticsPayload(
+      event: .appActiveDaily,
+      context: ProductAnalyticsContext(
+        platform: .macOS,
+        appVersion: "2.63.6",
+        build: "202608250001",
+        osMajorMinor: "26.0",
+        distributionChannel: .direct,
+        localeLanguageCode: "en",
+        architecture: "arm64"
+      ),
+      distinctID: UUID()
+    )
+  }
+
+  private func temporaryQueueURL() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathComponent("analytics_queue.json")
+  }
+}
+
+private final class RequestRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var storedRequests: [URLRequest] = []
+  let statusCode: Int
+
+  init(statusCode: Int = 200) { self.statusCode = statusCode }
+  var requests: [URLRequest] { lock.withLock { storedRequests } }
+  func append(_ request: URLRequest) { lock.withLock { storedRequests.append(request) } }
+}
+
+private final class RecordingURLProtocol: URLProtocol {
+  nonisolated(unsafe) static var recorder: RequestRecorder?
+
+  override static func canInit(with _: URLRequest) -> Bool { true }
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let recorder = Self.recorder, let url = request.url else { return }
+    var recordedRequest = request
+    if recordedRequest.httpBody == nil, let stream = recordedRequest.httpBodyStream {
+      stream.open()
+      defer { stream.close() }
+      var data = Data()
+      var buffer = [UInt8](repeating: 0, count: 4_096)
+      while stream.hasBytesAvailable {
+        let count = stream.read(&buffer, maxLength: buffer.count)
+        guard count > 0 else { break }
+        data.append(buffer, count: count)
+      }
+      recordedRequest.httpBody = data
+    }
+    recorder.append(recordedRequest)
+    let response = HTTPURLResponse(
+      url: url,
+      statusCode: recorder.statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: nil
+    )!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: Data())
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+#endif

--- a/landing-page/privacy.html
+++ b/landing-page/privacy.html
@@ -124,7 +124,7 @@
   <main>
     <p class="eyebrow">Privacy Policy</p>
     <h1>Your words stay under your control.</h1>
-    <p>Last updated: 17 July 2026</p>
+    <p>Last updated: 25 August 2026</p>
 
     <section class="summary" aria-label="Privacy summary">
       <p><strong>JustSpeakToIt does not sell your data, show ads, or track you across apps and websites.</strong> Local transcription can stay on your device. Cloud features are optional and send only the data needed to the service you choose.</p>
@@ -147,6 +147,11 @@
     <h2>Diagnostics</h2>
     <p>JustSpeakToIt may send crash reports and performance diagnostics to Sentry so we can find and fix reliability problems. This diagnostic data is not used for advertising or tracking and is not linked to your identity. We configure diagnostics to avoid collecting transcript contents, recordings, and API keys.</p>
 
+    <h2>Optional anonymous product analytics</h2>
+    <p>The direct-download Mac app may ask you to opt in to anonymous product analytics hosted by PostHog EU Cloud in Frankfurt. Nothing is sent until you choose to share. Declining does not affect the app, and you can withdraw consent at any time in Settings.</p>
+    <p>The initial rollout records daily app activity, onboarding progress, and the first successful transcription using a fixed set of coarse properties. It never includes transcripts, audio, prompts, clipboard text, keystrokes, API keys, screen content, names, or email addresses. Each Mac uses a separate random identifier that is not synced through iCloud or linked to Sentry. Opting out deletes that identifier and any queued events. Raw product events are retained for no more than 12 months.</p>
+    <p>This product-analytics transport is not included in the Mac App Store, iOS, or keyboard-extension builds.</p>
+
     <h2>Data we do not collect</h2>
     <ul>
       <li>No advertising identifiers or cross-app tracking data.</li>
@@ -156,7 +161,7 @@
     </ul>
 
     <h2>Your choices</h2>
-    <p>You can use local transcription, remove provider credentials, disable iCloud features, clear History, and delete the app's local data at any time. You can also manage microphone, speech recognition, iCloud, and Live Activity permissions in system Settings.</p>
+    <p>You can use local transcription, disable anonymous analytics, remove provider credentials, disable iCloud features, clear History, and delete the app's local data at any time. You can also manage microphone, speech recognition, iCloud, and Live Activity permissions in system Settings.</p>
 
     <h2>Children</h2>
     <p>JustSpeakToIt is a general-purpose productivity app and is not directed at children. We do not knowingly collect personal information from children through a developer-operated account or service.</p>


### PR DESCRIPTION
## Summary

Adds the consent-gated phase-one PostHog EU rollout for the direct-download/Sparkle macOS build.

- explicit opt-in during onboarding and a late prompt for existing users
- permanent Settings privacy toggle with synchronous identity/queue purge on opt-out
- audited minimal PostHog `/capture` transport; no SDK remote config, replay, surveys, flags, autocapture, or error capture
- 1,000-event / 7-day oldest-first durable queue
- phase-one events only: daily activity, onboarding funnel, and first successful transcription
- production key injected from `POSTHOG_PROJECT_KEY`; transport and UI remain dormant when absent
- PostHog configuration and transport compiled out of Mac App Store builds
- privacy policy, security documentation, and public website disclosure updated

## Verification

- `swift build --target SpeakApp`
- `swift build -Xswiftc -DAPP_STORE --target SpeakApp`
- 25 analytics/catalogue tests passed
- 7 distribution-plist tests passed
- strict lint on the new transport and tests: 0 violations

## Activation gate

Before production capture, create/configure the PostHog EU production project according to #776 and add its public ingestion key as the repository secret `POSTHOG_PROJECT_KEY`. With no key, released builds make no PostHog request and show no analytics UI.

Refs #776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional, anonymous product analytics for direct-download macOS builds.
  * Added first-launch consent prompt and an analytics toggle in Settings.
  * Added onboarding, transcription, and daily activity measurements when enabled.
  * Analytics data is hosted in the EU and excludes sensitive transcription content.
  * App Store, iOS, and keyboard-extension builds do not include analytics.
* **Documentation**
  * Updated privacy and security documentation with consent, data handling, retention, and opt-out details.
* **Validation**
  * Added checks confirming App Store builds exclude analytics configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->