### PR TITLE
feat(mac): add compact HUD with independent live transcript

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -557,9 +557,9 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   }
 
   /// When on, the HUD is drawn in its compact form (a pulsing dot, a live level
-  /// meter, the timer and a single scrolling transcript line). It replaces the
-  /// full-size live transcript, so `showLiveTranscriptInHUD` is ignored while
-  /// this is enabled.
+  /// meter and the timer). It stands alongside `showLiveTranscriptInHUD`, which
+  /// still governs whether the scrolling transcript line is drawn: the compact
+  /// HUD can run with the live transcript on or off, independently.
   @Published var showCompactHUD: Bool {
     didSet { store(showCompactHUD, key: .showCompactHUD) }
   }

--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -316,6 +316,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     case postProcessingStreamingEnabled
     case hudSizePreference
     case showLiveTranscriptInHUD
+    case showCompactHUD
     case showSidebarShortcutHints
     case speedMode
     case livePolishModel
@@ -553,6 +554,14 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
 
   @Published var showLiveTranscriptInHUD: Bool {
     didSet { store(showLiveTranscriptInHUD, key: .showLiveTranscriptInHUD) }
+  }
+
+  /// When on, the HUD is drawn in its compact form (a pulsing dot, a live level
+  /// meter, the timer and a single scrolling transcript line). It replaces the
+  /// full-size live transcript, so `showLiveTranscriptInHUD` is ignored while
+  /// this is enabled.
+  @Published var showCompactHUD: Bool {
+    didSet { store(showCompactHUD, key: .showCompactHUD) }
   }
 
   @Published var showSidebarShortcutHints: Bool {
@@ -1053,6 +1062,8 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     showHUDDuringSessions = defaults.object(forKey: DefaultsKey.showHUD.rawValue) as? Bool ?? true
     showLiveTranscriptInHUD =
       defaults.object(forKey: DefaultsKey.showLiveTranscriptInHUD.rawValue) as? Bool ?? true
+    showCompactHUD =
+      defaults.object(forKey: DefaultsKey.showCompactHUD.rawValue) as? Bool ?? false
     showSidebarShortcutHints =
       defaults.object(forKey: DefaultsKey.showSidebarShortcutHints.rawValue) as? Bool ?? true
     appVisibility =

--- a/Sources/SpeakApp/CompactHUDView.swift
+++ b/Sources/SpeakApp/CompactHUDView.swift
@@ -1,0 +1,300 @@
+import Foundation
+import SpeakCore
+import SwiftUI
+
+/// The compact heads-up display: a small card showing a pulsing record dot, a
+/// live audio-level meter, the elapsed timer and a single scrolling transcript
+/// line. Selected with the "Show compact HUD" setting, it takes over from the
+/// full ``HUDOverlay`` content while enabled.
+///
+/// Layout (top row): the dot sits on the left, the level meter is centred, and
+/// the timer sits on the right. The dot pulses on a steady beat to show the app
+/// is live (it does not react to volume). The meter is the only element that
+/// tracks how loudly you are speaking. Beneath the top row, a single transcript
+/// line is anchored to the right so the newest words stay visible while older
+/// ones scroll off the left.
+struct CompactHUDContent: View {
+  @ObservedObject var manager: HUDManager
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  private var snapshot: HUDManager.Snapshot { manager.snapshot }
+  private var phase: HUDManager.Snapshot.Phase { snapshot.phase }
+
+  var body: some View {
+    VStack(spacing: 7) {
+      topRow
+      transcriptLine
+      captureFooter
+    }
+    .padding(.horizontal, 18)
+    .padding(.vertical, 12)
+    .frame(width: 244)
+    .background(cardBackground)
+    .overlay(
+      RoundedRectangle(cornerRadius: 20, style: .continuous)
+        .stroke(dotColor.opacity(0.4), lineWidth: 1.5)
+    )
+    .shadow(color: .black.opacity(0.16), radius: 16, x: 0, y: 10)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("compactHUD")
+  }
+
+  // MARK: - Top row (dot · meter · timer)
+
+  private var topRow: some View {
+    ZStack {
+      if phase == .recording {
+        CompactLevelMeter(level: manager.audioLevel, animates: !reduceMotion)
+      }
+      HStack(spacing: 8) {
+        recordDot
+        Spacer(minLength: 8)
+        timerLabel
+      }
+    }
+    .frame(height: 24)
+  }
+
+  @ViewBuilder
+  private var recordDot: some View {
+    let size: CGFloat = 15
+    Group {
+      if shouldPulse, !reduceMotion {
+        TimelineView(.animation) { context in
+          let elapsed = context.date.timeIntervalSinceReferenceDate
+          let pulse = 0.5 + 0.5 * sin(elapsed * .pi * 1.6)
+          Circle()
+            .fill(dotColor)
+            .frame(width: size, height: size)
+            .scaleEffect(0.9 + 0.12 * pulse)
+            .shadow(color: dotColor.opacity(0.25 + 0.4 * pulse), radius: 3 + 5 * pulse)
+        }
+      } else {
+        Circle()
+          .fill(dotColor)
+          .frame(width: size, height: size)
+      }
+    }
+    .frame(width: 22, height: 22, alignment: .center)
+    .accessibilityLabel("\(snapshot.headline) indicator")
+    .accessibilityAddTraits(.updatesFrequently)
+  }
+
+  @ViewBuilder
+  private var timerLabel: some View {
+    if phaseHasTimer {
+      Text(compactElapsed)
+        .font(.system(size: 15, weight: .medium).monospacedDigit())
+        .foregroundStyle(.secondary)
+        .accessibilityLabel("Elapsed time: \(compactElapsed)")
+        .accessibilityAddTraits(.updatesFrequently)
+    } else {
+      // Reserve the trailing slot so the dot stays hard against the left edge.
+      Color.clear.frame(width: 1, height: 1)
+    }
+  }
+
+  // MARK: - Transcript / status line
+
+  @ViewBuilder
+  private var transcriptLine: some View {
+    if phase == .recording {
+      if let text = snapshot.liveText, !text.isEmpty {
+        Text(text)
+          .font(.system(size: 14))
+          .foregroundStyle(.primary)
+          .lineLimit(1)
+          .truncationMode(.head)
+          .frame(maxWidth: .infinity, alignment: .trailing)
+          .accessibilityLabel("Transcript: \(text)")
+      }
+    } else if !statusText.isEmpty {
+      Text(statusText)
+        .font(.system(size: 13))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .frame(maxWidth: .infinity, alignment: .center)
+        .accessibilityLabel(statusText)
+    }
+  }
+
+  private var statusText: String {
+    switch phase {
+    case .success, .failure:
+      return snapshot.subheadline ?? snapshot.headline
+    default:
+      return snapshot.headline
+    }
+  }
+
+  // MARK: - Capture footer (device · model)
+
+  @ViewBuilder
+  private var captureFooter: some View {
+    let health = manager.captureHealth
+    if !health.providerLabel.isEmpty || !health.inputDeviceName.isEmpty {
+      HStack(spacing: 6) {
+        Image(systemName: health.noInputDevicesAvailable ? "mic.slash.fill" : "mic.fill")
+          .font(.system(size: 9, weight: .semibold))
+          .foregroundStyle(health.noInputDevicesAvailable ? Color.red : .secondary)
+        Text(deviceLabel(health))
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.tail)
+        if !health.providerLabel.isEmpty {
+          Text(verbatim: "·")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.tertiary)
+          Text(health.providerLabel)
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .layoutPriority(1)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .center)
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel("Input \(deviceLabel(health)), provider \(health.providerLabel)")
+    }
+  }
+
+  private func deviceLabel(_ health: CaptureHealthSnapshot) -> String {
+    health.noInputDevicesAvailable ? "No microphone" : health.inputDeviceName
+  }
+
+  // MARK: - Derived state
+
+  /// The dot pulses only while the app is live (armed or recording); processing
+  /// and terminal phases show a steady dot.
+  private var shouldPulse: Bool {
+    phase == .recording || phase == .armed
+  }
+
+  /// Mirrors the full HUD: the timer is shown for every non-terminal phase
+  /// except `armed`, which has no running clock.
+  private var phaseHasTimer: Bool {
+    phase.isTerminal == false && phase != .armed
+  }
+
+  private var compactElapsed: String {
+    Self.elapsedLabel(for: snapshot.elapsed)
+  }
+
+  /// Minutes and seconds with a trailing `s`, no fractional seconds:
+  /// `40s`, `1:23s`. Whole seconds only, so it counts up a second at a time.
+  /// Exposed at package scope for testing.
+  static func elapsedLabel(for elapsed: TimeInterval) -> String {
+    let totalSeconds = Int(max(elapsed, 0))
+    let minutes = totalSeconds / 60
+    let seconds = totalSeconds % 60
+    return minutes > 0
+      ? String(format: "%d:%02ds", minutes, seconds)
+      : "\(seconds)s"
+  }
+
+  private var cardBackground: some View {
+    RoundedRectangle(cornerRadius: 20, style: .continuous)
+      .fill(colorScheme == .dark ? Color(white: 0.15) : Color.white)
+  }
+
+  private var dotColor: Color {
+    switch phase {
+    case .armed:
+      return .green
+    case .recording, .failure:
+      return .red
+    case .transcribing:
+      return .brandLagoon
+    case .postProcessing:
+      return .brandAccent
+    case .delivering, .success:
+      return .green
+    case .editing:
+      return .brandAccentWarm
+    case .hidden:
+      return .gray
+    }
+  }
+}
+
+/// A small upright equaliser that rises and falls with the recording level.
+/// Each bar has a fixed relative weight so the cluster keeps a natural shape,
+/// scaled by the current audio level (0...1). A short floor keeps every bar
+/// faintly visible so the meter never disappears entirely mid-recording.
+private struct CompactLevelMeter: View {
+  let level: Float
+  let animates: Bool
+
+  private let weights: [CGFloat] = [0.55, 0.85, 0.62, 1.0, 0.6]
+  private let maxHeight: CGFloat = 22
+
+  var body: some View {
+    HStack(alignment: .bottom, spacing: 3) {
+      ForEach(weights.indices, id: \.self) { index in
+        Capsule()
+          .fill(meterGradient)
+          .frame(width: 3.5, height: barHeight(for: index))
+          .animation(animates ? .easeOut(duration: 0.12) : nil, value: level)
+      }
+    }
+    .frame(height: maxHeight, alignment: .bottom)
+    .accessibilityHidden(true)
+  }
+
+  private func barHeight(for index: Int) -> CGFloat {
+    let clamped = CGFloat(min(max(level, 0), 1))
+    return max(3, weights[index] * clamped * maxHeight)
+  }
+
+  private var meterGradient: LinearGradient {
+    LinearGradient(
+      gradient: Gradient(colors: [
+        Color(red: 0.18, green: 0.75, blue: 0.48),
+        Color(red: 0.55, green: 0.80, blue: 0.32),
+        Color(red: 0.90, green: 0.71, blue: 0.24)
+      ]),
+      startPoint: .bottom,
+      endPoint: .top
+    )
+  }
+}
+
+struct CompactHUDContent_Previews: PreviewProvider {
+  static var previews: some View {
+    Group {
+      compact(name: "Compact – Recording")
+      compact(name: "Compact – Dark")
+        .preferredColorScheme(.dark)
+    }
+  }
+
+  private static func compact(name: String) -> some View {
+    let settings = AppSettings()
+    settings.showCompactHUD = true
+    let manager = HUDManager(appSettings: settings)
+    manager.beginRecording()
+    manager.updateCaptureHealth(
+      CaptureHealthSnapshot(
+        microphonePermission: .granted,
+        noInputDevicesAvailable: false,
+        inputDeviceName: "USB Audio",
+        providerLabel: "Deepgram Nova-3 (Streaming)",
+        latencyTier: .fast
+      )
+    )
+    manager.updateLiveTranscription(
+      text: "so the meter sits in the middle and the newest words stay on the right",
+      isFinal: false,
+      confidence: 0.94
+    )
+    manager.updateAudioLevel(0.6)
+    return CompactHUDContent(manager: manager)
+      .environmentObject(settings)
+      .frame(width: 520, height: 320)
+      .previewDisplayName(name)
+  }
+}

