### PR TITLE
feat(site): auto-select the compatible Mac download

### DIFF
--- a/landing-page/_headers
+++ b/landing-page/_headers
@@ -5,3 +5,6 @@
 /.well-known/appspecific/com.tesla.3p.public-key.pem
   Content-Type: application/x-pem-file
   Access-Control-Allow-Origin: *
+
+/download-architecture.js
+  Cache-Control: public, max-age=0, must-revalidate

--- a/landing-page/download-architecture.js
+++ b/landing-page/download-architecture.js
@@ -1,0 +1,54 @@
+const ARM64_DOWNLOAD = "/download/mac";
+const UNIVERSAL_DOWNLOAD = "/download/mac-intel";
+
+export function classifyArchitecture(value) {
+  const architecture = String(value || "").toLowerCase();
+  if (/arm|aarch64/.test(architecture)) return "arm64";
+  if (/x86|x64|amd64|ia32/.test(architecture)) return "intel";
+  return "unknown";
+}
+
+export async function detectMacArchitecture(navigatorObject) {
+  const userAgent = `${navigatorObject?.userAgent || ""} ${navigatorObject?.platform || ""}`;
+  if (!/Macintosh|MacIntel|MacPPC|Mac68K/i.test(userAgent)) return "unknown";
+
+  const userAgentData = navigatorObject?.userAgentData;
+  if (!userAgentData?.getHighEntropyValues) return "unknown";
+
+  try {
+    const hints = await userAgentData.getHighEntropyValues(["architecture", "bitness"]);
+    return classifyArchitecture(hints.architecture);
+  } catch {
+    return "unknown";
+  }
+}
+
+export function downloadForArchitecture(architecture) {
+  // Universal is the safe fallback: it contains both x86_64 and arm64. Safari
+  // deliberately does not expose reliable CPU architecture information.
+  return architecture === "arm64" ? ARM64_DOWNLOAD : UNIVERSAL_DOWNLOAD;
+}
+
+export async function enhanceMacDownloads(documentObject, navigatorObject) {
+  const architecture = await detectMacArchitecture(navigatorObject);
+  const download = downloadForArchitecture(architecture);
+  const label = architecture === "arm64"
+    ? "Apple Silicon"
+    : architecture === "intel"
+      ? "Intel"
+      : "Universal compatible";
+
+  documentObject.querySelectorAll("[data-auto-mac-download]").forEach((link) => {
+    link.href = download;
+    link.dataset.detectedArchitecture = architecture;
+    link.setAttribute("aria-label", `Download Just Speak to It for ${label}`);
+  });
+  documentObject.querySelectorAll("[data-download-architecture]").forEach((element) => {
+    element.textContent = label;
+  });
+  return { architecture, download };
+}
+
+if (typeof document !== "undefined" && typeof navigator !== "undefined") {
+  enhanceMacDownloads(document, navigator);
+}

--- a/landing-page/download-architecture.test.js
+++ b/landing-page/download-architecture.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyArchitecture,
+  detectMacArchitecture,
+  downloadForArchitecture,
+} from "./download-architecture.js";
+
+test("classifies browser architecture hints", () => {
+  assert.equal(classifyArchitecture("arm"), "arm64");
+  assert.equal(classifyArchitecture("aarch64"), "arm64");
+  assert.equal(classifyArchitecture("x86"), "intel");
+  assert.equal(classifyArchitecture("x86_64"), "intel");
+  assert.equal(classifyArchitecture(""), "unknown");
+});
+
+test("uses high-entropy hints on a Mac", async () => {
+  const navigatorObject = {
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    userAgentData: {
+      getHighEntropyValues: async () => ({ architecture: "arm", bitness: "64" }),
+    },
+  };
+  assert.equal(await detectMacArchitecture(navigatorObject), "arm64");
+});
+
+test("does not infer architecture from Safari's ambiguous MacIntel platform", async () => {
+  assert.equal(await detectMacArchitecture({ platform: "MacIntel" }), "unknown");
+});
+
+test("falls back to the compatible universal download", () => {
+  assert.equal(downloadForArchitecture("arm64"), "/download/mac");
+  assert.equal(downloadForArchitecture("intel"), "/download/mac-intel");
+  assert.equal(downloadForArchitecture("unknown"), "/download/mac-intel");
+});

