### PR TITLE
feat(mac): add dedicated HUD settings section

### DIFF
--- a/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
@@ -143,6 +143,18 @@ extension SettingsView {
                 "After Speak pastes your transcript, we put your original clipboard content back automatically."
               )
             }
+          }
+        }
+      }
+      .speakTooltip("Control how Speak delivers transcripts and how gently we touch your clipboard and interface.")
+
+      SettingsCard(title: "Heads-Up Display", systemImage: "rectangle.on.rectangle", tint: Color.brandLagoon) {
+        VStack(alignment: .leading, spacing: 12) {
+          Text("Choose what Speak shows while a recording or transcription session is active.")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+
+          VStack(alignment: .leading, spacing: 8) {
             settingsToggle(
               "Show HUD during sessions",
               isOn: settingsBinding(\AppSettings.showHUDDuringSessions),
@@ -167,7 +179,7 @@ extension SettingsView {
           }
         }
       }
-      .speakTooltip("Control how Speak delivers transcripts and how gently we touch your clipboard and interface.")
+      .speakTooltip("Configure the HUD shown while Speak is listening and transcribing.")
 
       SettingsCard(title: "App Behaviour", systemImage: "gearshape.2", tint: Color.brandAccentWarm) {
         VStack(alignment: .leading, spacing: 12) {


### PR DESCRIPTION
## Summary
- move HUD visibility controls out of Output
- add a dedicated Heads-Up Display card in General Settings
- preserve all existing preference keys and behaviour

## Verification
- make lint
- swift test --filter CompactHUDSettingsTests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Heads-Up Display settings card with options to:
    - Show the HUD during sessions
    - Display the live transcript
    - Use the compact HUD layout
  - Moved the related tooltip from the Output settings card to the new HUD card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->