### PR TITLE
feat(mac): add shorten error display HUD toggle

### DIFF
--- a/Sources/SpeakApp/AppSettings.swift
+++ b/Sources/SpeakApp/AppSettings.swift
@@ -317,6 +317,7 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
     case hudSizePreference
     case showLiveTranscriptInHUD
     case showCompactHUD
+    case shortenErrorDisplay
     case showSidebarShortcutHints
     case speedMode
     case livePolishModel
@@ -562,6 +563,14 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
   /// HUD can run with the live transcript on or off, independently.
   @Published var showCompactHUD: Bool {
     didSet { store(showCompactHUD, key: .showCompactHUD) }
+  }
+
+  /// When on, a failure or cancellation message auto-hides after
+  /// `HUDManager.shortFailureDisplayDuration` instead of the standard
+  /// `HUDManager.standardFailureDisplayDuration`. Success messages are
+  /// unaffected - only the failure/cancellation duration shortens.
+  @Published var shortenErrorDisplay: Bool {
+    didSet { store(shortenErrorDisplay, key: .shortenErrorDisplay) }
   }
 
   @Published var showSidebarShortcutHints: Bool {
@@ -1064,6 +1073,8 @@ final class AppSettings: ObservableObject { // swiftlint:disable:this type_body_
       defaults.object(forKey: DefaultsKey.showLiveTranscriptInHUD.rawValue) as? Bool ?? true
     showCompactHUD =
       defaults.object(forKey: DefaultsKey.showCompactHUD.rawValue) as? Bool ?? false
+    shortenErrorDisplay =
+      defaults.object(forKey: DefaultsKey.shortenErrorDisplay.rawValue) as? Bool ?? false
     showSidebarShortcutHints =
       defaults.object(forKey: DefaultsKey.showSidebarShortcutHints.rawValue) as? Bool ?? true
     appVisibility =

--- a/Sources/SpeakApp/HUDManager.swift
+++ b/Sources/SpeakApp/HUDManager.swift
@@ -70,6 +70,11 @@ final class HUDManager: ObservableObject {
   private var timer: Timer?
   private var phaseStartDate: Date?
   private var autoHideTimer: Timer?
+  /// The interval most recently passed to `scheduleAutoHide`. `Timer.timeInterval`
+  /// reads back as 0 for a non-repeating timer, so this is the only way to
+  /// observe which duration a `finishSuccess`/`finishFailure` call actually
+  /// scheduled - test-only visibility, never read by production code.
+  private(set) var lastScheduledAutoHideDuration: TimeInterval?
 
   init(
     appSettings: AppSettings,
@@ -186,24 +191,46 @@ final class HUDManager: ObservableObject {
     transition(.editing, headline: "Editing", subheadline: subheadline)
   }
 
+  /// How long a success confirmation stays on screen before it auto-hides.
+  static let successDisplayDuration: TimeInterval = 2.4
+
+  /// The default interval a failure or cancellation message stays on screen.
+  static let standardFailureDisplayDuration: TimeInterval = 6.0
+
+  /// The interval used when the "Shorten error display" preference is on -
+  /// 50% longer than `successDisplayDuration`, so a failure still reads as
+  /// slower than a success without lingering nearly 3x as long.
+  static let shortFailureDisplayDuration: TimeInterval = 3.6
+
+  /// Resolves the auto-hide interval for a failure/cancellation message from
+  /// the "Shorten error display" preference. A caller-supplied
+  /// `displayDuration` (eg the 3s "voice edit in progress" refusal) always
+  /// wins - the preference only changes the shared default the other
+  /// `finishFailure` call sites fall back to.
+  static func failureDisplayDuration(shortenErrorDisplay: Bool) -> TimeInterval {
+    shortenErrorDisplay ? shortFailureDisplayDuration : standardFailureDisplayDuration
+  }
+
   func finishSuccess(message: String) {
     transition(
       .success(message: message), headline: "Completed", subheadline: message, showsTimer: false)
-    scheduleAutoHide(after: 2.4)
+    scheduleAutoHide(after: Self.successDisplayDuration)
   }
 
   func finishFailure(message: String) {
     finishFailure(headline: "Something went wrong", message: message, showRetryHint: false)
   }
 
-  func finishFailure(headline: String, message: String, displayDuration: TimeInterval = 6.0) {
+  func finishFailure(headline: String, message: String, displayDuration: TimeInterval? = nil) {
     finishFailure(headline: headline, message: message, showRetryHint: false, displayDuration: displayDuration)
   }
 
-  func finishFailure(headline: String, message: String, showRetryHint: Bool, displayDuration: TimeInterval = 6.0) {
+  func finishFailure(headline: String, message: String, showRetryHint: Bool, displayDuration: TimeInterval? = nil) {
     transition(
       .failure(message: message), headline: headline, subheadline: message, showsTimer: false, showRetryHint: showRetryHint)
-    scheduleAutoHide(after: displayDuration)
+    let resolvedDuration = displayDuration
+      ?? Self.failureDisplayDuration(shortenErrorDisplay: appSettings.shortenErrorDisplay)
+    scheduleAutoHide(after: resolvedDuration)
   }
 
   func hide() {
@@ -260,6 +287,7 @@ final class HUDManager: ObservableObject {
   }
 
   private func scheduleAutoHide(after delay: TimeInterval) {
+    lastScheduledAutoHideDuration = delay
     autoHideTimer?.invalidate()
     guard delay > 0 else { return }
     // Use target-selector Timer pattern to completely bypass Swift concurrency runtime.

--- a/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
+++ b/Sources/SpeakApp/Views/Settings/SettingsView+General.swift
@@ -176,6 +176,15 @@ extension SettingsView {
               "Shrink the HUD to a pulsing dot, a live level meter and the timer. The scrolling "
                 + "transcript line still follows the \"Show live transcript in HUD\" setting above."
             )
+            settingsToggle(
+              "Shorten error display",
+              isOn: settingsBinding(\AppSettings.shortenErrorDisplay),
+              tint: .brandLagoon
+            )
+            .speakTooltip(
+              "Auto-dismiss failure and cancellation messages after 3.6 seconds instead of 6, "
+                + "so they don't linger far longer than a success confirmation."
+            )
           }
         }
       }

--- a/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
+++ b/Tests/SpeakAppTests/AppSettingsDefaultsTests.swift
@@ -99,6 +99,12 @@ final class AppSettingsDefaultsTests: XCTestCase {
     }
 
     @MainActor
+    func testCoreDefaults_shortenErrorDisplayIsFalse() {
+        let settings = AppSettings(defaults: defaults)
+        XCTAssertFalse(settings.shortenErrorDisplay)
+    }
+
+    @MainActor
     func testReconcileAPIKeyIdentifiers_replacesStaleMetadataAndPersistsCanonicalSet() {
         defaults.set(
             ["openrouter.apiKey", "deepgram.apiKey", "assemblyai.apiKey"],

--- a/Tests/SpeakAppTests/CompactHUDSettingsTests.swift
+++ b/Tests/SpeakAppTests/CompactHUDSettingsTests.swift
@@ -88,4 +88,22 @@ final class CompactHUDSettingsTests: XCTestCase {
     func testElapsedLabel_NegativeElapsed_ClampsToZero() {
         XCTAssertEqual(CompactHUDContent.elapsedLabel(for: -5), "0s")
     }
+
+    @MainActor
+    func testShortenErrorDisplay_PersistsWhenToggled() {
+        let settings = AppSettings(defaults: defaults)
+        settings.shortenErrorDisplay = true
+        let reloaded = AppSettings(defaults: defaults)
+        XCTAssertTrue(reloaded.shortenErrorDisplay)
+    }
+
+    /// The error-display duration preference is independent state: toggling
+    /// it leaves the compact HUD preference untouched.
+    @MainActor
+    func testShortenErrorDisplay_DoesNotClearCompactHUDPreference() {
+        let settings = AppSettings(defaults: defaults)
+        settings.showCompactHUD = true
+        settings.shortenErrorDisplay = true
+        XCTAssertTrue(settings.showCompactHUD)
+    }
 }

--- a/Tests/SpeakAppTests/HUDManagerFailureDurationTests.swift
+++ b/Tests/SpeakAppTests/HUDManagerFailureDurationTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import SpeakApp
+
+/// Covers the "Shorten error display" preference: off keeps the historical
+/// 6s failure/cancellation duration, on cuts it to 3.6s (50% longer than the
+/// 2.4s success duration, per Phill's ruling 2026-08-27). A caller-supplied
+/// `displayDuration` always overrides the preference.
+final class HUDManagerFailureDurationTests: XCTestCase {
+  @MainActor
+  func testFailureDisplayDuration_preferenceOff_isStandardSixSeconds() {
+    XCTAssertEqual(
+      HUDManager.failureDisplayDuration(shortenErrorDisplay: false),
+      HUDManager.standardFailureDisplayDuration
+    )
+    XCTAssertEqual(HUDManager.standardFailureDisplayDuration, 6.0)
+  }
+
+  @MainActor
+  func testFailureDisplayDuration_preferenceOn_isFiftyPercentLongerThanSuccess() {
+    XCTAssertEqual(
+      HUDManager.failureDisplayDuration(shortenErrorDisplay: true),
+      HUDManager.shortFailureDisplayDuration
+    )
+    XCTAssertEqual(
+      HUDManager.shortFailureDisplayDuration,
+      HUDManager.successDisplayDuration * 1.5,
+      accuracy: 0.0001
+    )
+  }
+
+  @MainActor
+  func testFinishFailure_preferenceOff_schedulesStandardDuration() {
+    let settings = AppSettings()
+    settings.shortenErrorDisplay = false
+    let manager = HUDManager(appSettings: settings)
+
+    manager.finishFailure(message: "Something broke")
+
+    XCTAssertEqual(manager.lastScheduledAutoHideDuration, HUDManager.standardFailureDisplayDuration)
+  }
+
+  @MainActor
+  func testFinishFailure_preferenceOn_schedulesShortDuration() {
+    let settings = AppSettings()
+    settings.shortenErrorDisplay = true
+    let manager = HUDManager(appSettings: settings)
+
+    manager.finishFailure(message: "Something broke")
+
+    XCTAssertEqual(manager.lastScheduledAutoHideDuration, HUDManager.shortFailureDisplayDuration)
+  }
+
+  @MainActor
+  func testFinishFailure_explicitDisplayDurationOverridesPreference() {
+    let settings = AppSettings()
+    settings.shortenErrorDisplay = true
+    let manager = HUDManager(appSettings: settings)
+
+    manager.finishFailure(headline: "Voice edit in progress", message: "Finish or cancel it first.", displayDuration: 3)
+
+    XCTAssertEqual(manager.lastScheduledAutoHideDuration, 3)
+  }
+
+  @MainActor
+  func testFinishSuccess_durationIsUnaffectedByShortenErrorDisplayPreference() {
+    let settings = AppSettings()
+    settings.shortenErrorDisplay = true
+    let manager = HUDManager(appSettings: settings)
+
+    manager.finishSuccess(message: "Delivered")
+
+    XCTAssertEqual(manager.lastScheduledAutoHideDuration, HUDManager.successDisplayDuration)
+  }
+}


### PR DESCRIPTION
## Summary
- Failure/cancellation HUD messages default to 6s auto-hide, 2.5x the 2.4s success duration
- Adds a "Shorten error display" setting toggle that cuts it to 3.6s (50% longer than success) when on
- A caller-supplied explicit duration (eg the 3s "voice edit in progress" refusal) still overrides the preference

## Test plan
- [x] `swift test` - full suite, 2021 tests, 0 failures
- [x] `make lint` - 0 violations
- [ ] Manual: toggle on/off in Settings > Heads-Up Display, trigger a cancelled recording, confirm dismiss timing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Shorten error display” setting in HUD preferences.
  * Failure and cancellation messages can now dismiss automatically after 3.6 seconds instead of 6 seconds.
  * Success message timing remains unchanged.
  * Custom display durations continue to override the preference.

* **Bug Fixes**
  * The new preference is saved and restored correctly without affecting other HUD settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->