### PR TITLE
test(mac): add launched-app journey fixture target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,10 @@ jobs:
             -scheme SpeakApp \
             -destination "platform=macOS" \
             -only-testing:SpeakAppUITests/CoreJourneyFixtureUITests \
-            -skipPackagePluginValidation
+            -skipPackagePluginValidation \
+            CODE_SIGN_IDENTITY="-" \
+            DEVELOPMENT_TEAM="" \
+            CODE_SIGN_STYLE=Manual
 
   release-validation:
     name: Build & Test (Release)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,30 @@ jobs:
           path: .artifacts/core-journey-e2e
           if-no-files-found: error
 
+  core-journey-fixture-ui:
+    name: Core Journey Fixture UI
+    runs-on: macos-latest
+    timeout-minutes: 10
+    needs: release-paths
+    if: needs.release-paths.outputs.core-journey == 'true'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Tuist
+        run: brew install tuist
+
+      - name: Generate macOS project
+        run: tuist generate --no-open
+
+      - name: Test launched fixture app
+        run: |
+          xcodebuild test \
+            -workspace "Just Speak to It.xcworkspace" \
+            -scheme SpeakApp \
+            -destination "platform=macOS" \
+            -only-testing:SpeakAppUITests/CoreJourneyFixtureUITests \
+            -skipPackagePluginValidation
+
   release-validation:
     name: Build & Test (Release)
     runs-on: macos-latest

--- a/Docs/core-journey-e2e.md
+++ b/Docs/core-journey-e2e.md
@@ -34,6 +34,18 @@ The fixture-app/UI layer described in #802 can be promoted once its permission
 bootstrap is reliable on cold hosted runners; it must reuse this same command
 and budget rather than creating a second required gate.
 
+## Launched-app layer (in progress)
+
+`CoreJourneyFixtureApp` is the stable Accessibility destination for the next
+layer. It exposes one named editable field and readiness marker, avoiding AX
+tree drift from depending on TextEdit or third-party editors in CI. Its first UI
+test proves the fixture can be launched, focused, typed into and read back.
+
+The next increment launches Speak with an isolated E2E profile and deterministic
+provider fixtures, injects the supported hotkey gesture, and asserts delivery
+into this field. It remains advisory until Accessibility permission bootstrap
+passes the cold-runner flake gate; the existing contract gate stays required.
+
 ## Updating the gate
 
 Keep only one representative journey per external branch here. Put

--- a/Docs/core-journey-e2e.md
+++ b/Docs/core-journey-e2e.md
@@ -39,7 +39,9 @@ and budget rather than creating a second required gate.
 `CoreJourneyFixtureApp` is the stable Accessibility destination for the next
 layer. It exposes one named editable field and readiness marker, avoiding AX
 tree drift from depending on TextEdit or third-party editors in CI. Its first UI
-test proves the fixture can be launched, focused, typed into and read back.
+test proves the fixture launches with keyboard focus, accepts typed text and can
+be read back. The bounded `Core Journey Fixture UI` CI job runs this launched-app
+test whenever core-journey paths change so the fixture cannot silently decay.
 
 The next increment launches Speak with an isolated E2E profile and deterministic
 provider fixtures, injects the supported hotkey gesture, and asserts delivery

--- a/Project.swift
+++ b/Project.swift
@@ -412,6 +412,15 @@ let widgetTarget: Target = .target(
     settings: .settings(base: iosWidgetSettings)
 )
 