--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -614,7 +614,7 @@
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .7C5.6.7.4 5.9.4 12.3c0 5.1 3.3 9.4 7.8 10.9.6.1.8-.3.8-.6v-2.2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.3 1 .1-.8.4-1.3.8-1.6-2.5-.3-5.2-1.3-5.2-5.7 0-1.3.4-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.2 1.2a11 11 0 0 1 5.8 0c2.2-1.5 3.2-1.2 3.2-1.2.6 1.6.2 2.8.1 3.1.8.9 1.2 1.9 1.2 3.1 0 4.4-2.7 5.4-5.2 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6a11.6 11.6 0 0 0 7.8-10.9C23.6 5.9 18.4.7 12 .7Z"/></svg>
           <span>GitHub</span>
         </a>
-        <a class="button button--orange nav__download" href="/download/mac">Download for Mac</a>
+        <a class="button button--orange nav__download" href="/download/mac-intel" data-auto-mac-download>Download for Mac</a>
       </div>
     </div>
   </header>
@@ -626,10 +626,10 @@
           <h1>Your voice.<br>Your model.<br>Your words.</h1>
           <p class="hero__lede">Fast, private dictation for Mac, iPhone, and iPad. Run speech models locally, stream with your own provider keys, and paste polished text anywhere.</p>
           <div class="hero__actions">
-            <a class="button button--orange" href="/download/mac">Download for Mac <span class="button__note">Apple Silicon</span> <span aria-hidden="true">→</span></a>
+            <a class="button button--orange" href="/download/mac-intel" data-auto-mac-download>Download for Mac <span class="button__note" data-download-architecture>Checking your Mac…</span> <span aria-hidden="true">→</span></a>
             <a class="button button--outline" href="#models">Explore the models</a>
           </div>
-          <p class="hero__alt">Intel Mac? <a href="/download/mac-intel">Download the legacy universal build</a> — it also runs on Apple Silicon.</p>
+          <p class="hero__alt">Choose manually: <a href="/download/mac">Apple Silicon</a> · <a href="/download/mac-intel">Intel (universal)</a>.</p>
         </div>
 
         <div class="product-stage" aria-label="Real screenshots of Just Speak to It on Mac and iPhone">
@@ -682,7 +682,7 @@
       <div class="shell">
         <div class="app-rail reveal">
           <div class="app-rail__lead"><h2 class="section-title">Native on every Apple screen you use.</h2></div>
-          <article class="app-choice" style="--link-color:var(--orange-deep)"><svg class="app-choice__icon" viewBox="0 0 52 52" fill="none" stroke="var(--orange)" stroke-width="2.5" aria-hidden="true"><rect x="8" y="7" width="36" height="27" rx="2"/><path d="M3 42h46M15 34l-4 8m26-8 4 8"/></svg><h3>Mac — Direct download</h3><p>Fast updates and full access to local model support.</p><a href="/download/mac">Download for Apple Silicon →</a><p class="app-choice__alt"><a href="/download/mac-intel">Intel Mac (legacy universal build)</a></p></article>
+          <article class="app-choice" style="--link-color:var(--orange-deep)"><svg class="app-choice__icon" viewBox="0 0 52 52" fill="none" stroke="var(--orange)" stroke-width="2.5" aria-hidden="true"><rect x="8" y="7" width="36" height="27" rx="2"/><path d="M3 42h46M15 34l-4 8m26-8 4 8"/></svg><h3>Mac — Direct download</h3><p>Fast updates and full access to local model support.</p><a href="/download/mac-intel" data-auto-mac-download>Download the best build for this Mac →</a><p class="app-choice__alt">Manual downloads: <a href="/download/mac">Apple Silicon</a> · <a href="/download/mac-intel">Intel (universal)</a></p></article>
           <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>Mac — App Store</h3><p>Sandboxed store distribution for a familiar install and update path.</p><span class="app-choice__status">Submitted for App Review</span></article>
           <article class="app-choice" style="--link-color:var(--blue)"><svg class="app-choice__icon" viewBox="0 0 52 52" aria-hidden="true"><rect width="52" height="52" rx="12" fill="#087af5"/><path d="M18 36 29 15m-6 15h15M14 30h5m14-15 6 11M15 36l3-6" fill="none" stroke="#fff" stroke-width="4.2" stroke-linecap="round"/></svg><h3>iPhone &amp; iPad — App Store</h3><p>Action Button, Shortcuts, Live Activity, and iCloud history.</p><span class="app-choice__status">Submitted for App Review</span></article>
         </div>