--- a/Sources/SpeakApp/CompactHUDView.swift
+++ b/Sources/SpeakApp/CompactHUDView.swift
@@ -32,7 +32,7 @@ struct CompactHUDContent: View {
     .background(cardBackground)
     .overlay(
       RoundedRectangle(cornerRadius: 20, style: .continuous)
-        .stroke(dotColor.opacity(0.4), lineWidth: 1.5)
+        .stroke((washColor ?? Color.gray).opacity(0.35), lineWidth: 1.5)
     )
     .shadow(color: .black.opacity(0.16), radius: 16, x: 0, y: 10)
     .accessibilityElement(children: .contain)
@@ -196,10 +196,30 @@ struct CompactHUDContent: View {
   }
 
   private var cardBackground: some View {
-    let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
-    return shape
+    RoundedRectangle(cornerRadius: 20, style: .continuous)
       .fill(.thickMaterial)
-      .overlay(shape.fill(dotColor.opacity(0.18)))
+      .overlay(washOverlay)
+  }
+
+  /// The card stays calm grey while arming, recording and processing; it only
+  /// takes on colour for the final outcome - green on delivery, red on failure.
+  @ViewBuilder
+  private var washOverlay: some View {
+    if let washColor {
+      RoundedRectangle(cornerRadius: 20, style: .continuous)
+        .fill(washColor.opacity(0.18))
+    }
+  }
+
+  private var washColor: Color? {
+    switch phase {
+    case .delivering, .success:
+      return .green
+    case .failure:
+      return .red
+    default:
+      return nil
+    }
   }
 
   private var dotColor: Color {

--- a/Sources/SpeakApp/CompactHUDView.swift
+++ b/Sources/SpeakApp/CompactHUDView.swift
@@ -111,7 +111,7 @@ struct CompactHUDContent: View {
           .frame(maxWidth: .infinity, alignment: .trailing)
           .accessibilityLabel("Transcript: \(text)")
       }
-    } else if phase != .recording, !statusText.isEmpty {
+    } else if !Self.isLiveTranscriptPhase(phase), !statusText.isEmpty {
       Text(statusText)
         .font(.system(size: 13))
         .foregroundStyle(.secondary)
@@ -170,11 +170,19 @@ struct CompactHUDContent: View {
 
   // MARK: - Derived state
 
-  /// The scrolling transcript line is shown only while recording and only when
-  /// the "Show live transcript in HUD" preference is on, so it can be switched
-  /// off independently of the compact HUD.
+  /// The scrolling transcript line is shown only in the live-transcript phases
+  /// (recording and voice-edit) and only when the "Show live transcript in HUD"
+  /// preference is on, so it can be switched off independently of the compact
+  /// HUD. This mirrors the full HUD, which shows its transcript for the same
+  /// phases and preference.
   private var showsLiveTranscript: Bool {
     Self.showsLiveTranscript(phase: phase, showLiveTranscriptInHUD: settings.showLiveTranscriptInHUD)
+  }
+
+  /// The phases that carry live transcription text: active recording and the
+  /// voice-edit listening phase. Matches the full HUD's transcript gating.
+  static func isLiveTranscriptPhase(_ phase: HUDManager.Snapshot.Phase) -> Bool {
+    phase == .recording || phase == .editing
   }
 
   /// Pure decision for the transcript line, exposed at package scope for testing.
@@ -182,7 +190,7 @@ struct CompactHUDContent: View {
     phase: HUDManager.Snapshot.Phase,
     showLiveTranscriptInHUD: Bool
   ) -> Bool {
-    phase == .recording && showLiveTranscriptInHUD
+    isLiveTranscriptPhase(phase) && showLiveTranscriptInHUD
   }
 
   /// The dot pulses only while the app is live (armed or recording); processing

--- a/Sources/SpeakApp/CompactHUDView.swift
+++ b/Sources/SpeakApp/CompactHUDView.swift
@@ -15,7 +15,6 @@ import SwiftUI
 /// ones scroll off the left.
 struct CompactHUDContent: View {
   @ObservedObject var manager: HUDManager
-  @Environment(\.colorScheme) private var colorScheme
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   private var snapshot: HUDManager.Snapshot { manager.snapshot }
@@ -197,8 +196,10 @@ struct CompactHUDContent: View {
   }
 
   private var cardBackground: some View {
-    RoundedRectangle(cornerRadius: 20, style: .continuous)
-      .fill(colorScheme == .dark ? Color(white: 0.15) : Color.white)
+    let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
+    return shape
+      .fill(.thickMaterial)
+      .overlay(shape.fill(dotColor.opacity(0.18)))
   }
 
   private var dotColor: Color {

--- a/Sources/SpeakApp/CompactHUDView.swift
+++ b/Sources/SpeakApp/CompactHUDView.swift
@@ -18,7 +18,9 @@ import SwiftUI
 struct CompactHUDContent: View {
   @ObservedObject var manager: HUDManager
   @EnvironmentObject private var settings: AppSettings
+  @Environment(\.colorScheme) private var colorScheme
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
   private var snapshot: HUDManager.Snapshot { manager.snapshot }
   private var phase: HUDManager.Snapshot.Phase { snapshot.phase }
@@ -40,6 +42,7 @@ struct CompactHUDContent: View {
     .shadow(color: .black.opacity(0.16), radius: 16, x: 0, y: 10)
     .accessibilityElement(children: .contain)
     .accessibilityIdentifier("compactHUD")
+    .accessibilityAddTraits(.isModal)
   }
 
   // MARK: - Top row (dot · meter · timer)
@@ -221,10 +224,18 @@ struct CompactHUDContent: View {
       : "\(seconds)s"
   }
 
+  @ViewBuilder
   private var cardBackground: some View {
-    RoundedRectangle(cornerRadius: 20, style: .continuous)
-      .fill(.thickMaterial)
-      .overlay(washOverlay)
+    let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
+    if reduceTransparency {
+      shape
+        .fill(colorScheme == .dark ? Color.black : Color.white)
+        .overlay(washOverlay)
+    } else {
+      shape
+        .fill(.thickMaterial)
+        .overlay(washOverlay)
+    }
   }
 
   /// The card stays calm grey while arming, recording and processing; it only

--- a/Sources/SpeakApp/CompactHUDView.swift
+++ b/Sources/SpeakApp/CompactHUDView.swift
@@ -12,9 +12,12 @@ import SwiftUI
 /// is live (it does not react to volume). The meter is the only element that
 /// tracks how loudly you are speaking. Beneath the top row, a single transcript
 /// line is anchored to the right so the newest words stay visible while older
-/// ones scroll off the left.
+/// ones scroll off the left. The transcript line honours the same
+/// "Show live transcript in HUD" preference as the full HUD, so it can be turned
+/// off independently while the compact HUD stays on.
 struct CompactHUDContent: View {
   @ObservedObject var manager: HUDManager
+  @EnvironmentObject private var settings: AppSettings
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   private var snapshot: HUDManager.Snapshot { manager.snapshot }
@@ -98,7 +101,7 @@ struct CompactHUDContent: View {
 
   @ViewBuilder
   private var transcriptLine: some View {
-    if phase == .recording {
+    if showsLiveTranscript {
       if let text = snapshot.liveText, !text.isEmpty {
         Text(text)
           .font(.system(size: 14))
@@ -108,7 +111,7 @@ struct CompactHUDContent: View {
           .frame(maxWidth: .infinity, alignment: .trailing)
           .accessibilityLabel("Transcript: \(text)")
       }
-    } else if !statusText.isEmpty {
+    } else if phase != .recording, !statusText.isEmpty {
       Text(statusText)
         .font(.system(size: 13))
         .foregroundStyle(.secondary)
@@ -166,6 +169,21 @@ struct CompactHUDContent: View {
   }
 
   // MARK: - Derived state
+
+  /// The scrolling transcript line is shown only while recording and only when
+  /// the "Show live transcript in HUD" preference is on, so it can be switched
+  /// off independently of the compact HUD.
+  private var showsLiveTranscript: Bool {
+    Self.showsLiveTranscript(phase: phase, showLiveTranscriptInHUD: settings.showLiveTranscriptInHUD)
+  }
+
+  /// Pure decision for the transcript line, exposed at package scope for testing.
+  static func showsLiveTranscript(
+    phase: HUDManager.Snapshot.Phase,
+    showLiveTranscriptInHUD: Bool
+  ) -> Bool {
+    phase == .recording && showLiveTranscriptInHUD
+  }
 
   /// The dot pulses only while the app is live (armed or recording); processing
   /// and terminal phases show a steady dot.

--- a/Sources/SpeakApp/HUDView.swift
+++ b/Sources/SpeakApp/HUDView.swift
@@ -13,11 +13,17 @@ struct HUDOverlay: View {
 
   var body: some View {
     if manager.snapshot.phase.isVisible {
-      presentedContent
-        .padding(.bottom, 24)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-        .ignoresSafeArea()
-        .accessibilityIdentifier("hudOverlay")
+      Group {
+        if settings.showCompactHUD {
+          CompactHUDContent(manager: manager)
+        } else {
+          presentedContent
+        }
+      }
+      .padding(.bottom, 24)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+      .ignoresSafeArea()
+      .accessibilityIdentifier("hudOverlay")
     }
   }
 

--- a/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
@@ -155,6 +155,16 @@ extension SettingsView {
               tint: .brandLagoon
             )
             .speakTooltip("Show real-time transcription text in the HUD while recording.")
+            .disabled(settings.showCompactHUD)
+            settingsToggle(
+              "Show compact HUD",
+              isOn: settingsBinding(\AppSettings.showCompactHUD),
+              tint: .brandLagoon
+            )
+            .speakTooltip(
+              "Shrink the HUD to a pulsing dot, a live level meter, the timer and one scrolling "
+                + "transcript line. Replaces the full live transcript while it's on."
+            )
           }
         }
       }

--- a/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
@@ -154,16 +154,15 @@ extension SettingsView {
               isOn: settingsBinding(\AppSettings.showLiveTranscriptInHUD),
               tint: .brandLagoon
             )
-            .speakTooltip("Show real-time transcription text in the HUD while recording.")
-            .disabled(settings.showCompactHUD)
+            .speakTooltip("Show real-time transcription text in the HUD while recording, full or compact.")
             settingsToggle(
               "Show compact HUD",
               isOn: settingsBinding(\AppSettings.showCompactHUD),
               tint: .brandLagoon
             )
             .speakTooltip(
-              "Shrink the HUD to a pulsing dot, a live level meter, the timer and one scrolling "
-                + "transcript line. Replaces the full live transcript while it's on."
+              "Shrink the HUD to a pulsing dot, a live level meter and the timer. The scrolling "
+                + "transcript line still follows the \"Show live transcript in HUD\" setting above."
             )
           }
         }

--- a/Tests/SpeakAppTests/CompactHUDSettingsTests.swift
+++ b/Tests/SpeakAppTests/CompactHUDSettingsTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import SpeakCore
+
+@testable import SpeakApp
+
+final class CompactHUDSettingsTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        suiteName = "com.speakapp.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    @MainActor
+    func testCompactHUD_DefaultsToOff() {
+        let settings = AppSettings(defaults: defaults)
+        XCTAssertFalse(settings.showCompactHUD)
+    }
+
+    @MainActor
+    func testCompactHUD_PersistsWhenToggled() {
+        let settings = AppSettings(defaults: defaults)
+        settings.showCompactHUD = true
+        let reloaded = AppSettings(defaults: defaults)
+        XCTAssertTrue(reloaded.showCompactHUD)
+    }
+
+    /// The live-transcript preference is independent state: enabling the compact
+    /// HUD ignores it at render time but must not silently clear it, so it is
+    /// restored if the compact HUD is switched back off.
+    @MainActor
+    func testCompactHUD_DoesNotClearLiveTranscriptPreference() {
+        let settings = AppSettings(defaults: defaults)
+        settings.showLiveTranscriptInHUD = true
+        settings.showCompactHUD = true
+        XCTAssertTrue(settings.showLiveTranscriptInHUD)
+    }
+
+    func testElapsedLabel_UnderOneMinute_IsSecondsWithSuffix() {
+        XCTAssertEqual(CompactHUDContent.elapsedLabel(for: 0), "0s")
+        XCTAssertEqual(CompactHUDContent.elapsedLabel(for: 7.78), "7s")
+        XCTAssertEqual(CompactHUDContent.elapsedLabel(for: 59.9), "59s")
+    }
+
+    func testElapsedLabel_OneMinuteAndOver_IsMinutesColonSeconds() {
+        XCTAssertEqual(CompactHUDContent.elapsedLabel(for: 60), "1:00s")
+        XCTAssertEqual(CompactHUDContent.elapsedLabel(for: 83), "1:23s")
+        XCTAssertEqual(CompactHUDContent.elapsedLabel(for: 600), "10:00s")
+    }
+
+    func testElapsedLabel_NegativeElapsed_ClampsToZero() {
+        XCTAssertEqual(CompactHUDContent.elapsedLabel(for: -5), "0s")
+    }
+}

--- a/Tests/SpeakAppTests/CompactHUDSettingsTests.swift
+++ b/Tests/SpeakAppTests/CompactHUDSettingsTests.swift
@@ -35,15 +35,32 @@ final class CompactHUDSettingsTests: XCTestCase {
         XCTAssertTrue(reloaded.showCompactHUD)
     }
 
-    /// The live-transcript preference is independent state: enabling the compact
-    /// HUD ignores it at render time but must not silently clear it, so it is
-    /// restored if the compact HUD is switched back off.
+    /// The live-transcript preference is independent state: toggling the compact
+    /// HUD leaves it untouched, so each can be set without disturbing the other.
     @MainActor
     func testCompactHUD_DoesNotClearLiveTranscriptPreference() {
         let settings = AppSettings(defaults: defaults)
         settings.showLiveTranscriptInHUD = true
         settings.showCompactHUD = true
         XCTAssertTrue(settings.showLiveTranscriptInHUD)
+    }
+
+    /// The compact HUD draws the scrolling transcript line only while recording
+    /// and only when the live-transcript preference is on, so the line can be
+    /// turned off independently while the compact HUD stays on.
+    func testCompactHUD_ShowsLiveTranscriptOnlyWhenRecordingAndEnabled() {
+        XCTAssertTrue(
+            CompactHUDContent.showsLiveTranscript(phase: .recording, showLiveTranscriptInHUD: true)
+        )
+        XCTAssertFalse(
+            CompactHUDContent.showsLiveTranscript(phase: .recording, showLiveTranscriptInHUD: false)
+        )
+        XCTAssertFalse(
+            CompactHUDContent.showsLiveTranscript(phase: .armed, showLiveTranscriptInHUD: true)
+        )
+        XCTAssertFalse(
+            CompactHUDContent.showsLiveTranscript(phase: .success(message: "Done"), showLiveTranscriptInHUD: true)
+        )
     }
 
     func testElapsedLabel_UnderOneMinute_IsSecondsWithSuffix() {

--- a/Tests/SpeakAppTests/CompactHUDSettingsTests.swift
+++ b/Tests/SpeakAppTests/CompactHUDSettingsTests.swift
@@ -45,16 +45,26 @@ final class CompactHUDSettingsTests: XCTestCase {
         XCTAssertTrue(settings.showLiveTranscriptInHUD)
     }
 
-    /// The compact HUD draws the scrolling transcript line only while recording
-    /// and only when the live-transcript preference is on, so the line can be
-    /// turned off independently while the compact HUD stays on.
-    func testCompactHUD_ShowsLiveTranscriptOnlyWhenRecordingAndEnabled() {
+    /// The compact HUD draws the scrolling transcript line only in the
+    /// live-transcript phases (recording and voice-edit) and only when the
+    /// live-transcript preference is on, so the line can be turned off
+    /// independently while the compact HUD stays on. Mirrors the full HUD.
+    func testCompactHUD_ShowsLiveTranscriptOnlyInLiveTranscriptPhasesWhenEnabled() {
+        // On in the live-transcript phases.
         XCTAssertTrue(
             CompactHUDContent.showsLiveTranscript(phase: .recording, showLiveTranscriptInHUD: true)
         )
+        XCTAssertTrue(
+            CompactHUDContent.showsLiveTranscript(phase: .editing, showLiveTranscriptInHUD: true)
+        )
+        // Off when the preference is off, even in a live-transcript phase.
         XCTAssertFalse(
             CompactHUDContent.showsLiveTranscript(phase: .recording, showLiveTranscriptInHUD: false)
         )
+        XCTAssertFalse(
+            CompactHUDContent.showsLiveTranscript(phase: .editing, showLiveTranscriptInHUD: false)
+        )
+        // Off in non-live-transcript phases regardless of the preference.
         XCTAssertFalse(
             CompactHUDContent.showsLiveTranscript(phase: .armed, showLiveTranscriptInHUD: true)
         )


### PR DESCRIPTION
# feat(mac): add compact HUD with independent live transcript

## Description
## Compact HUD

Adds an optional compact heads-up display for macOS: a small card with a
pulsing record dot, a live level meter, the elapsed timer and a single
scrolling transcript line, selected by a new **Show compact HUD** setting
(off by default).

### Motivation
The full HUD is tall enough to cover the bottom of the screen — including a
text field you're dictating into. The compact HUD is a low-height alternative
that keeps the bottom of the screen clear.

### User-visible changes
- New **Show compact HUD** toggle under Settings → General → Output (default off).
- The compact HUD honours the existing **Show live transcript in HUD**
  preference independently — you can run the compact HUD with the transcript
  line on or off, and both HUDs treat that setting the same way (transcript
  shown during recording and voice-edit).
- No change to the full HUD or to default behaviour.

### Testing
- New `CompactHUDSettingsTests` cover persistence and the render-time
  transcript decision. Compact-HUD suite green; package builds under Xcode 26.
- Behind a default-off setting, so existing users see no change until they opt in.


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [ ] Existing tests pass with `make test`
- Verification notes / screenshots / logs:

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed
- [x] I have added appropriate comments

## Related Issues
Fixes #(issue number)

## Screenshots (if applicable)

<img width="250" height="111" alt="image" src="https://github.com/user-attachments/assets/f7793830-b701-4edb-89c0-af07f0d08318" />
<img width="294" height="99" alt="image" src="https://github.com/user-attachments/assets/638c782f-5764-4b4f-ac3d-4dd850f52c7f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional compact recording HUD with status, activity indicator, audio-level meter, timer, transcript, and capture details.
  * Added a persistent “Show compact HUD” setting in General settings.
  * Compact HUD supports accessibility labels, color-coded states, reduced-motion preferences, and reduced-transparency settings.

* **Bug Fixes**
  * Kept compact HUD preferences independent from live-transcript settings.

* **Tests**
  * Added coverage for setting persistence, transcript visibility, and elapsed-time formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->