### PR TITLE
test(mac): preserve core journey UI diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
         with:
           name: core-journey-fixture-ui-${{ github.run_attempt }}
           path: .artifacts/core-journey-fixture-ui
+          include-hidden-files: true
           if-no-files-found: error
 
   release-validation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,11 +124,14 @@ jobs:
               - 'Config/**'
               - '.github/workflows/ci.yml'
             core-journey:
+              - 'Project.swift'
               - 'Package.swift'
               - 'Package.resolved'
               - 'Sources/SpeakApp/**'
               - 'Sources/SpeakCore/**'
               - 'Sources/SpeakHotKeys/**'
+              - 'Tests/Fixtures/CoreJourneyTargetApp/**'
+              - 'Tests/SpeakAppUITests/**'
               - 'Tests/SpeakAppTests/**'
               - 'Tests/SpeakCoreTests/**'
               - 'Tests/SpeakHotKeysTests/**'
@@ -181,15 +184,27 @@ jobs:
 
       - name: Test launched fixture app
         run: |
+          set -o pipefail
+          mkdir -p .artifacts/core-journey-fixture-ui
           xcodebuild test \
             -workspace "Just Speak to It.xcworkspace" \
             -scheme SpeakApp \
             -destination "platform=macOS" \
             -only-testing:SpeakAppUITests/CoreJourneyFixtureUITests \
+            -resultBundlePath .artifacts/core-journey-fixture-ui/CoreJourneyFixture.xcresult \
             -skipPackagePluginValidation \
             CODE_SIGN_IDENTITY="-" \
             DEVELOPMENT_TEAM="" \
-            CODE_SIGN_STYLE=Manual
+            CODE_SIGN_STYLE=Manual \
+            | tee .artifacts/core-journey-fixture-ui/xcodebuild.log
+
+      - name: Upload launched-app diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: core-journey-fixture-ui-${{ github.run_attempt }}
+          path: .artifacts/core-journey-fixture-ui
+          if-no-files-found: error
 
   release-validation:
     name: Build & Test (Release)

--- a/Docs/core-journey-e2e.md
+++ b/Docs/core-journey-e2e.md
@@ -42,6 +42,8 @@ tree drift from depending on TextEdit or third-party editors in CI. Its first UI
 test proves the fixture launches with keyboard focus, accepts typed text and can
 be read back. The bounded `Core Journey Fixture UI` CI job runs this launched-app
 test whenever core-journey paths change so the fixture cannot silently decay.
+It uploads the full `xcresult`, xcodebuild log, and a final fixture screenshot on
+every run, so failures can be inspected without reproducing the runner state.
 
 The next increment launches Speak with an isolated E2E profile and deterministic
 provider fixtures, injects the supported hotkey gesture, and asserts delivery

--- a/Tests/SpeakAppUITests/CoreJourneyFixtureUITests.swift
+++ b/Tests/SpeakAppUITests/CoreJourneyFixtureUITests.swift
@@ -4,7 +4,13 @@ final class CoreJourneyFixtureUITests: XCTestCase {
     func testFixtureProvidesNamedEditableTarget_acceptsAndReadsBackText() {
         let fixture = XCUIApplication(bundleIdentifier: "com.justspeaktoit.core-journey-fixture")
         fixture.launch()
-        defer { fixture.terminate() }
+        addTeardownBlock {
+            let screenshot = XCTAttachment(screenshot: fixture.screenshot())
+            screenshot.name = "Core journey fixture final state"
+            screenshot.lifetime = .keepAlways
+            self.add(screenshot)
+            fixture.terminate()
+        }
 
         let field = fixture.textViews["coreJourneyTargetField"]
         XCTAssertTrue(field.waitForExistence(timeout: 10))


### PR DESCRIPTION
## Summary

- upload the launched fixture UI test's full xcresult and xcodebuild log on every run
- attach a final fixture screenshot to make CI-only UI failures inspectable
- trigger the core-journey jobs when the Tuist project, fixture app, or macOS UI tests change
- document the available launched-app diagnostics

## Validation

- `git diff --check`
- workflow YAML parsed successfully with Ruby YAML
- `tuist generate --no-open` succeeded
- the selected `xcodebuild` UI target compiled successfully; local UI automation stalled during runner startup on this host and was stopped (CI is the authoritative launched-app environment)

Part of #802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved core journey UI test diagnostics with automatic final-state screenshots.
  * Preserved test output and results for easier investigation when checks fail.
  * CI now uploads test results, full build logs, and screenshots after every run.

* **Documentation**
  * Updated core journey testing documentation to describe available failure diagnostics.

* **Chores**
  * Expanded CI change detection to cover related project and UI test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->