@@ -707,11 +707,13 @@
   <footer class="footer">
     <div class="shell footer__main">
       <a class="brand" href="#top"><span class="brand__wave" aria-hidden="true"><i style="--h:10px"></i><i style="--h:20px"></i><i style="--h:28px"></i><i style="--h:18px"></i><i style="--h:25px"></i><i style="--h:13px"></i></span><span>Just Speak to It</span></a>
-      <div class="footer__cta"><h2>Ready when you are.</h2><a class="button button--orange" href="/download/mac">Download for Mac</a></div>
+      <div class="footer__cta"><h2>Ready when you are.</h2><a class="button button--orange" href="/download/mac-intel" data-auto-mac-download>Download for Mac</a></div>
       <nav class="footer__links" aria-label="Footer"><a href="https://github.com/crmitchelmore/justspeaktoit">GitHub</a><a href="/privacy">Privacy</a><a href="mailto:hello@justspeaktoit.com">Contact</a></nav>
     </div>
     <div class="shell footer__legal">© 2026 Chris Mitchelmore. Just Speak to It is open source.</div>
   </footer>
+
+  <script type="module" src="/download-architecture.js"></script>
 
 </body>
 </html>

--- a/landing-page/package.json
+++ b/landing-page/package.json
@@ -6,8 +6,9 @@
   "type": "module",
   "scripts": {
     "dev": "bun run serve.ts",
-    "build": "mkdir -p dist && cp index.html dist/",
-    "preview": "bun run serve.ts"
+    "build": "mkdir -p dist && cp index.html download-architecture.js dist/",
+    "preview": "bun run serve.ts",
+    "test": "node --test download-architecture.test.js"
   },
   "devDependencies": {
     "@types/bun": "latest"


### PR DESCRIPTION
## What problem this solves

The latest release already provides an Apple-Silicon-only DMG and an Intel-compatible universal DMG, but the website's primary buttons always select Apple Silicon. Intel users must notice a smaller secondary link, and an incorrect click downloads an incompatible app.

## Why this change was made

- Adds best-effort architecture detection using browser high-entropy architecture hints.
- Routes detected Apple Silicon Macs to `/download/mac` and detected Intel Macs to `/download/mac-intel`.
- Uses the universal build as the safe fallback when Safari or another browser withholds CPU architecture, so the automatic button is never incompatible.
- Keeps explicit Apple Silicon and Intel (universal) links visible for manual selection.
- Avoids permanently caching the stable detector script.

## User impact

The primary Mac download buttons select the smallest compatible build when detection is available and a compatible universal build otherwise. Intel remains clearly downloadable from every relevant download area.

## Evidence

- `npm test`: 4 architecture resolver tests passed.
- `npm run build`: passed and includes the detector script.
- Latest v2.67.0 Intel-compatible asset verified locally: the main executable contains `x86_64 arm64`, strict code-sign verification passes, and Gatekeeper reports `accepted`, `source=Notarized Developer ID`.
- Both production redirect targets return their expected release assets.

Follow-up to #774.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Mac download selection for Apple Silicon and Intel devices.
  * Added manual download options for Apple Silicon and Intel Macs.
  * Updated download links with architecture-specific labels and accessibility information.
* **Bug Fixes**
  * Unknown or unsupported Mac architectures now safely use the universal download.
* **Tests**
  * Added coverage for architecture detection and fallback behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->