### PR TITLE
fix(mac): make onboarding analytics consent selectable

### DIFF
--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -356,7 +356,7 @@ struct OnboardingView: View {
             }
             .padding(.top, 20)
             .padding(.bottom, 30)
-            
+
             // Content
             Group {
                 switch state.currentStep {
@@ -375,7 +375,7 @@ struct OnboardingView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            
+
             Spacer()
             
             // Navigation buttons
@@ -1208,50 +1208,56 @@ struct CompleteStepView: View {
     @Binding var isComplete: Bool
     
     var body: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 80))
-                .foregroundColor(.green)
+        ScrollView(.vertical) {
+            VStack(spacing: 20) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 80))
+                    .foregroundColor(.green)
             
-            Text("You're All Set!")
-                .font(.title)
-                .fontWeight(.bold)
+                Text("You're All Set!")
+                    .font(.title)
+                    .fontWeight(.bold)
             
-            Text("Just Speak to It is ready to use")
-                .foregroundColor(.secondary)
-            
-            VStack(alignment: .leading, spacing: 16) {
-                TipRow(icon: "keyboard", text: "Press \(state.selectedHotKey.displayString) to start recording")
-                TipRow(icon: "text.cursor", text: "Click in any text field, then record")
-                TipRow(icon: "gearshape.fill", text: "Right-click the menu bar icon for settings")
-            }
-            .padding(.horizontal, 40)
-            .padding(.top, 20)
-            
-            Text("Tip: The app runs in your menu bar")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .padding(.top, 10)
+                Text("Just Speak to It is ready to use")
+                    .foregroundColor(.secondary)
 
-            if AppEnvironment.shared?.analyticsAvailable == true {
-                Toggle(
-                    "Share anonymous analytics",
-                    isOn: Binding(
-                        get: { state.settings.analyticsEnabled },
-                        set: { state.settings.analyticsEnabled = $0 }
+                if AppEnvironment.shared?.analyticsAvailable == true {
+                    Toggle(
+                        "Share anonymous analytics",
+                        isOn: Binding(
+                            get: { state.settings.analyticsEnabled },
+                            set: { state.settings.analyticsEnabled = $0 }
+                        )
                     )
-                )
                     .toggleStyle(.checkbox)
                     .font(.callout)
-                Text(
-                    "Optional. Never includes transcripts, audio, prompts, clipboard text, "
-                        + "keystrokes, API keys, screen content or personal identity."
-                )
+                    .accessibilityIdentifier("onboardingAnalyticsConsentToggle")
+                    Text(
+                        "Optional. Never includes transcripts, audio, prompts, clipboard text, "
+                            + "keystrokes, API keys, screen content or personal identity."
+                    )
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 440)
+                }
+
+                VStack(alignment: .leading, spacing: 16) {
+                    TipRow(icon: "keyboard", text: "Press \(state.selectedHotKey.displayString) to start recording")
+                    TipRow(icon: "text.cursor", text: "Click in any text field, then record")
+                    TipRow(icon: "gearshape.fill", text: "Right-click the menu bar icon for settings")
+                }
+                .padding(.horizontal, 40)
+                .padding(.top, 20)
+
+                Text("Tip: The app runs in your menu bar")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.top, 10)
             }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 12)
         }
     }
 }

--- a/Sources/SpeakApp/OnboardingView.swift
+++ b/Sources/SpeakApp/OnboardingView.swift
@@ -296,6 +296,23 @@ final class OnboardingState: ObservableObject {
             settings.postProcessingEnabled = false
         }
     }
+
+    func skipAPIKeySetup() {
+        apiKey = ""
+        validationError = nil
+        Self.disableUnavailablePostProcessing(in: settings)
+    }
+
+    static func disableUnavailablePostProcessing(in settings: AppSettings) {
+        let availability = ModelCredentialResolver.availability(
+            for: settings.postProcessingModel,
+            purpose: .postProcessing,
+            storedAPIKeyIdentifiers: settings.trackedAPIKeyIdentifiers
+        )
+        if case .missing = availability {
+            settings.postProcessingEnabled = false
+        }
+    }
 }
 
 enum OnboardingStep: Int, CaseIterable {
@@ -400,6 +417,7 @@ struct OnboardingView: View {
                 
                 if state.currentStep == .apiKey {
                     Button("Skip for Now") {
+                        state.skipAPIKeySetup()
                         withAnimation {
                             // Skip API key and test recording, go straight to complete
                             state.currentStep = .complete

--- a/Tests/SpeakAppTests/OnboardingStateTests.swift
+++ b/Tests/SpeakAppTests/OnboardingStateTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+@testable import SpeakApp
+
+final class OnboardingStateTests: XCTestCase {
+    @MainActor
+    func testKeylessCompletion_disablesUnavailablePostProcessing() {
+        let defaults = makeDefaults()
+        let settings = AppSettings(defaults: defaults)
+        settings.postProcessingEnabled = true
+        settings.postProcessingModel = "openai/gpt-5-mini"
+
+        OnboardingState.disableUnavailablePostProcessing(in: settings)
+
+        XCTAssertFalse(settings.postProcessingEnabled)
+        XCTAssertFalse(defaults.bool(forKey: "postProcessingEnabled"))
+    }
+
+    @MainActor
+    func testKeylessCompletion_preservesAvailableLocalPostProcessing() {
+        let settings = AppSettings(defaults: makeDefaults())
+        settings.postProcessingEnabled = true
+        settings.postProcessingModel = "local/post-processing/rules"
+
+        OnboardingState.disableUnavailablePostProcessing(in: settings)
+
+        XCTAssertTrue(settings.postProcessingEnabled)
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "OnboardingStateTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}


### PR DESCRIPTION
## Summary

- constrain the final onboarding step to a scrollable content region so it cannot overlap the fixed navigation footer
- move the optional analytics choice above the shortcut tips so it remains immediately discoverable
- add a stable accessibility identifier to the checkbox for UI automation
- turn post-processing off when onboarding is completed without the credential required by the selected post-processing model
- preserve enabled post-processing when its selected engine is genuinely local and needs no API key

Fixes #819.

## Root cause

The final-step content became taller after analytics consent was added, but onboarding still uses a fixed 600 × 550 window with a separately laid-out navigation footer. SwiftUI allowed the content to overflow into that footer. The checkbox could therefore remain visible while the footer intercepted pointer events.

## Verification

- `swift build --target SpeakApp`
- strict SwiftLint on `Sources/SpeakApp/OnboardingView.swift` (0 violations)
- `swift test --filter OnboardingStateTests` (2 passed)
- `git diff --check`