+let coreJourneyFixtureTarget: Target = .target(
+    name: "CoreJourneyFixtureApp",
+    destinations: .macOS,
+    product: .app,
+    bundleId: "com.justspeaktoit.core-journey-fixture",
+    infoPlist: .default,
+    sources: ["Tests/Fixtures/CoreJourneyTargetApp/**"]
+)
+
 let macUITestsTarget: Target = .target(
     name: "SpeakAppUITests",
     destinations: .macOS,
@@ -419,7 +428,8 @@ let macUITestsTarget: Target = .target(
     bundleId: "com.justspeaktoit.uitests",
     sources: ["Tests/SpeakAppUITests/**"],
     dependencies: [
-        .target(name: "SpeakApp")
+        .target(name: "SpeakApp"),
+        .target(name: "CoreJourneyFixtureApp")
     ]
 )
 
@@ -470,7 +480,7 @@ if isWatchAppEnabled {
 if isIOSKeyboardEnabled {
     projectTargets.append(keyboardTarget)
 }
-projectTargets += [widgetTarget, macUITestsTarget, iosUITestsTarget, iosTestsTarget]
+projectTargets += [widgetTarget, coreJourneyFixtureTarget, macUITestsTarget, iosUITestsTarget, iosTestsTarget]
 
 let project = Project(
     name: "Just Speak to It",

--- a/Tests/Fixtures/CoreJourneyTargetApp/CoreJourneyTargetApp.swift
+++ b/Tests/Fixtures/CoreJourneyTargetApp/CoreJourneyTargetApp.swift
@@ -1,0 +1,50 @@
+import AppKit
+
+/// Stable Accessibility destination for the launched-app dictation journey.
+@main
+final class CoreJourneyTargetApp: NSObject, NSApplicationDelegate {
+    private var window: NSWindow?
+
+    static func main() {
+        let application = NSApplication.shared
+        let delegate = CoreJourneyTargetApp()
+        application.delegate = delegate
+        application.run()
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let field = NSTextView(frame: NSRect(x: 24, y: 48, width: 592, height: 288))
+        field.isEditable = true
+        field.isRichText = false
+        field.font = .monospacedSystemFont(ofSize: 16, weight: .regular)
+        field.setAccessibilityIdentifier("coreJourneyTargetField")
+        field.setAccessibilityLabel("Core journey target field")
+
+        let scrollView = NSScrollView(frame: field.frame)
+        scrollView.documentView = field
+        scrollView.hasVerticalScroller = true
+        scrollView.setAccessibilityIdentifier("coreJourneyTargetScrollView")
+
+        let status = NSTextField(labelWithString: "Fixture ready")
+        status.frame = NSRect(x: 24, y: 16, width: 592, height: 20)
+        status.setAccessibilityIdentifier("coreJourneyFixtureStatus")
+
+        let content = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 360))
+        content.addSubview(scrollView)
+        content.addSubview(status)
+
+        let window = NSWindow(
+            contentRect: content.bounds,
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Core Journey Target"
+        window.contentView = content
+        window.setAccessibilityIdentifier("coreJourneyTargetWindow")
+        window.makeKeyAndOrderFront(nil)
+        window.makeFirstResponder(field)
+        NSApp.activate(ignoringOtherApps: true)
+        self.window = window
+    }
+}

--- a/Tests/SpeakAppUITests/CoreJourneyFixtureUITests.swift
+++ b/Tests/SpeakAppUITests/CoreJourneyFixtureUITests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+final class CoreJourneyFixtureUITests: XCTestCase {
+    func testFixtureProvidesNamedFocusedEditableTarget() {
+        let fixture = XCUIApplication(bundleIdentifier: "com.justspeaktoit.core-journey-fixture")
+        fixture.launch()
+        defer { fixture.terminate() }
+
+        let field = fixture.textViews["coreJourneyTargetField"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10))
+        field.click()
+        field.typeText("fixture accepts deterministic output")
+        XCTAssertEqual(field.value as? String, "fixture accepts deterministic output")
+        XCTAssertTrue(fixture.staticTexts["coreJourneyFixtureStatus"].exists)
+    }
+}

--- a/Tests/SpeakAppUITests/CoreJourneyFixtureUITests.swift
+++ b/Tests/SpeakAppUITests/CoreJourneyFixtureUITests.swift
@@ -1,13 +1,17 @@
 import XCTest
 
 final class CoreJourneyFixtureUITests: XCTestCase {
-    func testFixtureProvidesNamedFocusedEditableTarget() {
+    func testFixtureProvidesNamedEditableTarget_acceptsAndReadsBackText() {
         let fixture = XCUIApplication(bundleIdentifier: "com.justspeaktoit.core-journey-fixture")
         fixture.launch()
         defer { fixture.terminate() }
 
         let field = fixture.textViews["coreJourneyTargetField"]
         XCTAssertTrue(field.waitForExistence(timeout: 10))
+        let focusedField = fixture.textViews.matching(
+            NSPredicate(format: "hasKeyboardFocus == true")
+        ).firstMatch
+        XCTAssertEqual(focusedField.identifier, "coreJourneyTargetField")
         field.click()
         field.typeText("fixture accepts deterministic output")
         XCTAssertEqual(field.value as? String, "fixture accepts deterministic output")


### PR DESCRIPTION
## What Problem This Solves

Issue #802 needs a true launched-app journey, but depending on TextEdit or third-party editors makes the Accessibility tree and installed app versions nondeterministic in CI. The current required gate proves process-boundary contracts but has no stable external destination app.

## Why This Change Was Made

- Adds `CoreJourneyFixtureApp`, a deliberately tiny macOS app with one named editable AX field and readiness marker.
- Makes the fixture a dependency of `SpeakAppUITests`.
- Adds the first UI test proving the fixture launches, focuses, accepts text, and exposes the exact value for assertions.
- Documents how this becomes the destination for hotkey → capture → provider fixture → delivery journeys.

This is the first launched-app layer, not a claim that the whole #802 matrix is complete. The existing fast contract gate remains required while permission bootstrap and cold-runner stability are proven.

## User Impact

No production code or release target behaviour changes. This creates the deterministic external field needed to catch future regressions at the real app/Accessibility boundary.

## Evidence

- `make lint` — 0 violations across 633 files.
- `xcodebuild -workspace "Just Speak to It.xcworkspace" -scheme SpeakApp -destination "platform=macOS" -only-testing:SpeakAppUITests/CoreJourneyFixtureUITests test` — 1 UI test passed in 5.9s.
- `tuist generate --no-open` — successful.

Progresses crmitchelmore/justspeaktoit#802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS fixture app with an accessible text field and status display for end-to-end validation.
  * Added a UI test that launches the fixture, enters text, and verifies the displayed result.

* **Documentation**
  * Documented the in-progress launched-app end-to-end testing workflow and its current advisory status.

* **Tests**
  * Added automated CI coverage for the fixture-based UI test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->